### PR TITLE
replace instances of circle.yml

### DIFF
--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -110,7 +110,7 @@ Finally, let's specify a path to store the results of the tests.
           path: /tmp/test-results
 ```
 
-And we're done! Let's see what the whole `circle.yml` looks like now:
+And we're done! Let's see what the whole `config.yml` looks like now:
 
 ```yaml
 version: 2

--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -101,7 +101,7 @@ If it is the right branch, we'll add the SSH key fingerprint directly. Note the 
             fi
 ```
 
-And we're done! Let's see what the whole `circle.yml` looks like now:
+And we're done! Let's see what the whole `config.yml` looks like now:
 
 ```yaml
 version: 2

--- a/jekyll/_cci2/language-php.md
+++ b/jekyll/_cci2/language-php.md
@@ -143,7 +143,7 @@ Finally, let's run our tests using PHPUnit.
           command: vendor/bin/phpunit
 ```
 
-And we're done! Let's see what the whole `circle.yml` looks like now:
+And we're done! Let's see what the whole `config.yml` looks like now:
 
 ```yaml
 version: 2

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -113,7 +113,7 @@ Finally, let's specify where those test results are actually located.
           path: "test-reports/"
 ```
 
-And we're done! Let's see what the whole `circle.yml` looks like now:
+And we're done! Let's see what the whole `config.yml` looks like now:
 
 {% raw %}
 ```yaml

--- a/jekyll/_cci2/local-builds.md
+++ b/jekyll/_cci2/local-builds.md
@@ -10,13 +10,13 @@ order: 90
 
 CircleCI 2.0's CLI reproduces the CircleCI build environment locally and runs builds as if they are running in CircleCI. The tool enables better debugging and faster configuration.
 
-### 1. Getting a working `circle.yml` configuration
+### 1. Getting a working `config.yml` configuration
 
-Getting the syntax correct for your `circle.yml` file can take a bit of effort. Instead of having to push a commit and build on CircleCI to test this, local builds allow you to experiment locally.
+Getting the syntax correct for your `config.yml` file can take a bit of effort. Instead of having to push a commit and build on CircleCI to test this, local builds allow you to experiment locally.
 
 **Note:** local builds don't require that you commit changes to Git. The local build will build what's currently on your file system. So you can iterate quickly by making changes to files and rerunning your local build.
 
-**Note 2:** local builds do not cache dependencies. So you may want to comment out dependency sections to speed things up while testing YAML syntax locally. Or use the `--config` flag to specify a local specific `circle.yml` that doesn't pull in large dependencies.
+**Note 2:** local builds do not cache dependencies. So you may want to comment out dependency sections to speed things up while testing YAML syntax locally. Or use the `--config` flag to specify a local specific `config.yml` that doesn't pull in large dependencies.
 
 ### 2. Troubleshooting container configurations
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -44,7 +44,7 @@ To learn more, please see the [Project Walkthrough]( {{ site.baseurl }}/2.0/proj
 
 # Configuration Equivalents
 
-CircleCI 2.0 introduces a completely new syntax in `.circleci/config.yml`. This article will help you convert your 1.0 `circle.yml` to 2.0 syntax.
+CircleCI 2.0 introduces a completely new syntax in `.circleci/config.yml`. This article will help you convert your 1.0 `circle.yml` to a 2.0 `config.yml`.
 
 
 ## Machine


### PR DESCRIPTION
We still had a few lingering references to `circle.yml`, but that's not a thing anymore!

Replaced all instances of `circle.yml` to `config.yml`.