### PR TITLE
Update Python demo projects

### DIFF
--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -7,64 +7,36 @@ categories: [language-guides]
 order: 6
 ---
 
-## Overview
+## New to CircleCI 2.0?
 
-This guide will help you get started with a Python project on CircleCI. If you’re in a rush, just copy the sample configuration below into `.circleci/config.yml` in your project’s root directory and start building.
+If you're new to CircleCI 2.0, we recommend reading our [Project Walkthrough]({{ site.baseurl }}/2.0/project-walkthrough/) for a detailed explanation of our configuration using Python and Flask as an example.
 
-Otherwise, we recommend reading our [walkthrough](#config-walkthrough) for a detailed explanation of our configuration.
+## Quickstart: demo Python Django reference project
 
-## Sample Configuration
+We maintain a reference Python Django project to show how to build Django on CircleCI 2.0:
 
-{% raw %}
-```YAML
-version: 2
-jobs:
-  build:
-    docker:
-      - image: python:3.5
-        environment:
-          FLASK_CONFIG: testing
-          DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
-      - image: postgres:9.5.5
-        environment:
-          POSTGRES_USER: ubuntu
-          POSTGRES_DB: circle_test
-          POSTGRES_PASSWORD: ""
-    working_directory: /home/ubuntu/cci-demo-flask
-    steps:
-      - checkout
-      - run:
-          name: Install Yarn
-          command: |
-            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68576280 86E50310
-            echo "deb http://deb.nodesource.com/node_7.x jessie main" | tee /etc/apt/sources.list.d/nodesource.list
-            echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-            apt-get update -qq
-            apt-get install -y -qq nodejs yarn
-      - restore_cache:
-          key: projectname-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      - run: yarn && pip install -r requirements.txt
-      - save_cache:
-          key: projectname-{{ .Branch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - "/home/ubuntu/.yarn-cache"
-      - run: python manage.py test --coverage
-      - store_artifacts:
-          path: test-reports/coverage
-          destination: reports
-      - store_test_results:
-          path: "test-reports/"
-```
-{% endraw %}
+- <a href="https://github.com/CircleCI-Public/circleci-demo-python-django"> target="_blank">Demo Python Django Project on GitHub</a>
+- <a href="https://circleci.com/gh/CircleCI-Public/circleci-demo-python-django"> target="_blank">Demo Python Django Project building on CircleCI</a>
 
-## Get the Code
+In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-python-django/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using CircleCI 2.0 with Python projects.
 
-The configuration above is from a demo Python/flask app, which you can access at [https://github.com/circleci/cci-demo-flask](https://github.com/circleci/cci-demo-flask).
+## Alternative: Python Flask demo reference project
 
-Fork the project and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
+The [Project Walkthrough]({{ site.baseurl }}/2.0/project-walkthrough/) uses a Flask application: <https://github.com/CircleCI-Public/cci-demo-python-flask>
 
-Now we’re ready to build a `config.yml` from scratch.
+## Pre-built CircleCI Docker images
 
+We recommend using a CircleCI pre-built image that comes pre-installed with tools that are useful in a CI environment. You can select the Python version you need from Docker Hub: <https://hub.docker.com/r/circleci/python/>. The demo project uses an official CircleCI image.
+
+Database images for use as a secondary 'service' container are also available.
+
+## Build the demo Django project yourself
+
+A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
+
+1. Fork the project on GitHub to your own account
+2. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to the project you just forked
+3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 ---
 
 ## Config Walkthrough
@@ -77,110 +49,49 @@ version: 2
 
 Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deploy (BTD) process. Our sample app only needs a `build` job, so everything else is going to live under that key.
 
-We also need to specify container images for this build in `docker`.
-
-We'll need to tell the Flask app to run in `testing` mode by setting it in `environment`, as well as where to find the database (DB). This is a special local URL linked to an additional Docker container.
+We need to specify a working directory container images for this build in `docker` section:
 
 ```YAML
 ...
 jobs:
   build:
+    working_directory: ~/circleci-demo-python-django
     docker:
-      - image: python:3.5
+      - image: circleci/python:3.6.1
+      - image: circleci/postgres:9.6.2
         environment:
-          FLASK_CONFIG: testing
-          DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
-```
-
-We'll also create a container for PostgreSQL, along with 3 environment variables for initializing the database.
-
-```YAML
-...
-      - image: postgres:9.5.5
-        environment:
-          POSTGRES_USER: ubuntu
+          POSTGRES_USER: root
           POSTGRES_DB: circle_test
-          POSTGRES_PASSWORD: ""
 ```
 
-In each job, we specify a `working_directory`. In this sample config, we’ll name it after the project in our home directory.
+Now we need to add several `steps` within the `build` job:
+
 
 ```YAML
-...
-    working_directory: /home/ubuntu/cci-demo-flask
-```
-
-Now we need to add several `steps` within the `build` job.
-
-You could install NPM, but we’re going to use Yarn for reasons that are outside the scope of this document.
-
-```YAML
-...
     steps:
       - checkout
-      - run:
-          name: Install Yarn
-          command: |
-            apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68576280 86E50310
-            echo "deb http://deb.nodesource.com/node_7.x jessie main" | tee /etc/apt/sources.list.d/nodesource.list
-            echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-            apt-get update -qq
-            apt-get install -y -qq nodejs yarn
-```
-
-Let's restore the Yarn package cache if it's available.
-
-{% raw %}
-```YAML
-...
       - restore_cache:
-          key: projectname-{{ .Branch }}-{{ checksum "yarn.lock" }}
-```
-{% endraw %}
-
-Install both Yarn and Python dependencies.
-
-```YAML
-...
-      - run: yarn && pip install -r requirements.txt
-```
-
-Specify where to save that Yarn cache.
-
-{% raw %}
-```YAML
-...
+          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - run:
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
       - save_cache:
-          key: projectname-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
           paths:
-            - "/home/ubuntu/.yarn-cache"
-```
-{% endraw %}
-
-Run our tests.
-
-```YAML
-...
-      - run: python manage.py test --coverage
-```
-
-Store test results as an artifact.
-
-```YAML
-...
+            - "venv"
+      - run:
+          command: |
+            . venv/bin/activate
+            python manage.py test
       - store_artifacts:
-          path: test-reports/coverage
-          destination: reports
+          path: test-reports/
+          destination: tr1
 ```
 
-Finally, let's specify where those test results are actually located.
+You can learn more about each of these steps in our [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/)
 
-```YAML
-...
-      - store_test_results:
-          path: "test-reports/"
-```
+Success! You just set up CircleCI 2.0 for a Python Django app. Check out our [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-python-django) to see how this looks when building on CircleCI.
 
-Nice! You just set up CircleCI for a Flask app. Nice! Check out our [project’s build page](https://circleci.com/gh/circleci/cci-demo-flask).
-
-If you have any questions, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.
+If you have any questions about the specifics of testing your Python application, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.

--- a/jekyll/_cci2/project-walkthrough.md
+++ b/jekyll/_cci2/project-walkthrough.md
@@ -24,7 +24,7 @@ CircleCI is a very flexible platform so you should be able to adapt this tutoria
 
 ![Circulate demo app screenshot]({{ site.baseurl }}/assets/img/docs/walkthrough0.png)
 
-The source for the application is here: [cci-demo-walkthrough](https://github.com/circleci/cci-demo-walkthrough).
+The source for the application is here: [cci-demo-python-flask](https://github.com/CircleCI-Public/cci-demo-python-flask).
 
 ### The Stack
 
@@ -41,7 +41,7 @@ Finally, we'll deploy the application to Heroku and discuss other deployment opt
 To use CircleCI, your code must be available on GitHub or Bitbucket, in either a private or public repository. We'll be assuming GitHub for this walkthrough, but the same flow applies to Bitbucket as well.
 
 <div class="alert alert-info" role="alert">
-<strong>Tip:</strong> If you're following along and want to use the code, you should fork and clone the <a class="alert-link" href="https://github.com/circleci/cci-demo-walkthrough">cci-demo-walkthrough</a> project. On your local machine, delete the <code>.circleci</code> directory and make a commit. You now have a clean project ready to start configuring for use with CircleCI.
+<strong>Tip:</strong> If you're following along and want to use the code, you should fork and clone the <a class="alert-link" href="https://github.com/CircleCI-Public/cci-demo-python-flask">cci-demo-walkthrough</a> project. On your local machine, delete the <code>.circleci</code> directory and make a commit. You now have a clean project ready to start configuring for use with CircleCI.
 </div>
 
 ## Create CircleCI config file


### PR DESCRIPTION
This updates the language docs for Python and links to the correct demo projects on the CircleCI public org for Flask and Django from this doc and the walkthrough.

It's not complete yet, but I'm merging since the old demo Flask app was inaccurate and causing issues for people trying to follow the instructions.

More comments and information will be added soon.