### PR TITLE
Create Configuration Reference doc

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1,12 +1,16 @@
 ---
 layout: classic-docs2
-title: "Job Steps"
-short-title: "Job Steps"
+title: "Configuration Reference"
+short-title: "Configuration Reference"
 categories: [configuring-jobs]
-order: 2
+order: 2000
 ---
 
-**TODO: Add orientation and context.**
+**TODO: Add orientation and context. This docs is full reference for config spec.**
+
+**TODO: Add missing config info.**
+
+## Job Steps
 
 ## **run**
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -28,7 +28,7 @@ While this configuration can be powerful, there are some drawbacks. Maybe you wa
 
 In 2.0, jobs are broken into granular steps. You can compose these steps within a job at your discretion. This gives you greater flexibility to run your build the way you want.
 
-To learn more, please see [Configuring Job Steps]( {{ site.baseurl }}/2.0/job-steps/).
+To learn more, please see [Configuring Job Steps]( {{ site.baseurl }}/2.0/configuration-reference/#job-steps/).
 
 ### Custom Build Image
 
@@ -247,7 +247,7 @@ jobs:
 
 Please note that you need to have a restore cache step by yourself in 2.0. There are also lots of cache prefix options available.
 
-Read about them in [Job Steps]( {{ site.baseurl }}/2.0/job-steps/).
+Read about them in [Configuring Job Steps]( {{ site.baseurl }}/2.0/configuration-reference/#job-steps/).
 
 ## Deployment
 
@@ -265,4 +265,4 @@ deployment:
 
 Currently, 2.0 doesn’t support automatic deployment via integrations (like the above Heroku example).
 
-You can write your own manual `deploy` steps as shown in the `deploy` section of the `config.yml` [configuration example here](/docs/2.0/job-steps/).
+You can write your own manual `deploy` steps as shown in the `deploy` section of the `config.yml` [configuration example here](/docs/2.0/configuration-reference/#job-steps/).

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -28,7 +28,7 @@ While this configuration can be powerful, there are some drawbacks. Maybe you wa
 
 In 2.0, jobs are broken into granular steps. You can compose these steps within a job at your discretion. This gives you greater flexibility to run your build the way you want.
 
-To learn more, please see [Configuring Job Steps]( {{ site.baseurl }}/2.0/configuration-reference/#job-steps/).
+To learn more, please see [Configuring Job Steps]( {{ site.baseurl }}/2.0/configuration-reference/#job-steps).
 
 ### Custom Build Image
 
@@ -247,7 +247,7 @@ jobs:
 
 Please note that you need to have a restore cache step by yourself in 2.0. There are also lots of cache prefix options available.
 
-Read about them in [Configuring Job Steps]( {{ site.baseurl }}/2.0/configuration-reference/#job-steps/).
+Read about them in [Configuring Job Steps]( {{ site.baseurl }}/2.0/configuration-reference/#job-steps).
 
 ## Deployment
 
@@ -265,4 +265,4 @@ deployment:
 
 Currently, 2.0 doesn’t support automatic deployment via integrations (like the above Heroku example).
 
-You can write your own manual `deploy` steps as shown in the `deploy` section of the `config.yml` [configuration example here](/docs/2.0/configuration-reference/#job-steps/).
+You can write your own manual `deploy` steps as shown in the `deploy` section of the `config.yml` [configuration example here](/docs/2.0/configuration-reference/#job-steps).


### PR DESCRIPTION
Following Discussion with Anton, we will have a full 'Configuration Reference' doc that has the full config spec. So this renames 'Job Steps' to 'Configuration Reference' ready for that doc to be filled out.