### PR TITLE
Add a third party info include banner

### DIFF
--- a/jekyll/_includes/third-party-info.html
+++ b/jekyll/_includes/third-party-info.html
@@ -1,0 +1,7 @@
+<div class="alert alert-info" role="alert">
+  <p>
+    <span class="fa fa-bullhorn" style="color: green; font-size: 125%;" aria-hidden="true"></span>
+    <strong>3rd Party Library or Application Notice: {{ include.app }}</strong><br>
+    {{ include.app }} is not developed or supported by CircleCI. Please check with the owner if you have issues using it with CircleCI. If you're unable to resolve the issue you can <a class="alert-link" href="https://discuss.circleci.com/">search and ask on our forum, Discuss</a>. 
+  </p>
+</div>


### PR DESCRIPTION
Adds an include that will display like this:

![image](https://cloud.githubusercontent.com/assets/809823/24959777/90fcbfe2-1f8b-11e7-8a27-eb6cc5eda024.png)

Call it with:

```
{% include third-party-info.html app='GitHub'%}
```