### PR TITLE
Removing build-tools-23.02 from pre-installed list

### DIFF
--- a/jekyll/_data/precise/versions.yml
+++ b/jekyll/_data/precise/versions.yml
@@ -284,7 +284,6 @@ phantomjs: "1.9.8"
 
 android_sdk_packages:
   - "platform-tools"
-  - "build-tools-23.0.2"
   - "build-tools-23.0.1"
   - "build-tools-22.0.1"
   - "build-tools-21.1.2"


### PR DESCRIPTION
Related to https://github.com/circleci/circleci-docs/pull/65