### PR TITLE
2.0 doesn't support env-var interpolation yet

### DIFF
--- a/jekyll/_cci2/language-clojure.md
+++ b/jekyll/_cci2/language-clojure.md
@@ -39,8 +39,8 @@ jobs:
       - run: bin/lein deps
       - save_cache:
           paths:
-            - $HOME/.m2
-            - $HOME/.lein
+            - ~/.m2
+            - ~/.lein
           key: {{ checksum "project.clj" }}
       - run: bin/lein do test, uberjar
       - store_artifacts:
@@ -116,8 +116,8 @@ Finally we store the uberjar as an [artifact](https://circleci.com/docs/1.0/buil
       - run: bin/lein deps
       - save_cache:
           paths:
-            - $HOME/.m2
-            - $HOME/.lein
+            - ~/.m2
+            - ~/.lein
           key: {{ checksum "project.clj" }}
       - run: bin/lein do test, uberjar
       - store_artifacts:


### PR DESCRIPTION
So use tilda instead