### PR TITLE
Improve visibility of API docs

### DIFF
--- a/jekyll/_api/index.html
+++ b/jekyll/_api/index.html
@@ -1,5 +1,17 @@
 ---
-layout: index-page
+layout: classic-docs
 title: "CircleCI API Documentation"
 permalink: /api/
 ---
+
+<p>The current version of the CircleCI API is <code>1.1</code>.</p>
+
+<p><strong>CircleCI 1.0 and 2.0 are both supported by this version of the API.</strong></p>
+
+<div class="category-section">
+    <h2>API Reference</h2>
+        <ul class="list-unstyled">
+            <li><a href="/docs/api/v1-reference/">CircleCI API v1.1 Reference</a></li>
+        </ul>
+</div>
+

--- a/jekyll/_api/v1-reference.md
+++ b/jekyll/_api/v1-reference.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: CircleCI API v1.x Reference
+title: CircleCI API v1.1 Reference
 categories: [reference]
 description: Using the CircleCI API
 ---
@@ -9,6 +9,8 @@ The CircleCI API is a RESTful, fully-featured API that allows you to do almost
 anything in CircleCI. You can access all information and trigger all actions. 
 The only thing we don't provide access to is billing functions, which must be 
 done from the CircleCI web UI.
+
+CircleCI 1.0 and 2.0 are supported by API version `1.1`.
 
 ## Summary
 

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -17,14 +17,14 @@ title: CircleCI Documentation
 		<p>Documentation specific to customers administering self-hosted, behind the firewall CircleCI Enterprise.</p>
 </div>
 <div class="category-section">
+	<h2><a href="/docs/api/v1-reference/">API Docs</a></h2>
+		<p>API reference. Current version <code>1.1</code> includes support for CircleCI 1.0, 2.0 and Enterprise.</p>
+</div>
+<div class="category-section">
 	<h2><a href="https://discuss.circleci.com/">Community</a></h2>
 		<p>We welcome your feedback, questions and feature requests on our community forums - <a href="https://discuss.circleci.com/">Discuss</a>. Searching the forums is a great way to find solutions to specific issues not covered by the docs.</p>
 </div>
 <div class="category-section">
 	<h2>Support</h2>
 		<p>Engineering support is available for customers on paid plans. You can submit a ticket from within the application by clicking the question mark icon at the bottom right of the screen.</p>
-</div>
-<div class="category-section">
-  <h2>Contribute</h2>
-    <p>CircleCI documentation is <a href="{{ site.gh_url }}">open source</a>, and we welcome your feedback and/or pull requests to improve or correct anything you find here.</p>
 </div>


### PR DESCRIPTION
The current landing page for the API section looks cramped:

![image](https://cloud.githubusercontent.com/assets/809823/24923138/86cb02fc-1ee8-11e7-8cae-7f9de7b2cb2f.png)

This adds some context and improves layout:

![image](https://cloud.githubusercontent.com/assets/809823/24923174/9fc665b2-1ee8-11e7-8a82-636aa37b4ce4.png)

The current docs 'home' page does not have a link to the API:

![image](https://cloud.githubusercontent.com/assets/809823/24923192/b2e52232-1ee8-11e7-95ba-a019d9b26ad2.png)

This removes the 'Contribute' section (since that is at the bottom of all pages) and replaces it with an API section:

![image](https://cloud.githubusercontent.com/assets/809823/24923228/d027f5cc-1ee8-11e7-869e-ae004c44a225.png)

The title of the API reference page has been changed from `1.x` to `1.1` since the doc is specific to 1.1. URLs have not been changed.