### PR TITLE
make audience/voice consistent across 2.0 index page

### DIFF
--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -8,16 +8,16 @@ Thanks for your interest in CircleCI 2.0!
 
 We are currently in Beta, so lots will be changing here. We LOVE it when you make suggestions (or, even better, make pull requests on the <a href="{{ site.gh_url }}">open source repo</a> that powers these docs) that address any errors or shortcomings you find here.
 
-## I'm new to CircleCI, where should I go?
+## If you're completely new to CircleCI...
 
-If you’re completely new to CircleCI, then go read about [what we do]({{ site.baseurl }}/2.0/about-circleci/) and follow up with your [first steps]({{ site.baseurl }}/2.0/first-steps/).
+Read about [what we do]({{ site.baseurl }}/2.0/about-circleci/) and follow up with your [first steps]({{ site.baseurl }}/2.0/first-steps/).
 
-## I'm a current CircleCI user, where can I learn what's new in 2.0?
+## If you're familiar with CircleCI...
 
-If you’re familiar with CircleCI, you should check out the major changes in 2.0 and learn how to [migrate from 1.0]({{ site.baseurl }}/2.0/migrating-from-1-2/).
+Check out the major changes in 2.0 and learn how to [migrate from 1.0]({{ site.baseurl }}/2.0/migrating-from-1-2/).
 
-Do you just want to see working configuration for a [sample project]({{ site.baseurl }}/2.0/project-walkthrough/)? Or maybe you have a [specific language or framework]({{ site.baseurl }}/2.0/demo-apps/) in mind?
+Do you just want to see working configuration for a [sample project]({{ site.baseurl }}/2.0/project-walkthrough/)? Or maybe you have a [specific language or framework]({{ site.baseurl }}/2.0/demo-apps/) in mind? Wherever you start, we’re thrilled to have you here.
 
-Wherever you start, we’re thrilled to have you here. Happy building!
+Happy building!
 
 _The CircleCI Team_


### PR DESCRIPTION
It's weird to be talking about "we're" doing as CircleCI devs and then shift
to a question where "I'm" new to CircleCI. This change makes the voice
consistent across the doc.