### PR TITLE
[CIRCLE-3496] Stop requiring ESXI migrations in CCIE iOS setup guide

### DIFF
--- a/jekyll/_ccie/ios-install.md
+++ b/jekyll/_ccie/ios-install.md
@@ -88,8 +88,6 @@ user=>
           :private-key (slurp path-to-private-key)}))
           fleet "osx"]
 
-
-  (circle.backend.model.esxi-vm/run-migrations!) ;; Safe to run multiple times
   (circle.backend.model.esxi-vm/create-esxi-box
    num-vms
    encrypted-keypair


### PR DESCRIPTION
Starting on the next CCIE release, it will no longer be necessary to run ESXI migrations when setting up iOS infrastructure. The migrations will be run via `circleci run-migrations` instead.