### PR TITLE
Bump Yarn version to 0.18.1

### DIFF
--- a/jekyll/_docs/install-and-use-yarn.md
+++ b/jekyll/_docs/install-and-use-yarn.md
@@ -15,7 +15,7 @@ description: "How to modify `circle.yml` in order to install and use Yarn on Cir
 ```
 machine:
   environment:
-    YARN_VERSION: 0.18.0
+    YARN_VERSION: 0.18.1
     PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 ```
 
@@ -70,7 +70,7 @@ machine:
 ```
 machine:
   environment:
-    YARN_VERSION: 0.18.0
+    YARN_VERSION: 0.18.1
     PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 
 dependencies:


### PR DESCRIPTION
Yarn 0.18.0 was essentially a release candidate whereas 0.18.1 is a stable release (yes, the Yarn RC process needs some improvements, see https://github.com/yarnpkg/yarn/issues/2161). Because of this, the CircleCI docs should suggest installing 0.18.1.