### PR TITLE
Fix issue with parenthesis appearing in Liquid if blocks.

### DIFF
--- a/jekyll/_docs/enterprise.html
+++ b/jekyll/_docs/enterprise.html
@@ -11,7 +11,7 @@ layout: classic-docs
 	{% assign docs_found = 0 %}
 	{% assign sorted = (site.docs | sort: 'order') %}
 	{% for doc in sorted %}
-		{% if (doc.categories contains category.slug) and (doc.slug != category.index) and (doc.visible == 1)  %}
+		{% if doc.categories contains category.slug and doc.slug != category.index and doc.visible == 1  %}
 			{% assign docs_found = docs_found | plus: 1 %}
 			{% if docs_found < 4 %}
 					{% if doc.short-title %}

--- a/jekyll/_docs/enterprise/resources.html
+++ b/jekyll/_docs/enterprise/resources.html
@@ -12,7 +12,7 @@ description: "Resources"
 	{% assign docs_found = 0 %}
 	{% assign sorted = (site.docs | sort: 'order') %}
 	{% for doc in sorted %}
-		{% if (doc.categories contains category.slug) and (doc.slug != category.index) and (doc.visible == 1)  %}
+		{% if doc.categories contains category.slug and doc.slug != category.index and doc.visible == 1  %}
 			{% assign docs_found = docs_found | plus: 1 %}
 			{% if doc.short-title %}
 				<li class="{% if page.path contains doc.url %}active{% endif %}"><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.short-title }}</a></li>

--- a/jekyll/_layouts/classic-category.html
+++ b/jekyll/_layouts/classic-category.html
@@ -5,7 +5,7 @@ layout: classic-docs
 {% assign category = page.categories[0] %}
 <ul class="list-unstyled">
 {% for doc in sorted %}
-	{% if doc.categories contains category and doc.slug != page.slug and doc.hide != true and (doc.visible == 1) %}
+	{% if doc.categories contains category and doc.slug != page.slug and doc.hide != true and doc.visible == 1 %}
 		<li><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></li>
 	{% endif %}
 {% endfor %}

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -10,7 +10,7 @@ layout: classic-docs
 	<ul class="list-unstyled">
 	{% assign docs_found = 0 %}
 	{% for doc in site.docs %}
-		{% if (doc.categories contains category.slug) and (doc.slug != category.index) and (doc.hide != True) %}
+		{% if doc.categories contains category.slug and doc.slug != category.index and doc.hide != True %}
 			{% assign docs_found = docs_found | plus: 1 %}
 			{% if docs_found < 4 %}
 				{% if doc.short-title %}


### PR DESCRIPTION
The combination of the additional parenthesis added during the CCIE Docs merge in addition to updated Jekyll causes Liquid to spit out errors. This removes those unnecessary parenthesis.