### PR TITLE
Because circleci-android23 image is gone, replace references with cir…

### DIFF
--- a/jekyll/_docs/android.md
+++ b/jekyll/_docs/android.md
@@ -94,15 +94,20 @@ a few minutes. You can start the emulator and wait for it to finish with somethi
 the following:
 
 ```
+# Disable emulator audio
+machine:
+  environment:
+    QEMU_AUDIO_DRV: none
+
 test:
   pre:
-    - emulator -avd circleci-android22 -no-audio -no-window:
+    - emulator -avd circleci-android24 -no-window:
         background: true
         parallel: true
     - circle-android wait-for-boot
 ```
 
-`circleci-android23` is an AVD preinstalled on the machine for Android 23 on the ARM V7 EABI.
+`circleci-android24` is an AVD preinstalled on the machine for Android 24 on the ARM V7 EABI.
 There's also a corresponding `circleci-android22`; alternatively, you can
 [create your own][create-avd] if these don't suit your purposes.
 
@@ -232,7 +237,7 @@ deployment:
 test:
   override:
     # start the emulator
-    - emulator -avd circleci-android22 -no-audio -no-window:
+    - emulator -avd circleci-android24 -no-window:
         background: true
         parallel: true
     # wait for it to have booted


### PR DESCRIPTION
…cleci-android24. Also, handle the fact that `-no-audio` isn't a valid parameter (nor is `-noaudio`): http://stackoverflow.com/questions/40272884/running-android-emulator-with-noaudio-option-returns-qemu-system-i386-exe-au