### PR TITLE
wget instead of curl

### DIFF
--- a/jekyll/_cci1/browser-testing-with-sauce-labs.md
+++ b/jekyll/_cci1/browser-testing-with-sauce-labs.md
@@ -31,7 +31,7 @@ test:
     - python -m hello.hello_app:
         background: true
     # Wait for app to be ready
-    - curl --retry 10 --retry-delay 2 -v http://localhost:5000
+    - wget --retry-connrefused --no-check-certificate -T 30 http://localhost:5000
     # Run selenium tests
     - nosetests
   post:


### PR DESCRIPTION
curl dies immediately if the connection is refused (e.g. as the app is starting). wget can retry on connection refused, which is much more robust during an app boot.