### PR TITLE
Update docker.md

### DIFF
--- a/jekyll/_docs/docker.md
+++ b/jekyll/_docs/docker.md
@@ -49,7 +49,7 @@ machine:
 dependencies:
   override:
     - docker info
-    - docker build -t circleci/elasticsearch .
+    - docker build --rm=false -t circleci/elasticsearch .
 
 test:
   override:


### PR DESCRIPTION
`docker build` now defaults to `--rm=true`, this has problems with intermediate images on circleci
This new option should fix many users having problems using docker cache