### PR TITLE
Add missing close-parenthesis to "environment" documentation page

### DIFF
--- a/_docs/environment.md
+++ b/_docs/environment.md
@@ -14,7 +14,7 @@ In the future, we plan to allow as much of this to be configurable as possible.
 Please [contact us](mailto:sayhi@circleci.com) if some part of our environment is not suitable for you, and we will try to come up with a workaround.
 
 If any version is not listed here, SSH into our build boxes to check it manually (and [contact us](mailto:sayhi@circleci.com)
-so we can update this doc.
+so we can update this doc).
 
 ## Base
 


### PR DESCRIPTION
Fixes a missing closing parenthesis on your documentation page describing what environments are available for testing.

Obviously not anything major, just pointing out a grammatical error I happened to stumble across.