### PR TITLE
Make FOSS CTA appear on CCIE Docs too.

### DIFF
--- a/jekyll/_docs/enterprise.html
+++ b/jekyll/_docs/enterprise.html
@@ -1,5 +1,5 @@
 ---
-layout: classic-docs
+layout: enterprise-cat
 ---
 
 {% for category in site.data.categories %}

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -17,7 +17,7 @@
 			<article>
 				<h1>{{ page.title }}</h1>
 				{{ content }}
-				{% if page.collection == "docs" and page.layout == "classic-docs" %}
+				{% if page.collection == "docs" and page.layout == "classic-docs" or page.layout == "enterprise" %}
 					{% include doc-footer.html %}
 				{% endif %}
 			</article>

--- a/jekyll/_layouts/enterprise-cat.html
+++ b/jekyll/_layouts/enterprise-cat.html
@@ -1,0 +1,5 @@
+---
+layout: classic-docs
+---
+{{content}}
+


### PR DESCRIPTION
@ndintenfass This fixes the issue where the GitHub CTA (and license info while we're at it) doesn't appear in the footer of CCIE Docs.