### PR TITLE
Fix section index page URLs.

### DIFF
--- a/jekyll/_api/index.html
+++ b/jekyll/_api/index.html
@@ -1,5 +1,5 @@
 ---
 layout: index-page
 title: "CircleCI API Documentation"
-permalink: /api/index.html
+permalink: /api/
 ---

--- a/jekyll/_cci1/index.md
+++ b/jekyll/_cci1/index.md
@@ -2,7 +2,7 @@
 layout: classic-docs
 page-type: index
 title: "CircleCI 1.0 Documentation"
-permalink: /1.0/index.html
+permalink: /1.0/
 ---
 
 {% for category in site.data.categories %}

--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -1,7 +1,7 @@
 ---
 layout: classic-docs
 title: "Welcome to CircleCI 2.0"
-permalink: /2.0/index.html
+permalink: /2.0/
 ---
 
 Thanks for your interest in CircleCI 2.0!

--- a/jekyll/_ccie/index.html
+++ b/jekyll/_ccie/index.html
@@ -1,5 +1,5 @@
 ---
 layout: index-page
 title: "Enterprise"
-permalink: /enterprise/index.html
+permalink: /enterprise/
 ---


### PR DESCRIPTION
The URLs for section index pages were showing up incorrectly in the sitemap. This PR fixes that.

cc: @michaelcstearns 