### PR TITLE
Start docker daemon in GKE CD example

### DIFF
--- a/jekyll/_docs/continuous-deployment-with-google-container-engine.md
+++ b/jekyll/_docs/continuous-deployment-with-google-container-engine.md
@@ -108,6 +108,7 @@ can use them during the deployment phase.
 dependencies:
   pre:
     #...
+    - sudo service docker start
     - docker build -t us.gcr.io/${PROJECT_NAME}/hello:$CIRCLE_SHA1 .
     - docker tag us.gcr.io/${PROJECT_NAME}/hello:$CIRCLE_SHA1 us.gcr.io/${PROJECT_NAME}/hello:latest
 ```


### PR DESCRIPTION
Fixes this error

```sh
docker build -t gcr.io/${PROJECT_NAME}/foo:$CIRCLE_SHA1 .
Post http:///var/run/docker.sock/v1.20/build?cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile&memory=0&memswap=0&rm=1&t=gcr.io%2Ffoo%2Ffoo%3Afbf996f13de9e89db91bbe54a1cdfd952a91a359&ulimits=null: dial unix /var/run/docker.sock: no such file or directory.
* Are you trying to connect to a TLS-enabled daemon without TLS?
* Is your docker daemon up and running?

docker build -t gcr.io/${PROJECT_NAME}/foo:$CIRCLE_SHA1 . returned exit code 1

Action failed: docker build -t gcr.io/${PROJECT_NAME}/foo:$CIRCLE_SHA1 .
```