### PR TITLE
Fix OS Matrix occurrences.

### DIFF
--- a/jekyll/_cci1/docker.md
+++ b/jekyll/_cci1/docker.md
@@ -30,7 +30,7 @@ to use the command on CircleCI.
 
 ### Version Support
 
-{% include os-matrix.html trusty=site.data.trusty.versions.summary.docker precise=site.data.precise.versions.docker %}
+{% include os-matrix.html trusty=site.data.trusty.versions-ubuntu-14_04-XXL.summary.docker precise=site.data.precise.versions.docker %}
 
 ## Deployment to a Docker registry
 

--- a/jekyll/_cci1/language-go.md
+++ b/jekyll/_cci1/language-go.md
@@ -16,7 +16,7 @@ root directory.
 
 The pre-installed version of Go depends on which image your build is using:
 
-{% include os-matrix.html trusty=site.data.trusty.versions.summary.go precise=site.data.precise.versions.golang %}
+{% include os-matrix.html trusty=site.data.trusty.versions-ubuntu-14_04-XXL.summary.go precise=site.data.precise.versions.golang %}
 
 Unlike some other languages on CircleCI, you would not specify the Go version 
 in the machine section of `circle.yml`.

--- a/jekyll/_cci1/yarn.md
+++ b/jekyll/_cci1/yarn.md
@@ -14,7 +14,7 @@ description: "How to use the Yarn package manager on CircleCI."
 
 ## Version Support
 
-{% include os-matrix.html trusty=site.data.trusty.versions.summary.nodejs.yarn %}
+{% include os-matrix.html trusty=site.data.trusty.versions-ubuntu-14_04-XXL.summary.nodejs.yarn %}
 
 ## Setup
 


### PR DESCRIPTION
Fixes #1024.

The following commit broke the use of the OS Matrix. Fixed the datafile path. https://github.com/circleci/circleci-docs/commit/900897fef1b1ecd691a7dd407026e66c2a0ad959#diff-992354a1328175b1b05dfe6ae0d2f285