### PR TITLE
Adding howto for performing Maven releases

### DIFF
--- a/jekyll/_docs/perform-maven-release.md
+++ b/jekyll/_docs/perform-maven-release.md
@@ -1,0 +1,105 @@
+---
+layout: classic-docs
+title: Perform a Maven Release
+categories: [how-to]
+description: How to perform a maven release
+---
+
+Using the [CircleCI REST API]({{ site.baseurl }}/api/) and a few configuration additions, it
+becomes possible to [prepre/perform a Maven release](http://maven.apache.org/maven-release/maven-release-plugin/examples/prepare-release.html).
+
+## Preparation
+
+### User Key
+
+First, create a user key for your project since your build environment will need the ability
+push new commits back to your source repository. This can be created by going to the
+"Checkout SSH keys" section of your Project Settings. If a user key hasn't already been
+added, you will see and should click the button "Create and add [username] key".
+
+### POM file
+
+You will also need to prepare your project's `pom.xml` according to the
+[release plugin usage](http://maven.apache.org/maven-release/maven-release-plugin/usage.html).
+Mainly that consists of adding the `scm` block with a `developerConnection` and a declaration
+of the latest release plugin.
+
+For GitHub projects, the `scm` block will look like the following, replacing `ORG` and `PROJECT`:
+
+```
+<scm>
+  <developerConnection>scm:git:git@github.com:ORG/PROJECT.git</developerConnection>
+  <tag>HEAD</tag>
+</scm>
+```
+
+Also, in order to simplify the Maven invocation below, configure the tag syntax within the
+`plugin` declaration, such as:
+
+```
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-release-plugin</artifactId>
+    <version>2.5.3</version>
+    <configuration>
+        <tagNameFormat>v@{project.version}</tagNameFormat>
+    </configuration>
+</plugin>
+```
+
+This particular example results in `v1.2.3` type version tags derived from the project's version.
+
+### CircleCI project file
+
+Finally, add a "conditional hook" to your `circle.yml` that will be activated by triggering
+the build via the API.
+
+In your configuration's `test` section create or add to the `post` steps as shown here:
+
+```
+test:
+  post:
+    - if [[ $GIT_USER_EMAIL ]]; then git config --global user.email "$GIT_USER_EMAIL" ; fi
+    - if [[ $GIT_USER_NAME ]]; then git config --global user.name "$GIT_USER_NAME" ; fi
+    - if [[ $RELEASE ]]; then mvn -B release:prepare -DreleaseVersion=$RELEASE -DdevelopmentVersion=$NEXT ; fi
+```
+
+That snippet implies four environment variables that will be important to note:
+
+* `GIT_USER_EMAIL`
+* `GIT_USER_NAME`
+* `RELEASE`
+* `NEXT`
+
+The variable names shown here are arbitrary, but just make sure to reference the same when
+invoking the build, below. The use and invocation of the target `release:prepare` can be
+customized as needed for your project.
+
+## Trigger a Maven release build
+
+Using your REST client of choice, you can trigger a Maven release by invoking the
+equivalent to this example curl operation:
+
+```
+curl -X POST -H "Content-Type: application/json" -d '{
+    "build_parameters": {
+        "RELEASE": "1.1.1",
+        "NEXT": "1.2-SNAPSHOT",
+        "GIT_USER_EMAIL": "me@example.com",
+        "GIT_USER_NAME": "Via CircleCI"
+    }
+}' "https://circleci.com/api/v1.1/project/github/ORG/PROJECT/tree/master?circle-token=TOKEN"
+```
+
+**NOTE**: replace `TOKEN` in the URL shown with the API token from your
+[account dashboard](https://circleci.com/account/api).
+Be sure to also replace `ORG` and `PROJECT` in the URL shown.
+
+Within the JSON body, adjust these fields as needed for this particular release build:
+
+* `GIT_USER_EMAIL` : your actual email address used for typical commits to this repo
+* `GIT_USER_NAME` : can be your real name or a CI indicator, such as "Via CircleCI".
+   With the later it becomes easier to spot the CI commits in your log history.
+* `RELEASE` : a non-SNAPSHOT version that you want to release
+* `NEXT` : the next development version to set in the POM and should
+  end with "-SNAPSHOT"

--- a/jekyll/_docs/perform-maven-release.md
+++ b/jekyll/_docs/perform-maven-release.md
@@ -103,3 +103,4 @@ Within the JSON body, adjust these fields as needed for this particular release 
 * `RELEASE` : a non-SNAPSHOT version that you want to release
 * `NEXT` : the next development version to set in the POM and should
   end with "-SNAPSHOT"
+


### PR DESCRIPTION
Without this procedure I found myself needing to run the Maven release target locally on my development machine; however, that felt very dirty given the pristine, deterministic environment of a CircleCI build.