### PR TITLE
URL to Sauce Connect Documentation has changed

### DIFF
--- a/jekyll/_cci1/browser-testing-with-sauce-labs.md
+++ b/jekyll/_cci1/browser-testing-with-sauce-labs.md
@@ -7,7 +7,7 @@ description: How to test Sauce Labs on Circleci
 ---
 
 You can run Selenium WebDriver tests with Sauce Labs on CircleCI using Sauce Labs'
-secure tunnel, [Sauce Connect](https://docs.saucelabs.com/reference/sauce-connect/).
+secure tunnel, [Sauce Connect](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy).
 Sauce Connect allows you to run a test server within the CircleCI build container
 and expose it (using a URL like `localhost:8080`) to Sauce Labs' browsers. If you
 run your browser tests after deploying to a publicly accessible staging environment,


### PR DESCRIPTION
The current URL to https://docs.saucelabs.com/reference/sauce-connect/ redirects to https://wiki.saucelabs.com/display/DOCS/Setting+Up+Sauce+Connect results in an error page that the content has been deleted. Sauce Lab's documentation for Sauce Connect points to https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy