### PR TITLE
Fix typo in CCI1 Docker page

### DIFF
--- a/jekyll/_cci1/docker.md
+++ b/jekyll/_cci1/docker.md
@@ -7,7 +7,7 @@ description: Continuous Integration and Delivery with Docker
 
 **CircleCI 2.0 is now in Beta with native Docker support. Please see the [Beta access page](https://circleci.com/beta-access/) and the [2.0 Documentation]({{ site.baseurl }}/2.0/).**
 
-CircleCI 1.0 offers support for running Docker within build containers. Support for Docker on CircleCI 1.0 is limited to Docker up to version 1.9 and has several limitations. **If you're starting a new project that uses Docker,we strongly recommend using CircleCI 2.0. This documentation is for customers using Docker for existing projects on CircleCI 1.0.**
+CircleCI 1.0 offers support for running Docker within build containers. Support for Docker on CircleCI 1.0 is limited to Docker up to version 1.9 and has several limitations. **If you're starting a new project that uses Docker, we strongly recommend using CircleCI 2.0. This documentation is for customers using Docker for existing projects on CircleCI 1.0.**
 
 ---
 


### PR DESCRIPTION
Just adds a space.