### PR TITLE
Tell search indexes not to index docs set to 'hide'.

### DIFF
--- a/jekyll/_includes/head.html
+++ b/jekyll/_includes/head.html
@@ -1,5 +1,5 @@
 <head>
-	{% unless page.search %}<meta name="robots" content="noindex" />{% endif %}
+	{% unless page.search %}<meta name="robots" content="noindex" />{% endunless %}
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />

--- a/jekyll/_includes/head.html
+++ b/jekyll/_includes/head.html
@@ -1,4 +1,5 @@
 <head>
+	{% unless page.search %}<meta name="robots" content="noindex" />{% endif %}
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />


### PR DESCRIPTION
Was considering `robots.txt` for this however after reading [this article](https://support.google.com/webmasters/answer/6062608?hl=en) by Google, determined that using the `noindex` meta tag is what we need. This method actually works better in statically generated sites for fine-grain control.

Simply, if the page is set to search=false, add the noindex meta tag to its head.

FYI: Related, `page.hide` is also used to hide from sidebar and the in-page search.