### PR TITLE
Unlock rspec_junit_formatter gem version

### DIFF
--- a/jekyll/_docs/test-metadata.md
+++ b/jekyll/_docs/test-metadata.md
@@ -21,7 +21,7 @@ For RSpec:
 Add this to your gemfile:
 
 ```
-gem 'rspec_junit_formatter', '0.2.2'
+gem 'rspec_junit_formatter'
 ```
 
 For Minitest:


### PR DESCRIPTION
Version 0.2.3 has been released, and there doesn't seem to be any reason to lock the gem to a specific version. (The gem originally needed to be run from the CircleCI fork, but that's no longer the case.)