### PR TITLE
Orientation for 2.0 landing page

### DIFF
--- a/jekyll/_cci2/about-circleci.md
+++ b/jekyll/_cci2/about-circleci.md
@@ -1,0 +1,59 @@
+---
+layout: classic-docs2
+title: "About CircleCI"
+short-title: "About CircleCI"
+categories: [what-is-circleci]
+order: 1
+---
+
+CircleCI is a modern **continuous integration** and **continous delivery** platform.
+
+Our hosted solution is available at <https://circleci.com/> or you can run [CircleCI Enterprise](https://circleci.com/enterprise/) behind the firewall, inside your private cloud or data center.
+
+## Continuous Integration 
+
+Continuous Integration regularly tests all changes that you make to your code-base. Developers push code into a shared repository several times a day. The integrations are then verified by an automated build and test tool. CircleCI is here to do that for you.
+
+Integrating regularly means that you detect errors early. Each change is usually small, so it's relatively easy to find the code that introduced the problem.
+
+You will likely include several types of tests: 
+
+* [Unit Tests][wiki-unittest]
+* [Integration Tests][wiki-inttest]
+* [Functional Tests][wiki-functest] (also known as End-to-End tests) 
+
+[Software Testing][wiki-codetest] covers a broad range of techniques, processes and tools. The way that you write tests varies depending on the language and framework you are using.
+
+## Continuous Deployment
+
+If your tests pass, then you can deploy your code to development, staging, production, or other environments. The way you do this will depend on the infrastructure you are deploying to. Some examples:
+
+* [AWS CodeDeploy][doc-awscd]
+* [AWS EC2 Container Service (ECS)][doc-awsecs]
+* [AWS S3][doc-awss3]
+* [Google Container Engine (GKE)][doc-gke]
+* [Heroku][doc-heroku]
+* [Deploy Using SSH][doc-sshdeploy]
+
+## CircleCI's Role
+
+CircleCI integrates with your version control system (GitHub/Bitbucket) and automatically runs a series of steps every time a change is detected in the repository (e.g., when you push commits or open a PR).
+
+A CircleCI job consists of a series of steps which are generally:
+
+* Dependencies
+* Testing
+* Deployment
+
+
+[wiki-ci]: https://en.wikipedia.org/wiki/Continuous_integration
+[wiki-unittest]: https://en.wikipedia.org/wiki/Unit_testing
+[wiki-inttest]: https://en.wikipedia.org/wiki/Integration_testing
+[wiki-functest]: https://en.wikipedia.org/wiki/Functional_testing
+[wiki-codetest]: https://en.wikipedia.org/wiki/Software_testing
+[doc-awscd]:  {{ site.baseurl }}/1.0/continuous-deployment-with-aws-codedeploy/
+[doc-awsecs]:  {{ site.baseurl }}/1.0/continuous-deployment-with-aws-ec2-container-service/
+[doc-awss3]:  {{ site.baseurl }}/1.0/continuous-deployment-with-amazon-s3/
+[doc-gke]:  {{ site.baseurl }}/1.0/continuous-deployment-with-google-container-engine/
+[doc-heroku]:  {{ site.baseurl }}/1.0/continuous-deployment-with-heroku/
+[doc-sshdeploy]:  {{ site.baseurl }}/1.0/introduction-to-continuous-deployment/#deploy-over-ssh

--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -12,7 +12,7 @@ CircleCI 2.0 is a powerful tool. While it is in Beta you should be comfortable w
 
 ## Getting Started Articles for Beta users
 
-- [First Steps](docs/2.0/first-steps/)
+- [First Steps](/docs/2.0/first-steps/)
 - [FAQ](/docs/2.0/faq/)
 - [Configuring CircleCI 2.0](/docs/2.0/configuration/)
 - [Exceutor Types](/docs/2.0/executor-types/)

--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -4,10 +4,19 @@ title: "Welcome to CircleCI 2.0"
 permalink: /2.0/index.html
 ---
 
-Along with the recent work on improving our architecture, we’ve also been updating our docs. That means:
+Thank you for your interest in CircleCI 2.0.
 
-- improved search
-- version selector
-- simpler docs hierarchy
+We are in the process of adding documentation for 2.0. Some sections are empty and many new articles will be added in the coming days.
 
-Lots more coming, but in the meantime, check out one of our quickstart guides to get started with CircleCI 2.0.
+CircleCI 2.0 is a powerful tool. While it is in Beta you should be comfortable with YAML configuration files, writing shell commands and have some familiarity with Docker.
+
+## Getting Started Articles for Beta users
+
+- [First Steps](docs/2.0/first-steps/)
+- [FAQ](/docs/2.0/faq/)
+- [Configuring CircleCI 2.0](/docs/2.0/configuration/)
+- [Exceutor Types](/docs/2.0/executor-types/)
+- [Managing Parallelism](/docs/2.0/managing-parallelism/)
+- [Language Guides for Go, JavaScript, PHP, Python, Ruby](/docs/2.0/language-guides)
+
+We'll update this page as more articles are added during Beta.

--- a/jekyll/_cci2/language-guides.md
+++ b/jekyll/_cci2/language-guides.md
@@ -1,0 +1,6 @@
+---
+layout: category-page
+title: Language Guides
+categories: [language-guides]
+description: Language Guides
+---


### PR DESCRIPTION
Adds a basic 2.0 about page and creates some links to existing content on the 2.0 docs index page.

This will be regularly updated with links to new docs as they are written during Beta.