### PR TITLE
Fix invalid json in project_post

### DIFF
--- a/jekyll/_data/api.yml
+++ b/jekyll/_data/api.yml
@@ -626,7 +626,8 @@ project_post:
       "tag": "v0.1" // optional
       "parallel": 2, //optional, default null
       "build_parameters": { // optional
-      "RUN_EXTRA_TESTS": "true"
+        "RUN_EXTRA_TESTS": "true"
+      }
     }
   response: |
     {


### PR DESCRIPTION
We were missing a `}` - Thanks to https://twitter.com/gsdev90/status/832217568337342464 for seeing it