### PR TITLE
Fix docker exec workaround example

### DIFF
--- a/jekyll/_docs/docker.md
+++ b/jekyll/_docs/docker.md
@@ -286,9 +286,9 @@ To work around this, you can the following command, customized for
 your container name and the command you want to run, using LXC
 directly:
 
-````
+```
 sudo lxc-attach -n "$(docker inspect --format '{{.Id}}' $MY_CONTAINER_NAME)" -- bash -c $MY_COMMAND
-````
+```
 
 ### Caching Docker layers
 


### PR DESCRIPTION
Too many backticks were used for the docker exec workaround example, causing the curly braces and their contents to not be displayed.