### PR TITLE
front matter descriptions and trailing fixes links

### DIFF
--- a/jekyll/_docs/adding-read-write-deployment-key.md
+++ b/jekyll/_docs/adding-read-write-deployment-key.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Adding read/write deployment key
+description: What to know when adding read/write deployment keys
 ---
 
 When you add a new project on CircleCI, we will create a deployment key in the repository on GitHub. The deployment key is read-only, so CircleCI cannot push to your repository with the key. This is good from the security standpoint of view. However, sometimes you may want push to the repository from builds and you cannot do this with a read-only deployment key. You can manually add a read/write deployment key with the following steps.

--- a/jekyll/_docs/android.md
+++ b/jekyll/_docs/android.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Test Android Applications
 short-title: Android
 categories: [mobile-platforms]
+description: Testing android applications on circleci
 ---
 
 
@@ -45,7 +46,7 @@ test:
     - ./gradlew assembleDebug
 ```
 
-or build a release `.apk` and save it to [artifacts]({{ site.baseurl }}/build-artifacts) with
+or build a release `.apk` and save it to [artifacts]({{ site.baseurl }}/build-artifacts/) with
 
 ```
 test:

--- a/jekyll/_docs/api.md
+++ b/jekyll/_docs/api.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: CircleCI REST API
 categories: [reference]
 last_updated: Aug 23, 2012
+description: Using circleci rest api  
 ---
 
 <h2 id="intro">The CircleCI API</h2>
@@ -46,7 +47,7 @@ All Circle API endpoints begin with `"https://circleci.com/api/v1/"`.
   GET: /project/:username/:project/:build_num
 </dt>
 <dd>
-  Full details for a single build. The response includes all of the fields from the build summary. This is also the payload for the [notification webhooks]({{ site.baseurl }}/configuration#notify), in which case this object is the value to a key named 'payload'.
+  Full details for a single build. The response includes all of the fields from the build summary. This is also the payload for the [notification webhooks]({{ site.baseurl }}/configuration/#notify), in which case this object is the value to a key named 'payload'.
 </dd>
 <dt>
   GET: /project/:username/:project/:build_num/artifacts
@@ -203,7 +204,7 @@ The branch name should be url-encoded.
 
 <h2 id="build">Single Build</h2>
 
-<span class='label label-info'>Note:</span> This is also the payload for the [notification webhooks]({{ site.baseurl }}/configuration#notify), in which case this object is the value to a key named 'payload'.
+<span class='label label-info'>Note:</span> This is also the payload for the [notification webhooks]({{ site.baseurl }}/configuration/#notify), in which case this object is the value to a key named 'payload'.
 
 {{ site.data.api.build | api_endpoint }}
 
@@ -232,7 +233,7 @@ You can retry a build with ssh by swapping "retry" with "ssh":
 
 <h2 id="new-build-branch">Trigger a new Build with a Branch</h2>
 
-<span class='label label-info'>Note:</span> For more about build parameters, read about [using parameterized builds]({{ site.baseurl }}/parameterized-builds)
+<span class='label label-info'>Note:</span> For more about build parameters, read about [using parameterized builds]({{ site.baseurl }}/parameterized-builds/)
 
 {{ site.data.api.project_branch | api_endpoint }}
 
@@ -277,7 +278,7 @@ You can retry a build with ssh by swapping "retry" with "ssh":
 
 {{ site.data.api.test_metadata | api_endpoint }}
 
-<span class='label label-info'>Note:</span> [Learn how to set up your builds to collect test metadata]({{ site.baseurl }}/test-metadata)
+<span class='label label-info'>Note:</span> [Learn how to set up your builds to collect test metadata]({{ site.baseurl }}/test-metadata/)
 
 ## SSH Keys
 

--- a/jekyll/_docs/background-process.md
+++ b/jekyll/_docs/background-process.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Start background processes from circle.yml
 categories: [how-to]
 last_updated: Feb 5, 2014
+description: How to start a background process from circle.yml
 ---
 
 Starting a background process from [circle.yml](/docs/configuration)

--- a/jekyll/_docs/browser-debugging.md
+++ b/jekyll/_docs/browser-debugging.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: "Interacting with the browser on CircleCI's VM"
 last_updated: "October 20, 2014"
+description: How to interacting with a browser on Circleci's vm
 ---
 
 Integration tests can be hard to debug, especially when they're running on a remote machine.
@@ -15,7 +16,7 @@ and then view them when the build finishes.
 
 Saving screenshots is straightforward: it's a built-in feature in WebKit and Selenium, and supported by most test suites:
 
-*   [Manually, using Selenium directly](http://docs.seleniumhq.org/docs/04_webdriver_advanced.jsp#remotewebdriver)
+*   [Manually, using Selenium directly](http://docs.seleniumhq.org/docs/04_webdriver_advanced.jsp/#remotewebdriver)
 *   [Automaticaly on failure, using Cucumber](https://github.com/mattheworiordan/capybara-screenshot)
 *   [Automaticaly on failure, using Behat and Mink](https://gist.github.com/michalochman/3175175)
 

--- a/jekyll/_docs/browser-testing-with-sauce-labs.md
+++ b/jekyll/_docs/browser-testing-with-sauce-labs.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Test with Sauce Labs
 categories: [how-to]
 last_updated: July 28, 2014
+description: How to test Sauce Labs on Circleci
 ---
 
 You can run Selenium WebDriver tests with Sauce Labs on CircleCI using Sauce Labs'

--- a/jekyll/_docs/build-artifacts.md
+++ b/jekyll/_docs/build-artifacts.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Build artifacts
 categories: [reference]
+description: Dealing with build artifacts
 last_updated: August 1, 2014
 ---
 
@@ -13,14 +14,14 @@ read-only `$CIRCLE_ARTIFACTS`
 [environment variable](/docs/environment-variables).
 
 If you prefer, you can also
-[configure directories and files whose contents will](/docs/configuration#artifacts)
+[configure directories and files whose contents will](/docs/configuration/#artifacts)
 be saved.
 
 After the build finishes, everything in these directories is saved and linked to the build.
 
 ![]({{ site.baseurl }}/assets/img/docs/artifacts.png)
 
-You'll find links to the artifacts at the top of the build page. You can also consume them via our [API](/docs/api#build-artifacts).
+You'll find links to the artifacts at the top of the build page. You can also consume them via our [API](/docs/api/#build-artifacts).
 
 That's all there is to it!
 

--- a/jekyll/_docs/bundler-latest.md
+++ b/jekyll/_docs/bundler-latest.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Do you need the latest version of Bundler?
 last_updated: Feb 3, 2013
+description: Latest versions of bundler
 ---
 
 CircleCI typically tracks the latest stable version of bundler.

--- a/jekyll/_docs/cabal-test-timeout.md
+++ b/jekyll/_docs/cabal-test-timeout.md
@@ -1,13 +1,14 @@
 ---
 layout: classic-docs
 title: Unexpected Timeouts During `cabal test`
+description: What to do during unexpected time outs
 ---
 
 By default, Circle times out tests if they have not produced output for 180
 seconds. `cabal test`, even with `--show-details=always`,
 only produces output as each test suite completes, so it may be necessary
 to
-[set a higher timeout for commands that run it:](/docs/configuration#modifiers)
+[set a higher timeout for commands that run it:](/docs/configuration/#modifiers)
 
 ```
 test:

--- a/jekyll/_docs/cant-follow.md
+++ b/jekyll/_docs/cant-follow.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Why can I not follow a project?
 last_updated: Feb 2, 2013
+description: Trouble following projects
 ---
 
 GitHub requires admin permissions to add an SSH key to a

--- a/jekyll/_docs/capybara-timeout.md
+++ b/jekyll/_docs/capybara-timeout.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: "unable to obtain stable firefox connection in 60 seconds"
+description: Firefox connection issues
 last_updated: Feb 2, 2013
 ---
 

--- a/jekyll/_docs/chromedriver-moving-elements.md
+++ b/jekyll/_docs/chromedriver-moving-elements.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: ChromeDriver raises an 'Element is not clickable' exception
+description: Element no clickable issue
 last_updated: Aug 7, 2013
 ---
 
@@ -15,5 +16,5 @@ This behaviour is due to the ChromeDriver implementation (there is an
 tracking a fix in ChromeDriver itself).
 
 You can use
-[explicit waits](http://docs.seleniumhq.org/docs/04_webdriver_advanced.jsp#explicit-and-implicit-waits-reference)
+[explicit waits](http://docs.seleniumhq.org/docs/04_webdriver_advanced.jsp/#explicit-and-implicit-waits-reference)
 along with a custom expected condition to wait until an element has stopped moving before clicking.

--- a/jekyll/_docs/clojure-12.md
+++ b/jekyll/_docs/clojure-12.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: "java.lang.NoSuchMethodError: clojure.lang.KeywordLookupSite"
+description: Dealing with java.lang.NoSuchMethodError: clojure.lang.KeywordLookupSite
 last_updated: Feb 2, 2013
 ---
 

--- a/jekyll/_docs/code-coverage.md
+++ b/jekyll/_docs/code-coverage.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Generating code coverage metrics
 short-title: Code Coverage
 categories: [how-to]
+description: Generating code coverage metrics
 last_updated: Sep 12, 2013
 ---
 
@@ -15,7 +16,7 @@ or using partners.
 ## See coverage in CircleCI
 
 It's straightforward to see simple coverage results from your build.
-Simply add a coverage library to your project, and configure it to write the results out to CircleCI's [artifacts directory]({{ site.baseurl }}/build-artifacts).
+Simply add a coverage library to your project, and configure it to write the results out to CircleCI's [artifacts directory]({{ site.baseurl }}/build-artifacts/).
 CircleCI will upload coverage results and make them visible as part of your build.
 
 ### Adding and configuring a coverage library
@@ -48,7 +49,7 @@ end
 SimpleCov.start
 ```
 
-The [simplecov README](https://github.com/colszowka/simplecov#getting-started) has more details.
+The [simplecov README](https://github.com/colszowka/simplecov/#getting-started) has more details.
 
 #### Python, Node, Java, PHP, etc
 
@@ -71,8 +72,8 @@ In the meantime, add your coverage library of choice. Options include:
     for C or C++.
 
 Configure your library to save results in the directory specified by the CIRCLE_ARTIFACTS environment variable.
-Alternatively, add a [test.post command]({{ site.baseurl }}/configuration#test)
-to copy your artifacts into the [artifacts directory]({{ site.baseurl }}/build-artifacts).
+Alternatively, add a [test.post command]({{ site.baseurl }}/configuration/#test)
+to copy your artifacts into the [artifacts directory]({{ site.baseurl }}/build-artifacts/).
 
 ### Seeing the results in the CircleCI UI
 
@@ -82,7 +83,7 @@ tab on the build page:
 ![]({{ site.baseurl }}/assets/img/docs/artifacts_listing.png)
 
 You can also get them via the
-[CircleCI API](https://circleci.com/docs/api#build-artifacts).
+[CircleCI API](https://circleci.com/docs/api/#build-artifacts).
 
 And then of course, by viewing the generated HTML,
 you can see beautifully rendered HTML in the UI.
@@ -99,7 +100,7 @@ code quality services:
 If you're a Coveralls customer, follow
 [their guide to set up your coverage stats.](https://coveralls.io/docs)
 You'll need to add `COVERALLS_REPO_TOKEN` to your CircleCI
-[environment variables](https://circleci.com/docs/environment-variables).
+[environment variables](https://circleci.com/docs/environment-variables/).
 
 Coveralls will automatically handle the merging of coverage stats in
 parallel builds.

--- a/jekyll/_docs/composer-api-rate-limit.md
+++ b/jekyll/_docs/composer-api-rate-limit.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Composer hitting GitHub API rate limits
+description: GitHub API rate limits as composer
 last_updated: May 23, 2013
 ---
 

--- a/jekyll/_docs/config-sample.md
+++ b/jekyll/_docs/config-sample.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Sample circle.yml file
 categories: [reference]
+description: Making a circle.yml file
 last_updated: May 2, 2013
 ---
 

--- a/jekyll/_docs/configuration.md
+++ b/jekyll/_docs/configuration.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Configuring CircleCI
 categories: [getting-started,reference]
+description: How to configure CircleCI
 last_updated: August 1, 2014
 ---
 
@@ -13,7 +14,7 @@ You place the file in your git repo's root directory and CircleCI reads the file
 If you want a quick look at how to set up your `circle.yml`
 file, check out our [sample file](/docs/config-sample).
 
-Should you have a test failure, our [troubleshooting section]({{ site.baseurl }}/troubleshooting)
+Should you have a test failure, our [troubleshooting section]({{ site.baseurl }}/troubleshooting/)
 can likely tell you the best way to solve the problem.
 If you find yourself repeatedly consulting this guide, please
 [contact us](mailto:sayhi@circleci.com) and let us know what you're working on.
@@ -66,14 +67,14 @@ Allowed modifiers are:
 *   **timeout**: if a command runs this many seconds without output, kill it (default:600s)
 *   **pwd**: run commands using this value as the current working directory (default: the checkout directory named for your project, except in the `machine` and `checkout/pre` sections, where it defaults to `$HOME`.)
 *   **environment**: a hash creating a list of environment variables set for this command
-    (see [Machine configuration](#machine) for this modifier's properties when used in the `machine` section of the file)
+    (see [Machine configuration](/#machine) for this modifier's properties when used in the `machine` section of the file)
 *   **parallel**: (only used with commands in the `test` section)
-    if you have [ manually set up parallelism]({{ site.baseurl }}/parallel-manual-setup), set this to true to run a command across all VMs
+    if you have [ manually set up parallelism]({{ site.baseurl }}/parallel-manual-setup/), set this to true to run a command across all VMs
 *   **files**:
     The files identified by the file list (or globs) will be appended to the
     command arguments. The files will be distributed across all containers
     running the build. Check
-    [manual parallelism setup document]({{ site.baseurl }}/parallel-manual-setup#auto-balancing) for more details.
+    [manual parallelism setup document]({{ site.baseurl }}/parallel-manual-setup/#auto-balancing) for more details.
 *   **background**: when "true", runs a command in the background.  It is similar to ending a shell command with '&amp;', but works correctly over ssh.  Useful for starting servers, which your tests will connect to.
 
 Note that YAML is very strict about indentation each time you add a new property.
@@ -182,7 +183,7 @@ machine:
 ```
 
 CircleCI will automatically update the `/etc/hosts` file with these values.
-Hostnames [must be well formed](http://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names).
+Hostnames [must be well formed](http://en.wikipedia.org/wiki/Hostname/#Restrictions_on_valid_host_names).
 CircleCI will only accept hostnames that contain alpha-numeric characters,
 hyphens (-) and dots (.).
 
@@ -202,13 +203,13 @@ machine:
     version: 1.9.3-p0-falcon
 ```
 
-The complete list of supported Ruby versions is found [here](/docs/environment#ruby).
+The complete list of supported Ruby versions is found [here](/docs/environment/#ruby).
 
 <h3 id="node-version">Node.js version</h3>
 
 CircleCI uses [NVM](https://github.com/creationix/nvm)
 to manage Node versions. See
-[supported Node versions](/docs/environment#nodejs)
+[supported Node versions](/docs/environment/#nodejs)
 for a complete list. If you do not specify a version, CircleCI uses
 `{{ versions.default_node }}`.
 
@@ -232,7 +233,7 @@ machine:
 ```
 
 The default version of Java is `oraclejdk7`.
-See [supported Java versions](/docs/environment#java)
+See [supported Java versions](/docs/environment/#java)
 for a complete list.
 
 ### PHP version
@@ -248,7 +249,7 @@ machine:
     version: 5.4.5
 ```
 
-See [supported PHP versions](/docs/environment#php) for a complete list.
+See [supported PHP versions](/docs/environment/#php) for a complete list.
 
 ### Python version
 
@@ -262,13 +263,13 @@ machine:
     version: 2.7.5
 ```
 
-See [supported Python versions](/docs/environment#python)
+See [supported Python versions](/docs/environment/#python)
 for a complete list.
 
 ### GHC version
 
 You can choose from a
-[number of available GHC versions](/docs/environment#haskell)
+[number of available GHC versions](/docs/environment/#haskell)
 in your `circle.yml`:
 
 ```
@@ -280,13 +281,13 @@ machine:
 ### Other languages
 
 Our [test environment](/docs/environment) document has more configuration information about
-[other languages](/docs/environment#other) including [Python](/docs/environment#python),
-[Clojure](/docs/environment#clojure), [C/C++](/docs/environment#other),
-[Golang](/docs/environment#other) and [Erlang](/docs/environment#other).
+[other languages](/docs/environment#other) including [Python](/docs/environment/#python),
+[Clojure](/docs/environment#clojure), [C/C++](/docs/environment/#other),
+[Golang](/docs/environment#other) and [Erlang](/docs/environment/#other).
 
 <h3 id="services">Databases and other services</h3>
 
-CircleCI supports a large number of [databases and other services](/docs/environment#databases).
+CircleCI supports a large number of [databases and other services](/docs/environment/#databases).
 Most popular ones are running by default on our build machines (bound to localhost), including Postgres, MySQL, Redis and MongoDB.
 
 You can enable other databases and services from the `services` section:
@@ -387,7 +388,7 @@ Caches are private, and are not shared with other projects.
 
 Your web framework typically includes commands to create your database, install your schema, and run your migrations.
 You can use `override`, `pre`, and/or `post` to modify `database` commands.
-See [Setting up your test database](/docs/manually#databases) for more information.
+See [Setting up your test database](/docs/manually/#databases) for more information.
 
 If our inferred `database.yml` isn't working for you, you may need to `override` our setup commands (as shown in the following example).
 If that is the case, please [contact us](mailto:sayhi@circleci.com)
@@ -438,7 +439,7 @@ test:
 ```
 
 CircleCI also supports the use of `minitest_globs`
-(a list of file globs, using [Ruby's Dir.glob syntax](http://ruby-doc.org/core-2.0/Dir.html#glob-method))
+(a list of file globs, using [Ruby's Dir.glob syntax](http://ruby-doc.org/core-2.0/Dir.html/#glob-method))
 that can list the file globs to be used during testing.
 
 By default, when testing in parallel, CircleCI runs all tests in the test/unit, test/integration, and
@@ -622,7 +623,7 @@ notify:
 ```
 
 The JSON packet is identical to the result of the
-[Build API](/docs/api#build)
+[Build API](/docs/api/#build)
 call for the same build, except that it is wrapped in a "payload" key:
 
 ```

--- a/jekyll/_docs/continuous-deployment-with-aws-codedeploy.md
+++ b/jekyll/_docs/continuous-deployment-with-aws-codedeploy.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Continuous Deployment with AWS CodeDeploy
 categories: [how-to]
+description: Continuous Deployment with AWS CodeDeploy
 last_updated: September 29, 2014
 ---
 

--- a/jekyll/_docs/continuous-deployment-with-heroku.md
+++ b/jekyll/_docs/continuous-deployment-with-heroku.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Continuous Deployment with Heroku
 categories: [how-to]
+description: Continuous Deployment with Heroku
 last_updated: May 7, 2013
 ---
 
@@ -123,7 +124,7 @@ deployment:
 
 As previously mentioned, Heroku displays a default "Application Offline for Maintenance" HTML page telling users that an application is currently unavailable and to check back later.
 Should you wish, you can create a
-[custom](http://devcenter.heroku.com/articles/error-pages#customize-pages)
+[custom](http://devcenter.heroku.com/articles/error-pages#/customize-pages)
 service unavailable page for your app.
 
 <h2 id="migrations">Heroku and database migrations</h2>
@@ -137,7 +138,7 @@ CircleCI supports such command-driven database migrations as well as database mi
 
 Before migrating, Heroku recommends that you use the `heroku pgbackups`
 command to
-[capture a snapshot](http://devcenter.heroku.com/articles/migrate-heroku-postgres-with-pgbackups#capture-source-snapshot)
+[capture a snapshot](http://devcenter.heroku.com/articles/migrate-heroku-postgres-with-pgbackups/#capture-source-snapshot)
 so that you can easily revert the database back to its previous state.
 
 ### Migration guides
@@ -145,7 +146,7 @@ so that you can easily revert the database back to its previous state.
 Here are migration-related articles that you might find useful.
 
 *   [Rails](http://guides.rubyonrails.org/migrations.html)
-*   [node.js](http://github.com/nearinfinity/node-db-migrate#readme)
+*   [node.js](http://github.com/nearinfinity/node-db-migrate/#readme)
 *   [Django (Python web framework)](http://djangopro.com/2011/01/django-database-migration-tool-south-explained)
 
 <h2 id="caches">Clearing caches after a deployment</h2>
@@ -165,6 +166,6 @@ You might want to write a standalone script that uses the memcache client to cal
 
 Here are related articles that you might find useful.
 
-*   [Memcachier documentation](http://devcenter.heroku.com/articles/memcachier#getting-started)
+*   [Memcachier documentation](http://devcenter.heroku.com/articles/memcachier/#getting-started)
 *   [Redis documentation](http://redis.io/documentation)
 *   [Django's cache framework documentation](http://docs.djangoproject.com/en/1.5/topics/cache)

--- a/jekyll/_docs/continuous-deployment-with-ninefold.md
+++ b/jekyll/_docs/continuous-deployment-with-ninefold.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Continuous Deployment with Ninefold
 categories: [how-to]
+description: Continuous Deployment with Ninefold
 last_updated: October 14, 2014
 ---
 

--- a/jekyll/_docs/deploy-bluemix.md
+++ b/jekyll/_docs/deploy-bluemix.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Continuous Deployment to IBM Bluemix and Pivotal Web Service
 categories: [how-to]
+description: Continuous Deployment to IBM Bluemix and Pivotal Web Service
 last_updated: Oct 1, 2014
 ---
 
@@ -11,7 +12,7 @@ to use the [Cloud Foundry command line tool 'cf'](https://github.com/cloudfoundr
 
 ## Quickstart
 
-To deploy to Bluemix from CircleCI you will need to [set your Bluemix password](/docs/environment-variables#setting-environment-variables-for-all-commands-without-adding-them-to-git) 
+To deploy to Bluemix from CircleCI you will need to [set your Bluemix password](/docs/environment-variables/#setting-environment-variables-for-all-commands-without-adding-them-to-git) 
 and username, and modify 3 sections in circle.yml. 
 
 Here's a minimal example circle.yml configuration:
@@ -58,7 +59,7 @@ dependencies:
 
 You should store your Bluemix password in an environment variables, which you can
 manage through the web UI as described
-[in this document](/docs/environment-variables#setting-environment-variables-for-all-commands-without-adding-them-to-git).
+[in this document](/docs/environment-variables/#setting-environment-variables-for-all-commands-without-adding-them-to-git).
 For the sake of convenience, we'll assume you store your Bluemix user there too; in BLUEMIX_PASSWORD and BLUEMIX_USER respectively.
 
 We'll configure 'cf' in our post test section of our circle.yml like:
@@ -76,7 +77,7 @@ test:
 
 With the cli installed and configured, next you need to **configure continuous deployment.**
 You may want to read up on configuring
-[continuous deployment with circle.yml](/docs/configuration#deployment)
+[continuous deployment with circle.yml](/docs/configuration/#deployment)
 in general if your needs are more complex than what's shown here.
 
 For the sake of this example, let's deploy the master branch to

--- a/jekyll/_docs/deploy-google-app-engine.md
+++ b/jekyll/_docs/deploy-google-app-engine.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Continuous Deployment to Google App Engine
 categories: [how-to]
+description: Continuous Deployment to Google App Engine
 last_updated: July 19, 2013
 ---
 

--- a/jekyll/_docs/docker.md
+++ b/jekyll/_docs/docker.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Continuous Integration and Delivery with Docker
 categories: [how-to]
+description: Continuous Integration and Delivery with Docker
 last_updated: December 8, 2014
 ---
 
@@ -330,7 +331,7 @@ dependencies:
 when checking for cached ADD commands, as discussed
 [here](https://github.com/docker/docker/issues/7387). One workaround until Docker
 adds more options is to
-[set file modification times to the commit time](https://git.wiki.kernel.org/index.php/ExampleScripts#Setting_the_timestamps_of_the_files_to_the_commit_timestamp_of_the_commit_which_last_touched_them).
+[set file modification times to the commit time](https://git.wiki.kernel.org/index.php/ExampleScripts/#Setting_the_timestamps_of_the_files_to_the_commit_timestamp_of_the_commit_which_last_touched_them).
 
 2. Make sure you tag the image you use in the FROM command in your Dockerfile, even if it
 is the default "latest" tag (e.g. use `FROM dockerfile/java:latest` instead of just

--- a/jekyll/_docs/dont-run.md
+++ b/jekyll/_docs/dont-run.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Skip code which should not run on your CI server
 categories: [how-to]
+description: Skip code which should not run on your CI server
 last_updated: Feb 2, 2013
 ---
 

--- a/jekyll/_docs/environment-variables.md
+++ b/jekyll/_docs/environment-variables.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Environment variables
 categories: [reference]
+description: How to work with environment variables
 ---
 
 We export a number of environment variables during each build, which you may find
@@ -54,7 +55,7 @@ We publish the details of the currently running build in these variables:
   	`CIRCLE_TAG`
   </dt>
   <dd>
-  	The name of the git tag being tested, e.g. 'release-v1.5.4', if the build is running [for a tag]({{ site.baseurl }}/configuration#tags).
+  	The name of the git tag being tested, e.g. 'release-v1.5.4', if the build is running [for a tag]({{ site.baseurl }}/configuration/#tags).
   </dd>
   <dt>
     `CIRCLE_SHA1`
@@ -211,7 +212,7 @@ The only gotcha is that each command runs in its own shell, so just adding an
 #### Setting environment variables for all commands using circle.yml
 
 You can set environment variables in your `circle.yml` file, that
-[will be set for every command](/docs/configuration#environment).
+[will be set for every command](/docs/configuration/#environment).
 
 #### Setting environment variables for all commands without adding them to git
 
@@ -236,5 +237,5 @@ You can use standard bash syntax in your commands:
 RAILS_ENV=test bundle exec rake test
 ```
 
-You can also use [the environment modifier](/docs/configuration#modifiers) in your
+You can also use [the environment modifier](/docs/configuration/#modifiers) in your
 `circle.yml` file.

--- a/jekyll/_docs/environment.md
+++ b/jekyll/_docs/environment.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Test environment
 categories: [reference]
+description: Test environment 
 last_updated: Apr 7, 2015
 ---
 
@@ -117,7 +118,7 @@ We use RVM to give you access to a wide variety of Ruby
 versions. Below are the versions of Ruby that we pre-install; you can specify versions not listed here (supported by RVM) in your circle.yml file and we will install them as part of the build - this will add to your build time, however, if you let us know the version you are using we will update the VM accordingly.
 
 You can
-[choose the exact version you need directly, from the following list:](/docs/configuration#ruby-version)
+[choose the exact version you need directly, from the following list:](/docs/configuration/#ruby-version)
 
 {% for version in site.data.versions.ruby_versions %}
 - `{{ version }}`
@@ -154,7 +155,7 @@ If you do not specify a version, we use `{{ versions.default_node }}`.
 ### Python
 
 We use `python {{ versions.python }}` by default, although you can
-[control the version in your circle.yml file](/docs/configuration#python-version).
+[control the version in your circle.yml file](/docs/configuration/#python-version).
 Packages can be installed using `pip {{ versions.pip }}` and
 `virtualenv {{ versions.virtualenv }}`.
 
@@ -169,7 +170,7 @@ Please [contact us](mailto:sayhi@circleci.com) if other versions of Python would
 ### PHP
 
 We use `php {{ versions.php }}`, by default, although you can
-[control the version in your circle.yml file](/docs/configuration#php-version).
+[control the version in your circle.yml file](/docs/configuration/#php-version).
 Packages can be installed using `composer`, `pear`, and `pecl`.
 
 Supported versions are:
@@ -235,7 +236,7 @@ We have the following versions of GHC and tools installed:
 *   `happy-1.19.3`
 *   `alex-3.1.3`
 
-You can [specify which GHC version](/docs/configuration#ghc-version)
+You can [specify which GHC version](/docs/configuration/#ghc-version)
 you'd like in your `circle.yml`.
 
 <h3 id="other">Other languages</h3>

--- a/jekyll/_docs/external-resources.md
+++ b/jekyll/_docs/external-resources.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Use resources which are not in your repository
 categories: [how-to]
+description: How to use resources not in your repository
 last_updated: Feb 2, 2012
 ---
 
@@ -10,6 +11,6 @@ There are a number of techniques to do this:
 *   CircleCI supports `git submodule`, and has advanced SSH key management to let you access multiple repositories from a single test suite.
     From your project's **Project Settings > Checkout SSH keys**
     page, you can add a "user key" with one-click, allowing you access code from multiple repositories in your test suite.
-    Git submodules can be easily set up in your `circle.yml` file (see [example 1](/docs/configuration#checkout)).
+    Git submodules can be easily set up in your `circle.yml` file (see [example 1](/docs/configuration/#checkout)).
 *   CircleCI's VMs are connected to the internet. You can download dependencies directly while setting up your project, using
     `curl` or `wget`.

--- a/jekyll/_docs/faq.md
+++ b/jekyll/_docs/faq.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Frequently Asked Questions
 short-title: FAQ
 categories: [getting-started]
+description: Frequently Asked Questions
 last_updated: February 23, 2015
 ---
 

--- a/jekyll/_docs/file-ordering.md
+++ b/jekyll/_docs/file-ordering.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: File-ordering bugs on Linux systems
 categories: [troubleshooting]
+description: Dealing with file-ordering bugs on Linux systems
 last_updated: Feb 2, 2013
 ---
 

--- a/jekyll/_docs/filesystem.md
+++ b/jekyll/_docs/filesystem.md
@@ -2,6 +2,7 @@
 layout: classic-docs-parent
 title: Filesystem layout problems
 categories: [troubleshooting]
+description: Filesystem layout problems
 children:
   - missing-dir
   - missing-file

--- a/jekyll/_docs/fork-pr-builds.md
+++ b/jekyll/_docs/fork-pr-builds.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Building Pull Requests from forks
 short-title: Fork PR Builds
 categories: [reference]
+description: How to build Pull Requests from forks
 last_updated: April 2, 2015
 ---
 

--- a/jekyll/_docs/getting-started.md
+++ b/jekyll/_docs/getting-started.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Getting Started with CircleCI
 categories: [getting-started]
+description: Getting Started with CircleCI
 last_updated: April 29, 2013
 ---
 
@@ -19,7 +20,7 @@ If you do, your tests will be up and running in a flash.
 Add
 your [first project](https://circleci.com/dashboard/) now!
 
-(**Related: &nbsp;**[What happens when you add a project?]({{ site.baseurl }}/what-happens))
+(**Related: &nbsp;**[What happens when you add a project?]({{ site.baseurl }}/what-happens/))
 
 ### When the magic doesn't work?
 
@@ -30,7 +31,7 @@ Here are some common issues and where you can find their fixes.
 *   If we didn't run an important step or omitted some tests,
     [add a `circle.yml` file](/docs/configuration)
     to tweak your test run.
-*   If we didn't infer anything, you can [set up your project manually]({{ site.baseurl }}/manually).
+*   If we didn't infer anything, you can [set up your project manually]({{ site.baseurl }}/manually/).
 *   Sometimes, your tests will fail on our server even though they work locally.
     Read our list of [common problems](/docs/troubleshooting) and their solutions.
 

--- a/jekyll/_docs/gettingstarted.md
+++ b/jekyll/_docs/gettingstarted.md
@@ -2,4 +2,5 @@
 layout: classic-category
 title: Getting Started
 categories: [getting-started]
+description: Getting Started
 ---

--- a/jekyll/_docs/git-bundle-install.md
+++ b/jekyll/_docs/git-bundle-install.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Git errors during a bundle install
+description: Git errors during a bundle install
 last_updated: Feb 3, 2013
 ---
 

--- a/jekyll/_docs/git-npm-install.md
+++ b/jekyll/_docs/git-npm-install.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Git errors during npm install
+description: Git errors during npm install
 last_updated: Sep 16, 2013
 ---
 

--- a/jekyll/_docs/git-pip-install.md
+++ b/jekyll/_docs/git-pip-install.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Git errors during pip install
+description: Git errors during pip install
 last_updated: Feb 3, 2013
 ---
 

--- a/jekyll/_docs/github-3rdparty-app-restrictions.md
+++ b/jekyll/_docs/github-3rdparty-app-restrictions.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Re-enabling CircleCI after enabling third-party application restrictions for a GitHub organization
+description: Re-enabling CircleCI after enabling third-party application restrictions for a GitHub organization
 last_updated: Jan 26, 2015
 ---
 

--- a/jekyll/_docs/github-permissions.md
+++ b/jekyll/_docs/github-permissions.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Why does CircleCI need all those permissions?
+description: CircleCI permissions explanation 
 last_updated: Feb 3, 2013
 ---
 

--- a/jekyll/_docs/github-privacy.md
+++ b/jekyll/_docs/github-privacy.md
@@ -2,6 +2,7 @@
 layout: classic-docs-parent
 title: GitHub integration
 categories: [privacy-and-security]
+description: GitHub integration
 children:
   - github-3rdparty-app-restrictions
   - cant-follow

--- a/jekyll/_docs/github-security-ssh-keys.md
+++ b/jekyll/_docs/github-security-ssh-keys.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: GitHub security and SSH keys
+description: GitHub security and SSH keys
 last_updated: May 1, 2013
 ---
 

--- a/jekyll/_docs/google-auth.md
+++ b/jekyll/_docs/google-auth.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Authentication with Google Cloud Platform
 categories: [how-to]
+description: Authentication with Google Cloud Platform
 ---
 
 Before using the `gcloud` command line tool to deploy your app to Google Cloud Platform, you'll need to authenticate it in order to give it the correct permissions. In order to do this, you'll need to create a [JSON Service Account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount). This Service Account can then be encoded in base64 and added as a CircleCI environment variable. Your build script can then decode the JSON file and it use to authenticate the gcloud tool, which can then be used to deploy and interact with your project.

--- a/jekyll/_docs/google-cloud-platform.md
+++ b/jekyll/_docs/google-cloud-platform.md
@@ -2,6 +2,8 @@
 layout: classic-docs
 title: Deploying to Google Cloud Platform
 categories: [how-to]
+description: Deploying to Google Cloud Platform
+categories: [how-to]
 ---
 
 ## Prerequisites

--- a/jekyll/_docs/google-cloud-test-lab.md
+++ b/jekyll/_docs/google-cloud-test-lab.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Testing with Google Cloud Test Lab
 categories: [how-to]
+description: Testing with Google Cloud Test Lab
 ---
 
 This guide is based off of commands in Google Cloud Test Lab that are currently

--- a/jekyll/_docs/how-cache-works.md
+++ b/jekyll/_docs/how-cache-works.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: How cache works
 categories: [reference]
+description: How the cache works
 last_updated: Jun 25, 2015
 ---
 

--- a/jekyll/_docs/how-parallelism-works.md
+++ b/jekyll/_docs/how-parallelism-works.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Does parallelism really work?
 categories: [parallelism]
+description: A look at parallelism
 last_updated: Feb 2, 2013
 ---
 

--- a/jekyll/_docs/how-to.md
+++ b/jekyll/_docs/how-to.md
@@ -2,4 +2,5 @@
 layout: classic-category
 title: How-To
 categories: [how-to]
+description: How-To
 ---

--- a/jekyll/_docs/installing-custom-software.md
+++ b/jekyll/_docs/installing-custom-software.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Install custom software
 categories: [how-to]
+description: How to install custom software
 last_updated: May 2, 2013
 ---
 
@@ -43,7 +44,7 @@ To reduce the time spent installing dependencies, CircleCI will cache them betwe
 You can add arbitrary directories to this cache, allowing you to avoid the overhead of building your custom software during the build.
 
 Tell CircleCI to save a cached copy using the
-[`cache_directories` setting, in your `circle.yml` file](/docs/configuration#cache-directories).
+[`cache_directories` setting, in your `circle.yml` file](/docs/configuration/#cache-directories).
 
 ```
 dependencies:

--- a/jekyll/_docs/installing-elasticsearch.md
+++ b/jekyll/_docs/installing-elasticsearch.md
@@ -1,11 +1,12 @@
 ---
 layout: classic-docs
 title: Install a custom version of Elasticsearch
+description: Installing a custom version of Elasticsearch
 last_updated: March 10, 2014
 ---
 
 CircleCI supports a large number of
-[services](/docs/environment#databases) which can be enabled from a circle.yml file checked into your repo's root directory. To enable Elasticsearch, add the following to your circle.yml:
+[services](/docs/environment/#databases) which can be enabled from a circle.yml file checked into your repo's root directory. To enable Elasticsearch, add the following to your circle.yml:
 
 ```
 machine:
@@ -50,7 +51,7 @@ To reduce the time spent installing dependencies, CircleCI can cache them betwee
 You can add arbitrary directories to the cache, allowing you to avoid the overhead of building your custom software during the build.
 
 Tell CircleCI to save a cached copy using the
-[`cache_directories` settings in your `circle.yml` file](/docs/configuration#cache-directories).
+[`cache_directories` settings in your `circle.yml` file](/docs/configuration/#cache-directories).
 Then check for the directory before you download elasticsearch:
 
 ```

--- a/jekyll/_docs/introduction-to-continuous-deployment.md
+++ b/jekyll/_docs/introduction-to-continuous-deployment.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Introduction to Continuous Deployment
+description: Introduction to Continuous Deployment
 last_updated: March 12, 2014
 ---
 
@@ -16,7 +17,7 @@ Continuous Deployment easy.
 ### Deployment syntax
 
 Tell Circle about your deployment requirements in the `deployment`
-section of your [circle.yml]({{ site.baseurl }}/configuration) file.
+section of your [circle.yml]({{ site.baseurl }}/configuration/) file.
 Within this section, you can can define custom deployment steps for each
 branch, directing Circle to use specific deployment tools or custom scripts.
 Deployment commands are triggered only after a successful build.
@@ -97,8 +98,8 @@ deployment:
 ### Deploy to a PaaS
 
 Circle has customers deploying to Heroku, Engine Yard, Google App Engine, Elastic Beanstalk, Dot Cloud, Nodejistu and other PaaSes. We have detailed instructions on deployment to
-[Heroku]({{ site.baseurl }}/continuous-deployment-with-heroku),
-[Google App Engine]({{ site.baseurl }}/deploy-google-app-engine)
-and [Bluemix]({{ site.baseurl }}/deploy-bluemix).
+[Heroku]({{ site.baseurl }}/continuous-deployment-with-heroku/),
+[Google App Engine]({{ site.baseurl }}/deploy-google-app-engine/)
+and [Bluemix]({{ site.baseurl }}/deploy-bluemix/).
 If you'd like help setting up your deployment, please
 [contact us](mailto:sayhi@circleci.com).

--- a/jekyll/_docs/ios-builds-on-os-x.md
+++ b/jekyll/_docs/ios-builds-on-os-x.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Test iOS applications on OS X
 short-title: iOS builds on OS X
 categories: [mobile-platforms]
+description: Testing iOS applications on OS X
 last_updated: March 2nd, 2016
 ---
 
@@ -70,7 +71,7 @@ machine:
 
 CircleCI will automatically detect if your project is using [CocoaPods](http://cocoapods.org/)
 to manage dependencies. If you are using CocoaPods, then we recommend that you
-check your [Pods directory into source control](http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control).
+check your [Pods directory into source control](http://guides.cocoapods.org/using/using-cocoapods.html/#should-i-ignore-the-pods-directory-in-source-control).
 This will ensure that you have a deterministic, reproducable build.
 
 If CircleCI finds a `Podfile` and the `Pods` directory is not present (or empty)
@@ -80,7 +81,7 @@ If CircleCI finds a `Podfile` and the `Pods` directory is not present (or empty)
 We cannot handle all setups automatically, so for some projects you might need
 to invoke CocoaPods manually with some custom configuration. To do this you will
 need to override the `dependencies` section of your `circle.yml` file.
-See our [documentation on overriding build phases for more information on this.](/docs/configuration#phases).
+See our [documentation on overriding build phases for more information on this.](/docs/configuration/#phases).
 If you need more help please reach out to our support team who are always happy
 to help out.
 
@@ -177,7 +178,7 @@ test:
 ### Environment variables
 You can customize the behavior of CircleCI's automatic build commands by setting
 the following environment variables in a `circle.yml` file or at
-**Project Settings > Environment Variables** (see [here](/docs/environment-variables#custom) for more info
+**Project Settings > Environment Variables** (see [here](/docs/environment-variables/#custom) for more info
 about environment variables):
 
 * `XCODE_WORKSPACE` - The path to your `.xcworkspace` file relative to the git repository root
@@ -188,7 +189,7 @@ about environment variables):
 precedence over project.
 
 If more than one scheme is present, then you should specify the
-`XCODE_SCHEME` [environment variable](/docs/environment-variables#custom).
+`XCODE_SCHEME` [environment variable](/docs/environment-variables/#custom).
 Otherwise a scheme will be chosen arbitrarily.
 
 You can also use the Environment Variables section to add all the
@@ -390,7 +391,7 @@ iPhoneSimulator: Timed out waiting 120 seconds for simulator to boot, current st
   Sometimes the issue would only be present with one of these tools but not the other.
 
 * **Errors while installing code signing certificates.** Please check out [the Troubleshooting
-  section](/docs/ios-code-signing#troubleshooting) of the code signing doc.
+  section](/docs/ios-code-signing/#troubleshooting) of the code signing doc.
 
 ### A note on code-generating tools
 Many iOS app developers use tools that generate substantial amounts of code. In such

--- a/jekyll/_docs/ios-code-signing.md
+++ b/jekyll/_docs/ios-code-signing.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Set up code signing for iOS projects
 short-title: iOS code signing
 categories: [how-to]
+description: Setting up code signing for iOS projects
 last_updated: March 2nd, 2016
 ---
 
@@ -74,7 +75,7 @@ gem install fastlane
 
 The tools take a few minutes to install, so a little patience is
 required. For more information check out the [Fastlane installation
-guide](https://github.com/fastlane/fastlane/blob/master/docs/Guide.md#fastlane)
+guide](https://github.com/fastlane/fastlane/blob/master/docs/Guide.md/#fastlane)
 
 ### 2. Create and Upload a Code Signing Certificate
 
@@ -103,11 +104,11 @@ You can now upload the `.p12` file to your project on CircleCI in
 `Project Settings` > `iOS Code Signing`. When your build runs this `p12`
 file will be added to the `circle` keychain automatically.
 
-![The code signing section in the project settings]({{ site.baseurl }}/assets/img/docs/code-signing-settings-section.png)
+![The code signing section in the project settings]({{ site.baseurl }}/assets/img/docs/code-signing-settings-section.png/)
 
-![The code signing welcome screen]({{ site.baseurl }}/assets/img/docs/code-signing-splash-screen.png)
+![The code signing welcome screen]({{ site.baseurl }}/assets/img/docs/code-signing-splash-screen.png/)
 
-![Uploaded key on the code signing page]({{ site.baseurl }}/assets/img/docs/code-signing-key-uploaded.png)
+![Uploaded key on the code signing page]({{ site.baseurl }}/assets/img/docs/code-signing-key-uploaded.png/)
 
 ### 3. Create A Provisioning Profile
 
@@ -163,7 +164,7 @@ machine:
 We recommend using [Fastlane Gym](https://github.com/fastlane/gym) to
 build a signed app. `gym` is pre-installed on our containers, so it's
 easy to set up. The first step is to add a new [deployment
-command]({{ site.baseurl }}/configuration#deployment) in your
+command]({{ site.baseurl }}/configuration/#deployment) in your
 `circle.yml` file.
 
 ```
@@ -180,7 +181,7 @@ deployment:
 ```
 
 You should take a few minutes to read [the documentation on deployments
-using CircleCI]({{ site.baseurl }}/configuration#deployment).
+using CircleCI]({{ site.baseurl }}/configuration/#deployment).
 The deployment stanza above instructs CircleCI to run the `gym` command
 on each successful build of the `master` branch. The `beta_distribution`
 is just a name for the deployment. You can use any name here.
@@ -221,7 +222,7 @@ Credentials" step of the build on CircleCI. This is listed under
 "machine". Expand the output and you should see output like the
 following:
 
-![The output of the code signing step that ran correctly]({{ site.baseurl }}/assets/img/docs/code-signing-correct-step-output.png)
+![The output of the code signing step that ran correctly]({{ site.baseurl }}/assets/img/docs/code-signing-correct-step-output.png/)
 
 In this example there is one valid code-signing identity, `"iPhone
 Distribution: UTAH STREET LABS INC (GL92ZZ6423)"`. The goal is to pass

--- a/jekyll/_docs/language-haskell.md
+++ b/jekyll/_docs/language-haskell.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Continuous Integration and Continuous Deployment with Haskell
 short-title: Haskell
 categories: [languages]
+description: Continuous Integration and Continuous Deployment with Haskell
 last_updated: April 17, 2014
 ---
 
@@ -18,7 +19,7 @@ checked into the root of your repository.
 ### Version
 
 Circle has
-[several versions of GHC](/docs/environment#haskell)
+[several versions of GHC](/docs/environment/#haskell)
 available. We use `{{ versions.ghc }}`
 as the default; if you'd like a particular version, you
 can specify it in your `circle.yml`:
@@ -35,8 +36,8 @@ If we find a Cabal file at the root of your repository, we install your
 dependencies and run `cabal build` and `cabal test`.
 You can customize this easily in your `circle.yml` by setting
 the `override`, `pre`, and `post` properties in the
-[dependencies](/docs/configuration#dependencies)
-and [test](/docs/configuration#test) sections.
+[dependencies](/docs/configuration/#dependencies)
+and [test](/docs/configuration/#test) sections.
 
 ```
 test:
@@ -44,7 +45,7 @@ test:
     - cabal bench
 ```
 
-Circle can [cache directories](/docs/configuration#cache-directories)
+Circle can [cache directories](/docs/configuration/#cache-directories)
 in between builds to avoid unnecessary work. If you use Cabal, our inferred
 commands build your project in a Cabal sandbox and cache the sandbox.
 This helps your build run as quickly as possible.

--- a/jekyll/_docs/language-java.md
+++ b/jekyll/_docs/language-java.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Continuous Integration and Continuous Deployment with Java
 short-title: Java
 categories: [languages]
+description: Continuous Integration and Continuous Deployment with Java
 last_updated: April 21, 2014
 ---
 
@@ -14,7 +15,7 @@ with a [circle.yml](/docs/configuration) file.
 
 ### Version
 
-Circle has [several versions of the Oracle JDK](/docs/environment#java)
+Circle has [several versions of the Oracle JDK](/docs/environment/#java)
 available. We use `{{ versions.default_java_version }}`
 as the default; if you'd like a particular version, you can specify it in your `circle.yml`
 
@@ -71,5 +72,5 @@ Depending on your build tooling, we will infer different commands:
 
 You can easily customize inferred build commands in your `circle.yml`
 by setting the `override`, `pre`, `post` in the
-[dependencies](/docs/configuration#dependencies) and
-[test](/docs/configuration#test) sections.
+[dependencies](/docs/configuration/#dependencies) and
+[test](/docs/configuration/#test) sections.

--- a/jekyll/_docs/language-nodejs.md
+++ b/jekyll/_docs/language-nodejs.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Continuous Integration and Continuous Deployment with Node.js
 short-title: Node.js
 categories: [languages]
+description: Continuous Integration and Continuous Deployment with Node.js
 last_updated: February 13, 2015
 ---
 
@@ -10,13 +11,13 @@ Circle has great support for Node.js applications.
 We inspect your code before each build to infer your settings, dependencies, and test steps.
 
 If your project has any special requirements, you can augment or override our
-inferred commands from a [circle.yml]({{ site.baseurl }}/configuration)
-file checked into your repo's root directory. You can also add [deployment]({{ site.baseurl }}/configuration#deployment)
+inferred commands from a [circle.yml]({{ site.baseurl }}/configuration/)
+file checked into your repo's root directory. You can also add [deployment]({{ site.baseurl }}/configuration/#deployment)
 commands that will run after a green build.
 
 ### Version
 
-Circle has [several Node versions]({{ site.baseurl }}/environment#nodejs)
+Circle has [several Node versions]({{ site.baseurl }}/environment/#nodejs)
 pre-installed.
 We use `{{ versions.default_node }}`
 as our default version. If you'd like a specific version, then you can specify it in your circle.yml:
@@ -45,7 +46,7 @@ dependencies:
 If you need to authenticate with `npm` before downloading the
 dependencies, you could store the `npm` credentials in the
 [secure environment
-variables](https://circleci.com/docs/environment-variables#setting-environment-variables-for-all-commands-without-adding-them-to-git)
+variables](https://circleci.com/docs/environment-variables/#setting-environment-variables-for-all-commands-without-adding-them-to-git)
 and then use the following script to perform the authentication:
 
 ```
@@ -62,16 +63,16 @@ $NPM_EMAIL
 
 ### Databases
 
-We have pre-installed more than a dozen [databases and queues]({{ site.baseurl }}/environment#databases),
+We have pre-installed more than a dozen [databases and queues]({{ site.baseurl }}/environment/#databases),
 including PostgreSQL and MySQL. If needed, you can
-[manually set up your test database]({{ site.baseurl }}/manually#dependencies) from your circle.yml.
+[manually set up your test database]({{ site.baseurl }}/manually/#dependencies) from your circle.yml.
 
 ### Testing
 
 Circle will run `npm test` when you specify a test script in `package.json`.
 We also run your Mocha tests as well as run any `test` targets in Cakefiles or Makefiles.
 
-You can [add additional test commands]({{ site.baseurl }}/configuration#test)
+You can [add additional test commands]({{ site.baseurl }}/configuration/#test)
 from your circle.yml. For example, you could run a custom `test.sh` script:
 
 ```
@@ -82,7 +83,7 @@ test:
 
 ### Deployment
 
-Circle offers first-class support for [deployment]({{ site.baseurl }}/configuration#deployment).
+Circle offers first-class support for [deployment]({{ site.baseurl }}/configuration/#deployment).
 When a build is green, Circle will deploy your project as directed
 in your `circle.yml` file.
 We can deploy to Nodejitsu and other PaaSes as well as to

--- a/jekyll/_docs/language-php.md
+++ b/jekyll/_docs/language-php.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Continuous Integration and Continuous Deployment with PHP
 short-title: PHP
 categories: [languages]
+description: Continuous Integration and Continuous Deployment with PHP
 last_updated: March 12, 2014
 ---
 
@@ -13,7 +14,7 @@ configuration via a `circle.yml` checked into your repo's root directory.
 
 ### Version
 
-Circle supports more than a dozen [versions of PHP,](/docs/environment#php)
+Circle supports more than a dozen [versions of PHP,](/docs/environment/#php)
 and uses `{{ versions.default_php }}` as the default. You can set a custom
 version of PHP in the machine section of your circle.yml:
 
@@ -32,7 +33,7 @@ Circle has the composer, pear, and pecl package managers installed.
 If we find a composer.json file, then we'll automatically run `composer install`.
 
 To install your dependencies with either `pear` or `pecl`,
-you have to include [dependency commands](/docs/configuration#dependencies)
+you have to include [dependency commands](/docs/configuration/#dependencies)
 in your `circle.yml` file.
 The following example shows how to install the MongoDB extension using `pecl`.
 
@@ -69,9 +70,9 @@ you'll have to specify your PHP version in your `circle.yml` in order to edit PH
 ### Databases
 
 We have pre-installed more than a dozen
-[databases and queues](/docs/environment#databases),
+[databases and queues](/docs/environment/#databases),
 including PostgreSQL and MySQL. If needed, you have the option of
-[manually setting up your test database](/docs/manually#dependencies).
+[manually setting up your test database](/docs/manually/#dependencies).
 
 <h3 id="php-apache">Using the Apache Webserver</h3>
 
@@ -138,7 +139,7 @@ dependencies:
 
 ### Deployment
 
-Circle offers first-class support for [deployment](/docs/configuration#deployment).
+Circle offers first-class support for [deployment](/docs/configuration/#deployment).
 When a build is green, Circle will deploy your project as directed
 in your `circle.yml` file. We can deploy to PaaS providers as well as to
 physical servers under your control.

--- a/jekyll/_docs/language-python.md
+++ b/jekyll/_docs/language-python.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Continuous Integration and Continuous Deployment with Python
 short-title: Python
 categories: [languages]
+description: Continuous Integration and Continuous Deployment with Python
 last_updated: March 12, 2014
 ---
 
@@ -17,7 +18,7 @@ When Circle detects Python, we automatically use `virtualenv`
 to create an isolated Python environment using Python `{{ versions.default_python }}`.
 
 We have
-[many versions of Python](/docs/environment#python)
+[many versions of Python](/docs/environment/#python)
 pre-installed. If you don't want to use the default, you can specify your Python version from your circle.yml:
 
 ```
@@ -40,7 +41,7 @@ when we find a `requirements.txt`, or `distutils`
 when we find a `setup.py` file.
 
 You can also
-[add custom dependencies commands from your `circle.yml`, for example:](/docs/configuration#dependencies)
+[add custom dependencies commands from your `circle.yml`, for example:](/docs/configuration/#dependencies)
 
 ```
 dependencies:
@@ -50,9 +51,9 @@ dependencies:
 ### Databases
 
 Circle has pre-installed more than a dozen
-[databases and queues](/docs/environment#databases),
+[databases and queues](/docs/environment/#databases),
 including PostgreSQL and MySQL. If needed, you can
-[manually set up your test database](/docs/manually#dependencies)
+[manually set up your test database](/docs/manually/#dependencies)
 from your `circle.yml`.
 
 ### Testing
@@ -60,7 +61,7 @@ from your `circle.yml`.
 CircleCI automatically runs `tox` when we find a `tox.ini` file,
 and runs `nosetests` when we find a `unittest.py` file.
 If you are using Django, then Circle will run `manage.py test`.
-You can [add custom test commands](/docs/configuration#test)
+You can [add custom test commands](/docs/configuration/#test)
 from your `circle.yml`:
 
 ```
@@ -75,7 +76,7 @@ class-style tests, not bare-function nose-style tests.
 
 ### Deployment
 
-CircleCI has [first-class support for deployment](/docs/configuration#deployment)
+CircleCI has [first-class support for deployment](/docs/configuration/#deployment)
 with Fabric or Paver.
 To set up deployment after green builds, you can add commands to the deployment section of your `circle.yml`:
 

--- a/jekyll/_docs/language-ruby-on-rails.md
+++ b/jekyll/_docs/language-ruby-on-rails.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Continuous Integration and Continuous Deployment with Ruby/Rails
 short-title: Ruby/Rails
 categories: [languages]
+description: Continuous Integration and Continuous Deployment with Ruby/Rails
 last_updated: March 12, 2014
 ---
 
@@ -19,7 +20,7 @@ checked into your repo's root directory.
 ### Version
 
 We use [RVM](https://rvm.io/) to provide access to a wide variety of
-[Ruby versions](/docs/environment#languages).
+[Ruby versions](/docs/environment/#languages).
 The default version of Ruby is either
 {{ versions.default_ruby }} or {{ versions.old_ruby }},
 whichever we think is best for your project.
@@ -41,7 +42,7 @@ works with testing tools that require a browser.
 If Circle detects a Gemfile, we automatically run `bundle install`. Your
 gems are automatically cached between builds to save time downloading dependencies.
 You can add additional project dependencies from the
-[dependencies section of your circle.yml](/docs/configuration#dependencies):
+[dependencies section of your circle.yml](/docs/configuration/#dependencies):
 
 ```
 dependencies:
@@ -55,17 +56,17 @@ Circle manages all your database requirements,
 such as running your `rake` commands for creating, loading,
 and migrating your database.
 We have pre-installed more than a dozen
-[databases and queues](/docs/environment#databases),
+[databases and queues](/docs/environment/#databases),
 including PostgreSQL, MySQL, and MongoDB.
 You can add custom database commands from the
-[database section of your circle.yml](/docs/configuration#database).
+[database section of your circle.yml](/docs/configuration/#database).
 
 ### Testing
 
 Circle will automatically infer your test commands if you're
 using Test::Unit, RSpec, Cucumber, Spinach, Jasmine, or Konacha.
 You can also add additional commands from the
-[test section of your circle.yml](/docs/configuration#test):
+[test section of your circle.yml](/docs/configuration/#test):
 
 ```
 test:
@@ -87,7 +88,7 @@ For other testing libraries, we have instructions for [manually setting up paral
 
 Circle offers first-class support for deployment to your staging and production environments.
 When your build is green, Circle will run the commands from the
-[deployment section of your circle.yml](/docs/configuration#deployment).
+[deployment section of your circle.yml](/docs/configuration/#deployment).
 
 You can find more detailed instructions in the
 [Continuous Deployment doc](/docs/introduction-to-continuous-deployment).

--- a/jekyll/_docs/language-scala.md
+++ b/jekyll/_docs/language-scala.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Continuous Integration and Continuous Deployment with Scala
 short-title: Scala
 categories: [languages]
+description: Continuous Integration and Continuous Deployment with Scala
 last_updated: Mar 3, 2015
 ---
 
@@ -17,12 +18,12 @@ checked into the root of your repository.
 
 ### Version
 
-Circle has [several versions of Scala](/docs/environment#scala)
+Circle has [several versions of Scala](/docs/environment/#scala)
 available.
 
 You can specify the JVM version you want to run Scala on top of by
 following
-[the steps described in the Java doc](https://circleci.com/docs/configuration#java-version).
+[the steps described in the Java doc](https://circleci.com/docs/configuration/#java-version).
 
 ### Using a custom version of sbt
 
@@ -64,7 +65,7 @@ dependencies:
 
 ### Dependencies & Tests
 
-Circle can [cache directories](/docs/configuration#cache-directories)
+Circle can [cache directories](/docs/configuration/#cache-directories)
 in between builds to avoid unnecessary work.
 
 By default, when we detect a Scala project, we will run `sbt

--- a/jekyll/_docs/languages.md
+++ b/jekyll/_docs/languages.md
@@ -2,4 +2,5 @@
 layout: classic-category
 title: Languages
 categories: [languages]
+description: Languages
 ---

--- a/jekyll/_docs/look-at-code.md
+++ b/jekyll/_docs/look-at-code.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Does Circle look at my code?
 categories: [privacy-and-security]
+description: Circle security policy issues
 last_updated: Feb 2, 2013
 ---
 

--- a/jekyll/_docs/manually.md
+++ b/jekyll/_docs/manually.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Manual build setup
 categories: [getting-started]
+description: Manual build setup
 last_updated: April 29, 2013
 ---
 
@@ -66,7 +67,7 @@ If you need anything else installed, please [contact us](mailto:sayhi@circleci.c
 and CircleCI support should be able to accommodate you.
 Be aware that for security reasons, we don't provide root access.
 
-The [machine section](/docs/configuration#machine)
+The [machine section](/docs/configuration/#machine)
 of the `circle.yml` file is the place where you can tweak common settings, such as timezone, language version used, and
 `/etc/hosts` contents.
 
@@ -108,7 +109,7 @@ dependencies:
 
 <h2 id="databases">Setting up your test databases</h2>
 
-We have already installed [most databases that you'll need](/docs/environment#databases)
+We have already installed [most databases that you'll need](/docs/environment/#databases)
 on our virtual machine.
 
 At this point, you'll want to create your database, load it with your schema, and (possibly) preload it with data.

--- a/jekyll/_docs/migrating-from-jenkins.md
+++ b/jekyll/_docs/migrating-from-jenkins.md
@@ -2,17 +2,18 @@
 layout: classic-docs
 title: Migrating from Jenkins to CircleCI
 categories: [how-to]
+description: Migrating from Jenkins to CircleCI
 ---
 
 Jenkins is a very popular open-source CI tool, so many users that are new to CircleCI have used it at some point. This document provides the basics that a longtime Jenkins user needs to know when making the switch.
 
 ## Quick Start
 
-CircleCI is a very different product from Jenkins with a lot of different concepts on how to manage CI and CD (see [High-Level Differences]({{ site.baseurl }}/migrating-from-jenkins#high-level-differences) below), but it won’t take long to migrate the basic functionality of your Jenkins build to CircleCI. If you just want to jump in and get started, try one of these three options:
+CircleCI is a very different product from Jenkins with a lot of different concepts on how to manage CI and CD (see [High-Level Differences]({{ site.baseurl }}/migrating-from-jenkins/#high-level-differences/) below), but it won’t take long to migrate the basic functionality of your Jenkins build to CircleCI. If you just want to jump in and get started, try one of these three options:
 
 
 <ol>
-<li>**Inference:** Follow your project on CircleCI [link to instructions] and run a build without any custom configuration. CircleCI infers what build and test steps need to be run based on your project’s structure, so everything may work just fine automatically. If the inferred steps mostly work, then you can just add a couple [tweaks]({{ site.baseurl }}/configuration).</li>
+<li>**Inference:** Follow your project on CircleCI [link to instructions] and run a build without any custom configuration. CircleCI infers what build and test steps need to be run based on your project’s structure, so everything may work just fine automatically. If the inferred steps mostly work, then you can just add a couple [tweaks]({{ site.baseurl }}/configuration/).</li>
 
 <li>**Copy-paste your commands from “Execute Shell”:** If you really want to simply duplicate your project exactly as it is in Jenkins, then you can add a file called `circle.yml` to the root of your project with the following content:
 
@@ -27,10 +28,10 @@ test:
     - echo "Probably copy-pasted from 'Execute Shell' on Jenkins"
 ```
 
-  Some programs and utilities are [pre-installed on CircleCI]({{ site.baseurl }}/environment), but anything else required by your build must be installed in the `dependencies` section. Your project’s dependencies will be [cached]({{ site.baseurl }}/how-cache-works) for the next build, so that they only need to be fully downloaded and installed once.</li>
+  Some programs and utilities are [pre-installed on CircleCI]({{ site.baseurl }}/environment/), but anything else required by your build must be installed in the `dependencies` section. Your project’s dependencies will be [cached]({{ site.baseurl }}/how-cache-works) for the next build, so that they only need to be fully downloaded and installed once.</li>
 
 
-<li>**Manual configuration:** If CircleCI’s inference doesn’t work for your project, or if you were using other plugins or options than “Execute Shell” in Jenkins to run your build steps, then you may need to manually port your build from Jenkins. This is usually pretty simple as documented [here]({{ site.baseurl }}/manually).</li>
+<li>**Manual configuration:** If CircleCI’s inference doesn’t work for your project, or if you were using other plugins or options than “Execute Shell” in Jenkins to run your build steps, then you may need to manually port your build from Jenkins. This is usually pretty simple as documented [here]({{ site.baseurl }}/manually/).</li>
 </ol>
 
 
@@ -48,7 +49,7 @@ Almost all configuration of CircleCI builds is stored in a file called `circle.y
 
 It’s often up to an ops person or team to manage Jenkins servers. These people generally get involved with various CI maintenance tasks like installing dependencies and troubleshooting issues.
 
-It’s never necessary to access a CircleCI environment to install dependencies because every build starts in a fresh environment where custom dependencies must be installed automatically (ensuring that the entire build process is truly automated). Troubleshooting in the build environment can be done easily and securely by any developer using CircleCI’s [SSH feature]({{ site.baseurl }}/ssh-build).
+It’s never necessary to access a CircleCI environment to install dependencies because every build starts in a fresh environment where custom dependencies must be installed automatically (ensuring that the entire build process is truly automated). Troubleshooting in the build environment can be done easily and securely by any developer using CircleCI’s [SSH feature]({{ site.baseurl }}/ssh-build/).
 
 If you install CircleCI Enterprise on your own hardware, the divide between the host OS (at the “metal”/VM level) and the containerized build environments can be extremely useful for security and ops (see Your builds in containers below). Ops team members can do what they need to on the host OS without affecting builds, and they never need to give developers access. Developers, on the other hand, can use CircleCI’s SSH feature to debug builds at the container level as much as they like without affecting ops.
 
@@ -85,7 +86,7 @@ Talking about containerization in build systems can be complicated because arbit
 
   If you use a tool like Docker in your workflow, you will likely also want to run it on CI. Jenkins doesn’t provide any built-in support for this, and it is up to you to make sure it is installed and available within your build environment.
 
-  Docker has long been one of the tools that is pre-installed on CircleCI, so you can access Docker in your builds by adding “docker” to the “services” section of your `circle.yml` file. See our in-depth [Docker doc]({{ site.baseurl }}/docker) for more info.
+  Docker has long been one of the tools that is pre-installed on CircleCI, so you can access Docker in your builds by adding “docker” to the “services” section of your `circle.yml` file. See our in-depth [Docker doc]({{ site.baseurl }}/docker/) for more info.
 
 #### Your builds in containers:
 
@@ -102,4 +103,4 @@ Talking about containerization in build systems can be complicated because arbit
 
 It is possible to run multiple tests in parallel on a Jenkins build using techniques like multithreading, but this can cause subtle issues related to shared resources like databases and filesystems.
 
-CircleCI lets you increase the parallelism in any project’s settings so that each build for that project uses multiple containers at once. Tests are evenly split between containers allowing the total build to run in a fraction of the time it normally would. Unlike with simple multithreading, tests are strongly isolated from each other in their own environments. You can read more about parallelism on CircleCI [here]({{ site.baseurl }}/setting-up-parallelism).
+CircleCI lets you increase the parallelism in any project’s settings so that each build for that project uses multiple containers at once. Tests are evenly split between containers allowing the total build to run in a fraction of the time it normally would. Unlike with simple multithreading, tests are strongly isolated from each other in their own environments. You can read more about parallelism on CircleCI [here]({{ site.baseurl }}/setting-up-parallelism/).

--- a/jekyll/_docs/missing-dir.md
+++ b/jekyll/_docs/missing-dir.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: A directory is missing from your repository
+description: What to do when a directory is missing from a repo
 last_updated: Feb 3, 2013
 ---
 

--- a/jekyll/_docs/missing-file.md
+++ b/jekyll/_docs/missing-file.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: An important file is missing from your repository
+description: What to do when an important file is missing from your repository
 last_updated: Feb 3, 2013
 ---
 

--- a/jekyll/_docs/mobile.md
+++ b/jekyll/_docs/mobile.md
@@ -2,4 +2,5 @@
 layout: classic-category
 title: Mobile Platforms
 categories: [mobile-platforms]
+description: Mobile Platforms
 ---

--- a/jekyll/_docs/nightly-builds.md
+++ b/jekyll/_docs/nightly-builds.md
@@ -2,16 +2,17 @@
 layout: classic-docs
 title: Nightly Builds
 categories: [how-to]
+description: Nightly Builds
 last_updated: May 22, 2014
 ---
 
-The [experimental Parameterized Build API]({{ site.baseurl }}/parameterized-builds)
-allows you to trigger a build using the [CircleCI API]({{ site.baseurl }}/api#new-build)
+The [experimental Parameterized Build API]({{ site.baseurl }}/parameterized-builds/)
+allows you to trigger a build using the [CircleCI API]({{ site.baseurl }}/api/#new-build)
 and inject environment variables into the build environment.
 
 You can customize your `circle.yml` to take different actions, such as running a much more extensive test suite, when certain build parameters are present.
 
-[Parameterized builds]({{ site.baseurl }}/parameterized-builds) are still an experimental feature.
+[Parameterized builds]({{ site.baseurl }}/parameterized-builds/) are still an experimental feature.
 We're very interested in what you create with build parameters and would love to get your
 [feedback](mailto:sayhi@circleci.com) on using them.
 

--- a/jekyll/_docs/not-specified-ruby-commands.md
+++ b/jekyll/_docs/not-specified-ruby-commands.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: CircleCI is running the Ruby commands not present in the config
+description: CircleCI is running the Ruby commands not present in the config
 last_updated: Feb 3, 2013
 ---
 

--- a/jekyll/_docs/oom.md
+++ b/jekyll/_docs/oom.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Your build hit the 4G memory limit
 categories: [troubleshooting]
+description: What happens when your build hit the 4G memory limit
 last_updated: Feb 25, 2014
 ---
 

--- a/jekyll/_docs/parallel-manual-setup.md
+++ b/jekyll/_docs/parallel-manual-setup.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Manually setting up parallelism
 categories: [parallelism]
+description: Manually setting up parallelism
 last_updated: Feb 2, 2013
 ---
 

--- a/jekyll/_docs/parallelism.md
+++ b/jekyll/_docs/parallelism.md
@@ -2,4 +2,5 @@
 layout: classic-category
 title: Parallelism
 categories: [parallelism]
+description: Parallelism
 ---

--- a/jekyll/_docs/parameterized-builds.md
+++ b/jekyll/_docs/parameterized-builds.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Parameterized Builds
+description: Parameterized Builds
 last_updated: May 22, 2014
 ---
 
@@ -8,7 +9,7 @@ The Parameterized Build API is currently available as an early-access preview.
 The API and functionality may change based on what we learn from your feedback.
 
 The Parameterized Build API allows you to trigger a build using the
-[CircleCI API]({{ site.baseurl }}/api)
+[CircleCI API]({{ site.baseurl }}/api/)
 and inject environment variables which are made available within the containers that run the build.
 
 These environment variables can then be used to influence the steps that are run during the build.
@@ -28,7 +29,7 @@ Note: all the examples use `bash` and `curl` but there is nothing to stop you us
 
 <h3 id="detail">Triggering Parameterized Builds</h3>
 
-Builds are triggered by POSTing to [the trigger new build API]({{ site.baseurl }}/api#new-build).
+Builds are triggered by POSTing to [the trigger new build API]({{ site.baseurl }}/api/#new-build).
 
 A POST with an empty body will trigger a new build of the named branch.
 You can include build parameters by sending a JSON body with `Content-type: application/json`:
@@ -98,7 +99,7 @@ Build parameters are exported as environment variables inside the build's contai
 
 ### Example
 
-We've put together a [how to]({{ site.baseurl }}/nightly-builds)
+We've put together a [how to]({{ site.baseurl }}/nightly-builds/)
 showing how to use build parameters in `circle.yml` so you can trigger nightly builds.
 
 Obviously this is just one example of what you could do.

--- a/jekyll/_docs/permissions-and-access-during-deployment.md
+++ b/jekyll/_docs/permissions-and-access-during-deployment.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Permissions and access during deployment
 categories: [reference]
+description: Permissions and access during deployment
 last_updated: May 7, 2015
 ---
 

--- a/jekyll/_docs/php-memcached-compile-error.md
+++ b/jekyll/_docs/php-memcached-compile-error.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Adding memcached with pecl on CircleCI
+description: Adding memcached with pecl on CircleCI
 last_updated: May 23, 2013
 ---
 

--- a/jekyll/_docs/polling-project-status.md
+++ b/jekyll/_docs/polling-project-status.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Polling project status using CCMenu, CCTray, etc.
 categories: [reference]
+description: Polling project status using CCMenu, CCTray, etc.
 last_updated: Feb 2, 2013
 ---
 

--- a/jekyll/_docs/privacy-security.md
+++ b/jekyll/_docs/privacy-security.md
@@ -2,4 +2,5 @@
 layout: classic-category
 title: Privacy and Security
 categories: [privacy-and-security]
+description: Privacy and Security
 ---

--- a/jekyll/_docs/pushing-packages-to-packagecloud.md
+++ b/jekyll/_docs/pushing-packages-to-packagecloud.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Pushing packages to packagecloud
 categories: [how-to]
+description: How to push packages to packagecloud
 last_updated: November 4, 2014
 ---
 
@@ -12,8 +13,8 @@ last_updated: November 4, 2014
 To push packages to packagecloud from CircleCI you must:
 
   - Set an environment variable named `PACKAGECLOUD_TOKEN` on the **Project settings > Environment variables** page.  The value must match your packagecloud API access token. Visit your [API token settings page](https://packagecloud.io/api_token) on packagecloud to get your API token.
-  - Create a [circle.yml](/docs/configuration) file which installs the package_cloud gem and pushes the package to the [OS and version of your choice](https://packagecloud.io/docs#os_distro_version).
-For more info on your API access token, please refer to the API Tokens section in [API docs](https://packagecloud.io/docs/api#api_tokens).
+  - Create a [circle.yml](/docs/configuration) file which installs the package_cloud gem and pushes the package to the [OS and version of your choice](https://packagecloud.io/docs/#os_distro_version).
+For more info on your API access token, please refer to the API Tokens section in [API docs](https://packagecloud.io/docs/api/#api_tokens).
 
 ```
 dependencies:

--- a/jekyll/_docs/reference.md
+++ b/jekyll/_docs/reference.md
@@ -2,4 +2,5 @@
 layout: classic-category
 title: Reference
 categories: [reference]
+description: Reference
 ---

--- a/jekyll/_docs/requires-admin.md
+++ b/jekyll/_docs/requires-admin.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: CircleCI requires Admin permissions
+description: CircleCI admin permissions
 last_updated: Feb 3, 2013
 ---
 

--- a/jekyll/_docs/rspec-exit-codes.md
+++ b/jekyll/_docs/rspec-exit-codes.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: RSpec is failing but CircleCI reports my tests have passed
+description: What is happening when RSpec is failing but CircleCI reports my tests have passed 
 last_updated: Dec 20, 2013
 ---
 

--- a/jekyll/_docs/ruby-debugger-problems.md
+++ b/jekyll/_docs/ruby-debugger-problems.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: The Ruby debugger gem won't build
+description: What is happening when the Ruby debugger gem won't build
 last_updated: Dec 20, 2013
 ---
 

--- a/jekyll/_docs/ruby-exception-during-schema-load.md
+++ b/jekyll/_docs/ruby-exception-during-schema-load.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: rake db:schema:load fails
+description: rake db:schema:load fails
 last_updated: Feb 3, 2013
 ---
 
@@ -90,5 +91,5 @@ a way that spec/factories.rb isn't loaded unless tests are
 actually run.
 
 The idiomatic way to do this is by putting that code in
-[initializer files](http://guides.rubyonrails.org/configuring.html#using-initializer-files),
+[initializer files](http://guides.rubyonrails.org/configuring.html/#using-initializer-files),
 which are only run once the complete application is loaded.

--- a/jekyll/_docs/setting-up-parallelism.md
+++ b/jekyll/_docs/setting-up-parallelism.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Setting up parallelism
 categories: [getting-started,parallelism]
+description: Setting up parallelism
 last_updated: Nov 21, 2014
 ---
 
@@ -21,4 +22,4 @@ runners, including RSpec, Cucumber, minitest, Django, Nose, and more.  For the m
 
 However, if our
 inferred parallel test commands don't work, or if you want to do custom test splitting,
-see [our doc on manually setting up parallelism]({{ site.baseurl }}/parallel-manual-setup).
+see [our doc on manually setting up parallelism]({{ site.baseurl }}/parallel-manual-setup/).

--- a/jekyll/_docs/shipio-to-circleci-migration.md
+++ b/jekyll/_docs/shipio-to-circleci-migration.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Ship.io to CircleCI Migration
 short_title: Ship.io
+description:Ship.io to CircleCI Migration
 ---
 
 Coming from Ship.io? You've come to the right place, we'll help you get started. 
@@ -19,14 +20,14 @@ For iOS projects, please [contact support](mailto:sayhi@circleci.com) with the n
 You can easily migrate your Android projects from Ship.io to CircleCI in a few simple steps.
 
 1. Add your project on the [Add Projects page](https://circleci.com/add-projects). 
-2. After adding your project, CircleCI will usually infer your build settings. Sometimes the magic doesn't always work. Please take a look at our [getting started]({{ site.baseurl }}/getting-started) documentation. 
-3. Check out the [Testing Android on CircleCI]({{ site.baseurl }}/android) documentation.
+2. After adding your project, CircleCI will usually infer your build settings. Sometimes the magic doesn't always work. Please take a look at our [getting started]({{ site.baseurl }}/getting-started/) documentation. 
+3. Check out the [Testing Android on CircleCI]({{ site.baseurl }}/android/) documentation.
 
 
 ## iOS FAQ: How do I...
 
 ### Set environment variables
-You can set environment variables through the **Project Settings > Environment Variables** page of your project, or through [circle.yml]({{ site.baseurl }}/configuration#environment).
+You can set environment variables through the **Project Settings > Environment Variables** page of your project, or through [circle.yml]({{ site.baseurl }}/configuration/#environment).
 
 ### Use Xcode 7
 Include a `circle.yml` file in the repo's root directory with the following contents:
@@ -44,13 +45,13 @@ CircleCI will automatically detect your shared scheme. If you have more than one
 CircleCI will detect your workspace. If you have more than one workspace, you can specify the path to your `.xcworkspace` file relative to the git repository root using the `XC_WORKSPACE` environment variable.
 
 ### Run scripts
-Make sure any scripts that you want to run are included in your repository. You can run your script using a bash command (e.g. `./example_script.sh`) configured in our UI (through **Project Settings > Dependency/Test Commands**) or in a [circle.yml]({{ site.baseurl }}/configuration) file.
+Make sure any scripts that you want to run are included in your repository. You can run your script using a bash command (e.g. `./example_script.sh`) configured in our UI (through **Project Settings > Dependency/Test Commands**) or in a [circle.yml]({{ site.baseurl }}/configuration/) file.
 
 ### Configure build notifications
 You can configure build notifications using the "Notifications" section of your Project Settings. Email notifications can be configured from the [Account page](https://circleci.com/account).
 
 ### Customize the build commands
-You can add to or override our inferred commands through your Project Settings or through a [circle.yml file]({{ site.baseurl }}/configuration).
+You can add to or override our inferred commands through your Project Settings or through a [circle.yml file]({{ site.baseurl }}/configuration/).
 
 ### Deploy my app
 We recommend using [fastlane](https://medium.com/mitoo-insider/how-to-set-up-continuous-delivery-for-ios-with-fastlane-and-circleci-c7dae19df2ed). 
@@ -123,14 +124,14 @@ Please don't hesitate to give our [support team](mailto:sayhi@circleci.com) a sh
 
 ### Additional resources 
 
-[Configuring custom AVDs](https://developer.android.com/tools/devices/managing-avds-cmdline.html#AVDCmdLine)
+[Configuring custom AVDs](https://developer.android.com/tools/devices/managing-avds-cmdline.html/#AVDCmdLine)
 
-[Getting Started on CircleCI]({{ site.baseurl }}/getting-started)
+[Getting Started on CircleCI]({{ site.baseurl }}/getting-started/)
 
 [An excellent CircleCI and Android Gradle how-to](http://blog.originate.com/blog/2015/03/22/android-and-ci-and-gradle-a-how-to/)
 
-[Debugging Android applications on CircleCI]({{ site.baseurl }}/oom#out-of-memory-errors-in-android-builds)
-[CircleCI & Android 101]({{ site.baseurl }}/android)
+[Debugging Android applications on CircleCI]({{ site.baseurl }}/oom/#out-of-memory-errors-in-android-builds)
+[CircleCI & Android 101]({{ site.baseurl }}/android/)
 
 [CircleCI Docs]({{ site.baseurl }}/)
 

--- a/jekyll/_docs/skip-a-build.md
+++ b/jekyll/_docs/skip-a-build.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Skip a build
 categories: [how-to]
+description: How to skip a build
 ---
 
 CircleCI supports the `[ci skip]` or `[skip ci]` standard for ignoring builds.

--- a/jekyll/_docs/ssh-between-build-containers.md
+++ b/jekyll/_docs/ssh-between-build-containers.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: SSH between build containers
 categories: [parallelism]
+description: SSH between build containers
 last_updated: Apr 22, 2015
 ---
 

--- a/jekyll/_docs/ssh-build.md
+++ b/jekyll/_docs/ssh-build.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: SSH access to builds
 categories: [troubleshooting]
+description: SSH access to builds
 ---
 
 Often the best way to troubleshoot problems is to ssh into a

--- a/jekyll/_docs/status-badges.md
+++ b/jekyll/_docs/status-badges.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Embeddable status badges
 categories: [reference]
+description: Embeddable status badges
 last_updated: July 30, 2014
 ---
 

--- a/jekyll/_docs/test-metadata.md
+++ b/jekyll/_docs/test-metadata.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Collecting test metadata
+description: Collecting test metadata 
 last_updated: Feb 17, 2015
 ---
 
@@ -48,7 +49,7 @@ timing information.
 
 If you have a custom test step that produces JUnit XML output - most test runners support this in some form - you can write the XML
 files to the `$CIRCLE_TEST_REPORTS` directory.  We'll automatically store the files in your
-[build artifacts]({{ site.baseurl }}/build-artifacts) and parse the XML.
+[build artifacts]({{ site.baseurl }}/build-artifacts/) and parse the XML.
 
 You can tell us the type of test by putting the files in a subdirectory of `$CIRCLE_TEST_REPORTS`.
 For example, if you have RSpec tests, you would write your XML files to `$CIRCLE_TEST_REPORTS/rspec`.
@@ -56,7 +57,7 @@ For example, if you have RSpec tests, you would write your XML files to `$CIRCLE
 ### Cucumber
 
 For custom Cucumber steps, you should generate a file using the JSON formatter that ends
-with `.cucumber` and write it to the `$CIRCLE_TEST_REPORTS/cucumber` directory.  Your [circle.yml]({{ site.baseurl }}/configuration) might be:
+with `.cucumber` and write it to the `$CIRCLE_TEST_REPORTS/cucumber` directory.  Your [circle.yml]({{ site.baseurl }}/configuration/) might be:
 
 ```
 test:
@@ -68,7 +69,7 @@ test:
 
 ### PHPUnit
 
-For PHPUnit tests, you should generate a file using the `--log-junit` comment line option and write it to the `$CIRCLE_TEST_REPORTS/phpunit` directory.  Your [circle.yml]({{ site.baseurl }}/configuration) might be:
+For PHPUnit tests, you should generate a file using the `--log-junit` comment line option and write it to the `$CIRCLE_TEST_REPORTS/phpunit` directory.  Your [circle.yml]({{ site.baseurl }}/configuration/) might be:
 
 ```
 test:
@@ -114,4 +115,4 @@ You can use [test2junit](https://github.com/ruedigergad/test2junit) to convert C
 
 ## API
 
-You can access test metadata for a build from the [API]({{ site.baseurl }}/api#test-metadata).
+You can access test metadata for a build from the [API]({{ site.baseurl }}/api/#test-metadata).

--- a/jekyll/_docs/test-with-solr.md
+++ b/jekyll/_docs/test-with-solr.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Test with Solr
 categories: [how-to]
+description: How to test with Solr
 last_updated: Jul 23, 2013
 ---
 

--- a/jekyll/_docs/test-with-sphinx.md
+++ b/jekyll/_docs/test-with-sphinx.md
@@ -2,6 +2,7 @@
 layout: classic-docs
 title: Test with Sphinx
 categories: [how-to]
+description: How to test with Sphinx
 last_updated: Apr 7, 2015
 ---
 

--- a/jekyll/_docs/time-date.md
+++ b/jekyll/_docs/time-date.md
@@ -2,6 +2,7 @@
 layout: classic-docs-parent
 title: Time and Date Problems
 categories: [troubleshooting]
+description: Time and Date Problems
 children:
   - time-day
   - time-seconds

--- a/jekyll/_docs/time-day.md
+++ b/jekyll/_docs/time-day.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Time-based results are one day off
+description: Time-based results are one day off
 last_updated: Feb 3, 2013
 ---
 
@@ -15,7 +16,7 @@ If that's the case, you may end up with test failures looking like this:
         got: Sat, 29 May 2012 (using ==)
 ```
 
-Fortunately, it's easy to [change CircleCI's timezone](/docs/configuration#timezone)
+Fortunately, it's easy to [change CircleCI's timezone](/docs/configuration/#timezone)
 to match yours.
 
 When making this change, it might be a good time to check what time zone your server is in.
@@ -30,4 +31,4 @@ A common problem is that one part of the time interval you're measuring will be 
 This leads to a 2 hour window in which your tests might fail.
 
 One nice solution is to just try again, preferably at a different time of day.
-Try to avoid midnight in both your local timezone, and the time zone that CircleCI uses (UTC unless you [changed](/docs/configuration#timezone) it).
+Try to avoid midnight in both your local timezone, and the time zone that CircleCI uses (UTC unless you [changed](/docs/configuration/#timezone) it).

--- a/jekyll/_docs/time-seconds.md
+++ b/jekyll/_docs/time-seconds.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Time-based results are a few seconds off
+description: Time-based results are a few seconds off
 last_updated: Feb 3, 2013
 ---
 
@@ -19,5 +20,5 @@ this is very possibly a bug with CircleCI.
 
 Another cause of this bug is a rendering problem.
 CircleCI may not use the same exact browser as you use locally (this, of course, is a good thing), so it may catch a rendering bug that you don't.
-Check out [CircleCI's program versions](/docs/environment#browsers)
+Check out [CircleCI's program versions](/docs/environment/#browsers)
 to see if this is the case.

--- a/jekyll/_docs/troubleshooting-browsers.md
+++ b/jekyll/_docs/troubleshooting-browsers.md
@@ -2,6 +2,7 @@
 layout: classic-docs-parent
 title: Browsers
 categories: [troubleshooting]
+description: Browsers
 children:
   - browser-debugging
   - chromedriver-moving-elements

--- a/jekyll/_docs/troubleshooting-clojure.md
+++ b/jekyll/_docs/troubleshooting-clojure.md
@@ -3,6 +3,7 @@ layout: classic-docs-parent
 title: Troubleshooting Clojure
 short-title: Clojure
 categories: [troubleshooting]
+description: Troubleshooting Clojure
 children:
   - clojure-12
 ---

--- a/jekyll/_docs/troubleshooting-guide.md
+++ b/jekyll/_docs/troubleshooting-guide.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Troubleshooting guide
 short-title: Troubleshooting guide
 categories: [troubleshooting]
+description: Troubleshooting guide
 last_updated: February 26, 2015
 ---
 
@@ -14,7 +15,7 @@ compilation of the ones we see most frequently:
 - Different language version. Make sure that you are using the same
   version of the language on CircleCI and locally. Check out
   [this documentation
-  page](https://circleci.com/docs/configuration#ruby-version) for more
+  page](https://circleci.com/docs/configuration/#ruby-version) for more
   details.
 - Different versions of packages you rely on. Try explicitly specifying
   the versions for the packages you are using in your build in your
@@ -25,7 +26,7 @@ compilation of the ones we see most frequently:
   modules, which in combination with unset machine timezone can deliver
   unexpected test failures. You can find an example for setting the
   timezone for your machine [in this doc
-  section](https://circleci.com/docs/configuration#machine).
+  section](https://circleci.com/docs/configuration/#machine).
 - File ordering. Some filesystems maintain an ordered file structure for
   every directory, which means that all the files are read in a
   consistent order every time. The filesystem in our build containers in

--- a/jekyll/_docs/troubleshooting-haskell.md
+++ b/jekyll/_docs/troubleshooting-haskell.md
@@ -3,6 +3,7 @@ layout: classic-docs-parent
 title: Troubleshooting Haskell
 short-title: Haskell
 categories: [troubleshooting]
+description: Troubleshooting Haskell
 children:
   - cabal-test-timeout
 ---

--- a/jekyll/_docs/troubleshooting-nodejs.md
+++ b/jekyll/_docs/troubleshooting-nodejs.md
@@ -3,6 +3,7 @@ layout: classic-docs-parent
 title: Troubleshooting Node.js
 short-title: Node.js
 categories: [troubleshooting]
+description: Troubleshooting Node.js
 children:
   - git-npm-install
 ---

--- a/jekyll/_docs/troubleshooting-php.md
+++ b/jekyll/_docs/troubleshooting-php.md
@@ -3,6 +3,7 @@ layout: classic-docs-parent
 title: Troubleshooting PHP
 short-title: PHP
 categories: [troubleshooting]
+description: Troubleshooting PHP
 children:
   - php-memcached-compile-error
   - composer-api-rate-limit

--- a/jekyll/_docs/troubleshooting-python.md
+++ b/jekyll/_docs/troubleshooting-python.md
@@ -3,6 +3,7 @@ layout: classic-docs-parent
 title: Troubleshooting Python
 short-title: Python
 categories: [troubleshooting]
+description: Troubleshooting Python
 children:
   - git-pip-install
 ---

--- a/jekyll/_docs/troubleshooting-ruby.md
+++ b/jekyll/_docs/troubleshooting-ruby.md
@@ -3,6 +3,7 @@ layout: classic-docs-parent
 title: Troubleshooting Ruby
 short-title: Ruby
 categories: [troubleshooting]
+description: Troubleshooting Ruby
 children:
   - bundler-latest
   - rspec-exit-codes

--- a/jekyll/_docs/troubleshooting.md
+++ b/jekyll/_docs/troubleshooting.md
@@ -2,4 +2,5 @@
 layout: classic-category
 title: Troubleshooting
 categories: [troubleshooting]
+description: Troubleshooting
 ---

--- a/jekyll/_docs/unexpected-rake-errors.md
+++ b/jekyll/_docs/unexpected-rake-errors.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Rake giving ActionFailed errors
+description: Rake giving ActionFailed errors
 last_updated: Feb 3, 2013
 ---
 

--- a/jekyll/_docs/unrecognized-ruby-version.md
+++ b/jekyll/_docs/unrecognized-ruby-version.md
@@ -1,13 +1,14 @@
 ---
 layout: classic-docs
 title: CircleCI does not recognize the Ruby version
+description: Why does CircleCI not recognize the Ruby version
 last_updated: Feb 3, 2013
 ---
 
 We infer your Ruby version from your `.rvmrc` file, `.ruby-version` file, or Gemfile.
-You can also specify it in your [circle.yml](/docs/configuration#ruby-version)
+You can also specify it in your [circle.yml](/docs/configuration/#ruby-version)
 file.
 If you don't do any of the above, we'll use Ruby `{{ versions.default_ruby }}`
 or `{{ versions.old_ruby }}`, whichever we think is best.
-You can[control the version](/docs/configuration#ruby-version)
+You can[control the version](/docs/configuration/#ruby-version)
 if we got it wrong.

--- a/jekyll/_docs/unusual.md
+++ b/jekyll/_docs/unusual.md
@@ -2,14 +2,15 @@
 layout: classic-docs
 title: Can I test projects with unusual requirements?
 categories: [getting-started]
+description: How to test projects with unusual requirements?
 last_updated: April 29, 2013
 ---
 
 CircleCI is completely configurable.
 We have a simple setup for projects that follow established conventions, but we also support many variations on the theme.
 
-*   You can [ run tests from a subdirectory of your repository]({{ site.baseurl }}/configuration#example-running-phpunit-on-a-special-directory).
-*   You can [override every single phase of your tests]({{ site.baseurl }}/configuration)
+*   You can [ run tests from a subdirectory of your repository]({{ site.baseurl }}/configuration/#example-running-phpunit-on-a-special-directory).
+*   You can [override every single phase of your tests]({{ site.baseurl }}/configuration/)
     with custom settings or minor tweaks.
 *   Though you'll rarely need it, you can tweak your code to
-    [avoid certain behaviours]({{ site.baseurl }}/dont-run) during your CI builds.
+    [avoid certain behaviours]({{ site.baseurl }}/dont-run/) during your CI builds.

--- a/jekyll/_docs/what-happens.md
+++ b/jekyll/_docs/what-happens.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: What happens when you add a project?
+description: What happens when you add a project?
 last_updated: May 2, 2013
 ---
 


### PR DESCRIPTION
This adds trailing / for normal and anchor links and adds descriptions to front matter for each doc. 

@felicianotech  questionable:
- **Intro to continous deployment (Line 59)**   branch:  /^((?!master).)*$/  # not the master branch
- **Deployment w/ heroku (Line 157)**  #caching