### PR TITLE
Add indication to not add a passphrase

### DIFF
--- a/jekyll/_docs/adding-read-write-deployment-key.md
+++ b/jekyll/_docs/adding-read-write-deployment-key.md
@@ -9,7 +9,8 @@ When you add a new project on CircleCI, we will create a deployment key in the r
 
 Suppose your GitHub repository is `https://github.com/you/test-repo` and the project on CircleCI is `https://circleci.com/gh/you/test-repo`.
 
-- Create a ssh key pair by following the [GitHub instruction](https://help.github.com/articles/generating-ssh-keys/)
+- Create a ssh key pair by following the [GitHub instructions](https://help.github.com/articles/generating-ssh-keys/)  
+  Note: when asked "Enter passphrase (empty for no passphrase)", do ***not*** enter a passphrase.
 - Go to `https://github.com/you/test-repo/settings/keys` on GitHub and add the public key that you just created. Make sure to check on **Allow write access** and save the key. You can enter any title in the **Title** field.
 - Go to `https://circleci.com/gh/you/test-repo/edit#ssh` on CircleCI and add the private key that you just created. Enter `github.com` in the **Hostname** field and press the submit button.
 


### PR DESCRIPTION
when creating an SSH key to be used to tag the github repo