### PR TITLE
passing a map to machine

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -104,13 +104,14 @@ When you choose the `machine` executor, your build will run in a dedicated, ephe
 ```YAML
 jobs:
   build:
-    machine: true
+    machine:
+      enabled: true
 ```
 
 The VM will run Ubuntu 14.04 with a few additional tools installed. It isn’t possible to specify other images.
 
 ### Why Use the Machine Executor?
-- your application requires full access to OS resources
+- Your application requires full access to OS resources
 
 ### Advantages
 - Gives full control over build environment


### PR DESCRIPTION
Currently `machine` only takes a map. Giving a single value will lead to config error.

Bad
https://circleci.com/gh/kimh/picard-test/1033

Good
https://circleci.com/gh/kimh/picard-test/1034

