### PR TITLE
Fix API HTTP basic auth curl example

### DIFF
--- a/jekyll/_docs/api.md
+++ b/jekyll/_docs/api.md
@@ -172,11 +172,13 @@ To authenticate, add an API token using your [account dashboard](https://circlec
 ```
 curl https://circleci.com/api/v1.1/me?circle-token=:token
 ```
-Alternatively you can authenticate using HTTP Basic authentication, by passing the `-u` flag to the `curl` command, like so:
+Alternatively you can use the API token as the username for HTTP Basic Authentication, by passing the `-u` flag to the `curl` command, like so:
 
 ```
-curl -u <circle-token> https://circleci.com/api/...
+curl -u <circle-token>: https://circleci.com/api/...
 ```
+
+(Note the colon `:`, which tells `curl` that there's no password.)
 
 ## Version Control System (:vcs-type)
 


### PR DESCRIPTION
Without the colon `:`, just doing `curl -u <circle-token>`, will prompt for the password.