### PR TITLE
renamed `setup_docker_engine` step

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -20,10 +20,10 @@ jobs:
     steps:
       # ... steps for building/testing app ...
 
-      - setup_docker_engine
+      - setup_remote_docker
 ```
 
-When `setup_docker_engine` executes, a remote environment will be created, and your current [primary container][primary-container] will be configured to use it. Then, any docker-related commands you use will be safely executed in this new environment.
+When `setup_remote_docker` executes, a remote environment will be created, and your current [primary container][primary-container] will be configured to use it. Then, any docker-related commands you use will be safely executed in this new environment.
 
 ### Example
 Here's an example where we build and push a Docker image for our [demo docker project](https://github.com/circleci/cci-demo-docker):
@@ -39,7 +39,7 @@ jobs:
       - checkout
       # ... steps for building/testing app ...
 
-      - setup_docker_engine   # (2)
+      - setup_remote_docker   # (2)
 
       # use a primary image that already has Docker (recommended)
       # or install it during a build like we do here
@@ -63,7 +63,7 @@ jobs:
 Let’s break down what’s happening during this build’s execution:
 
 1. All commands are executed in the [primary container][primary-container].
-2. Once `setup_docker_engine` is called, a new remote environment is created, and your primary container is configured to use it.
+2. Once `setup_remote_docker` is called, a new remote environment is created, and your primary container is configured to use it.
 3. All docker-related commands are also executed in your primary container, but building/pushing images and running containers happens in the remote Docker Engine.
 4. We use project environment variables to store credentials for Docker Hub.
 

--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -24,7 +24,7 @@ In order to use `docker-compose`, you'll need to have it in your [primary contai
 To activate the Remote Docker Environment, you need use [this special step]({{ site.baseurl }}/2.0/building-docker-images):
 
 ``` YAML
-- setup_docker_engine
+- setup_remote_docker
 ```
 
 After that, you can use `docker-compose` as usual. You can build images:

--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -12,7 +12,7 @@ If your application is distributed as a Docker image, you probably know that thi
 If this is the case, you might want to reuse the unchanged layers to significantly reduce image build times. By default, the [Remote Docker Environment]({{ site.baseurl }}/2.0/building-docker-images) doesn't provide layer caching, but you can enable this feature with a special option:
 
 ``` YAML
-- setup_docker_engine:
+- setup_remote_docker:
     reusable: true    # default - false
     exclusive: true   # default - true
 ```

--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -19,7 +19,7 @@ jobs:
     working_directory: ~/my_app
     steps:
       - checkout
-      - setup_docker_engine
+      - setup_remote_docker
 
       # start proprietary DB using private Docker image
       - run: |


### PR DESCRIPTION
`setup_docker_engine` step renamed into `setup_remote_docker`
Do not merge until https://github.com/circleci/build-agent/pull/318 released