### PR TITLE
Move custom-images under docker category

### DIFF
--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -3,7 +3,7 @@ layout: classic-docs
 title: "Building Custom Images for Docker Executor"
 short-title: "Building Custom Images"
 description: "Why and how to create custom Docker images"
-categories: [configuring-jobs]
+categories: [docker]
 order: 30
 ---
 


### PR DESCRIPTION
Current:
![screenshot from 2017-05-10 14-46-44](https://cloud.githubusercontent.com/assets/277819/25922828/8680dac0-358f-11e7-885e-5f9d52c082ae.png)

This moves the custom images doc out of the "configuing jobs" category which is already growing a bit long in the tooth. Also, the only relevant part to actual configuration here is where you can specify the custom image, but I honestly forgot where this page was -- it makes more sense under "docker" IMHO <3