### PR TITLE
Rename Demo App category and move demo app index inside it

### DIFF
--- a/jekyll/_cci2/demo-apps.md
+++ b/jekyll/_cci2/demo-apps.md
@@ -2,7 +2,7 @@
 layout: classic-docs2
 title: "CircleCI Demo Applications"
 short-title: "Demo App Index"
-categories: [languages-and-tools]
+categories: [language-guides]
 order: 0
 ---
 

--- a/jekyll/_cci2/demo-apps.md
+++ b/jekyll/_cci2/demo-apps.md
@@ -1,9 +1,9 @@
 ---
 layout: classic-docs2
 title: "CircleCI Demo Applications"
-short-title: "Demo Applications"
-categories: [language-guides]
-order: 100
+short-title: "Demo App Index"
+categories: [languages-and-tools]
+order: 0
 ---
 
 We’ve created several demo applications for various languages, so you can learn by example.

--- a/jekyll/_cci2/language-erlang.md
+++ b/jekyll/_cci2/language-erlang.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs2
-title: "Demo App: Erlang"
+title: "Language Guide: Erlang"
 short-title: "Erlang"
-categories: [languages-and-tools]
+categories: [language-guides]
 order: 2
 ---
 

--- a/jekyll/_cci2/language-erlang.md
+++ b/jekyll/_cci2/language-erlang.md
@@ -2,8 +2,8 @@
 layout: classic-docs2
 title: "Demo App: Erlang"
 short-title: "Erlang"
-categories: [demo-apps]
-order: 1
+categories: [languages-and-tools]
+order: 2
 ---
 
 You can use the following `.circleci/config.yml` to start building Phoenix apps. See below for an explanation of each step.

--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs2
-title: "Demo App: Go"
+title: "Language Guide: Go"
 short-title: "Go"
-categories: [languages-and-tools]
+categories: [language-guides]
 order: 3
 ---
 

--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -2,8 +2,8 @@
 layout: classic-docs2
 title: "Demo App: Go"
 short-title: "Go"
-categories: [demo-apps]
-order: 2
+categories: [languages-and-tools]
+order: 3
 ---
 
 This guide will help get you started with a Go project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you’re just looking for a sample `config.yml` file, then just skip to the end.

--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs2
-title: "Demo App: JavaScript"
+title: "Language Guide: JavaScript"
 short-title: "JavaScript"
-categories: [languages-and-tools]
+categories: [language-guides]
 order: 4
 ---
 

--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -2,8 +2,8 @@
 layout: classic-docs2
 title: "Demo App: JavaScript"
 short-title: "JavaScript"
-categories: [demo-apps]
-order: 3
+categories: [languages-and-tools]
+order: 4
 ---
 
 This guide will help get you started with a JavaScript project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you’re just looking for a sample `config.yml` file, then just skip to the end.

--- a/jekyll/_cci2/language-php.md
+++ b/jekyll/_cci2/language-php.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs2
-title: "Demo App: PHP"
+title: "Language Guide: PHP"
 short-title: "PHP"
-categories: [languages-and-tools]
+categories: [language-guides]
 order: 5
 ---
 

--- a/jekyll/_cci2/language-php.md
+++ b/jekyll/_cci2/language-php.md
@@ -2,8 +2,8 @@
 layout: classic-docs2
 title: "Demo App: PHP"
 short-title: "PHP"
-categories: [demo-apps]
-order: 4
+categories: [languages-and-tools]
+order: 5
 ---
 
 This guide will help get you started with a PHP project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you’re just looking for a sample `config.yml` file, then just skip to the end.

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs2
-title: "Demo App: Python"
+title: "Language Guide: Python"
 short-title: "Python"
-categories: [languages-and-tools]
+categories: [language-guides]
 order: 6
 ---
 

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -2,8 +2,8 @@
 layout: classic-docs2
 title: "Demo App: Python"
 short-title: "Python"
-categories: [demo-apps]
-order: 5
+categories: [languages-and-tools]
+order: 6
 ---
 
 This guide will help get you started with a Python project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you're just looking for a sample `config.yml` file, then just skip to the end.

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs2
-title: "Demo App: Ruby"
+title: "Language Guide: Ruby"
 short-title: "Ruby"
-categories: [languages-and-tools]
+categories: [language-guides]
 order: 7
 ---
 

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -2,8 +2,8 @@
 layout: classic-docs2
 title: "Demo App: Ruby"
 short-title: "Ruby"
-categories: [demo-apps]
-order: 6
+categories: [languages-and-tools]
+order: 7
 ---
 
 This guide will help get you started with a Ruby project on CircleCI 2.0. This walkthrough will be pretty thorough and will explain why we need each piece of configuration. If you’re just looking for a sample `config.yml` file, then just skip to the end.

--- a/jekyll/_data/categories.yml
+++ b/jekyll/_data/categories.yml
@@ -91,8 +91,8 @@
   name: "Getting Started"
 
 - section: cci2
-  slug: languages-and-tools
-  name: "Languages and Tools"
+  slug: language-guides
+  name: "Language Guides"
 
 - section: cci2
   slug: configuring-jobs

--- a/jekyll/_data/categories.yml
+++ b/jekyll/_data/categories.yml
@@ -91,8 +91,8 @@
   name: "Getting Started"
 
 - section: cci2
-  slug: demo-apps
-  name: "Demo Applications"
+  slug: languages-and-tools
+  name: "Languages and Tools"
 
 - section: cci2
   slug: configuring-jobs


### PR DESCRIPTION
This is a subtask of [CIRCLE-3339](https://circleci.atlassian.net/browse/CIRCLE-3339):

- rename category from "Demo Applications" back to "Languages and Tools"
- move "Demo App Index" into the sidebar under this category