### PR TITLE
Making enterprise FAQ more visible in "Resources" section

### DIFF
--- a/jekyll/_docs/enterprise/faq.md
+++ b/jekyll/_docs/enterprise/faq.md
@@ -2,7 +2,7 @@
 layout: enterprise
 title: FAQ
 category: [resources]
-order: 4
+order: 2
 description: "CircleCI Frequently Asked Questions (FAQs)."
 published: true
 ---


### PR DESCRIPTION
**Before**

<img width="359" alt="screen shot 2016-12-07 at 10 03 35 am" src="https://cloud.githubusercontent.com/assets/924390/20950683/7c5a5bd8-bc64-11e6-80a6-9d1a3b5c40f4.png">

**After**

<img width="329" alt="screen shot 2016-12-07 at 10 03 40 am" src="https://cloud.githubusercontent.com/assets/924390/20950693/8b0e7812-bc64-11e6-885f-d17da94f0795.png">

