### PR TITLE
incorrect override command for minitest metadata

### DIFF
--- a/jekyll/_docs/test-metadata.md
+++ b/jekyll/_docs/test-metadata.md
@@ -175,10 +175,10 @@ And modify your test command to this:
 ````
 test:
   override:
-    - bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS":
-      parallel: true
-      files:
-        - test/**/*_test.rb
+    - bundle exec rake test TESTOPTS="--ci-dir=$CIRCLE_TEST_REPORTS/reports":
+        parallel: true
+        files:
+          - test/**/*_test.rb
 ````
 
 #### <a name="test2junit-for-clojure-tests"></a>test2junit for Clojure tests


### PR DESCRIPTION
parallel and files requires 4 spaces indentation so that it can be recognized as a map.

also appending the reports folder with "reports" so that it will automatically get uploaded by the script instead of having the xml files be at the root level of the CIRCLE_TEST_REPORTS