### PR TITLE
Add an npm continuous deployment guide

### DIFF
--- a/jekyll/_docs/nodejs-and-npm.md
+++ b/jekyll/_docs/nodejs-and-npm.md
@@ -1,9 +1,10 @@
 ---
 layout: classic-docs-parent
-title: "Node.js &amp; NPM Guides"
+title: "Node.js &amp; npm Guides"
 categories: [how-to]
-description: "Various guides on using Node.js and NPM with CircleCI."
+description: "Various guides on using Node.js and npm with CircleCI."
 children:
   - npm-login
   - npm-private-module-dependency
+  - npm-continuous-deployment
 ---

--- a/jekyll/_docs/npm-continuous-deployment.md
+++ b/jekyll/_docs/npm-continuous-deployment.md
@@ -1,12 +1,12 @@
 ---
 layout: classic-docs
 title: "Continuous deployment with npm"
-short-title: "npm publish from CircleCI"
-description: "How to configure CircleCI to publish packages to npm automatically"
+description: "How to configure CircleCI to publish packages to npmjs.org automatically"
 ---
 
-Publishing to npm from CircleCI makes it easy for project collaborators to
-publish new versions of your package in a consistent and predictable way.
+Setting up CircleCI to publish packages to the npm registry makes it easy
+for project collaborators to release new package versions in a consistent
+and predictable way.
 
 1.  Obtain the npm authToken for the account that you wish to use to publish
     the package.
@@ -20,7 +20,7 @@ publish new versions of your package in a consistent and predictable way.
 
     In this case, the authToken is `00000000-0000-0000-0000-000000000000`.
 
-2.  Go to your project settings, and set the `NPM_TOKEN` variable to the
+2.  Go to your [project settings]({{site.baseurl}}environment-variables/#setting-environment-variables-for-all-commands-without-adding-them-to-git), and set the `NPM_TOKEN` variable to the
     obtained authToken.
 
 3.  Configure CircleCI to add the authToken to `~/.npmrc`:
@@ -53,6 +53,5 @@ publish new versions of your package in a consistent and predictable way.
 
     ```
     git push --follow-tags
-    ```
-
+    ``` 
 6.  If tests passed, CircleCI will publish the package to npm automatically.

--- a/jekyll/_docs/npm-continuous-deployment.md
+++ b/jekyll/_docs/npm-continuous-deployment.md
@@ -37,8 +37,8 @@ publish new versions of your package in a consistent and predictable way.
     deployment:
       npm:
         tag: /v[0-9]+(\.[0-9]+)*/
-        owner: taskworld
-        commands:
+        owner:
+       commands:
           - npm publish
     ```
 

--- a/jekyll/_docs/npm-continuous-deployment.md
+++ b/jekyll/_docs/npm-continuous-deployment.md
@@ -37,8 +37,7 @@ publish new versions of your package in a consistent and predictable way.
     deployment:
       npm:
         tag: /v[0-9]+(\.[0-9]+)*/
-        owner:
-       commands:
+        commands:
           - npm publish
     ```
 

--- a/jekyll/_docs/npm-continuous-deployment.md
+++ b/jekyll/_docs/npm-continuous-deployment.md
@@ -1,0 +1,59 @@
+---
+layout: classic-docs
+title: "Continuous deployment with npm"
+short-title: "npm publish from CircleCI"
+description: "How to configure CircleCI to publish packages to npm automatically"
+---
+
+Publishing to npm from CircleCI makes it easy for project collaborators to
+publish new versions of your package in a consistent and predictable way.
+
+1.  Obtain the npm authToken for the account that you wish to use to publish
+    the package.
+
+    You can do that by logging in to npm (`npm login`). This will save the
+    authToken to the `~/.npmrc` file. Look for the following line:
+
+    ```
+    //registry.npmjs.org/:_authToken=00000000-0000-0000-0000-000000000000
+    ```
+
+    In this case, the authToken is `00000000-0000-0000-0000-000000000000`.
+
+2.  Go to your project settings, and set the `NPM_TOKEN` variable to the
+    obtained authToken.
+
+3.  Configure CircleCI to add the authToken to `~/.npmrc`:
+
+    ```yaml
+    dependencies:
+      pre:
+        - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+    ```
+
+4.  Configure CircleCI to run `npm publish` on tagged commits:
+
+    ```yaml
+    deployment:
+      npm:
+        tag: /v[0-9]+(\.[0-9]+)*/
+        owner: taskworld
+        commands:
+          - npm publish
+    ```
+
+5.  When you want to publish a new version to npm, run `npm version` to create
+    a new version:
+
+    ```
+    npm version 10.0.1
+    ```
+
+    This will update the `package.json` file and creates a tagged Git commit.
+    Next, push the commit with tags:
+
+    ```
+    git push --follow-tags
+    ```
+
+6.  If tests passed, CircleCI will publish the package to npm automatically.


### PR DESCRIPTION
At @taskworld, we deploy packages to npm from CircleCI. I wanted to write a guide about it, but I think it may be more beneficial to just put it in CircleCI docs 😄 

p.s. [`npm` should be spelled using lowercase](https://github.com/google/shipshape/blob/master/third_party/node/lib/node_modules/npm/doc/misc/npm-faq.md#is-it-npm-or-npm-or-npm)

p.s.2. or is it called continuous __delivery__?