### PR TITLE
Fix incorrect indent in config.yml example

### DIFF
--- a/jekyll/_cci2/project-walkthrough.md
+++ b/jekyll/_cci2/project-walkthrough.md
@@ -195,7 +195,7 @@ To speed up our builds, we should cache our dependencies:
 ...
     steps:
       - checkout
-       - restore_cache:
+      - restore_cache:
           key: deps1-{% raw %}{{{% endraw %} .Branch {% raw %}}}{% endraw %}-{% raw %}{{{% endraw %} checksum "requirements/dev.txt" {% raw %}}}{% endraw %}
       - run:
           name: Install Python deps in a venv


### PR DESCRIPTION
Commit 2245bc8d409e0c3180bec6179ca49be065e589b2 introduced an extra white space.