### PR TITLE
Better regex for every branch except master

### DIFF
--- a/jekyll/_docs/introduction-to-continuous-deployment.md
+++ b/jekyll/_docs/introduction-to-continuous-deployment.md
@@ -56,7 +56,7 @@ You could also run deployments for everything but the master branch:
 ```
 deployment:
   development:
-    branch: /^((?!master).)*$/  # not the master branch
+    branch: /^(?!master$).*$/  # not the master branch
     commands:
       - ./deploy-development
 ```


### PR DESCRIPTION
Here is a better regex to match all branches except the master branch. The current regex in there will match any branch that even contains the word "master", which would not technically be everything but master ;)