### PR TITLE
Temporarily grep for Jekyll build errors until they fix their exit codes.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,11 @@ machine:
 dependencies:
   post:
     # https://github.com/jekyll/jekyll/issues/4122
-    - bundle exec jekyll build -s jekyll -d jekyll/_site/docs/
+    #- bundle exec jekyll build -s jekyll -d jekyll/_site/docs/
+
+    # https://github.com/jekyll/jekyll/issues/4713
+    - bundle exec jekyll build -s jekyll -d jekyll/_site/docs/ 2>&1 | tee $CIRCLE_ARTIFACTS/build-results.txt
+    - if grep -qi "error" $CIRCLE_ARTIFACTS/build-results.txt; then exit 2; fi
 test:
   post:
     # --empty-alt-ignore is temporary

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
 test:
   post:
     # --empty-alt-ignore is temporary
-    - bundle exec htmlproofer jekyll/_site --allow-hash-href --check-favicon --check-html --disable-external --empty-alt-ignore | tee $CIRCLE_ARTIFACTS/htmlproofer-results.txt
+    - bundle exec htmlproofer jekyll/_site --allow-hash-href --check-favicon --check-html --disable-external --empty-alt-ignore | tee $CIRCLE_ARTIFACTS/htmlproofer-results.txt; exit ${PIPESTATUS[0]}
 deployment:
   prod:
     branch: master


### PR DESCRIPTION
The `jekyll build` command seems to return exit code 1 for some errors but not others. These causes scenarios where some docs aren't being build due to YAML issues, Jekyll says there is an error, yet the build passes successfully anyway.

Opened an issue, turns out there's already an issue.  Until this is fixed, we grep the output of Jekyll build, which is saved into a file.