### PR TITLE
Fix chown command for GKE tutorial

### DIFF
--- a/jekyll/_cci1/continuous-deployment-with-google-container-engine.md
+++ b/jekyll/_cci1/continuous-deployment-with-google-container-engine.md
@@ -145,7 +145,7 @@ once. Our new image is now available in GCR for all our GCP infrastructure to
 access.
 
 ```
-sudo chown -R ubuntu:ubuntu /home/ubuntu/.kube
+sudo chown -R ubuntu:ubuntu ~/.kube
 ```
 
 Since we used `gcloud` as root (via sudo), the newly installed `kubectl` binary


### PR DESCRIPTION
Beginning 2017-04-05, Circle no longer seems to have a `/home/ubuntu` directory, so `.kube/` is no longer located there. I found `.kube/` now in `~/.kube`. By chowning the new `.kube/` location, the kubectl command functions correctly again, rather than complaining about missing credentials.