### PR TITLE
CircleCI 2.0 PHP Improvement

### DIFF
--- a/jekyll/_cci2/language-php.md
+++ b/jekyll/_cci2/language-php.md
@@ -48,9 +48,10 @@ jobs:
       - run:
           name: Install Composer
           command: |
-            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-            php -r "if (hash_file('SHA384', 'composer-setup.php') === 'aa96f26c2b67226a324c27919f1eb05f21c248b987e6195cad9690d5c1ff713d53020a02ac8c217dbf90a7eacc9d141d') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-            php composer-setup.php
+            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+            php -r "copy('https://composer.github.io/installer.sig', 'composer-setup.sig');" && \
+            php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('composer-setup.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+            php composer-setup.php && \
             php -r "unlink('composer-setup.php');"
       - run:
           name: Install Project Dependencies


### PR DESCRIPTION
Instead of confirming the composer installer using a hardcoded hash, which will fail the next time composer updates, you can instead copy down a signature file and compare that way.