### PR TITLE
WIP: Correct default java version and add missings

### DIFF
--- a/jekyll/_docs/build-image-trusty.md
+++ b/jekyll/_docs/build-image-trusty.md
@@ -74,15 +74,21 @@ actually installed correctly, we hardcode versions here.
 
 ### Java
 
-Default: `oraclejdk8`
+Default: `oraclejdk7`
 
 Pre-installed versions:
 
 - `oraclejdk8`
 
+- `oraclejdk7`
+
+- `oraclejdk6`
+
 - `openjdk8`
 
 - `openjdk7`
+
+- `openjdk6`
 
 ### Go
 


### PR DESCRIPTION
Changed to java 7 as default, but everything else uses site.data.trusty.versions.summary, which is also wrong so checking to see where that comes from.