### PR TITLE
Add small section about circielci-matrix

### DIFF
--- a/jekyll/_cci1/parallel-manual-setup.md
+++ b/jekyll/_cci1/parallel-manual-setup.md
@@ -155,3 +155,7 @@ This script partitions the test files into N equally sized buckets, and calls "t
 
 You can parallelize tests for RSpec, Cucumber, Minitest, Spinach and Turnip with [knapsack gem](https://github.com/ArturT/knapsack). It will split tests across CI nodes and it makes sure that tests will run comparable time on each CI node. Knapsack gem has [built in support for CircleCI](https://github.com/ArturT/knapsack#info-for-circleci-users).
 
+
+### Travis-CI like build matrix
+
+There is also a community project called [circleci-matrix](https://github.com/michaelcontento/circleci-matrix) which can be used to replicate Travis-CI's [build matrix](https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix) behaviour on CircleCI. Please head over to their [documentation for more details](https://github.com/michaelcontento/circleci-matrix)

--- a/jekyll/_cci1/parallel-manual-setup.md
+++ b/jekyll/_cci1/parallel-manual-setup.md
@@ -1,7 +1,6 @@
 ---
 layout: classic-docs
 title: Manually setting up parallelism
-categories: [parallelism]
 description: Manually setting up parallelism
 ---
 
@@ -153,9 +152,13 @@ This script partitions the test files into N equally sized buckets, and calls "t
 
 ### Test suite split with knapsack gem
 
+{% include third-party-info.html app='Knapsack'%}
+
 You can parallelize tests for RSpec, Cucumber, Minitest, Spinach and Turnip with [knapsack gem](https://github.com/ArturT/knapsack). It will split tests across CI nodes and it makes sure that tests will run comparable time on each CI node. Knapsack gem has [built in support for CircleCI](https://github.com/ArturT/knapsack#info-for-circleci-users).
 
 
 ### Build matrix support
+
+{% include third-party-info.html app='circleci-matrix'%}
 
 CircleCI 1.0 does not have native support for build matrices. However, there is a community project **not** maintained by CircleCI called [circleci-matrix](https://github.com/michaelcontento/circleci-matrix) which can be used to produce build matrix behaviour on CircleCI. Please see their [documentation for more details](https://github.com/michaelcontento/circleci-matrix). Note that in CircleCI 2.0 you can use parallel jobs to accomplish build matrix behaviors.

--- a/jekyll/_cci1/parallel-manual-setup.md
+++ b/jekyll/_cci1/parallel-manual-setup.md
@@ -156,6 +156,6 @@ This script partitions the test files into N equally sized buckets, and calls "t
 You can parallelize tests for RSpec, Cucumber, Minitest, Spinach and Turnip with [knapsack gem](https://github.com/ArturT/knapsack). It will split tests across CI nodes and it makes sure that tests will run comparable time on each CI node. Knapsack gem has [built in support for CircleCI](https://github.com/ArturT/knapsack#info-for-circleci-users).
 
 
-### Travis-CI like build matrix
+### Build matrix support
 
-There is also a community project called [circleci-matrix](https://github.com/michaelcontento/circleci-matrix) which can be used to replicate Travis-CI's [build matrix](https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix) behaviour on CircleCI. Please head over to their [documentation for more details](https://github.com/michaelcontento/circleci-matrix)
+CircleCI 1.0 does not have native support for build matrices. However, there is a community project **not** maintained by CircleCI called [circleci-matrix](https://github.com/michaelcontento/circleci-matrix) which can be used to produce build matrix behaviour on CircleCI. Please see their [documentation for more details](https://github.com/michaelcontento/circleci-matrix). Note that in CircleCI 2.0 you can use parallel jobs to accomplish build matrix behaviors.


### PR DESCRIPTION
We added a Jekyll include after the original PR, so this is a rebase of: https://github.com/circleci/circleci-docs/pull/949

Thanks for your input @michaelcontento

