### PR TITLE
Add version for gcloud/awscli/heroku

### DIFF
--- a/jekyll/_docs/build-image-trusty.md
+++ b/jekyll/_docs/build-image-trusty.md
@@ -240,6 +240,20 @@ machine:
     - beanstalkd
 ```
 
+## Integration Tools
+
+### gcloud
+
+Version: `{{ site.data.trusty.versions.summary.gcloud }}`
+
+### awscli
+
+Version: `{{ site.data.trusty.versions.summary.aws-cli }}`
+
+### heroku/heroku-toolbelt
+
+Version: `{{ site.data.trusty.versions.summary.heroku-toolbelt }}`
+
 ## Android
 
 ### SDK Tools


### PR DESCRIPTION
I just noticed that versions for integration tools were missing.