### PR TITLE
small markdown fixes, linky links, phrasing clarification

### DIFF
--- a/jekyll/_docs/github-security-ssh-keys.md
+++ b/jekyll/_docs/github-security-ssh-keys.md
@@ -14,12 +14,12 @@ Each deploy key is valid for only _one_ repository.
 In contrast, a GitHub user key has access to _all_ of your GitHub repositories.
 
 If your testing process refers to multiple repositories
-(if you have a Gemfile that points at a  private `git` repository, for example),
+(for example, if you have a Gemfile that points at a  private `git` repository),
 CircleCI will be unable to check out such repositories with only a deploy key.
 When testing requires access to different repositories, CircleCI will need a GitHub user key.
 
 You can provide CircleCI with a GitHub user key on your project's
-** Project Settings > Checkout SSH keys ** page.
+**Project Settings > Checkout SSH keys** page.
 CircleCI creates and associates this new SSH key with your GitHub user account
 and then has access to all your repositories.
 
@@ -35,7 +35,7 @@ Beware of someone stealing your code.
 
 <h2 id="machine-user-keys">Machine user keys</h2>
 
-A [machine user](https://developer.github.com/guides/managing-deploy-keys/#machine-users) is a GitHub user which you create only for automated tasks, they are not intended to be used by a human.
+A [machine user](https://developer.github.com/guides/managing-deploy-keys/#machine-users) is a GitHub user which you create only for automated tasks. Machine user accounts are not intended to be used by a human.
 
 You can add a machine user's SSH key to your projects on CircleCI and use that key as the *Checkout SSH key* for these projects, instead of using deploy keys or your own SSH keys.
 
@@ -45,11 +45,11 @@ Here are the steps to set a machine user's SSH key as a checkout key for your pr
 
 - First, you need to login to GitHub as the machine user.
 
-- Go to https://circleci.com and log in. GitHub will ask you to authorize CircleCI to access the machine user's account, so click on the **Authorize application** button.
+- Go to <https://circleci.com> and log in. GitHub will ask you to authorize CircleCI to access the machine user's account, so click on the **Authorize application** button.
 
-- Go to https://circleci.com/add-projects and follow the projects you want the machine user to have access to.
+- Go to <https://circleci.com/add-projects> and follow the projects you want the machine user to have access to.
 
-- Once followed, go to the ** Project Settings > Checkout SSH keys ** page and then click on the ***Authorize w/GitHub*** button. That gives us permission to create and upload SSH keys to GitHub on behalf of the machine user.
+- Once followed, go to the **Project Settings > Checkout SSH keys** page and then click on the ***Authorize w/GitHub*** button. That gives us permission to create and upload SSH keys to GitHub on behalf of the machine user.
 
 - Finally, click the ***Create and add XXXX user key*** button on the same page.
 


### PR DESCRIPTION
Some markdown readers seem fine with the spaces around `**`, but GH is not one of them! So be it.

Made CircleCI links into...links!