### PR TITLE
Rename picard circleci

### DIFF
--- a/jekyll/_cci2/local-builds.md
+++ b/jekyll/_cci2/local-builds.md
@@ -6,19 +6,19 @@ categories: [configuring-jobs]
 order: 3
 ---
 
-CircleCI’s CLI reproduces the CircleCI build environment locally and runs builds as if they were running in CircleCI. The tool enables better debugging and faster configuration.
+CircleCI’s CLI reproduces the CircleCI build environment locally and runs jobs as if they were running in CircleCI. The tool enables better debugging and faster configuration.
 
 ## Common Use Cases
 
 ### Debugging Configuration Syntax
 
-Getting the syntax correct for your `config.yml` file can take some effort. Instead of having to push a commit and build on CircleCI to test this, local builds allow you to experiment locally since they only build what’s currently on your file system.
+Getting the syntax correct for your `config.yml` file can take some effort. Instead of having to push a commit and run a job on CircleCI to test this, local builds allow you to experiment locally since they only build what’s currently on your file system.
 
 Note that local builds don’t cache dependencies. You may want to comment out dependency sections if you’re testing YAML syntax. Or use the `--config` flag to specify a local `config.yml` that doesn’t pull in large dependencies.
 
 ### Troubleshooting Container Configurations
 
-Builds have several containers that need to “talk” to each other. If you have a PostgreSQL container, it can take some effort to ensure your build can connect and create the relevant database with correct permissions on the correct port. Or you might be using a pre-built container, but you’re unsure if it has all the services you need or if they're running in the way you hope.
+Jobs have several containers that need to “talk” to each other. If you have a PostgreSQL container, it can take some effort to ensure your job can connect and create the relevant database with correct permissions on the correct port. Or you might be using a pre-built container, but you’re unsure if it has all the services you need or if they're running in the way you hope.
 
 Local builds allow you to quickly retry configurations such as connecting on different ports or with different users.
 
@@ -26,7 +26,7 @@ Local builds allow you to quickly retry configurations such as connecting on dif
 
 Imagine you’re a new developer on a team. It could take some time to figure out how to build and test an application.
 
-If the project has been configured to run on CircleCI, you can clone the repo, install the local build tool and simply run `circleci-builder build`. This is a great way to get set up quickly with the same environment as your team.
+If the project has been configured to run on CircleCI, you can clone the repo, install the local build tool and simply run `circleci-cli build`. This is a great way to get set up quickly with the same environment as your team.
 
 ## Requirements
 
@@ -37,22 +37,22 @@ To use the CircleCI CLI, you’ll need to install and configure Docker. Please f
 To install the CLI, run:
 
 ```Bash
-curl -o /usr/local/bin/circleci-builder https://circle-downloads.s3.amazonaws.com/releases/circleci-builder/circleci-builder-beta && chmod +x /usr/local/bin/circleci-builder
+curl -o /usr/local/bin/circleci-cli https://circle-downloads.s3.amazonaws.com/releases/circleci-builder/circleci-builder-beta && chmod +x /usr/local/bin/circleci-cli
 ```
 
 (If the current user doesn't have write permissions for `/usr/local/bin`, you might need to run the above commands with `sudo`.)
 
 ## Usage
 
-Calling `circleci-builder` without any options displays usage information:
+Calling `circleci-cli` without any options displays usage information:
 
 ```Bash
-$ circleci-builder
-The build agent to be used in circleci.
+$ circleci-cli
+The CLI tool to be used in circleci.
 
 Usage:
   circleci [flags]
-  circleci [command]
+  circleci [command]a
 
 Available Commands:
   build       run a full build locally

--- a/jekyll/_cci2/local-builds.md
+++ b/jekyll/_cci2/local-builds.md
@@ -29,9 +29,11 @@ Imagine you’re a new developer on a team. It could take some time to figure ou
 If the project has been configured to run on CircleCI, you can clone the repo, install the local build tool and simply run `circleci-builder build`. This is a great way to get set up quickly with the same environment as your team.
 
 ## Requirements
+
 To use the CircleCI CLI, you’ll need to install and configure Docker. Please follow the [docker installation instructions](https://docs.docker.com/engine/installation/).
 
 ## Installation
+
 To install the CLI, run:
 
 ```Bash
@@ -41,15 +43,16 @@ curl -o /usr/local/bin/circleci-builder https://circle-downloads.s3.amazonaws.co
 (If the current user doesn't have write permissions for `/usr/local/bin`, you might need to run the above commands with `sudo`.)
 
 ## Usage
+
 Calling `circleci-builder` without any options displays usage information:
 
 ```Bash
 $ circleci-builder
-The build agent to be used in Picard.
+The build agent to be used in circleci.
 
 Usage:
-  picard [flags]
-  picard [command]
+  circleci [flags]
+  circleci [command]
 
 Available Commands:
   build       run a full build locally
@@ -57,11 +60,11 @@ Available Commands:
   version     output version info
 
 Flags:
-  -c, --config string   config file (default is $HOME/.picard/agent.toml)
+  -c, --config string   config file (default is $HOME/.circleci/agent.toml)
       --taskId string   TaskID
       --verbose         emit verbose logging output
 
-Use 'picard [command] --help' for more information about a command.
+Use 'circleci [command] --help' for more information about a command.
 ```
 
 ## Updating

--- a/jekyll/_cci2/local-jobs.md
+++ b/jekyll/_cci2/local-jobs.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs2
-title: "Local Jobs"
+title: "Running Jobs Locally"
 short-title: "Running Jobs Locally"
 categories: [configuring-jobs]
 order: 3

--- a/jekyll/_cci2/local-jobs.md
+++ b/jekyll/_cci2/local-jobs.md
@@ -1,12 +1,12 @@
 ---
 layout: classic-docs2
-title: "Local Builds"
-short-title: "Local CircleCI Builder"
+title: "Local Jobs"
+short-title: "Running Jobs Locally"
 categories: [configuring-jobs]
 order: 3
 ---
 
-CircleCI’s CLI reproduces the CircleCI build environment locally and runs jobs as if they were running in CircleCI. The tool enables better debugging and faster configuration.
+The **CircleCI CLI** reproduces the CircleCI environment locally and runs jobs as if they were running on CircleCI. The tool enables better debugging and faster configuration.
 
 ## Common Use Cases
 
@@ -18,15 +18,15 @@ Note that local builds don’t cache dependencies. You may want to comment out d
 
 ### Troubleshooting Container Configurations
 
-Jobs have several containers that need to “talk” to each other. If you have a PostgreSQL container, it can take some effort to ensure your job can connect and create the relevant database with correct permissions on the correct port. Or you might be using a pre-built container, but you’re unsure if it has all the services you need or if they're running in the way you hope.
+Jobs have several containers that need to “talk” to each other. If you have a PostgreSQL container, you can quickly try different settings to ensure your job can connect and create the relevant database with correct permissions on the correct port. Or you might be using a pre-built container, but you’re unsure if it has all the services you need, or if they're running in the way you hope.
 
-Local builds allow you to quickly retry configurations such as connecting on different ports or with different users.
+Local jobs allow you to quickly retry configurations such as connecting on different ports or with different users.
 
 ### Testing a New Project
 
 Imagine you’re a new developer on a team. It could take some time to figure out how to build and test an application.
 
-If the project has been configured to run on CircleCI, you can clone the repo, install the local build tool and simply run `circleci-cli build`. This is a great way to get set up quickly with the same environment as your team.
+If the project has been configured to run on CircleCI, you can clone the repo, install the CircleCI CLI and run `circleci-cli build`. This is a great way to get set up quickly with the same environment as your team.
 
 ## Requirements
 
@@ -68,6 +68,9 @@ Use 'circleci [command] --help' for more information about a command.
 ```
 
 ## Updating
+
 The CLI tool automatically checks for updates and will prompt you if one is available.
 
-For a more detailed guide on how to use the CircleCI CLI, check out [Parallelism for Faster Jobs]({{ site.baseurl }}/2.0/parallelism-faster-jobs).
+## Using the CircleCI CLI non-locally
+
+The CircleCI CLI is available in all CircleCI environments. For example, check out [Parallelism for Faster Jobs]({{ site.baseurl }}/2.0/parallelism-faster-jobs) to see how you use the tool to manage paralellism in a remoted hosted environment.

--- a/jekyll/_cci2/local-jobs.md
+++ b/jekyll/_cci2/local-jobs.md
@@ -26,7 +26,7 @@ Local jobs allow you to quickly retry configurations such as connecting on diffe
 
 Imagine you’re a new developer on a team. It could take some time to figure out how to build and test an application.
 
-If the project has been configured to run on CircleCI, you can clone the repo, install the CircleCI CLI and run `circleci-cli build`. This is a great way to get set up quickly with the same environment as your team.
+If the project has been configured to run on CircleCI, you can clone the repo, install the CircleCI CLI and run `circleci build`. This is a great way to get set up quickly with the same environment as your team.
 
 ## Requirements
 
@@ -37,18 +37,18 @@ To use the CircleCI CLI, you’ll need to install and configure Docker. Please f
 To install the CLI, run:
 
 ```Bash
-curl -o /usr/local/bin/circleci-cli https://circle-downloads.s3.amazonaws.com/releases/circleci-builder/circleci-builder-beta && chmod +x /usr/local/bin/circleci-cli
+curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && chmod +x /usr/local/bin/circleci
 ```
 
 (If the current user doesn't have write permissions for `/usr/local/bin`, you might need to run the above commands with `sudo`.)
 
 ## Usage
 
-Calling `circleci-cli` without any options displays usage information:
+Calling `circleci` without any options displays usage information:
 
 ```Bash
-$ circleci-cli
-The CLI tool to be used in circleci.
+$ circleci
+The CLI tool to be used in CircleCI.
 
 Usage:
   circleci [flags]

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -6,21 +6,21 @@ categories: [configuring-jobs]
 order: 4
 ---
 
-One of the most powerful features of CircleCI is the ability to run your tests in parallel. In CircleCI 2.0 you manage this parallelism with a CLI tool called `picard`. We inject this agent into the primary job container so the `picard` command is always available in container `0`.
+One of the most powerful features of CircleCI is the ability to run your tests in parallel. In CircleCI 2.0 you manage this parallelism with a CLI tool called `circleci`. We inject this agent into the primary job container so the `circleci` command is always available in container `0`.
 
-Access help by running `picard tests help` or see below for descriptions of your options.
+Access help by running `circleci tests help` or see below for descriptions of your options.
 
 - This tool is available on circleci.com and within the [local CircleCI builder](/docs/2.0/local-builds/).
-- You can specify multiple globs.  This is pretty common for test suites in 1.0.  For example: `picard tests glob "tests/unit/*.java" "tests/functional/*.java"`
-- As you migrate from 1.0 to 2.0, it's worthwhile to manually check that your globs pick up exactly what you want and nothing else.  `picard tests glob` scans the filesystem based on the globs you pass it and returns plain text in Bash.  So you can do check your glob results by adding a line like the following:
+- You can specify multiple globs.  This is pretty common for test suites in 1.0.  For example: `circleci tests glob "tests/unit/*.java" "tests/functional/*.java"`
+- As you migrate from 1.0 to 2.0, it's worthwhile to manually check that your globs pick up exactly what you want and nothing else.  `circleci tests glob` scans the filesystem based on the globs you pass it and returns plain text in Bash.  So you can do check your glob results by adding a line like the following:
 
 ```YAML
 - type: shell
   command: |
   # Print all files in one line
-  echo $(picard tests glob "foo/**/*" "bar/**/*")
+  echo $(circleci tests glob "foo/**/*" "bar/**/*")
   # Print one file per line
-  picard tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo
+  circleci tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo
 ```
 
 ## Commands
@@ -35,20 +35,20 @@ Supported patterns:
 - `[abc]`: matches any character (excluding path separators) against characters in braces
 - `{foo,bar,...}`: matches a sequence of characters if any of the alternatives in braces matches
 
-`picard tests glob "**/*.java"`
+`circleci tests glob "**/*.java"`
 
 ### Splitting
 
-`picard` can be used to split a list of test files or classnames when running parallel builds on 2.0.
+`circleci` can be used to split a list of test files or classnames when running parallel builds on 2.0.
 
 The tool uses the environment to look up the total number of containers, along with the current container index. Then, the tool uses deterministic splitting algorithms to return a distinct subset of the input filenames or classnames on each container.
 
 The list of items to split can be provided via standard input or as a file argument.
 
-- piping: `picard tests glob test/**/*.java | picard tests split`
-- stdin redirection: `picard tests split < /path/to/items/to/split`
-- process substitution: `picard tests split <(picard tests glob test/**/*.java)`
-- from file: `picard tests split test_filenames.txt`
+- piping: `circleci tests glob test/**/*.java | circleci tests split`
+- stdin redirection: `circleci tests split < /path/to/items/to/split`
+- process substitution: `circleci tests split <(circleci tests glob test/**/*.java)`
+- from file: `circleci tests split test_filenames.txt`
 
 By default, it’s assumed that the items being split are filenames and should be split by name. However, the tool can also split by filesize or use historical data to split by test runtimes.
 
@@ -58,24 +58,24 @@ Items can be split by `name`, `filesize` (for filepaths), or `timings` (when run
 ##### **name**
 This is the default and splits items alphabetically.
 
-`picard tests glob "**/*.go" | picard tests split`
+`circleci tests glob "**/*.go" | circleci tests split`
 
 ##### **filesize**
 When the items are filepaths, this option will weight the split by filesize.
 
-`picard tests glob "**/*.go" | picard tests split --split-by=filesize`
+`circleci tests glob "**/*.go" | circleci tests split --split-by=filesize`
 
 ##### **timings**
 This split type uses historical timing data to weight the split. CircleCI automatically makes timing data from previous runs available inside your container in a default location so the CLI tool can discover them (`/.circleci-task-data/circle-test-results/`).
 
 When splitting by `timings`, the tool will assume it’s splitting filenames. If you’re splitting classnames, you’ll need to specify that with the `--timings-type` flag.
 
-`picard tests glob "**/*.go" | picard tests split --split-by=timings --timings-type=filename`
+`circleci tests glob "**/*.go" | circleci tests split --split-by=timings --timings-type=filename`
 
-`cat my_java_test_classnames | picard tests split --split-by=timings --timings-type=classname`
+`cat my_java_test_classnames | circleci tests split --split-by=timings --timings-type=classname`
 
 #### Additional flags
-- `--index`: set the container index for this invocation of `picard tests split`
+- `--index`: set the container index for this invocation of `circleci tests split`
 - `--total`: set the total number of containers to consider
 
 When running on CircleCI, these values will be automatically picked up from environment variables.

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -10,7 +10,7 @@ One of the most powerful features of CircleCI is the ability to run your tests i
 
 Access help by running `circleci tests help` or see below for descriptions of your options.
 
-- This tool is available on circleci.com and within the [local CircleCI builder](/docs/2.0/local-builds/).
+- This tool is available on circleci.com and within the [local CircleCI CLI](/docs/2.0/local-jobs/).
 - You can specify multiple globs.  This is pretty common for test suites in 1.0.  For example: `circleci tests glob "tests/unit/*.java" "tests/functional/*.java"`
 - As you migrate from 1.0 to 2.0, it's worthwhile to manually check that your globs pick up exactly what you want and nothing else.  `circleci tests glob` scans the filesystem based on the globs you pass it and returns plain text in Bash.  So you can do check your glob results by adding a line like the following:
 


### PR DESCRIPTION
The CLI tool has been renamed to `circleci` from `picard`.

Update the guide to install the tool locally as `circleci-cli` instead of `circleci-builder`.

Refer to 'jobs' instead of 'builds' where relevant.