### PR TITLE
Remove the mention of UUIDs from OS X troubleshooting doc

### DIFF
--- a/jekyll/_docs/troubleshooting-ios-and-OSX.md
+++ b/jekyll/_docs/troubleshooting-ios-and-OSX.md
@@ -21,9 +21,10 @@ A way to mitigate this is to launch the iOS simulator as a part of your dependen
 ```
 dependencies:
   pre:
-    - xcrun instruments -w 'E8DD285C-51EE-4DB5-B326-7E927686EC36' || true 
+  - xcrun instruments -w "iPhone 7 (10.1)" || true
 ```
 
 This will launch the simulator just like it would if you'd hit `CMD + R` on your machine in Xcode, and once your tests are supposed to start the iOS simulator is immediately available.
 
-A full list of UUIDs for iOS simulators is available [here]({{site.baseurl}}/ios-builds-on-os-x/).
+You can find the full list of simulators that are available in our OS X
+image [here]({{site.baseurl}}/ios-builds-on-os-x/#available-simulators).


### PR DESCRIPTION
We no longer recommend using UUIDs in `circle.yml`. We previously removed all UUID mentions from the [main](https://github.com/circleci/circleci-docs/pull/516) doc, now also removing it from the iOS / OS X troubleshooting doc.