### PR TITLE
Clear up the suggestion to use `--rm=false` with `docker build`.

### DIFF
--- a/jekyll/_docs/docker-btrfs-error.md
+++ b/jekyll/_docs/docker-btrfs-error.md
@@ -19,4 +19,5 @@ Please see [this](https://github.com/docker/docker/issues/9939) issue
 for more details.
 
 Normally, this is a red-herring and doesn't affect your builds, so you can simply 
-ignore it.
+ignore it. You can add the `--rm=false` flag to `docker build` to avoid seeing 
+this issue.

--- a/jekyll/_docs/docker.md
+++ b/jekyll/_docs/docker.md
@@ -64,6 +64,10 @@ deployment:
       - docker push circleci/elasticsearch
 ```
 
+Intermediate images [aren't handled well in the CircleCI container]({{site.baseurl}}/docker-btrfs-error/) 
+so using `--rm=false` with Docker build prevents a bunch of annoying (but not 
+serious) errors.
+
 For a complete example of building and deploying a Docker image to a
 registry, see the [circleci/docker-elasticsearch](https://github.com/circleci/docker-elasticsearch)
 example project on GitHub.
@@ -107,7 +111,7 @@ machine:
 dependencies:
   pre:
     - pip install awscli
-    - docker build -t circleci/hello:$CIRCLE_SHA1 .
+    - docker build --rm=false -t circleci/hello:$CIRCLE_SHA1 .
 
 test:
   post:
@@ -188,7 +192,7 @@ dependencies:
     - ~/kubernetes
   pre:
     - ./ensure-kubernetes-installed.sh
-    - docker build -t $EXTERNAL_REGISTRY_ENDPOINT/hello:$CIRCLE_SHA1 .
+    - docker build --rm=false -t $EXTERNAL_REGISTRY_ENDPOINT/hello:$CIRCLE_SHA1 .
 
 test:
   post:
@@ -323,7 +327,7 @@ dependencies:
 
   override:
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
-    - docker build -t circleci/elasticsearch .
+    - docker build --rm=false -t circleci/elasticsearch .
     - mkdir -p ~/docker; docker save circleci/elasticsearch > ~/docker/image.tar
 ```
 


### PR DESCRIPTION
This suggestion was added to the first example YAML but was missing from the rest.