### PR TITLE
Minor spelling fix (it's -> its)

### DIFF
--- a/jekyll/_cci2/local-jobs.md
+++ b/jekyll/_cci2/local-jobs.md
@@ -78,7 +78,7 @@ Although running jobs locally with `circleci` is very helpful, there are some li
 
 ### Machine Executor
 
-You cannot use the machine executor in local jobs. This is because the machine executor requires an extra VM to run it's jobs.
+You cannot use the machine executor in local jobs. This is because the machine executor requires an extra VM to run its jobs.
 
 ### Caching
 


### PR DESCRIPTION
Does what it says on the tin.