### PR TITLE
Reorder getting started 1.0 menu

### DIFF
--- a/jekyll/_cci1/configuration.md
+++ b/jekyll/_cci1/configuration.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Configuring CircleCI
 categories: [getting-started,reference]
 description: How to configure CircleCI
+order: 30
 ---
 
 CircleCI automatically infers settings from your code, so it's possible you won't need to add any custom configuration.

--- a/jekyll/_cci1/faq.md
+++ b/jekyll/_cci1/faq.md
@@ -4,6 +4,7 @@ title: Frequently Asked Questions
 short-title: FAQ
 categories: [getting-started]
 description: Frequently Asked Questions
+order: 60
 ---
 
 ## How do I subscribe to CircleCI announcements and get updates about new features and changes?

--- a/jekyll/_cci1/getting-started.md
+++ b/jekyll/_cci1/getting-started.md
@@ -3,13 +3,14 @@ layout: classic-docs
 title: Getting Started with CircleCI
 categories: [getting-started]
 description: Getting Started with CircleCI
+order: 20
 ---
 
 Setting up CircleCI usually takes only three mouse clicks:
 
-1.  Sign up with CircleCI.
-2.  Give CircleCI permission to access GitHub or Bitbucket on your behalf.
-3.  Click on a project.
+1.  [Sign up with CircleCI](https://circleci.com/signup/)
+2.  Give CircleCI permission to access GitHub or Bitbucket on your behalf
+3.  Click on a project
 
 It really is that easy for about 90 percent of our users.
 

--- a/jekyll/_cci1/introduction.md
+++ b/jekyll/_cci1/introduction.md
@@ -4,6 +4,7 @@ title: Introduction to Continuous Integration and CircleCI
 short-title: Introduction to CircleCI
 categories: [getting-started]
 description: "An introduction to Continuous Integration, Continuous Deployment, and how CircleCI can help."
+order: 10
 ---
 
 CircleCI acts as a platform for both [Continuous Integration][wiki-ci] and Continuous Deployment.

--- a/jekyll/_cci1/manually.md
+++ b/jekyll/_cci1/manually.md
@@ -3,6 +3,7 @@ layout: classic-docs
 title: Manual build setup
 categories: [getting-started]
 description: Manual build setup
+order: 40
 ---
 
 CircleCI is designed to set up most tests automatically because we infer your settings from your code.

--- a/jekyll/_cci1/setting-up-parallelism.md
+++ b/jekyll/_cci1/setting-up-parallelism.md
@@ -3,7 +3,7 @@ layout: classic-docs
 title: Setting up parallelism
 categories: [getting-started,parallelism]
 description: Setting up parallelism
-last_updated: Nov 21, 2014
+order: 50
 ---
 
 This guide assumes you already have a green build without parallelism. If you haven't set up your project yet, check out [getting started guide]({{ site.baseurl }}/1.0/getting-started/).


### PR DESCRIPTION
No order was set, so it was defaulting to alphabetical. This makes it more logical.