### PR TITLE
Add a note for builder boxes' private subnet

### DIFF
--- a/jekyll/_docs/enterprise/aws-private-subnet.md
+++ b/jekyll/_docs/enterprise/aws-private-subnet.md
@@ -8,6 +8,7 @@ description: "Information on private subnets in AWS."
 
 Private subnets on AWS are supported, but please make sure to use the following settings:
 
+  - The private subnet for builder boxes need either a NAT instance or internet gateway configured for the outbound traffic to the internet.
   - Enable [VPC Endpoint for S3](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/).  This should significantly improve S3 operations for CircleCI and other nodes within your subnet
   - Ensure that your NAT is adequately powered for heavy network operations.  Highly parallel builds using Docker and external network resources can strain your NATs.  This is very deployment-specific - but if you notice slowness in network and cache operations later, it's time to upgrade your NATs.
   - If you are integrating with https://github.com/, ensure that your network ACL whitelists github.com webhooks.  When integrating with GitHub, we recommend setting up CircleCI in a public subnet, or setup a public load balancer to forward github.com traffic.


### PR DESCRIPTION
I used https://github.com/circleci/enterprise-setup as-is and couldn't make builders to work in the initial try because the subnet for builders didn't have the access to the internet.