### PR TITLE
Add examples how to use balancing libraries for 2.0

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -80,3 +80,31 @@ When splitting by `timings`, the tool will assume it’s splitting filenames. If
 - `--total`: set the total number of containers to consider
 
 When running on CircleCI, these values will be automatically picked up from environment variables.
+
+## Balancing libraries
+
+The following libraries have built-in support for the CircleCI environment variables:
+
+{% include third-party-info.html app='Knapsack'%}
+
+* [Knapsack](https://github.com/ArturT/knapsack) - deterministic test suite split
+
+    A ruby gem for that will automatically divide your tests between parallel CI nodes, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber, Minitest, Spinach and Turnip.
+
+```YAML
+- run: bundle exec rake knapsack:rspec
+```
+
+* [Knapsack Pro](https://github.com/KnapsackPro/knapsack_pro-ruby) - dynamic optimal test suite split
+
+    Is more advanced version of knapsack gem. Knapsack Pro has automated recording of tests time execution across branches, commits and it can distribute tests across parallel CI nodes with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split.
+
+```YAML
+# some tests that are not balanced and executed only on first CI node
+- run: case $CIRCLE_NODE_INDEX in 0) npm test ;; esac
+
+# auto-balancing CI build time execution to be flat and optimal (as fast as possible).
+# Queue Mode does dynamic tests allocation so the previous not balanced run command won't
+# create a bottleneck on the CI node
+- run: bundle exec rake knapsack_pro:queue:rspec
+```


### PR DESCRIPTION
We added a Jekyll include after the original PR, so this is a rebase of: https://github.com/circleci/circleci-docs/pull/950

Thanks for your input @ArturT 