### PR TITLE
Remove todos

### DIFF
--- a/jekyll/_cci2/api-docs.md
+++ b/jekyll/_cci2/api-docs.md
@@ -4,6 +4,5 @@ title: "2.0 API Docs"
 short-title: "2.0 API Docs"
 categories: [api]
 order: 100
+published: false
 ---
-
-TODO: Information on using the API for 2.0 will be added shortly.

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -6,10 +6,6 @@ categories: [configuring-jobs]
 order: 2000
 ---
 
-**TODO: Add orientation and context. This docs is full reference for config spec.**
-
-**TODO: Add missing config info.**
-
 ## Job Steps
 
 ## **run**

--- a/jekyll/_cci2/deployments-and-uploads.md
+++ b/jekyll/_cci2/deployments-and-uploads.md
@@ -4,6 +4,5 @@ title: "Deployments and Uploads"
 short-title: "Deployments and Uploads"
 categories: [configuring-jobs]
 order: 98
+published: false
 ---
-
-TODO: Information on Deployments and Uploads for 2.0 is coming soon.

--- a/jekyll/_cci2/example-projects-list.md
+++ b/jekyll/_cci2/example-projects-list.md
@@ -5,7 +5,3 @@ short-title: "Example Projects for 2.0"
 categories: [example-projects]
 order: 100
 ---
-
-
-
-TODO: Links to example projects using 2.0 will be added shortly.

--- a/jekyll/_cci2/integrations.md
+++ b/jekyll/_cci2/integrations.md
@@ -4,6 +4,5 @@ title: "Integrations"
 short-title: "Integrations"
 categories: [configuring-jobs]
 order: 100
+published: false
 ---
-
-TODO: Information on Integrations for 2.0 is coming soon.

--- a/jekyll/_cci2/job-info-and-insights.md
+++ b/jekyll/_cci2/job-info-and-insights.md
@@ -4,6 +4,5 @@ title: "Job Information and Insights"
 short-title: "Job Information and Insights"
 categories: [configuring-jobs]
 order: 95
+published: false
 ---
-
-TODO: Information on CircleCI UI and Insights is coming soon.

--- a/jekyll/_cci2/notifications.md
+++ b/jekyll/_cci2/notifications.md
@@ -4,6 +4,5 @@ title: "Notifications"
 short-title: "Notifications"
 categories: [configuring-jobs]
 order: 100
+published: false
 ---
-
-TODO: Information on Notifications for 2.0 is coming soon.

--- a/jekyll/_cci2/project-walkthrough.md
+++ b/jekyll/_cci2/project-walkthrough.md
@@ -6,8 +6,6 @@ categories: [getting-started]
 order: 25
 ---
 
-**TODO: Rewrite as a full project walkthrough tutorial**
-
 Configuration for CircleCI is contained in a single file: `.circleci/config.yml`. This file is committed to your project’s repository along with the rest of your source code.
 
 This file is _extremely_ flexible, so it’s not realistic to list every possible thing you can put in here. Instead, we’ll create a sample `config.yml` file and explain the sections along the way.

--- a/jekyll/_data/categories.yml
+++ b/jekyll/_data/categories.yml
@@ -98,18 +98,18 @@
   slug: languages-and-tools
   name: "Languages and Tools"
 
-- section: cci2
-  slug: example-projects
-  name: "Example Projects"
+# - section: cci2
+#   slug: example-projects
+#   name: "Example Projects"
 
-- section: cci2
-  slug: troubleshooting-and-debugging
-  name: "Troubleshooting and Debugging"
+# - section: cci2
+#   slug: troubleshooting-and-debugging
+#   name: "Troubleshooting and Debugging"
 
-- section: cci2
-  slug: api
-  name: "API"
+# - section: cci2
+#   slug: api
+#   name: "API"
 
-- section: cci2
-  slug: help-and-support
-  name: "Help and Support"
+# - section: cci2
+#   slug: help-and-support
+#   name: "Help and Support"


### PR DESCRIPTION
@keybits 

TODOs are awesome for knowing what we need to do, but they don't really belong in polished docs. I've moved these TODOS to JIRA and also hidden categories that either only had a TODO or were empty.