### PR TITLE
Add notes on using non-pre-installed Node versions

### DIFF
--- a/jekyll/_cci1/language-nodejs.md
+++ b/jekyll/_cci1/language-nodejs.md
@@ -16,7 +16,7 @@ commands that will run after a green build.
 
 ### Version
 
-We have many versions of NodeJS pre-installed on [Ubuntu 12.04]( {{ site.baseurl }}/1.0/build-image-precise/#nodejs) and [Ubuntu 14.04]( {{ site.baseurl }}/1.0/build-image-trusty/#nodejs) build images.
+We have many versions of NodeJS pre-installed on [Ubuntu 12.04]( {{ site.baseurl }}/1.0/build-image-precise/#nodejs) and [Ubuntu 14.04]( {{ site.baseurl }}/1.0/build-image-trusty/#nodejs) build images. If a non-pre-installed version is specified, CircleCI will download and use that version.
 
 If you don't want to use the default, you can specify your version in `circle.yml`:
 


### PR DESCRIPTION
The existing [documentation](https://circleci.com/docs/1.0/language-nodejs/#version) on picking a NodeJS version point the user to the list of versions pre-installed on the Ubuntu containers. These lists do not contain newer NodeJS (e.g. 6.10.0). I think this implies that you can't specify that version number in `circle.yml`. In fact you can, and CircleCI just downloads and uses the version specified.

This PR adds a sentence explaining that you can use non-pre-installed versions.

I've only tested this with `v6.10.0`, and it may not be true for all versions of NodeJS.