### PR TITLE
Update elasticsearch install instructions

### DIFF
--- a/jekyll/_docs/installing-elasticsearch.md
+++ b/jekyll/_docs/installing-elasticsearch.md
@@ -39,7 +39,7 @@ dependencies:
     - tar -xvf elasticsearch-1.0.1.tar.gz
     - elasticsearch-1.0.1/bin/plugin --url https://example.com/plugin.zip --install example-plugin
     - elasticsearch-1.0.1/bin/elasticsearch: {background: true}
-    - sleep 10 && curl --retry 10 --retry-delay 5 -v http://127.0.0.1:9200/
+    - sleep 10 && wget --waitretry=5 --retry-connrefused -v http://127.0.0.1:9200/
 ```
 
 ## Caching


### PR DESCRIPTION
This ES healthcheck is prone to failure if ES takes longer than 10 seconds to boot and responds with a connection refused error. Switch to `wget` for the healthcheck to take advantage of the `--retry-connrefused` option, which will treat connection refused errors as transient and retry-able.