### PR TITLE
Grouping dependencies, database, and test together

### DIFF
--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -238,7 +238,7 @@ jobs:
       - run: bundle install --path vendor/bundle
 
      # Caching is fully customizable in 2.0
-     - save-cache:
+     - save_cache:
         key: dependency-cache-{{ checksum "Gemfile.lock" }}
         paths:
           - vendor/bundle

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -26,19 +26,19 @@ In 2.0, if your job uses Docker, we’ll run your job on a dedicated VM so you c
 
 While this configuration can be powerful, there are some drawbacks. Maybe you want to disable inference. Or maybe you need to save the dependency cache _after_ running tests since the tests themselves create _more_ dependencies.
 
-In 2.0, jobs are broken into granular steps. You can compose these steps within a job at your discretion. This gives you greater flexibility to run your build the way you want it.
+In 2.0, jobs are broken into granular steps. You can compose these steps within a job at your discretion. This gives you greater flexibility to run your build the way you want.
 
-To learn more, please see [Configuring CircleCI 2.0]( {{ site.baseurl }}/2.0/configuration) section.
+To learn more, please see [Configuring CircleCI 2.0]( {{ site.baseurl }}/2.0/configuration).
 
 ### Custom Build Image
 
 In 1.0, you’re restricted to the build image CircleCI provides. In Linux builds, there are 2 images you can use: Ubuntu 12.04 and 14.04. While these images come with many languages and tools pre-installed, it’s frustrating if you need a version of a service or dependency that isn’t included.
 
-Maybe you want to use a different version of MySQL than the one included in either of these images. Installing that adds time and complexity to your builds.
+Maybe you want to use a different version of MySQL than the one included in either default image. Installing another version adds time and complexity to your builds.
 
 In 2.0, we support almost all public Docker images. You can also create a custom image and run jobs on that. You can even compose multiple images together (like MySQL 5.7 + Redis 3.2) and run jobs on them as if they were a single image.
 
-To learn more, please see [job images]( {{ site.baseurl }}/2.0/configuration/#job-images) section.
+To learn more, please see [job images]( {{ site.baseurl }}/2.0/configuration/#job-images).
 
 ----
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -245,7 +245,9 @@ jobs:
 ```
 {% endraw %}
 
-There are lots of cache prefix options. Read about them in [Configuring CircleCI 2.0]( {{ site.baseurl }}/2.0/configuration).
+Please note that you need to have a restore cache step by yourself in 2.0. There are also lots of cache prefix options available.
+
+Read about them in [Configuring CircleCI 2.0]( {{ site.baseurl }}/2.0/configuration).
 
 ## Deployment
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -44,7 +44,7 @@ To learn more, please see [job images]( {{ site.baseurl }}/2.0/configuration/#jo
 
 # Configuration Equivalents
 
-CircleCI 2.0 introduces a completely new syntax in `circle.yml`. This article will help you convert your 1.0 `circle.yml` to 2.0 syntax.
+CircleCI 2.0 introduces a completely new syntax in `.circleci/config.yml`. This article will help you convert your 1.0 `circle.yml` to 2.0 syntax.
 
 
 ## Machine
@@ -54,7 +54,6 @@ CircleCI 2.0 introduces a completely new syntax in `circle.yml`. This article wi
 **1.0**
 
 ```
-# 1.0
 machine:
   environment:
     FOO: foo
@@ -93,7 +92,7 @@ jobs:
   build:
     working_directory: /tmp
 
-    # You can use any public Docker images in 2.0, so using ruby:2.3 Docker image is a 2.0 way
+    # In 2.0, we specify our Ruby version by using a public Docker image
     docker:
       - image: ruby:2.3
 ```
@@ -124,8 +123,6 @@ jobs:
 
 ## Checkout
 
-### Custom Checkout
-
 **1.0**
 
 ```
@@ -143,17 +140,13 @@ version: 2
 jobs:
   build:
     working_directory: /root/my-project
-
-    # We are using phusion/baseimage because it's small yet handy enough for the purpose of this document
     docker:
       - image: phusion/baseimage
-
     steps:
-      # Make sure you have git in your image. Otherwise the next checkout step will fail.
+      # Ensure your image has git, otherwise the checkout step will fail
       - run: apt-get -qq update; apt-get -y install git
 
-      # The timing when you checkout is not hardcoded anymore in 2.0.
-      # You can do that at anytime you want.
+      # Checkout timing is no longer hardcoded, so this step can occur anywhere
       - checkout
       - run: git submodule sync && git submodule update --init # use submodules
 ```
@@ -180,7 +173,7 @@ test:
 
 **2.0**
 
-In 2.0, `dependency`, `database`, and `test` sections are simply translated into the sequence of 'run' steps.
+The `dependency`, `database`, and `test` sections are translated into a sequence of 'run' steps.
 
 ```
 version: 2
@@ -190,8 +183,7 @@ jobs:
     docker:
       - image: ruby:2.3
 
-      # You can chose any DB that you want to use in 2.0
-      # The postgres image requires POSTGRES_USER env var
+      # You can use any DB here, but postgres requires the POSTGRES_USER environment variable
       - image: postgres:9.4.1
         environment:
           POSTGRES_USER: root
@@ -199,18 +191,17 @@ jobs:
     steps:
       - checkout
 
-      # You need to install dependencies that your project requires by yourself.
-      # Therefore, there is nothing to override in 2.0.
-      # Currently, the timeout for no output is hardcoded to 600 secs.
+      # There’s no inference in 2.0, which means there’s nothing to override
+      # You’ll need to manually install your project’s dependencies
+      # The current timeout for no output is hardcoded to 600 seconds
       - run: bundle install --path vendor/bundle
 
-      # Database is not created automatically in 2.0.
-      # Following is an example of setting up test DB in PostgreSQL
+      # The DB is not automatically created in 2.0, so we manually set up a test DB
       - run: sudo -u root createuser -h localhost --superuser ubuntu
       - run: sudo createdb -h localhost test_db
       - run: bundle exec rake db:create db:schema:load
 
-      # You can use any test commands you want to run in 2.0
+      # Run any test commands
       - run: bundle exec rspec
 
 ```
@@ -235,7 +226,6 @@ dependencies:
 
 {% raw %}
 ```
-# 2.0
 version: 2
 jobs:
   build:
@@ -247,8 +237,7 @@ jobs:
       - checkout
       - run: bundle install --path vendor/bundle
 
-     # Caching is fully customizable in 2.0.
-     # (1) There are many available keys that you can use as a cache prefix
+     # Caching is fully customizable in 2.0
      - save-cache:
         key: dependency-cache-{{ checksum "Gemfile.lock" }}
         paths:
@@ -256,7 +245,7 @@ jobs:
 ```
 {% endraw %}
 
-**(1)** To learn more about available options for cache prefixes, please see the [Configuring CircleCI 2.0]( {{ site.baseurl }}/2.0/configuration) page.
+There are lots of cache prefix options. Read about them in [Configuring CircleCI 2.0]( {{ site.baseurl }}/2.0/configuration).
 
 ## Deployment
 
@@ -272,8 +261,6 @@ deployment:
 
 **2.0**
 
-Automatic deployment via integrations that you might have used on CircleCI 1.0 (such as Heroku above) are not currently supported in 2.0.
+Currently, 2.0 doesn’t support automatic deployment via integrations (like the above Heroku example).
 
-You can write your own `deploy` manual steps as shown in the `deploy` sections of the `circle.yml` [configuration example here](/docs/2.0/configuration/).
-
-We're working on creating more comprehensive deployment documentation for 2.0.
+You can write your own manual `deploy` steps as shown in the `deploy` section of the `config.yml` [configuration example here](/docs/2.0/configuration/).


### PR DESCRIPTION
@technomancy suggested to group dependencies, database, and test sections into the same category because they are just bunch of run steps.

Also, cache_save -> save_cache