### PR TITLE
Adding a note about default job

### DIFF
--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -3,7 +3,7 @@ layout: classic-docs
 title: "Uploading Build Artifacts"
 short-title: "Uploading Build Artifacts"
 categories: [configuring-jobs]
-order: 98
+order: 5
 ---
 
 Sometimes, you'll want to upload artifacts created during builds so you can view them later. The following is an example of how to do that:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -22,9 +22,9 @@ The `version` field is intended to be used in order to issue warnings for deprec
 
 ## **`jobs`**
 
-Each job is an item in the `jobs` list. `build` is the default job and every config file must have a `build` job. This is the only job that will be automatically picked up and run by CircleCI.
+Each job is an item in the `jobs` list. `build` is the default job and is required in every `config.yml`. This is the only job that will be automatically picked up and run by CircleCI.
 
-Each job consists of a job's name as a key and a map as a value. A name should be unique within a current `jobs` list. The value map  has the following attributes:
+Each job consists of the job's name as a key and a map as a value. A name should be unique within a current `jobs` list. The value map has the following attributes:
 
 Key | Required | Type | Description
 ----|-----------|------|------------

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -22,7 +22,9 @@ The `version` field is intended to be used in order to issue warnings for deprec
 
 ## **`jobs`**
 
-Each job is an item in the `jobs` list. Each job consists of a job's name as a key and a map as a value. A name should be unique within a current `jobs` list. The value map  has the following attributes:
+Each job is an item in the `jobs` list. `build` is the default job and every config file must have a `build` job. This is the only job that will be automatically picked up and run by CircleCI.
+
+Each job consists of a job's name as a key and a map as a value. A name should be unique within a current `jobs` list. The value map  has the following attributes:
 
 Key | Required | Type | Description
 ----|-----------|------|------------

--- a/jekyll/_cci2/deployments.md
+++ b/jekyll/_cci2/deployments.md
@@ -3,7 +3,7 @@ layout: classic-docs
 title: "Deployments"
 short-title: "Deployments"
 categories: [configuring-jobs]
-order: 98
+order: 6
 ---
 
 There are 2 standard ways to deploy in 2.0:

--- a/jekyll/_cci2/deployments.md
+++ b/jekyll/_cci2/deployments.md
@@ -83,7 +83,9 @@ jobs:
             fi
 ```
 
-The above example shows how to trigger a `deploy` job for the deployment. Here, we're triggering the job by calling the CircleCI REST API with `curl`. The `deploy` job will then do the actual deployment. We have to manually trigger the `deploy` job because currently CircleCI only runs `build` job automatically. To learn more about jobs, check out our [documentation]({{ site.baseurl }}/2.0/configuration-reference/#jobs).
+The above example shows how to trigger a `deploy` job for the deployment. Here, we're triggering the job by calling the CircleCI REST API with `curl`. The `deploy` job will then do the actual deployment. We have to manually trigger this `deploy` job because `build` is the only job CircleCI currently runs automatically.
+
+To learn more about jobs, check out our [documentation]({{ site.baseurl }}/2.0/configuration-reference/#jobs).
 
 A few notes about this example:
 

--- a/jekyll/_cci2/deployments.md
+++ b/jekyll/_cci2/deployments.md
@@ -83,7 +83,7 @@ jobs:
             fi
 ```
 
-The above example shows how to trigger a `deploy` job for the deployment. Here, we're triggering the job by calling the CircleCI REST API with `curl`. The `deploy` job will then do the actual deployment.
+The above example shows how to trigger a `deploy` job for the deployment. Here, we're triggering the job by calling the CircleCI REST API with `curl`. The `deploy` job will then do the actual deployment. We have to manually trigger the `deploy` job because currently CircleCI only runs `build` job automatically. Please check out out [documentation]({{ site.baseurl }}/2.0/configuration-reference/#jobs) to learn more about jobs.
 
 A few notes about this example:
 

--- a/jekyll/_cci2/deployments.md
+++ b/jekyll/_cci2/deployments.md
@@ -83,7 +83,7 @@ jobs:
             fi
 ```
 
-The above example shows how to trigger a `deploy` job for the deployment. Here, we're triggering the job by calling the CircleCI REST API with `curl`. The `deploy` job will then do the actual deployment. We have to manually trigger the `deploy` job because currently CircleCI only runs `build` job automatically. Please check out out [documentation]({{ site.baseurl }}/2.0/configuration-reference/#jobs) to learn more about jobs.
+The above example shows how to trigger a `deploy` job for the deployment. Here, we're triggering the job by calling the CircleCI REST API with `curl`. The `deploy` job will then do the actual deployment. We have to manually trigger the `deploy` job because currently CircleCI only runs `build` job automatically. To learn more about jobs, check out our [documentation]({{ site.baseurl }}/2.0/configuration-reference/#jobs).
 
 A few notes about this example:
 


### PR DESCRIPTION
We should highlight the fact that CircleCI only runs `build` job automatically.