### PR TITLE
CIRCLE-2712 Provisioning Profiles upload in Project Settings

### DIFF
--- a/jekyll/_docs/ios-builds-on-os-x.md
+++ b/jekyll/_docs/ios-builds-on-os-x.md
@@ -162,9 +162,8 @@ build, sign and distribute your iOS app to beta-testers.
 The fastest way to get code signing working on CircleCI is to follow
 these steps:
 
-1. Upload your `.P12` file in **Project Settings > iOS Code Signing**.
-1. Add your provisioning profile  (`.mobileprovision`) file to your
-   repo.
+1. Upload your provisioning profile (`.mobileprovision`) and private key (`.p12`)
+   files in **Project Settings > iOS Code Signing**.
 1. Set `GYM_CODE_SIGNING_IDENTITY` environment variable
    to match your code-signing identity, ie `"iPhone Distribution: Acme Inc."`.
 1. Build with `gym` and deploy with `ipa`.

--- a/jekyll/_docs/ios-getting-started.md
+++ b/jekyll/_docs/ios-getting-started.md
@@ -106,7 +106,7 @@ This keychain is also added to the Xcode search path, so any credentials stored 
 
 #### Using your provisioning profile
 
-To use your provisioning profile with your CircleCI builds, you need to commit the `.mobileprovision` file to your repository. Your provisioning profiles will automatically be added to the `circle.keychain` at the start of the build.
+To use your provisioning profile with your CircleCI builds, you need to upload the `.mobileprovision` file on the **Project Settings** > **OS X Code Signing** page. Any provisioning profiles will automatically be added to the `circle.keychain` at the start of the build.
 
 ## Customising your build
 


### PR DESCRIPTION
In macOS builds you can now upload provisioning profiles rather than
having to have them present in the repository.

- Update the docs to reflect this.
- Update the docs to use the new fastlane syntax
- Fix some line-wrapping errors in literal code blocks.