### PR TITLE
Improve 'make this document better' links

### DIFF
--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -1,10 +1,12 @@
 <br />
 <hr />
-<h2>Help make this document better...</h2>
-<p>This guide, as well as the rest of our docs, are open-source and available on <a href="{{ site.gh_url }}">GitHub</a>. We welcome <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs">your contributions</a> to make these docs better.
+<h2>Help make this document better</h2>
+<p>This guide, as well as the rest of our docs, are open-source and available on <a href="{{ site.gh_url }}">GitHub</a>. We welcome your contributions.
 </p>
 <ul>
-	<li><a href="{{ site.gh_url }}/issues/new?title=RE%3A%20jekyll/{{ page.path }}" target=_blank>Open an issue about this page</a> to leave feedback.
-	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}">Suggest an edit of this page</a> if you have a way to make it better.
+	<li>Please read the <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs" target="_blank">contributing guide</a>.
+	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}" target="_blank">Suggest an edit to this page</a>.
+	<li><a href="{{ site.gh_url }}/issues/new?body=This issue is about <https://circleci.com/docs{{ page.url }}>" target="_blank">Open an issue about this page</a> to report an error or problem.
+	<li><a href="https://discuss.circleci.com/" target="_blank">Visit our forum 'Discuss'</a> to ask question and search for other solutions.
 </ul>
 <hr />

--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -4,9 +4,8 @@
 <p>This guide, as well as the rest of our docs, are open-source and available on <a href="{{ site.gh_url }}">GitHub</a>. We welcome your contributions.
 </p>
 <ul>
-	<li>Please read the <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs" target="_blank">contributing guide</a>.
-	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}" target="_blank">Suggest an edit to this page</a>.
-	<li><a href="{{ site.gh_url }}/issues/new?body=This issue is about <https://circleci.com/docs{{ page.url }}>" target="_blank">Open an issue about this page</a> to report an error or problem.
-	<li><a href="https://discuss.circleci.com/" target="_blank">Visit our forum 'Discuss'</a> to ask question and search for other solutions.
+	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}" target="_blank">Suggest an edit to this page</a> (please read the <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs" target="_blank">contributing guide</a> first).</li>
+	<li><a href="{{ site.gh_url }}/issues/new?body=This%20issue%20is%20about%20<https://circleci.com/docs{{ page.url }}>%20(source%20file%3A%20<{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}>)" target="_blank">Open an issue about this page</a> to report a problem.</li>
+	<li><a href="https://discuss.circleci.com/" target="_blank">Visit our forum 'Discuss'</a> to ask questions and search for solutions.</li>
 </ul>
 <hr />


### PR DESCRIPTION
closes #706

This simplifies some text, adds a link to Discuss on all docs pages and makes the link to a new issue fill out the 'body' rather than the title:

![image](https://cloud.githubusercontent.com/assets/809823/24153694/131447bc-0e47-11e7-81ed-bcea7a9272c9.png)

This means the person submitting the issue will have to create a title (thus preventing lots of unhelpfully titled issues with file name links) while automatically providing a link to the referring page.