### PR TITLE
Fix/sitemap

### DIFF
--- a/jekyll/sitemap.xml
+++ b/jekyll/sitemap.xml
@@ -2,13 +2,20 @@
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{% for doc in site.cci1 %}
-	{% unless doc.deprecated %}
+	<url>
+		<loc>{{ "/" | prepend: site.baseurl | prepend: site.url }}</loc>
+		<changefreq>monthly</changefreq>
+	</url>
+{% for section in site.collections %}
+	{% if section.label == "posts" or section.selectorName == false %}{% continue %}{% endif %}
+	{% assign docs = site.documents | where:"collection",section.label %}
+	{% for doc in docs %}
+		{% unless doc.hide %}
 		<url>
 			<loc>{{ doc.url | prepend: site.baseurl | prepend: site.url | uri_escape }}</loc>
 			<changefreq>{% if doc.changefreq %}{{ doc.changefreq }}{% else %}monthly{% endif %}</changefreq>
-			<lastmod>2016-04-04T14:00:00-07:00</lastmod>
 		</url>
-	{% endunless %}
+		{% endunless %}
+	{% endfor %}
 {% endfor %}
 </urlset>

--- a/jekyll/sitemap.xml
+++ b/jekyll/sitemap.xml
@@ -5,7 +5,7 @@
 {% for doc in site.cci1 %}
 	{% unless doc.deprecated %}
 		<url>
-			<loc>{{ doc.url | prepend: site.baseurl | prepend: site.url }}</loc>
+			<loc>{{ doc.url | prepend: site.baseurl | prepend: site.url | uri_escape }}</loc>
 			<changefreq>{% if doc.changefreq %}{{ doc.changefreq }}{% else %}monthly{% endif %}</changefreq>
 			<lastmod>2016-04-04T14:00:00-07:00</lastmod>
 		</url>


### PR DESCRIPTION
This fixes `sitemap.xml` for Docs. The sitemap file now properly supports Jekyll Collections. This will load all docs from within any collections available.

- specifically added the main index page, which we didn't have before
- entity escapes the URLs now since characters such as `&` are not allowed the the sitemap (and XML) syntax.
- ignores sections that are hidden (`selectorName == false`)
- ignores docs that are hidden (`hide == true`)
- validated output with W3C: https://validator.w3.org/
- uses Google's suggested scheme: https://www.sitemaps.org/protocol.html
---
Fixes #610 
---
@michaelcstearns Any notes you'd like to add?