### PR TITLE
Tell JCTL to use incremental Jekyll builds.

### DIFF
--- a/jctl
+++ b/jctl
@@ -19,7 +19,7 @@ function start {
 
 	# Building and serving is done separate to provide more feedback. nohup blocks errors.
 	echo "Building with jekyll..."
-	vagrant ssh -c "jekyll build -s /vagrant/jekyll -d /vagrant/jekyll/_site"
+	vagrant ssh -c "jekyll build --incremental -s /vagrant/jekyll -d /vagrant/jekyll/_site"
 	echo "Site built, now starting the server in the background..."
 	vagrant ssh -c "nohup jekyll serve --skip-initial-build -s /vagrant/jekyll -d /vagrant/jekyll/_site --host 0.0.0.0 --detach"
 	echo "Site should now be available in your browser at http://localhost:4040/docs/"


### PR DESCRIPTION
This is nothing life changing but, on my local machine, this improves `./jctl rebuild` time from approximately 38 seconds to approximately 13 seconds for subsequent builds.