### PR TITLE
Update Python versions in example Fixes #921

### DIFF
--- a/jekyll/_cci1/language-python.md
+++ b/jekyll/_cci1/language-python.md
@@ -30,7 +30,7 @@ If you need to use multiple Python versions simultaneously, you can make them av
 ```
 machine:
   post:
-    - pyenv global 2.7.9 3.4.2
+    - pyenv global 2.7.12 3.4.4
 ```
 These will be available as python2.7 and python3.4
 


### PR DESCRIPTION
The example was failing because the versions in the example were no longer on the 14.04 image.