### PR TITLE
add trailing forward slash for several docs

### DIFF
--- a/jekyll/_cci2/about-circleci.md
+++ b/jekyll/_cci2/about-circleci.md
@@ -39,7 +39,7 @@ If your tests pass, you can deploy your code to different environments, like dev
 
 ## Next Steps
 
-Set up an account and link a project by following these [first steps]({{ site.baseurl }}/2.0/first-steps), then check out our [Project Walkthrough]({{ site.baseurl }}/2.0/project-walkthrough).
+Set up an account and link a project by following these [first steps]({{ site.baseurl }}/2.0/first-steps/), then check out our [Project Walkthrough]({{ site.baseurl }}/2.0/project-walkthrough/).
 
 [wiki-ci]: https://en.wikipedia.org/wiki/Continuous_integration
 [wiki-unittest]: https://en.wikipedia.org/wiki/Unit_testing
@@ -52,4 +52,4 @@ Set up an account and link a project by following these [first steps]({{ site.ba
 [doc-gke]:  {{ site.baseurl }}/1.0/continuous-deployment-with-google-container-engine/
 [doc-heroku]:  {{ site.baseurl }}/1.0/continuous-deployment-with-heroku/
 [doc-sshdeploy]:  {{ site.baseurl }}/1.0/introduction-to-continuous-deployment/#deploy-over-ssh
-[first-steps]: {{ site.baseurl }}/2.0/first-steps
+[first-steps]: {{ site.baseurl }}/2.0/first-steps/

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -7,7 +7,7 @@ order: 1
 ---
 
 ## Overview
-For security reasons, the [Docker Executor]({{ site.baseurl }}/2.0/executor-types#docker-executor) doesn’t allow building Docker images within a [job space][job-space].
+For security reasons, the [Docker Executor]({{ site.baseurl }}/2.0/executor-types/#docker-executor) doesn’t allow building Docker images within a [job space][job-space].
 
 To help users build, run, and publish new images, we’ve introduced a special feature which creates a separate environment for each build. This environment is remote, fully-isolated and has been configured to execute Docker commands
 
@@ -65,7 +65,7 @@ Let’s break down what’s happening during this build’s execution:
 - We use project environment variables to store credentials for Docker Hub.
 
 ## Separation of Environments
-Since the [job space][job-space] and [remote docker]({{ site.baseurl }}/2.0/glossary#remote-docker) are separated environments, there's one caveat: containers running in your job space can’t directly communicate with containers running in remote docker.
+Since the [job space][job-space] and [remote docker]({{ site.baseurl }}/2.0/glossary/#remote-docker) are separated environments, there's one caveat: containers running in your job space can’t directly communicate with containers running in remote docker.
 
 ### Starting Services
 It’s impossible to start a service in remote docker and ping it directly from a primary container (and vice versa). To solve that, you’ll need to interact with a a service from remote docker, as well as through the same container:
@@ -116,5 +116,5 @@ jobs:
           docker run --network container:db my-app test
 ```
 
-[job-space]: {{ site.baseurl }}/2.0/glossary#job-space
-[primary-container]: {{ site.baseurl }}/2.0/glossary#primary-container
+[job-space]: {{ site.baseurl }}/2.0/glossary/#job-space
+[primary-container]: {{ site.baseurl }}/2.0/glossary/#primary-container

--- a/jekyll/_cci2/demo-apps.md
+++ b/jekyll/_cci2/demo-apps.md
@@ -20,12 +20,12 @@ Language | Framework | GitHub Repo Name
 [Ruby] | Rails | [cci-demo-rails]
 {: class="table"}
 
-[Elixir]: {{ site.baseurl }}/2.0/language-elixir
-[Go]: {{ site.baseurl }}/2.0/language-go
-[JavaScript]: {{ site.baseurl }}/2.0/language-javascript
-[PHP]: {{ site.baseurl }}/2.0/language-php
-[Python]: {{ site.baseurl }}/2.0/language-python
-[Ruby]: {{ site.baseurl }}/2.0/language-ruby
+[Elixir]: {{ site.baseurl }}/2.0/language-elixir/
+[Go]: {{ site.baseurl }}/2.0/language-go/
+[JavaScript]: {{ site.baseurl }}/2.0/language-javascript/
+[PHP]: {{ site.baseurl }}/2.0/language-php/
+[Python]: {{ site.baseurl }}/2.0/language-python/
+[Ruby]: {{ site.baseurl }}/2.0/language-ruby/
 
 [cci-demo-go]: https://github.com/circleci/cci-demo-go
 [cci-demo-react]: https://github.com/circleci/cci-demo-react

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -55,7 +55,7 @@ Images for the Docker build system can be specified in a few ways:
     - `gcr.io/google-containers/busybox@sha256:4bdd623e848417d9612...`
 
 ### Multiple Images
-It’s also possible to specify multiple images. When you do this, all containers will run in a common network. Every exposed port will be available on `localhost` from a [primary container]( {{ site.baseurl }}/2.0/glossary#primary-container).
+It’s also possible to specify multiple images. When you do this, all containers will run in a common network. Every exposed port will be available on `localhost` from a [primary container]( {{ site.baseurl }}/2.0/glossary/#primary-container).
 
 ```YAML
 jobs:
@@ -74,7 +74,7 @@ jobs:
 
 In a multi-image configuration build, steps are executed in the first container listed (main container).
 
-More details on the Docker Executor are available [here]( {{ site.baseurl }}/2.0/configuration-reference).
+More details on the Docker Executor are available [here]( {{ site.baseurl }}/2.0/configuration-reference/).
 
 ### Advantages
 - Fastest way to start a build
@@ -122,4 +122,4 @@ The VM will run Ubuntu 14.04 with a few additional tools installed. It isn’t p
 - Takes additional time to create VM
 - Only the default image is supported; your build may require additional provisioning.
 
-[building-docker-images]: {{ site.baseurl }}/2.0/building-docker-images
+[building-docker-images]: {{ site.baseurl }}/2.0/building-docker-images/

--- a/jekyll/_cci2/first-steps.md
+++ b/jekyll/_cci2/first-steps.md
@@ -26,6 +26,6 @@ You’ll automatically follow any new project that you push to, but you can also
 
 Now that you’ve integrated with a VCS and added one of your projects, you’ll need to create a `.circleci/config.yml` file to tell CircleCI what to do during each build.
 
-Head to our [Project Walkthrough]({{ site.baseurl }}/2.0/project-walkthrough) for a sample `config.yml` and explanation of each component of the file.
+Head to our [Project Walkthrough]({{ site.baseurl }}/2.0/project-walkthrough/) for a sample `config.yml` and explanation of each component of the file.
 
-Or, if you have a specific language in mind, check out our [demo applications]({{ site.baseurl }}/2.0/demo-apps).
+Or, if you have a specific language in mind, check out our [demo applications]({{ site.baseurl }}/2.0/demo-apps/).

--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -10,13 +10,13 @@ We are currently in Beta, so lots will be changing here. We LOVE it when you mak
 
 ## I'm new to CircleCI, where should I go?
 
-If you’re completely new to CircleCI, then go read about [what we do]({{ site.baseurl }}/2.0/about-circleci) and follow up with your [first steps]({{ site.baseurl }}/2.0/first-steps).
+If you’re completely new to CircleCI, then go read about [what we do]({{ site.baseurl }}/2.0/about-circleci/) and follow up with your [first steps]({{ site.baseurl }}/2.0/first-steps/).
 
 ## I'm a current CircleCI user, where can I learn what's new in 2.0?
 
-If you’re familiar with CircleCI, you should check out the major changes in 2.0 and learn how to [migrate from 1.0]({{ site.baseurl }}/2.0/migrating-from-1-2).
+If you’re familiar with CircleCI, you should check out the major changes in 2.0 and learn how to [migrate from 1.0]({{ site.baseurl }}/2.0/migrating-from-1-2/).
 
-Do you just want to see working configuration for a [sample project]({{ site.baseurl }}/2.0/project-walkthrough)? Or maybe you have a [specific language or framework]({{ site.baseurl }}/2.0/demo-apps) in mind?
+Do you just want to see working configuration for a [sample project]({{ site.baseurl }}/2.0/project-walkthrough/)? Or maybe you have a [specific language or framework]({{ site.baseurl }}/2.0/demo-apps/) in mind?
 
 Wherever you start, we’re thrilled to have you here. Happy building!
 

--- a/jekyll/_cci2/local-jobs.md
+++ b/jekyll/_cci2/local-jobs.md
@@ -96,4 +96,4 @@ We plan to remove this limitation in a future update.
 
 ## Using the CircleCI CLI non-locally
 
-The CircleCI CLI is available in all CircleCI environments. For example, check out [Parallelism for Faster Jobs]({{ site.baseurl }}/2.0/parallelism-faster-jobs) to see how you use the tool to manage paralellism in a remote hosted environment.
+The CircleCI CLI is available in all CircleCI environments. For example, check out [Parallelism for Faster Jobs]({{ site.baseurl }}/2.0/parallelism-faster-jobs/) to see how you use the tool to manage paralellism in a remote hosted environment.

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -25,7 +25,7 @@ While this configuration can be powerful, there are some drawbacks. Maybe you wa
 
 In 2.0, jobs are broken into granular steps. You can compose these steps within a job at your discretion. This gives you greater flexibility to run your build the way you want.
 
-To learn more, please see the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference).
+To learn more, please see the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/).
 
 ### Custom Build Image
 In 1.0, you’re restricted to the build image CircleCI provides. In Linux builds, there are 2 images you can use: Ubuntu 12.04 and 14.04. While these images come with many languages and tools pre-installed, it’s frustrating if you need a version of a service or dependency that isn’t included.


### PR DESCRIPTION
Missed the whole "complete URL" bit when adding links in the docs. This PR should fix all current links in docs.