### PR TITLE
Add Premium Support links to match inner

### DIFF
--- a/jekyll/_includes/global-footer.html
+++ b/jekyll/_includes/global-footer.html
@@ -33,6 +33,7 @@
           <ul class="list-unstyled">
             <li><a href="{{ site.baseurl }}/">Documentation</a></li>
             <li><a href="https://discuss.circleci.com/" target="_blank">Community</a></li>
+            <li><a href="https://circleci.com/support/premium-support/">Premium Support</a></li>
             <li><a href="https://circleci.com/security/">Security</a></li>
             <li><a href="https://circleci.com/privacy/">Privacy Policy</a></li>
             <li><a href="https://circleci.com/terms-of-service/">Terms of Service</a></li>

--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -45,6 +45,9 @@
             <li role="presentation">
               <a role="menuitem" tabindex="-1" href="https://discuss.circleci.com/" target="_blank" class="sub menu-item">Community</a>
             </li>
+            <li role="presentation">
+              <a role="menuitem" tabindex="-1" href="https://circleci.com/support/premium-support/" class="sub menu-item">Premium Support</a>
+            </li>
           </ul>
         </li>
         <li class="dropdown {% if page.nav-hl == 'more' %}active{% endif %}">

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -25,6 +25,6 @@ title: CircleCI Documentation
 		<p>We welcome your feedback, questions and feature requests on our community forums - <a href="https://discuss.circleci.com/">Discuss</a>. Searching the forums is a great way to find solutions to specific issues not covered by the docs.</p>
 </div>
 <div class="category-section">
-	<h2>Support</h2>
+	<h2><a href="https://circleci.com/support/premium-support/">Support</a></h2>
 		<p>Engineering support is available for customers on paid plans. You can submit a ticket from within the application by clicking the question mark icon at the bottom right of the screen.</p>
 </div>


### PR DESCRIPTION
This patch adds three things:

* Missing link to Premium Support in the header nav (to match inner)
* Link "Support" in "/docs" index page to Premium Support (Only non-linked header on page)
* Adds "Premium Support" link to footer (This is new, open to removing it)

![screenshot from 2017-05-09 02-23-45](https://cloud.githubusercontent.com/assets/277819/25816832/5caf94be-3460-11e7-9295-59c577844ede.png)

![screenshot from 2017-05-09 02-26-09](https://cloud.githubusercontent.com/assets/277819/25816841/623f4dde-3460-11e7-8c60-bcf0d08bbbac.png)
