### PR TITLE
Add in :vcs-type to examples

### DIFF
--- a/jekyll/_docs/nightly-builds.md
+++ b/jekyll/_docs/nightly-builds.md
@@ -3,7 +3,6 @@ layout: classic-docs
 title: Nightly Builds
 categories: [how-to]
 description: Nightly Builds
-last_updated: May 22, 2014
 ---
 
 The [Parameterized Build API]({{ site.baseurl }}/parameterized-builds/)
@@ -17,7 +16,7 @@ You can customize your `circle.yml` to take different actions, such as running a
 You've a straight-forward `circle.yml` for your project `example-corp/project-foo`.
 It just sets a Python version and deploys to your staging Heroku app.
 
-```
+```yaml
 machine:
   python:
     version: 2.7.6
@@ -35,7 +34,7 @@ These tests should be run once a day at least.
 
 Creating a conditional step is easy; `circle.yml` commands are just shell commands and build parameters are just environment variables:
 
-```
+```yaml
 machine:
   python:
     version: 2.7.6
@@ -66,7 +65,7 @@ _project=$1
 _branch=$2
 _circle_token=$3
 
-trigger_build_url=https://circleci.com/api/v1/project/github/${_project}/tree/${_branch}?circle-token=${_circle_token}
+trigger_build_url=https://circleci.com/api/v1.1/project/github/${_project}/tree/${_branch}?circle-token=${_circle_token}
 
 post_data=$(cat <<EOF
 {

--- a/jekyll/_docs/nightly-builds.md
+++ b/jekyll/_docs/nightly-builds.md
@@ -66,7 +66,7 @@ _project=$1
 _branch=$2
 _circle_token=$3
 
-trigger_build_url=https://circleci.com/api/v1/project/${_project}/tree/${_branch}?circle-token=${_circle_token}
+trigger_build_url=https://circleci.com/api/v1/project/github/${_project}/tree/${_branch}?circle-token=${_circle_token}
 
 post_data=$(cat <<EOF
 {

--- a/jekyll/_docs/parameterized-builds.md
+++ b/jekyll/_docs/parameterized-builds.md
@@ -45,7 +45,7 @@ curl \
   --header "Content-Type: application/json" \
   --data '{"build_parameters": {"param1": "value1", "param2": 500}}' \
   --request POST \
-  https://circleci.com/api/v1/project/circleci/mongofinil/tree/master?circle-token=$CIRCLE_TOKEN
+  https://circleci.com/api/v1/project/github/circleci/mongofinil/tree/master?circle-token=$CIRCLE_TOKEN
 ```
 
 The build will see the environment variables:

--- a/jekyll/_docs/parameterized-builds.md
+++ b/jekyll/_docs/parameterized-builds.md
@@ -2,7 +2,6 @@
 layout: classic-docs
 title: Parameterized Builds
 description: Parameterized Builds
-last_updated: May 22, 2014
 ---
 
 The Parameterized Build API allows you to trigger a build using the
@@ -45,7 +44,7 @@ curl \
   --header "Content-Type: application/json" \
   --data '{"build_parameters": {"param1": "value1", "param2": 500}}' \
   --request POST \
-  https://circleci.com/api/v1/project/github/circleci/mongofinil/tree/master?circle-token=$CIRCLE_TOKEN
+  https://circleci.com/api/v1.1/project/github/circleci/mongofinil/tree/master?circle-token=$CIRCLE_TOKEN
 ```
 
 The build will see the environment variables:


### PR DESCRIPTION
I had some difficulty following the examples until I found a slight difference between the current API docs ([ref](https://github.com/circleci/circleci-docs/blob/master/jekyll/_docs/api.md)) and the example code. This PR is aimed at making the examples valid again.

Thanks for the consideration!