### PR TITLE
Allow search engines to start indexing 2.0 docs.

### DIFF
--- a/jekyll/_cci1/index.md
+++ b/jekyll/_cci1/index.md
@@ -20,7 +20,7 @@ permalink: /1.0/index.html
 	<ul class="list-unstyled">
 	{% assign docs_found = 0 %}
 	{% for doc in site.cci1 %}
-		{% if doc.categories contains category.slug and doc.slug != catFile and doc.hide != True and doc.section == "cci1" %}
+		{% if doc.categories contains category.slug and doc.slug != catFile and doc.hide != true %}
 			{% assign docs_found = docs_found | plus: 1 %}
 			{% if docs_found < 4 %}
 				{% if doc.short-title %}

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -49,13 +49,6 @@ defaults:
       path: ""
     values:
       hide: false
-      section: cci1
       search: true
-  -
-    scope:
-      path: ""
-      type: cci2
-    values:
-      search: false
 
 segment: 'mAJ9W2SwLHgmJtFkpaXWCbwEeNk9D8CZ'

--- a/jekyll/_includes/head.html
+++ b/jekyll/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
 	{% unless page.search %}<meta name="robots" content="noindex" />{% endunless %}
-	<meta charset="utf-8">
+	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">


### PR DESCRIPTION
This allows search engines like Google to index docs from the 2.0 section.

Also, the change in `jekyll/_cci1/index.md` is actually a bugfix I caught while I was in that file.