### PR TITLE
Fix to `GOPATH` in machine environments

### DIFF
--- a/jekyll/_docs/language-go.md
+++ b/jekyll/_docs/language-go.md
@@ -82,7 +82,7 @@ machine:
     # GOROOT is not set by default
     GOROOT: ""
     PATH: "/usr/local/go/bin:/usr/local/go_workspace/bin:~/.go_workspace/bin:${PATH}"
-    GOPATH: "~/.go_workspace:/usr/local/go_workspace:${HOME}/.go_project"
+    GOPATH: "${HOME}/.go_workspace:/usr/local/go_workspace:${HOME}/.go_project"
 ```
 
 Every project built on CircleCI has a standard [CircleCI environment][env-doc] 


### PR DESCRIPTION
Go commands fail when GOPATH is prefixed with "~"

```
go: GOPATH entry cannot start with shell metacharacter '~': "~/.go_workspace"

go get -t -d -v ./... returned exit code 2

Action failed: go get -t -d -v ./...
```