### PR TITLE
Fix error when using Android build tools >= 23.0.2

### DIFF
--- a/jekyll/_docs/android.md
+++ b/jekyll/_docs/android.md
@@ -24,6 +24,7 @@ installed, you can install it as part of your build with:
 ```
 dependencies:
   pre:
+    - echo y | android update sdk --no-ui --all --filter "tools"
     - echo y | android update sdk --no-ui --all --filter "package-name"
 ```
 


### PR DESCRIPTION
I followed the docs and was not able to install build tools 23.0.3. I fixed it following the advice from the forums here:

https://discuss.circleci.com/t/installing-android-build-tools-23-0-2/924