### PR TITLE
Prepare categories.yml for upcoming changes.

### DIFF
--- a/jekyll/_data/categories.yml
+++ b/jekyll/_data/categories.yml
@@ -1,86 +1,82 @@
-- name: "Getting Started"
+## Here's how Categories work in CircleCI Docs
+#
+# - section: cci2                # mandatory - corresponds to the Jekyll collection this category is for
+#   slug: getting-started        # mandatory - lower-case, no spaces, unique within section, filename of the category's page: `_collection/<slug>.md`
+#   name: "Getting Started"      # mandatory - human version of category slug, how the category name is displayed on the website
+#   index: gettingstarted        # optional - alternate to slug for category page, filename of the category's page: `_collection/<index>.md`, exclusively for cci1 docs
+#   icon: "gettingstarted.svg"   # optional - filename for icon, located at `/assets/img/icons/<icon>`. Used for cci1 docs exclusively
+
+##
+# CircleCI 1.0 Docs
+##
+- section: cci1
   slug: getting-started
+  name: "Getting Started"
   index: gettingstarted
-  icon: "/docs/assets/img/icons/gettingstarted.svg"
-  section: cci1
+  icon: "gettingstarted.svg"
 
-- name: "Build Images"
+- section: cci1
   slug: build-images
-  index: build-images
-  icon: "/docs/assets/img/icons/build-images.svg"
-  section: cci1
+  name: "Build Images"
+  icon: "build-images.svg"
 
-- name: "Languages"
+- section: cci1
   slug: languages
-  index: languages
-  icon: "/docs/assets/img/icons/languages.svg"
-  section: cci1
+  name: "Languages"
+  icon: "languages.svg"
 
-- name: "Mobile Platforms"
+- section: cci1
   slug: mobile-platforms
+  name: "Mobile Platforms"
   index: mobile
-  icon: "/docs/assets/img/icons/mobile.svg"
-  section: cci1
+  icon: "mobile.svg"
 
-- name: "How-To"
+- section: cci1
   slug: how-to
-  index: how-to
-  icon: "/docs/assets/img/icons/how-to.svg"
-  section: cci1
+  name: "How-To"
+  icon: "how-to.svg"
 
-- name: "Troubleshooting"
+- section: cci1
   slug: troubleshooting
-  index: troubleshooting
-  icon: "/docs/assets/img/icons/troubleshooting.svg"
-  section: cci1
+  name: "Troubleshooting"
+  icon: "troubleshooting.svg"
 
-- name: "Reference"
+- section: cci1
   slug: reference
-  index: reference
-  icon: "/docs/assets/img/icons/reference.svg"
-  section: cci1
+  name: "Reference"
+  icon: "reference.svg"
 
-- name: "Parallelism"
+- section: cci1
   slug: parallelism
-  index: parallelism
-  icon: "/docs/assets/img/icons/parallelism.svg"
-  section: cci1
+  name: "Parallelism"
+  icon: "parallelism.svg"
 
-- name: "Privacy and Security"
+- section: cci1
   slug: privacy-and-security
+  name: "Privacy and Security"
   index: privacy-security
-  icon: "/docs/assets/img/icons/privacy-security.svg"
-  section: cci1
+  icon: "privacy-security.svg"
 
-- name: "Getting Started"
+
+##
+# CircleCI Enterprise  Docs
+##
+- section: ccie
   slug: documentation
-  index: documentation
-  section: enterprise
+  name: "Getting Started"
 
-- name: "Clustered Installation"
+- section: ccie
   slug: installation
-  index: installation
-  section: enterprise
+  name: "Clustered Installation"
 
-- name: "Resources"
+- section: ccie
   slug: resources
-  index: resources
-  section: enterprise
+  name: "Resources"
 
-- name: "Advanced Configuration"
+- section: ccie
   slug: advanced-config
-  index: advanced-config
-  section: enterprise
+  name: "Advanced Configuration"
 
-- name: "Troubleshooting"
+- section: ccie
   slug: troubleshooting
-  index: troubleshooting
-  section: enterprise
-
-
-# CCI2 Categories
-- name: "Getting Started"
-  slug: "getting-started"
-  index: getting-started
-  icon: "/docs/assets/img/icons/build-images.svg"
-  section: cci2
+  name: "Troubleshooting"

--- a/jekyll/_docs/enterprise.html
+++ b/jekyll/_docs/enterprise.html
@@ -3,7 +3,7 @@ layout: enterprise-cat
 ---
 
 {% for category in site.data.categories %}
-{% if category.section == "enterprise"  %}
+{% if category.section == "ccie"  %}
 <div class="category-section">
 <!-- 	<img src="{{ category.icon }}" class="../logo" alt="Category Icon" />
  -->	<h2>{{ category.name }}</h2>
@@ -11,7 +11,7 @@ layout: enterprise-cat
 	{% assign docs_found = 0 %}
 	{% assign sorted = site.docs | sort: 'order' %}
 	{% for doc in sorted %}
-		{% if doc.categories contains category.slug and doc.slug != category.index and doc.hide != true  and doc.section == "enterprise" %}
+		{% if doc.categories contains category.slug and doc.slug != category.slug and doc.hide != true  and doc.section == "enterprise" %}
 			{% assign docs_found = docs_found | plus: 1 %}
 			{% if docs_found < 4 %}
 					{% if doc.short-title %}
@@ -25,7 +25,7 @@ layout: enterprise-cat
 
 	{% if docs_found > 3 %}
 		{% assign more = docs_found | minus: 3 %}
-		<li><em><a href="{{ site.baseurl }}/enterprise/{{ category.index }}/">{{ more }} more</a></em></li>
+		<li><em><a href="{{ site.baseurl }}/enterprise/{{ category.slug }}/">{{ more }} more</a></em></li>
 	{% endif %}
 	</ul>
 </div>

--- a/jekyll/_includes/sidebar-cci1.html
+++ b/jekyll/_includes/sidebar-cci1.html
@@ -7,12 +7,12 @@
 	{% if page.url contains "enterprise" %}
 			<p>Looking for non-enterprise docs? <a href="{{ site.baseurl }}/">CircleCI.com Docs</a></p>
 		{% for category in site.data.categories %}
-		{% if category.section == "enterprise" %}
-                        <li><a href="{{ site.baseurl }}/enterprise/{{ category.index }}/">{{ category.name }}</a>
+		{% if category.section == "ccie" %}
+                        <li><a href="{{ site.baseurl }}/enterprise/{{ category.slug }}/">{{ category.name }}</a>
                                 <ul class="list-unstyled">
                                 {% assign sorted = (site.docs | sort: 'order') %}
                                 {% for doc in sorted %}
-                                        {% if doc.categories contains category.slug and doc.slug != category.index and doc.hide != true and doc.section == "enterprise" %}
+                                        {% if doc.categories contains category.slug and doc.slug != category.slug and doc.hide != true and doc.section == "enterprise" %}
                                                 {% if doc.short-title %}
                                                         {% assign title = doc.short-title %}
                                                 {% else %}
@@ -34,10 +34,15 @@
 	<p>Looking for Enterprise docs? <a href="{{ site.baseurl }}/enterprise">CircleCI Enterprise Docs</a></p>
 	{% for category in site.data.categories %}
 	{% if category.section == "cci1" %}
-                <li><a href="{{ site.baseurl }}/{{ category.index }}/">{{ category.name }}</a>
+		{% if category.index %}
+			{% assign catFile = category.index %}
+		{% else %}
+			{% assign catFile = category.slug %}
+		{% endif %}
+                <li><a href="{{ site.baseurl }}/{{ catFile }}/">{{ category.name }}</a>
                         <ul class="list-unstyled">
                         {% for doc in site.docs %}
-                                {% if doc.categories contains category.slug and doc.slug != category.index and doc.hide != true and doc.section == "cci1" %}
+                                {% if doc.categories contains category.slug and doc.slug != catFile and doc.hide != true and doc.section == "cci1" %}
                                         {% if doc.short-title %}
                                                 {% assign title = doc.short-title %}
                                         {% else %}

--- a/jekyll/_layouts/category-page.html
+++ b/jekyll/_layouts/category-page.html
@@ -1,0 +1,12 @@
+---
+layout: classic-docs
+---
+{% assign category = page.categories[0] %}
+{% assign sortedDocs = site.documents | where:"collection",page.collection | sort: 'order' %}
+<ul class="list-unstyled">
+{% for doc in sortedDocs %}
+	{% if doc.categories contains category and doc.slug != page.slug and doc.hide != true %}
+		<li><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></li>
+	{% endif %}
+{% endfor %}
+</ul>

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -4,14 +4,20 @@ layout: classic-docs
 
 {% for category in site.data.categories %}
 {% if category.section == "cci1" %}
-{% if category.slug != "installation" and category.slug != "resources" and category.slug != "documentation" and category.slug != "enterprise" %}
+
+{% if category.index %}
+	{% assign catFile = category.index %}
+{% else %}
+	{% assign catFile = category.slug %}
+{% endif %}
+
 <div class="category-section">
-	<img src="{{ category.icon }}" class="logo" alt="Category Icon" />
+	<img src="{{ site.baseurl }}/assets/img/icons/{{ category.icon }}" class="logo" alt="Category Icon" />
 	<h2>{{ category.name }}</h2>
 	<ul class="list-unstyled">
 	{% assign docs_found = 0 %}
 	{% for doc in site.docs %}
-		{% if doc.categories contains category.slug and doc.slug != category.index and doc.hide != True and doc.section == "cci1" %}
+		{% if doc.categories contains category.slug and doc.slug != catFile and doc.hide != True and doc.section == "cci1" %}
 			{% assign docs_found = docs_found | plus: 1 %}
 			{% if docs_found < 4 %}
 				{% if doc.short-title %}
@@ -25,10 +31,9 @@ layout: classic-docs
 
 	{% if docs_found > 3 %}
 		{% assign more = docs_found | minus: 3 %}
-		<li><em><a href="{{ site.baseurl }}/{{ category.index }}/">{{ more }} more</a></em></li>
+		<li><em><a href="{{ site.baseurl }}/{{ catFile }}/">{{ more }} more</a></em></li>
 	{% endif %}
 	</ul>
 </div>
-{% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
The main point of this PR is to clean up the way categories will be handled within CircleCI Docs. Docs will soon have multiple sections, provided by Jekyll's Collections. So categories will need to work equally well between 1.0 docs, 2.0 docs, CCIE docs, but be attached to a single section. This first PR allows that to happen.

## How Categories Work in CircleCI Docs

This is pulled from the actual commit:

```
- section: cci2                # mandatory - corresponds to the Jekyll collection this category is for
  slug: getting-started        # mandatory - lower-case, no spaces, unique within section, filename of the category's page: `_collection/<slug>.md`
  name: "Getting Started"      # mandatory - human version of category slug, how the category name is displayed on the website
  index: gettingstarted        # optional - alternate to slug for category page, filename of the category's page: `_collection/<index>.md`, exclusively for cci1 docs
  icon: "gettingstarted.svg"   # optional - filename for icon, located at `/assets/img/icons/<icon>`. Used for cci1 docs exclusively
```

`jekyll/_layouts/category-page.html` will be the layout for new category pages going forward. With this PR, no pages yet use it. It's designed to work regardless of which section/collection you use it in.

The rest of the changes are to make sure the existing category pages, main index page, and the sidebar work with the new `categories.yml`.