### PR TITLE
replace cache/yarn with yarn-cache

### DIFF
--- a/jekyll/_docs/install-and-use-yarn.md
+++ b/jekyll/_docs/install-and-use-yarn.md
@@ -32,7 +32,7 @@ dependencies:
       fi
   cache_directories:
     - ~/.yarn
-    - ~/.cache/yarn
+    - ~/.yarn-cache
 ```
 
 Here, the Yarn install script runs if and only if:
@@ -86,7 +86,7 @@ dependencies:
     - yarn install
   cache_directories:
     - ~/.yarn
-    - ~/.cache/yarn
+    - ~/.yarn-cache
 
 test:
   override:


### PR DESCRIPTION
I believe this is more consistent with the description at the top for `~/.yarn-cache`.