### PR TITLE
Added segment page tracking

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -27,3 +27,5 @@ defaults:
       path: ""
     values:
       hide: false
+
+segment: 'mAJ9W2SwLHgmJtFkpaXWCbwEeNk9D8CZ'

--- a/jekyll/_config_production.yml
+++ b/jekyll/_config_production.yml
@@ -1,1 +1,2 @@
 url: "https://circleci.com"
+segment: 'AbgkrgN4cbRhAVEwlzMkHbwvrXnxHh35'

--- a/jekyll/_includes/head.html
+++ b/jekyll/_includes/head.html
@@ -13,4 +13,5 @@
 	<link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}" />
 	<link rel='stylesheet' href="{{ "/assets/css/mobile.css" | prepend: site.baseurl }}" media="screen and (max-width: 800px)" />
 	<title>{% if page.title %}{{ page.title | escape }} - CircleCI{% else %}{{ site.title | escape }} - CircleCI{% endif %}</title>
+	{% include segment.html %}
 </head>

--- a/jekyll/_includes/segment.html
+++ b/jekyll/_includes/segment.html
@@ -1,0 +1,17 @@
+<script type="text/javascript">
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
+  analytics.load({{ site.segment | jsonify }});
+
+  var pageCategory = "docs";
+  // slice off the slashes on either end
+  var pageName     = {{ page.url | jsonify }}.slice(1, -1);
+
+  var properties = {
+    "title"      : {{ page["title"] | jsonify }},
+    "short-title": {{ page["short-title"] | jsonify }},
+    "categories" : {{ page["categories"] | jsonify }},
+    "description": {{ page["description"] | jsonify }}};
+
+  analytics.page(pageCategory, pageName, properties);
+  }}();
+</script>

--- a/jekyll/_includes/segment.html
+++ b/jekyll/_includes/segment.html
@@ -4,7 +4,7 @@
 
   var pageCategory = "docs";
   // slice off the slashes on either end
-  var pageName     = {{ page.url | jsonify }}.slice(1, -1);
+  var pageName     = {{ page.url | jsonify }}.slice(1, -1) || "default";
 
   var properties = {
     "title"      : {{ page["title"] | jsonify }},


### PR DESCRIPTION
We added all the meta data to the tracking properties, and make the doc's root subcategory "default".

For all other pages the category is `docs` and the subcategory is the url that follows with the leading and trailing slashes removed (ie: `i-am-some-article` or `enterprise/some-enterprise-article`)