### PR TITLE
Update compatible Ruby versions for Simplecov gem

### DIFF
--- a/_docs/code-coverage.md
+++ b/_docs/code-coverage.md
@@ -23,7 +23,7 @@ CircleCI will upload coverage results and make them visible as part of your buil
 
 #### Ruby
 
-In Ruby 1.9, you add the
+In Ruby 1.9+, you add the
 [simplecov gem](https://github.com/colszowka/simplecov)
 and configure your test suite to add code coverage.
 


### PR DESCRIPTION
Hi guys,

According to https://github.com/colszowka/simplecov#ruby-version-compatibility

simplecov is compatible with Ruby 1.9+ and the test suite is green until Ruby 2.2. 

Cheers! :smiley_cat: 