### PR TITLE
Added anchor links to article headings.

### DIFF
--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -71,7 +71,31 @@ div.article-container{
 	padding: 30px 43px 0;
 	width: 75%;
 }
-	article{
+	article{	
+		h2,
+		h3,
+		h4,
+		h5,
+		h6{
+			// &:hover{
+			//	color: black;
+			//	font-weight: 500;
+			//}
+
+			a{
+				padding-left: 5px;
+
+				&:hover{
+					text-decoration: none;
+				}
+			}
+
+			i.fa-link{
+				display: none;
+				font-size: smaller;
+			}
+		}
+
 		h1{
 			font-size: 2.25rem;
 		}

--- a/jekyll/assets/js/main.js
+++ b/jekyll/assets/js/main.js
@@ -3,10 +3,19 @@
 
 $( document ).ready(function() {
 
+	// Allow navigation to slide open and close on small devices
 	$("#nav-button").click(function(){
 		event.preventDefault();
 
 		$("#nav-button").toggleClass("open");
 		$("nav.sidebar").toggleClass("open");
+	});
+
+	// Give article headings direct links to anchors
+	$("article h2, article h3, article h4, article h5, article h6").filter("[id]").each(function () {
+		$(this).append('<a href="#' + $(this).attr("id") + '"><i class="fa fa-link"></i></a>');
+	});
+	$("article h2, article h3, article h4, article h5, article h6").filter("[id]").hover(function () {
+		$(this).find("i").toggle();
 	});
 });


### PR DESCRIPTION
This PR adds an anchor link to article headings (h2-h6 tags) when they are hovered over.

Fixes #73 

Issue #72 will be addressed in a separate commit.