### PR TITLE
Add heroku.com to ssh known host

### DIFF
--- a/jekyll/_cci2/project-walkthrough.md
+++ b/jekyll/_cci2/project-walkthrough.md
@@ -393,6 +393,9 @@ Now, create a `setup-heroku.sh` file in the `.circleci` folder and add the follo
     login $HEROKU_LOGIN
     password $HEROKU_API_KEY
   EOF
+  
+  # Add heroku.com to the list of known hosts
+  ssh-keyscan -H heroku.com >> ~/.ssh/known_hosts
 ```
 
 **Make sure to replace `cci-demo-walkthrough` with your own app's name.**


### PR DESCRIPTION
Without it, my build would be stuck on:
```
The authenticity of host 'heroku.com (50.xx.x.xx.xx)' can't be established.
RSA key fingerprint is 8b:48:5e:67:0e:c9:16:47:32:f2:87:0c:1f:c8:60:ad.
Are you sure you want to continue connecting (yes/no)?
```