### PR TITLE
Add/update label descriptions

### DIFF
--- a/LABELS.md
+++ b/LABELS.md
@@ -3,29 +3,30 @@ We use GitHub's labels to organize work on docs. Each issue has 3 labels: Status
 ## Status
 Status labels give information about how work is progressing on an issue:
 
-- Status: Abandoned
-- Status: Available
-- Status: Blocked
-- Status: Completed
-- Status: In Progress
-- Status: On Hold
-- Status: Review Needed
-- Status: Revision Needed
+- Available: open for development
+- Blocked: dependency preventing progress
+- Completed: closed & resolved
+- In Progress: in development
+- Review Needed: reviewer assigned, giving feedback
+- Revision Needed: review complete, addressing comments
+- Wontfix: closed & unresolved
 
 ## Type
 Type labels give information about the kind of issue:
 
-- Type: Enhancement
-- Type: Inaccuracy
-- Type: Question
-- Type: Structure
-- Type: Typo
+- Bug: technical problem
+- Copyedit: accuracy, clarity, consistency
+- Draft: brand new documentation
+- Feature: technical enhancement
+- Proofreading: typos, repeated words, spelling, punctuation, formatting
+- Question: request for information; route to Discuss
+- Substantive: structure, language, style, presentation
 
 ## Priority
 Priority labels tell us how important an issue is:
 
-- Priority: High
-- Priority: Medium
-- Priority: Low
+- High: today
+- Medium: this week
+- Low: this month
 
 To create our label system, we borrowed liberally from this article about [sane GitHub labels](https://medium.com/@dave_lunny/sane-github-labels-c5d2e6004b63#.c2sqrwkkg).


### PR DESCRIPTION
In order to use labels effectively, people need to understand what each
label means. Also:

- changed "Abandoned" to "Wontfix"
- removed "On Hold"
- reworked "Type" labels to suit a repo that's about writing