### PR TITLE
Add AWS CLI page

### DIFF
--- a/jekyll/_cci2/configure_aws_cli.md
+++ b/jekyll/_cci2/configure_aws_cli.md
@@ -1,0 +1,11 @@
+---
+layout: classic-docs
+title: "Configuring AWS CLI"
+short-title: "Configuring AWS CLI"
+categories: [configuring-jobs]
+order: 90
+---
+
+You can add your AWS credentials from **Project Settings > AWS Permissions** page.
+
+The **Access Key ID** and **Secret Access Key** that you entered will be automatically available in your primary build container and exposed as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environmental variables.

--- a/jekyll/_cci2/deployment_integrations.md
+++ b/jekyll/_cci2/deployment_integrations.md
@@ -1,10 +1,14 @@
 ---
 layout: classic-docs
-title: "Configuring AWS CLI"
-short-title: "Configuring AWS CLI"
-categories: [configuring-jobs]
-order: 90
+title: "Deployment Integrations"
+short-title: "Deployment Integrations"
+categories: [deploying]
+order: 1
 ---
+
+## AWS
+
+### Configuring AWS CLI
 
 You can add your AWS credentials from **Project Settings > AWS Permissions** page.
 

--- a/jekyll/_data/categories.yml
+++ b/jekyll/_data/categories.yml
@@ -103,6 +103,10 @@
   name: "Using Docker"
 
 - section: cci2
+  slug: deploying
+  name: "Deploying"
+
+- section: cci2
   slug: reference
   name: "Reference"
 


### PR DESCRIPTION
Now 2.0 uses AWS credentials configured from the project setting page.

I'm not sure if having a dedicated page for this is good since the page is very sparse. If there are better places, please let me know.