### PR TITLE
Escape curly braces

### DIFF
--- a/jekyll/_docs/docker.md
+++ b/jekyll/_docs/docker.md
@@ -286,9 +286,12 @@ To work around this, you can the following command, customized for
 your container name and the command you want to run, using LXC
 directly:
 
+{% raw %}
 ```
-sudo lxc-attach -n "$(docker inspect --format '{{.Id}}' $MY_CONTAINER_NAME)" -- bash -c $MY_COMMAND
+sudo lxc-attach -n "$(docker inspect --format "{{.Id}}" $MY_CONTAINER_NAME)" -- bash -c $MY_COMMAND
 ```
+{% endraw %}
+
 
 ### Caching Docker layers
 


### PR DESCRIPTION
Notice `Id` part doesn't show up in our doc.

![image](https://cloud.githubusercontent.com/assets/924390/16044255/adc74e1c-327e-11e6-85d2-fd6c8bd8f10a.png)
