### PR TITLE
Deprecated the NineFold guide.

### DIFF
--- a/jekyll/_docs/continuous-deployment-with-ninefold.md
+++ b/jekyll/_docs/continuous-deployment-with-ninefold.md
@@ -3,10 +3,10 @@ layout: classic-docs
 title: Continuous Deployment with Ninefold
 categories: [how-to]
 description: Continuous Deployment with Ninefold
-last_updated: October 14, 2014
+deprecated: "This guide has been deprecated since NineFold.com has shutdown."
 ---
 
-Deploying from CircleCI to [Ninefold](https://ninefold.com/) is easy with Ninefold's GitHub integration.
+Deploying from CircleCI to Ninefold is easy with Ninefold's GitHub integration.
 You can simply create a dedicated branch in your repo named "production" and setup Ninefold to deploy
 this branch. When you get a green build on CircleCI, you can deploy it to Ninefold using an entry like
 the following in the "deployment" section of your `circle.yml` file:


### PR DESCRIPTION
Added a `deprecated` front matter item with an explanation. This isn't technically supported in docs yet but will be.

Also removed the Ninefold link as it's now 404'ing.