### PR TITLE
Update docs for Xcode validation changes

### DIFF
--- a/jekyll/_cci1/ios-getting-started.md
+++ b/jekyll/_cci1/ios-getting-started.md
@@ -14,11 +14,13 @@ By default, we build projects on Linux, so you’ll need to enable macOS for you
 
 ## Assumptions and prerequisites
 
-When we run your project on macOS, we check for and validate the presence of:
+For our infererence to test your Xcode project, we check for and validate the presence of:
 
 - an Xcode workspace/project
 - with at least one shared scheme
 - and that the selected scheme has a test action
+
+If none of these are present, then we will not infer any Xcode related `test` commands for your project.
 
 ### Sharing Schemes
 


### PR DESCRIPTION
We no longer require the presence of these for a build to run, but we require them to infer test commands for the project, so the docs should reflect that too.