### PR TITLE
Added notes on working directory

### DIFF
--- a/jekyll/_docs/docker.md
+++ b/jekyll/_docs/docker.md
@@ -292,6 +292,7 @@ sudo lxc-attach -n "$(docker inspect --format "{{.Id}}" $MY_CONTAINER_NAME)" -- 
 ```
 {% endraw %}
 
+Note that these commands are run inside the container's root directory, so you may have to `cd` into your docker working directory first.
 
 ### Caching Docker layers
 


### PR DESCRIPTION
When using the [`docker exec` workaround](https://circleci.com/docs/docker/#docker-exec) it's useful to know that commands are run inside the container's root directory instead of the docker working directory as it would if we ran `docker exec`