### PR TITLE
Add note about authenticating w/ http basic

### DIFF
--- a/jekyll/_docs/api.md
+++ b/jekyll/_docs/api.md
@@ -166,7 +166,7 @@ To authenticate, add an API token using your [account dashboard](https://circlec
 ```
 curl https://circleci.com/api/v1.1/me?circle-token=:token
 ```
-Alternatively you authenticate using HTTP Basic authentication, by passing the `-u` flag to the `curl` command, like so:
+Alternatively you can authenticate using HTTP Basic authentication, by passing the `-u` flag to the `curl` command, like so:
 
 ```
 curl -u <circle-token> https://circleci.com/api/...

--- a/jekyll/_docs/api.md
+++ b/jekyll/_docs/api.md
@@ -166,6 +166,12 @@ To authenticate, add an API token using your [account dashboard](https://circlec
 ```
 curl https://circleci.com/api/v1.1/me?circle-token=:token
 ```
+Alternatively you authenticate using HTTP Basic authentication, by passing the `-u` flag to the `curl` command, like so:
+
+```
+curl -u <circle-token> https://circleci.com/api/...
+```
+
 ## Version Control System (:vcs-type)
 
 New with v1.1 of the api, for endpoints under /project you will now need to tell CircleCi what version control system type your project uses. Current choices are 'github' or 'bitbucket'. The command for recent builds for a project would be formatted like so:


### PR DESCRIPTION
Was a sad :panda_face: that I couldn't authenticate using `Authorization` header, such as:

```
curl -H "Authorization: Basic <my-token>" https://circleci.com/api/...
```