### PR TITLE
Adjust sizes of header tags.

### DIFF
--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -76,6 +76,19 @@ div.article-container{
 			font-size: 2.25rem;
 		}
 
+		h2{
+			font-size: 2rem;
+		}
+
+		h3{
+			margin-top: 10px;
+			font-size: 1.5rem;
+		}
+
+		h4{
+			font-size: 1.2rem;
+		}
+
 		img{
 			max-width: 100%;
 		}


### PR DESCRIPTION
The H2-H4 headers were extremely similar in font size. In fact, H3s and H4s were the exact same size. While writing a guide, I noticed that this issue made it harder to read.

I've adjusted the sizes a bit.

Thoughts?