### PR TITLE
Build tweaks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     #- bundle exec jekyll build -s jekyll -d jekyll/_site/docs/
 
     # https://github.com/jekyll/jekyll/issues/4713
-    - bundle exec jekyll build --source jekyll --destination jekyll/_site/docs/ 2>&1 | tee $CIRCLE_ARTIFACTS/build-results.txt
+    - bundle exec JEKYLL_ENV=production jekyll build --config jekyll/_config.yml,jekyll/_config_production.yml --source jekyll --destination jekyll/_site/docs/ 2>&1 | tee $CIRCLE_ARTIFACTS/build-results.txt
     - if grep -qi "error" $CIRCLE_ARTIFACTS/build-results.txt; then exit 2; fi
     - bundle exec jekyll build --source jekyll --destination jekyll/_staging_site/docs/ --future --drafts --unpublished
 test:

--- a/jctl
+++ b/jctl
@@ -21,7 +21,7 @@ function start {
 	echo "Building with jekyll..."
 	vagrant ssh -c "jekyll build -s /vagrant/jekyll -d /vagrant/jekyll/_site"
 	echo "Site built, now starting the server in the background..."
-	vagrant ssh -c "nohup jekyll serve -s /vagrant/jekyll -d /vagrant/jekyll/_site --host 0.0.0.0 --detach"
+	vagrant ssh -c "nohup jekyll serve --skip-initial-build -s /vagrant/jekyll -d /vagrant/jekyll/_site --host 0.0.0.0 --detach"
 	echo "Site should now be available in your browser at http://localhost:4040/docs/"
 }
 

--- a/jekyll/_config_production.yml
+++ b/jekyll/_config_production.yml
@@ -1,0 +1,1 @@
+url: "https://circleci.com"

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -2,7 +2,9 @@
 <html>
 {% include head.html %}
 <body class="{% if page.path == "index.html" %}homepage{% endif %}">
-{% include google-tag-manager.html %}
+{% if jekyll.environment == "production" %}
+	{% include google-tag-manager.html %}
+{% endif %}
 <div class="outer">
 	{% include global-nav.html %}
 	<div class="main-body">


### PR DESCRIPTION
- make `.jctl start` duplicate less work so it's faster
- added _config_production.yml so that we can change `site.url` to something real in production. Useful for sitemaps, rss feeds, anything that needs an absolute URL.
- set `JEKYLL_ENV` to production for CircleCI builds so that we can choose avoid Google Tag Manager in dev environments.