### PR TITLE
Fix broken more links on index - not sure why we even do this, though

### DIFF
--- a/jekyll/_layouts/index-page.html
+++ b/jekyll/_layouts/index-page.html
@@ -24,7 +24,7 @@ layout: classic-docs
 
 	{% if docs_found > 3 %}
 		{% assign more = docs_found | minus: 3 %}
-		<li><em><a href="{{ site.baseurl }}/{{ collection.prefix}}/{{ category.slug }}/">{{ more }} more</a></em></li>
+		<li><em><a href="{{ site.baseurl }}{{ collection.prefix}}/{{ category.slug }}/">{{ more }} more</a></em></li>
 	{% endif %}
 	</ul>
 </div>


### PR DESCRIPTION
We should consider showing way more than 3 per section -- the CCIE docs where you have to click to see "1 more" is unpleasant and not worth shortening. But, in the mean time this PR will at least prevent 404.