### PR TITLE
Reduce vertical space 'edit on GitHub' section takes up.

### DIFF
--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -1,15 +1,10 @@
-<br><br>
-<hr>
+<br />
+<hr />
 <h2>Help make this document better...</h2>
-<p>
-  This guide, as well as the rest of our docs, are open-source and available on <a href="{{ site.gh_url }}">GitHub</a>.
-</p>
-<p>
-  We welcome <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs">your contributions</a> to make these docs better.
+<p>This guide, as well as the rest of our docs, are open-source and available on <a href="{{ site.gh_url }}">GitHub</a>. We welcome <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs">your contributions</a> to make these docs better.
 </p>
 <ul>
-  <li><a href="{{ site.gh_url }}/issues/new?title=RE%3A%20jekyll/{{ page.path }}"
-  target=_blank>Open an issue about this page</a> to leave feedback.
-  <li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}">Suggest an edit of this page</a> if you have a way to make it better.
+	<li><a href="{{ site.gh_url }}/issues/new?title=RE%3A%20jekyll/{{ page.path }}" target=_blank>Open an issue about this page</a> to leave feedback.
+	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}">Suggest an edit of this page</a> if you have a way to make it better.
 </ul>
-<hr>
+<hr />


### PR DESCRIPTION
@smart-alek and various readers occasionally point out how much vertical space the "Edit on GitHub" section of docs take up. This is most noticeable with docs that are very short where this section might actually be the same size as the doc itself.

This PR reduces the height of this section by approximately 60 pixels or so. The copy remains the same.