### PR TITLE
Sync docs to prod

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,4 +19,4 @@ deployment:
     branch: master
     commands:
       - aws s3 sync jekyll/_staging_site/docs s3://static-staging.circleci.com/docs/ --delete
-      - aws s3 sync jekyll/_site s3://circle-production-docs --delete
+      - aws s3 sync jekyll/_site/docs s3://circle-production-static-site/docs/ --delete


### PR DESCRIPTION
They won't show up on the prod site until we tweak nginx, but we can go directly to the bucket url to see them until we're ready for that.