### PR TITLE
Amend instructions for connecting to host services

### DIFF
--- a/jekyll/_docs/docker.md
+++ b/jekyll/_docs/docker.md
@@ -353,4 +353,17 @@ test:
     - sudo /etc/init.d/postgresql restart
 ```
 
+Then, to connect to Postgres, you could add the IP of `docker0` into the hosts file
+on the container:
+
+```
+test:
+  pre:
+    ...
+  override:
+    - docker run --docker run --add-host dockerhost:`/sbin/ip route|awk '/docker0/ { print  $9}'` ... :
+        environment:
+          DATABASE_HOST=dockerhost
+```
+
 The similar approach would be required for any other service.


### PR DESCRIPTION
The IP of `docker0` needs to be provided to the container for it to be able to connect to e.g. Postgres. One way is the `--add-host` flag for `docker run`. This change adds instructions for doing so, so that people don't need to go looking for this info themselves.