### PR TITLE
testing fix for x-origin issue

### DIFF
--- a/jekyll/assets/js/main.js
+++ b/jekyll/assets/js/main.js
@@ -58,7 +58,7 @@ var trackEvent = function (name, properties, options, callback) {
 };
 
 // analytics tracking for CTA button clicks
-jQuery(document).ready(function($) {
+$(document).ready(function() {
   $("[data-analytics-action]").click(function (e) {
     var action = $(this).data('analytics-action');
     if (!action) { return; }


### PR DESCRIPTION
When trying to trigger tracking events on the docs site, a strange `cross-origin request blocked` error is issued. I can call the `trackEvent()` function with no problem, and it passes the info to segment (I checked in the segment debugger). So, I suspect the issue has something to do with the data binding that is calling the event. 

This commit changes the way jQuery is implemented, using the same method as is used in the rest of docs. I think the xorigin error may have been due to trying to reference the jquery library on outer, but we shall see. I'll need to push it to be sure.

@lewisl9029 @travis @JustinC474 