### PR TITLE
Build-tools 23.0.2 isn't actually installed

### DIFF
--- a/jekyll/_data/versions.yml
+++ b/jekyll/_data/versions.yml
@@ -284,7 +284,6 @@ phantomjs: "1.9.8"
 
 android_sdk_packages:
   - "platform-tools"
-  - "build-tools-23.0.2"
   - "build-tools-23.0.1"
   - "build-tools-22.0.1"
   - "build-tools-21.1.2"


### PR DESCRIPTION
(venv-2.7.9)ubuntu@box536:/usr/local/android-sdk-linux/build-tools$ ls -l
total 0
drwxr-xr-x 1 ubuntu ubuntu 394 Mar 22 02:56 20.0.0
drwxr-xr-x 1 ubuntu ubuntu 548 Mar 22 02:56 21.1.2
drwxr-xr-x 1 ubuntu ubuntu 572 Mar 22 02:56 22.0.1
drwxr-xr-x 1 ubuntu ubuntu 470 Mar 22 02:56 23.0.1