### PR TITLE
Save intermediate layer to allow caching

### DIFF
--- a/jekyll/_docs/docker.md
+++ b/jekyll/_docs/docker.md
@@ -323,7 +323,7 @@ dependencies:
 
   override:
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
-    - docker build -t circleci/elasticsearch .
+    - docker build -t circleci/elasticsearch --rm=false .
     - mkdir -p ~/docker; docker save circleci/elasticsearch > ~/docker/image.tar
 ```
 
@@ -334,6 +334,9 @@ specify. This will create significant performance problems because the save/load
 described above only caches
 the image layers (and thus tags) that you specify in the `docker save` command, so
 other tags will be re-pulled on every build if a tag is not specified in the FROM command.
+
+The `rm=false` flag is required for docker version `>0.9.0` in order to ensure
+intermediate layers are saved in the build.
 
 ### Connecting to services outside of the container
 


### PR DESCRIPTION
Since docker `0.9.0` all intermediate layers is removed by default.

https://github.com/docker/docker/issues/4291

As a result, the suggest patter with `docker save` will not work unless `rm=true` is specified.

This is a PR to address this.
