### PR TITLE
Add Elixir guide

### DIFF
--- a/jekyll/_cci2/language-erlang.md
+++ b/jekyll/_cci2/language-erlang.md
@@ -1,0 +1,86 @@
+---
+layout: classic-docs2
+title: "Language Guide: Erlang"
+short-title: "Erlang"
+categories: [languages-and-tools]
+order: 1
+---
+
+You can use the following `.circleci/config.yml` to start building Phoenix apps. See below for an explanation of each step.
+
+```yaml
+version: 2
+jobs:
+  build:
+    working_directory: ~/cci-demo-phoenix
+    docker:
+      - image: trenpixster/elixir:1.3.2
+      - image: postgres:9.4.1
+        environment:
+          POSTGRES_USER: ubuntu
+    steps:
+      - checkout
+      - run: mix deps.get
+      - run: mix ecto.create
+```
+
+## Config Walkthrough
+
+We always start with the version.
+
+```yaml
+version: 2
+```
+
+Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deploy process. Our sample app only needs a `build` job, so everything else is going to live under that key.
+
+In each job, we have the option of specifying a `working_directory`. In this sample config, we’ll name it after the project in our home directory.
+
+```yaml
+version: 2
+jobs:
+  build:
+    working_directory: ~/cci-demo-phoenix
+```
+
+This path will be used as the default working directory for the rest of the `job` unless otherwise specified.
+
+Directly beneath `working_directory`, we can specify container images for the build under a `docker` key.
+
+```yaml
+version: 2
+jobs:
+  build:
+    working_directory: ~/cci-demo-phoenix
+    docker:
+      - image: trenpixster/elixir:1.3.2
+      - image: postgres:9.4.1
+        environment:
+          POSTGRES_USER: ubuntu
+```
+
+We use 2 Docker images here: `trenpixster/elixir:1.3.2` as the primary build image and `postgres:9.4.1` as the database image.
+
+Now we’ll add several `steps` within the `build` job.
+
+We’ll do 3 things: checkout the codebase, install missing dependencies, and create the storage for the repo:
+
+```yaml
+version: 2
+jobs:
+  build:
+    working_directory: ~/cci-demo-phoenix
+    docker:
+      - image: trenpixster/elixir:1.3.2
+      - image: postgres:9.4.1
+        environment:
+          POSTGRES_USER: ubuntu
+    steps:
+      - checkout
+      - run: mix deps.get
+      - run: mix ecto.create
+```
+
+Nice! You just set up CircleCI for a Phoenix app.
+
+If you have any questions, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.

--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -3,7 +3,7 @@ layout: classic-docs2
 title: "Language Guide: Go"
 short-title: "Go"
 categories: [languages-and-tools]
-order: 1
+order: 2
 ---
 
 This guide should help get you started with a Go project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you’re just looking for a sample `config.yml` file, then just skip to the end.

--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -3,7 +3,7 @@ layout: classic-docs2
 title: "Language Guide: JavaScript"
 short-title: "JavaScript"
 categories: [languages-and-tools]
-order: 2
+order: 3
 ---
 
 This guide should help get you started with a JavaScript project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you’re just looking for a sample `config.yml` file, then just skip to the end.

--- a/jekyll/_cci2/language-php.md
+++ b/jekyll/_cci2/language-php.md
@@ -3,7 +3,7 @@ layout: classic-docs2
 title: "Language Guide: PHP"
 short-title: "PHP"
 categories: [languages-and-tools]
-order: 3
+order: 4
 ---
 
 This guide should help get you started with a PHP project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you’re just looking for a sample `config.yml` file, then just skip to the end.

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -3,7 +3,7 @@ layout: classic-docs2
 title: "Language Guide: Python"
 short-title: "Python"
 categories: [languages-and-tools]
-order: 4
+order: 5
 ---
 
 This guide should help get you started with a Python project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you're just looking for a sample `config.yml` file, then just skip to the end.

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -3,7 +3,7 @@ layout: classic-docs2
 title: "Language Guide: Ruby"
 short-title: "Ruby"
 categories: [languages-and-tools]
-order: 5
+order: 6
 ---
 
 This guide should help get you started with a Ruby project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you’re just looking for a sample `config.yml` file, then just skip to the end.


### PR DESCRIPTION
This was pulled from [this Discuss post](https://discuss.circleci.com/t/getting-started-with-picard-elixir/5804/3) and updated to the latest syntax.

@eric-hu @keybits Mind reviewing this for me?

One open question for this one is where (or if) we're hosting the sample project anywhere. I think Eric had this up and running [here](https://github.com/circleci/canary_phoenix).

So this might need one more commit to get the links in order.