### PR TITLE
Update Go language doc

### DIFF
--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -2,7 +2,7 @@
 layout: classic-docs
 title: "Language Guide: Go"
 short-title: "Go"
-description: "Overview and sample config for a Go project"
+description: "Building and Testing with Go (Golang) on CircleCI 2.0"
 categories: [language-guides]
 order: 3
 ---

--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -170,4 +170,4 @@ Finally, let's specify a path to store the results of the tests.
 
 Success! You just set up CircleCI 2.0 for a Go app. Check out our [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-go) to see how this looks when building on CircleCI.
 
-If you have any questions about the specifics of testing your Go applicatio, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.
+If you have any questions about the specifics of testing your Go application, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.


### PR DESCRIPTION
I have updated the Go demo project to build using the official CircleCI images (https://github.com/CircleCI-Public/circleci-demo-go/pull/3)

This updates the associated language doc:

- link to the correct repo on the CircleCI public org
- remove 'sample config' section since we should keep these in the projects themselves
- restructuring for clarity
- grammar and clarity fixes