### PR TITLE
Added --file flag to iOS app distribution with Hockeyapp

### DIFF
--- a/jekyll/_docs/ios-builds-on-os-x.md
+++ b/jekyll/_docs/ios-builds-on-os-x.md
@@ -281,6 +281,7 @@ deployment:
     commands:
       - gym
       - ipa distribute:hockeyapp
+          --file             /Users/distiller/<yourprojectname>/<yourappname>.ipa
           --token            "$HOCKEY_APP_TOKEN"
           --notes            "CircleCI build $CIRCLE_BUILD_NUM"
           --commit-sha       "$CIRCLE_SHA1"


### PR DESCRIPTION
Had the issue with new iOS customer NBCUniversal. The `ipa` gem tries to upload the file (no idea what file) anyways and then just fails and directly prints the Hockeyapp server output into stdout.