### PR TITLE
Fix run indentation

### DIFF
--- a/jekyll/_cci2/job-steps.md
+++ b/jekyll/_cci2/job-steps.md
@@ -38,10 +38,10 @@ Represents whether command should be run in the background. Default: false
 
 ```yaml
 - run:
-  command: bundle check || bundle install
-  shell: /bin/bash
-  environment:
-    FOO: "bar"
+    command: bundle check || bundle install
+    shell: /bin/bash
+    environment:
+      FOO: "bar"
 ```
 
 ## **checkout**
@@ -74,25 +74,25 @@ To use an ssh-agent, you’ll need to explicitly start one up:
 
 ```yaml
 - run:
-  name: Start ssh-agent
-  command: |
-    ssh-agent -s > ~/.ssh_agent_conf
-    source ~/.ssh_agent_conf
+    name: Start ssh-agent
+    command: |
+      ssh-agent -s > ~/.ssh_agent_conf
+      source ~/.ssh_agent_conf
 
-    for _k in $(ls ${HOME}/.ssh/id_*); do
-      ssh-add ${_k} || true
-    done
+      for _k in $(ls ${HOME}/.ssh/id_*); do
+        ssh-add ${_k} || true
+      done
 ```
 
 Then, load the ssh configuration in steps that require an ssh-agent:
 
 ```yaml
 - run:
-  name: run my special ssh command
-  command: |
-    source ~/.ssh_agent_conf
+    name: run my special ssh command
+    command: |
+      source ~/.ssh_agent_conf
 
-    my-command-that-uses-ssh
+      my-command-that-uses-ssh
 ```
 
 ## **store_artifacts**

--- a/jekyll/_cci2/project-walkthrough.md
+++ b/jekyll/_cci2/project-walkthrough.md
@@ -152,8 +152,8 @@ jobs:
   build:
     steps:
       - run:
-        name: run tests
-        command: make test
+          name: run tests
+          command: make test
 ```
 
 Here, we have a single step with an associated configuration map. Its type is `run`, its name is “run tests”, and the command is `make test`.


### PR DESCRIPTION
The `run` step does not accept a map, so there was incorrect indentation scattered across a couple of docs. Thanks to @drazisil for catching this!