### PR TITLE
Use wget to wait throughout.

### DIFF
--- a/jekyll/_docs/installing-elasticsearch.md
+++ b/jekyll/_docs/installing-elasticsearch.md
@@ -22,7 +22,7 @@ dependencies:
     - tar -xvf elasticsearch-1.0.1.tar.gz
     - elasticsearch-1.0.1/bin/elasticsearch: {background: true}
     # Make sure that Elasticsearch is up before running tests:
-    - sleep 10 && curl --retry 10 --retry-delay 5 -v http://127.0.0.1:9200/
+    - sleep 10 && wget --waitretry=5 --retry-connrefused -v http://127.0.0.1:9200/
 ```
 
 <span class='label label-info'>Note:</span>
@@ -59,5 +59,5 @@ dependencies:
   post:
     - if [[ ! -e elasticsearch-1.0.1 ]]; then wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.0.1.tar.gz && tar -xvf elasticsearch-1.0.1.tar.gz; fi
     - elasticsearch-1.0.1/bin/elasticsearch: {background: true}
-    - sleep 10 && curl --retry 10 --retry-delay 5 -v http://127.0.0.1:9200/
+    - sleep 10 && wget --waitretry=5 --retry-connrefused -v http://127.0.0.1:9200/
 ```


### PR DESCRIPTION
Updating for consistency, see https://github.com/circleci/circleci-docs/pull/300:
"This ES healthcheck is prone to failure if ES takes longer than 10 seconds to boot and responds with a connection refused error. Switch to `wget` for the healthcheck to take advantage of the `--retry-connrefused` option, which will treat connection refused errors as transient and retry-able."