### PR TITLE
Use JUnit formatter for cucumber output

### DIFF
--- a/jekyll/_docs/test-metadata.md
+++ b/jekyll/_docs/test-metadata.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: Collecting test metadata
-description: Collecting test metadata 
+description: Collecting test metadata
 last_updated: Feb 17, 2015
 ---
 
@@ -62,7 +62,7 @@ For custom Cucumber steps, you should generate a file using the JSON formatter t
 test:
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/cucumber
-    - bundle exec cucumber --format json --out $CIRCLE_TEST_REPORTS/cucumber/tests.cucumber
+    - bundle exec cucumber --format junit --out $CIRCLE_TEST_REPORTS/cucumber/junit.xml
 ```
 
 Note that `cucumber` allows for mulitple `--format` items to be present so you can do:


### PR DESCRIPTION
We found that the JSON formatter meant that the "Test Summary" didn't include
any details about the failures (other than the filename), meaning you had to
dig through each of the container tabs to find the detail, whereas the JUnit
formatter means the details are included in the summary.