### PR TITLE
Update yarn.md to clarify yarn is only available in the 14.04 base image

### DIFF
--- a/jekyll/_docs/yarn.md
+++ b/jekyll/_docs/yarn.md
@@ -8,13 +8,13 @@ description: "How to use the Yarn package manager on CircleCI."
 
 <img src="{{site.baseurl}}/assets/img/logos/yarn-logo.svg" style="display:block;margin:15px auto;width:40%;min-width:320px;" alt="Yarn Logo" />
 
-[Yarn][yarn-site] is an open-source package manager for JavaScript. Yarn is pre-installed on CircleCI and the packages it installs can be cached. This can potentially speed up builds but, more importantly, can reduce errors related to network connectivity.
+[Yarn][yarn-site] is an open-source package manager for JavaScript. Yarn is pre-installed on CircleCI's Ubuntu 14.04 base image and the packages it installs can be cached. This can potentially speed up builds but, more importantly, can reduce errors related to network connectivity.
 
 [yarn-site]: https://yarnpkg.com/
 
 ## Setup
 
-When CircleCI detects a JavaScript project, certain commands (like `npm install` or `npm test`) might be run. To use Yarn instead of npm, we override both the `dependencies` and `test` sections.
+When CircleCI detects a JavaScript project, certain commands (like `npm install` or `npm test`) might be run. To use Yarn instead of npm, we override both the `dependencies` and `test` sections. Make sure your project is configured to use the Ubuntu 14.04 base image otherwise yarn will not be available.
 
 ```yaml
 dependencies:


### PR DESCRIPTION
The current document does not mention that yarn is only available in the 14.04 base image and is not present in the 12.04 base image. This causes an error (see issue referenced below) when following the instructions on this page with a project configured to use the 12.04 base image.

Addresses the issue in https://github.com/circleci/circleci-docs/issues/543