### PR TITLE
Fix reference to default Linux image (now 14.04).

### DIFF
--- a/jekyll/_docs/build-image-trusty.md
+++ b/jekyll/_docs/build-image-trusty.md
@@ -6,9 +6,7 @@ description: Ubuntu 14.04 (Trusty)
 changefreq: "weekly"
 ---
 
-You can run your Linux builds on the default image, Ubuntu 14.04 (Trusty). You 
-can switch to Trusty from "Project Settings" -> "Build Environment" of your 
-project.
+The default image is Ubuntu 14.04 (Trusty), but you can always change the image directly by going to 'Project Settings' -> 'Build Environment'.
 
 Please note that you need to trigger a build by pushing commits to GitHub or 
 Bitbucket (instead of rebuilding) to apply the new setting.

--- a/jekyll/_docs/build-image-trusty.md
+++ b/jekyll/_docs/build-image-trusty.md
@@ -6,8 +6,9 @@ description: Ubuntu 14.04 (Trusty)
 changefreq: "weekly"
 ---
 
-You can run your Linux builds on Ubuntu 14.04 Trusty (the default). You can 
-switch to Trusty from "Project Settings" -> "Build Environment" of your project.
+You can run your Linux builds on the default image, Ubuntu 14.04 (Trusty). You 
+can switch to Trusty from "Project Settings" -> "Build Environment" of your 
+project.
 
 Please note that you need to trigger a build by pushing commits to GitHub or 
 Bitbucket (instead of rebuilding) to apply the new setting.

--- a/jekyll/_docs/build-image-trusty.md
+++ b/jekyll/_docs/build-image-trusty.md
@@ -3,11 +3,14 @@ layout: classic-docs
 title: Ubuntu 14.04 (Trusty)
 categories: [build-images]
 description: Ubuntu 14.04 (Trusty)
+changefreq: "weekly"
 ---
 
-You can run your Linux builds on Ubuntu 14.04 Trusty (default is Ubuntu 12.04). You can switch to Trusty from "Project Settings" -> "Build Environment" of your project.
+You can run your Linux builds on Ubuntu 14.04 Trusty (the default). You can 
+switch to Trusty from "Project Settings" -> "Build Environment" of your project.
 
-Please note that you need to trigger a build by pushing commits to GitHub or Bitbucket (instead of rebuilding) to apply the new setting.
+Please note that you need to trigger a build by pushing commits to GitHub or 
+Bitbucket (instead of rebuilding) to apply the new setting.
 
 ## Base
 


### PR DESCRIPTION
This doc referenced Ubuntu 12.04 as the default Linux image, which is no longer the case.