### PR TITLE
Remove multiple Python version info, Resolves #921

### DIFF
--- a/jekyll/_cci1/language-python.md
+++ b/jekyll/_cci1/language-python.md
@@ -25,15 +25,6 @@ machine:
     version: pypy-2.2.1
 ```
 
-If you need to use multiple Python versions simultaneously, you can make them available as follows:
-
-```
-machine:
-  post:
-    - pyenv global 2.7.9 3.4.2
-```
-These will be available as python2.7 and python3.4
-
 Please [contact us](mailto:support@circleci.com) if other versions of Python
 would be of use to you.
 


### PR DESCRIPTION
The example that this removes doesn't work.

2.0 provides much better support for testing against multiple Python versions and that will be documented soon.