### PR TITLE
Fix 1.0 API doc redirect.

### DIFF
--- a/jekyll/_cci1/api.md
+++ b/jekyll/_cci1/api.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs
 title: "CircleCI API"
-redirect: /docs/api/reference/
+redirect: /docs/api/v1-reference/
 ---
 
-<h1>This page has moved. You should be automatically redirected, but if that didn't work you can <a href="/docs/api/reference/">click here</a>.</h1> 
+<h1>This page has moved. You should be automatically redirected, but if that didn't work you can <a href="/docs/api/v1-reference/">click here</a>.</h1> 
 


### PR DESCRIPTION
This fixes the broken redirect from #795. Merge right away once tests pass since this is broken.