### PR TITLE
Add category to test-metadata so it shows in menu

### DIFF
--- a/jekyll/_docs/test-metadata.md
+++ b/jekyll/_docs/test-metadata.md
@@ -1,6 +1,7 @@
 ---
 layout: classic-docs
 title: Collecting test metadata
+categories: [how-to]
 description: Collecting test metadata 
 last_updated: Feb 17, 2015
 ---


### PR DESCRIPTION
The [Test Metadata](https://circleci.com/docs/test-metadata/) page wasn't linked from the sidebar menu. This adds it to the 'how-to' section.