### PR TITLE
Clean up the instructions for contributing to the docs 

### DIFF
--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -1,10 +1,15 @@
 <br><br>
 <hr>
 <h2>Help make this document better...</h2>
-<p>This guide, as well as the rest of our docs, are open-source and available on
-<a href="{{ site.gh_url }}">GitHub</a>. If you have improvements please feel free to
-<a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}">edit this file</a> (or clone
-the whole repo), and submit a pull request. You can also
-leave feedback or ask questions by opening an issue on this
-<a href="{{ site.gh_url }}/issues/new?title=RE%3A%20jekyll/{{ page.path }}"
-target=_blank>specific doc</a>.</p>
+<p>
+  This guide, as well as the rest of our docs, are open-source and available on <a href="{{ site.gh_url }}">GitHub</a>.
+</p>
+<p>
+  We welcome <a href="{{ site.gh_url }}//blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs">your contributions</a> to make these docs better.
+  <ul>
+    <li><a href="{{ site.gh_url }}/issues/new?title=RE%3A%20jekyll/{{ page.path }}"
+    target=_blank>Open an issue about this page</a> to leave feedback.
+    <li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}">Suggest an edit of this page</a> if you have a way to make it better.
+  </ul>
+</p>
+<hr>

--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -5,7 +5,7 @@
   This guide, as well as the rest of our docs, are open-source and available on <a href="{{ site.gh_url }}">GitHub</a>.
 </p>
 <p>
-  We welcome <a href="{{ site.gh_url }}//blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs">your contributions</a> to make these docs better.
+  We welcome <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs">your contributions</a> to make these docs better.
 </p>
 <ul>
   <li><a href="{{ site.gh_url }}/issues/new?title=RE%3A%20jekyll/{{ page.path }}"

--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -6,10 +6,10 @@
 </p>
 <p>
   We welcome <a href="{{ site.gh_url }}//blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs">your contributions</a> to make these docs better.
-  <ul>
-    <li><a href="{{ site.gh_url }}/issues/new?title=RE%3A%20jekyll/{{ page.path }}"
-    target=_blank>Open an issue about this page</a> to leave feedback.
-    <li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}">Suggest an edit of this page</a> if you have a way to make it better.
-  </ul>
 </p>
+<ul>
+  <li><a href="{{ site.gh_url }}/issues/new?title=RE%3A%20jekyll/{{ page.path }}"
+  target=_blank>Open an issue about this page</a> to leave feedback.
+  <li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}">Suggest an edit of this page</a> if you have a way to make it better.
+</ul>
 <hr>


### PR DESCRIPTION
Clean up the instructions for contributing to the docs to make them a bit more scannable and add a link to the CONTRIBUTING.md page directly