### PR TITLE
Add Redis to the list of services that can be started during the build

### DIFF
--- a/jekyll/_docs/configuration.md
+++ b/jekyll/_docs/configuration.md
@@ -298,6 +298,7 @@ machine:
     - cassandra
     - elasticsearch
     - rabbitmq-server
+    - redis
     - riak
     - beanstalkd
     - couchbase-server


### PR DESCRIPTION
Redis is not being started by default in the new image releases, so it would be important to mention it in the list of services that can be started via `circle.yml`.