### PR TITLE
Show how to call gym via fastlane in the iOS docs

### DIFF
--- a/jekyll/_docs/ios-builds-on-os-x.md
+++ b/jekyll/_docs/ios-builds-on-os-x.md
@@ -513,7 +513,7 @@ deployment:
     branch: master
       commands:
         # this will build the ipa file
-        - gym --scheme "App" --workspace "App.xcworkspace"
+        - fastlane gym --scheme "App" --workspace "App.xcworkspace"
         - ipa distribute:crashlytics
             --crashlytics_path Crashlytics.framework
             --api_token    "$CRASHLYTICS_API_KEY"


### PR DESCRIPTION
Invoking `fastlane` directly is no longer recommended, we should suggest using `fastlane gym` everywhere instead.