### PR TITLE
Gave sitemap.xml some smarts.

### DIFF
--- a/jekyll/_docs/environment.md
+++ b/jekyll/_docs/environment.md
@@ -1,9 +1,9 @@
 ---
 layout: classic-docs
-title: Test environment
+title: Test Environment
 categories: [reference]
-description: Test environment 
-last_updated: Apr 7, 2015
+description: Test environment
+changefreq: "weekly"
 ---
 
 Occasionally, bugs in tests arise because CircleCI's environment differs slightly from your local environment.

--- a/jekyll/sitemap.xml
+++ b/jekyll/sitemap.xml
@@ -6,7 +6,8 @@
 	{% unless doc.deprecated %}
 		<url>
 			<loc>{{ doc.url | prepend: site.baseurl | prepend: site.url }}</loc>
-			<changefreq>monthly</changefreq>
+			<changefreq>{% if doc.changefreq %}{{ doc.changefreq }}{% else %}monthly{% endif %}</changefreq>
+			<lastmod>2016-04-04T14:00:00-07:00</lastmod>
 		</url>
 	{% endunless %}
 {% endfor %}


### PR DESCRIPTION
Set the `lastmod` time in sitemap.xml to today, as a manual value. This is better than not having anything at all, which is where we've been at for awhile. In the future, will update `lastmod` dynamically by reading from Git.

The default `changefreq` value in sitemap.xml is 'monthly. An individual doc can now override that by using the `changefreq` Front Matter variable. For example, the Environment doc has been set to 'weekly' since it changes more often than other docs.