### PR TITLE
Add info about test suite split with knapsack gem

### DIFF
--- a/jekyll/_docs/parallel-manual-setup.md
+++ b/jekyll/_docs/parallel-manual-setup.md
@@ -147,7 +147,7 @@ fi
 
 This script partitions the test files into N equally sized buckets, and calls "test-runner" on the bucket for this machine. Note that you will still need to include `parallel: true` in `circle.yml` with this script.
 
-<h3 id="test-suite-split-with-knapsack-gem">Test suite split with knapsack gem</h3>
+### Test suite split with knapsack gem
 
 You can parallelize tests for RSpec, Cucumber, Minitest, Spinach and Turnip with [knapsack gem](https://github.com/ArturT/knapsack). It will split tests across CI nodes and it makes sure that tests will run comparable time on each CI node. Knapsack gem has [built in support for CircleCI](https://github.com/ArturT/knapsack#info-for-circleci-users).
 

--- a/jekyll/_docs/parallel-manual-setup.md
+++ b/jekyll/_docs/parallel-manual-setup.md
@@ -147,6 +147,10 @@ fi
 
 This script partitions the test files into N equally sized buckets, and calls "test-runner" on the bucket for this machine. Note that you will still need to include `parallel: true` in `circle.yml` with this script.
 
+<h3 id="test-suite-split-with-knapsack-gem">Test suite split with knapsack gem</h3>
+
+You can parallelize tests for RSpec, Cucumber, Minitest, Spinach and Turnip with [knapsack gem](https://github.com/ArturT/knapsack). It will split tests across CI nodes and it makes sure that tests will run comparable time on each CI node. Knapsack gem has [built in support for CircleCI](https://github.com/ArturT/knapsack#info-for-circleci-users).
+
 ## Contact Us
 
 If you set this up for a library or framework that we should be


### PR DESCRIPTION
I've updated page https://circleci.com/docs/parallel-manual-setup/ with info about test suite parallelisation with knapsack gem for test runners like rspec, minitest, cucumber, spinach and turnip.
