### PR TITLE
Switch example to use pre

### DIFF
--- a/jekyll/_cci1/how-cache-works.md
+++ b/jekyll/_cci1/how-cache-works.md
@@ -45,7 +45,7 @@ like this:
 
 ```yaml
 dependencies:
-  override:
+  pre:
     - mkdir ~/my_cache_dir
     # now add files and directories to the above directory
   cache_directories:


### PR DESCRIPTION
Suggesting overriding the inferred dependencies step without the context of what overriding does could (did :( ) cause someone to not notice they were reliant on inferred dependency steps later in their build.