### PR TITLE
Update 2.0 language docs

### DIFF
--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -11,12 +11,12 @@ Welcome to CircleCI 2.0 Beta! The Beta release of CircleCI 2.0 includes many imp
 
 Code that builds on Linux will generally build on CircleCI 2.0. For some language versions, CircleCI provides demo applications and Docker images for primary container use, as follows: 
 
-- **Clojure 1.8 and later**, see <https://github.com/circleci/cci-demo-clojure> and <https://hub.docker.com/r/circleci/clojure>
-- **Go 1.7 and later**, see <https://github.com/circleci/cci-demo-go> and <https://hub.docker.com/r/circleci/golang>
-- **Node.js 4 and later**, see <https://github.com/circleci/cci-demo-react> and <https://hub.docker.com/r/circleci/node>
-- **PHP 5 and later**, see <https://github.com/circleci/cci-demo-lumen> and <https://hub.docker.com/r/circleci/php>
-- **Python 2 and later**, see <https://github.com/circleci/cci-demo-flask> and <https://hub.docker.com/r/circleci/python>
-- **Ruby 2 and later**, see <https://github.com/circleci/cci-demo-rails> and <https://hub.docker.com/r/circleci/ruby> 
+- **Clojure 1.8 and later**, see <https://github.com/CircleCI-Public/circleci-demo-clojure-luminus> and <https://hub.docker.com/r/circleci/clojure>
+- **Go 1.7 and later**, see <https://github.com/CircleCI-Public/circleci-demo-go> and <https://hub.docker.com/r/circleci/golang>
+- **Node.js 4 and later**, see <https://github.com/CircleCI-Public/circleci-demo-javascript-express> and <https://hub.docker.com/r/circleci/node>
+- **PHP 5 and later**, see <https://github.com/CircleCI-Public/circleci-demo-php-laravel> and <https://hub.docker.com/r/circleci/php>
+- **Python 2 and later**, see <https://github.com/CircleCI-Public/cci-demo-python-flask> or <https://github.com/CircleCI-Public/circleci-demo-python-django> and <https://hub.docker.com/r/circleci/python>
+- **Ruby 2 and later**, see <https://github.com/CircleCI-Public/circleci-demo-ruby-rails> and <https://hub.docker.com/r/circleci/ruby> 
 
 In addition, CircleCI provides Docker database images for use as a secondary service container:
 

--- a/jekyll/_cci2/language-clojure.md
+++ b/jekyll/_cci2/language-clojure.md
@@ -2,7 +2,7 @@
 layout: classic-docs
 title: "Language Guide: Clojure"
 short-title: "Clojure"
-description: "Overview and sample config for a Clojure project"
+description: "Building and Testing with Clojure on CircleCI 2.0"
 categories: [language-guides]
 order: 2
 ---

--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -2,135 +2,44 @@
 layout: classic-docs
 title: "Language Guide: JavaScript"
 short-title: "JavaScript"
-description: "Overview and sample config for a JavaScript project"
+description: "Building and Testing with JavaScript and NodeJS on CircleCI 2.0"
 categories: [language-guides]
 order: 4
 ---
 
-## Overview
+## New to CircleCI 2.0?
 
-This guide will help you get started with a JavaScript project on CircleCI. If you’re in a rush, just copy the sample configuration below into `.circleci/config.yml` in your project’s root directory and start building.
+If you're new to CircleCI 2.0, we recommend reading our [Project Walkthrough]({{ site.baseurl }}/2.0/project-walkthrough/) for a detailed explanation of our configuration using Python and Flask as an example.
 
-Otherwise, we recommend reading our [walkthrough](#config-walkthrough) for a detailed explanation of our configuration.
+## Quickstart: demo JavaScript NodeJS reference project
 
-## Sample Configuration
+We maintain a reference JavaScript NodeJS project to show how to build Django on CircleCI 2.0:
 
-```YAML
-version: 2
-jobs:
-  build:
-    docker:
-      - image: node:7.4.0
-    working_directory: ~/cci-demo-react
-    steps:
-      - checkout
-      - run: mkdir -p ~/cci-demo-react/artifacts
-      - run: npm install
-      - run: npm test
-      - store_artifacts:
-          path: ~/cci-demo-react/artifacts
-      - add_ssh_keys
-      - deploy:
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              # Install Heroku fingerprint
-              mkdir -p ~/.ssh
-              echo 'heroku.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAu8erSx6jh+8ztsfHwkNeFr/SZaSOcvoa8AyMpaerGIPZDB2TKNgNkMSYTLYGDK2ivsqXopo2W7dpQRBIVF80q9mNXy5tbt1WE04gbOBB26Wn2hF4bk3Tu+BNMFbvMjPbkVlC2hcFuQJdH4T2i/dtauyTpJbD/6ExHR9XYVhdhdMs0JsjP/Q5FNoWh2ff9YbZVpDQSTPvusUp4liLjPfa/i0t+2LpNCeWy8Y+V9gUlDWiyYwrfMVI0UwNCZZKHs1Unpc11/4HLitQRtvuk0Ot5qwwBxbmtvCDKZvj1aFBid71/mYdGRPYZMIxq1zgP1acePC1zfTG/lvuQ7d0Pe0kaw==' >> ~/.ssh/known_hosts
+- <a href="https://github.com/CircleCI-Public/circleci-demo-javascript-express"> target="_blank">Demo JavaScript Node Project on GitHub</a>
+- <a href="https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express"> target="_blank">Demo JavaScript Node Project building on CircleCI</a>
 
-              git config --global push.default simple
-              git push -f git@heroku.com:cci-demo-react.git
-            fi
-```
+In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-javascript-express/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using CircleCI 2.0 with Node projects.
 
-## Get the Code
+## Pre-built CircleCI Docker images
 
-The configuration above is from a demo React app, which you can access at [https://github.com/circleci/cci-demo-react](https://github.com/circleci/cci-demo-react).
+We recommend using a CircleCI pre-built image that comes pre-installed with tools that are useful in a CI environment. You can select the Python version you need from Docker Hub: <https://hub.docker.com/r/circleci/node/>. The demo project uses an official CircleCI image.
 
-Fork the project and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
+Database images for use as a secondary 'service' container are also available.
 
-Now we’re ready to build a `config.yml` from scratch.
+## Build the demo JavaScript Node project yourself
+
+A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
+
+1. Fork the project on GitHub to your own account
+2. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to the project you just forked
+3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 ## Config Walkthrough
 
-We always start with the version.
+Details of the configuration steps will be updated soon. Please see the `.circleci/config.yml` file in the demo project to get started.
 
-```YAML
-version: 2
-```
+---
 
-Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deploy (BTD) process. Our sample app only needs a `build` job, so everything else is going to live under that key.
+Success! You just set up CircleCI 2.0 for a NodeJS app. Check out our [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express) to see how this looks when building on CircleCI.
 
-In each job, we specify a `working_directory`. In this sample config, we’ll name it after the project in our home directory.
-
-```YAML
-...
-jobs:
-  build:
-    working_directory: ~/cci-demo-react
-```
-
-This path will be used as the default working directory for the rest of the `job` unless otherwise specified.
-
-Directly beneath `working_directory`, we can specify container images for the build under a `docker` key.
-
-```YAML
-...
-    docker:
-      - image: node:7.4.0
-```
-
-Now we’ll add several `steps` within the `build` job.
-
-One difference between CircleCI Classic and 2.0 is that 2.0 doesn’t automatically make an artifacts directory. Let’s do that now.
-
-```YAML
-...
-    steps:
-      - checkout
-      - run: mkdir ~/cci-demo-react/artifacts
-```
-
-Next, let's install our dependencies. In CircleCI Classic, we would have done this in a separate `dependencies` stage.
-
-```YAML
-...
-      - run: npm install
-```
-
-Next, we run our tests. Like dependencies, this would have been run in a separate `test` stage in CircleCI Classic.
-
-```YAML
-...
-      - run: npm test
-```
-
-Remember when we created a directory for our artifacts? CircleCI won't unless we tell it where to look.
-
-```YAML
-...
-      - store_artifacts:
-          path: ~/cci-demo-react/artifacts
-```
-
-We also want to deploy our app to Heroku, so we'll do that with another step after adding the SSH keys needed for deploy. Because 2.0 doesn't yet have built-in commands to deploy by branch, we use a Bash conditional to determine if the current branch is appropriate.
-
-If it is the right branch, we'll add the SSH key fingerprint directly. Note the git commands as well.
-
-```YAML
-...
-      - add_ssh_keys
-      - deploy:
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              # Install Heroku fingerprint
-              mkdir -p ~/.ssh
-              echo 'heroku.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAu8erSx6jh+8ztsfHwkNeFr/SZaSOcvoa8AyMpaerGIPZDB2TKNgNkMSYTLYGDK2ivsqXopo2W7dpQRBIVF80q9mNXy5tbt1WE04gbOBB26Wn2hF4bk3Tu+BNMFbvMjPbkVlC2hcFuQJdH4T2i/dtauyTpJbD/6ExHR9XYVhdhdMs0JsjP/Q5FNoWh2ff9YbZVpDQSTPvusUp4liLjPfa/i0t+2LpNCeWy8Y+V9gUlDWiyYwrfMVI0UwNCZZKHs1Unpc11/4HLitQRtvuk0Ot5qwwBxbmtvCDKZvj1aFBid71/mYdGRPYZMIxq1zgP1acePC1zfTG/lvuQ7d0Pe0kaw==' >> ~/.ssh/known_hosts
-
-              git config --global push.default simple
-              git push -f git@heroku.com:cci-demo-react.git
-            fi
-```
-
-Nice! You just set up CircleCI for a React app. Check out our [project’s build page](https://circleci.com/gh/circleci/cci-demo-react).
-
-If you have any questions, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.
+If you have any questions about the specifics of testing your NodeJS application, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.

--- a/jekyll/_cci2/language-php.md
+++ b/jekyll/_cci2/language-php.md
@@ -2,196 +2,46 @@
 layout: classic-docs
 title: "Language Guide: PHP"
 short-title: "PHP"
-description: "Overview and sample config for a PHP project"
+description: "Building and Testing with PHP on CircleCI 2.0"
 categories: [language-guides]
 order: 5
 ---
 
-## Overview
+## New to CircleCI 2.0?
 
-This guide will help you get started with a PHP project on CircleCI. If you’re in a rush, just copy the sample configuration below into `.circleci/config.yml` in your project’s root directory and start building.
+If you're new to CircleCI 2.0, we recommend reading our [Project Walkthrough]({{ site.baseurl }}/2.0/project-walkthrough/) for a detailed explanation of our configuration using Python and Flask as an example.
 
-Otherwise, we recommend reading our [walkthrough](#config-walkthrough) for a detailed explanation of our configuration.
+## Quickstart: demo PHP Laravel reference project
 
-## Sample Configuration
+We maintain a reference PHP Laravel project to show how to build PHP on CircleCI 2.0:
 
-```YAML
-version: 2
-jobs:
-  build:
-    docker:
-      - image: php:7.0-apache
-        environment:
-          APP_ENV: local
-          APP_DEBUG: true
-          APP_KEY: kjcndjjksddwdwdw
-          DB_CONNECTION: mysql
-          DB_HOST: 127.0.0.1
-          DB_PORT: 3306
-          DB_DATABASE: testdb
-          DB_USERNAME: root
-          DB_PASSWORD: password
-          CACHE_DRIVER: memcached
-          QUEUE_DRIVER: sync
-      - image: mariadb:5.5
-        environment:
-          MYSQL_DATABASE: testdb
-          MYSQL_ROOT_PASSWORD: password
-    working_directory: /var/www/html
-    steps:
-      - run: apt-get update && apt-get -y install git unzip zlib1g-dev
-      - checkout
-      - run: docker-php-ext-install pdo pdo_mysql zip
-      - run:
-          name: Install Composer
-          command: |
-            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-            php -r "copy('https://composer.github.io/installer.sig', 'composer-setup.sig');" && \
-            php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('composer-setup.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
-            php composer-setup.php && \
-            php -r "unlink('composer-setup.php');"
-      - run: php composer.phar install
-      - run:
-          name: Initialize Database
-          command: |
-            php artisan migrate:refresh
-            php artisan db:seed
-      - run: vendor/bin/phpunit
-```
+- <a href="https://github.com/CircleCI-Public/circleci-demo-php-laravel"> target="_blank">Demo PHP Laravel Project on GitHub</a>
+- <a href="https://circleci.com/gh/CircleCI-Public/circleci-demo-php-laravel"> target="_blank">Demo PHP Laravel Project building on CircleCI</a>
 
-## Get the Code
+In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-php-laravel/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using CircleCI 2.0 with Python projects.
 
-The configuration above is from a demo PHP/Lumen app, which you can access at [https://github.com/circleci/cci-demo-lumen](https://github.com/circleci/cci-demo-lumen).
+## Pre-built CircleCI Docker images
 
-Fork the project and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
+We recommend using a CircleCI pre-built image that comes pre-installed with tools that are useful in a CI environment. You can select the Python version you need from Docker Hub: <https://hub.docker.com/r/circleci/php/>. The demo project uses an official CircleCI image.
 
-Now we’re ready to build a `config.yml` from scratch.
+Database images for use as a secondary 'service' container are also available.
+
+## Build the demo PHP project yourself
+
+A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
+
+1. Fork the project on GitHub to your own account
+2. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to the project you just forked
+3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 ---
 
 ## Config Walkthrough
 
-We always start with the version.
+Details of the configuration steps will be updated soon. Please see the `.circleci/config.yml` file in the demo project to get started.
 
-```YAML
-version: 2
-```
+---
 
-Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deploy (BTD) process. Our sample app only needs a `build` job, so everything else is going to live under that key.
+Success! You just set up CircleCI 2.0 for a PHP app. Check out our [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-php-laravel) to see how this looks when building on CircleCI.
 
-In each job, we have specify a `working_directory`. In this sample config, we’ll use Apache's default DocumentRoot so its vhost can serve the PHP project.
-
-```YAML
-...
-jobs:
-  build:
-    working_directory: /var/www/html
-```
-
-This path will be used as the default working directory for the rest of the `job` unless otherwise specified.
-
-Directly beneath `working_directory`, we’ll specify container images for this build in `docker`.
-
-We'll pull in the 7.0-apache image from the official PHP repository on Docker Hub along with MariaDB. Both images have their own `environment` settings.
-
-```YAML
-...
-    docker:
-      - image: php:7.0-apache
-        environment:
-          APP_ENV: local
-          APP_DEBUG: true
-          APP_KEY: kjcndjjksddwdwdw
-          DB_CONNECTION: mysql
-          DB_HOST: 127.0.0.1
-          DB_PORT: 3306
-          DB_DATABASE: testdb
-          DB_USERNAME: root
-          DB_PASSWORD: password
-          CACHE_DRIVER: memcached
-          QUEUE_DRIVER: sync
-      - image: mariadb:5.5
-        environment:
-          MYSQL_DATABASE: testdb
-          MYSQL_ROOT_PASSWORD: password
-```
-
-That’s a lot of environment variables! Let's explain a few:
-
-`DB_HOST: 127.0.0.1`
-
-If we specified the hostname `localhost` here, PHP would assume that we wanted to use a local socket file along with MySQL/MariaDB. But that wouldn't work because the DB isn't running in the same container as PHP, so we use TCP/IP instead.
-
-`MYSQL_DATABASE: testdb`
-
-If the Docker image sees this, it will create it and start up MariaDB; otherwise, the DB wouldn't even be started.
-
-`MYSQL_ROOT_PASSWORD: password`
-
-This sets a (horrible) root password so we can access the DB.
-
-Next, we'll add `steps` to the job. Normally, we’d check out our project's code first, but the Docker image we chose doesn’t include Git. Since we need to install Git anyway, we'll also install other system/distribution packages that we'll need.
-
-```YAML
-...
-    steps:
-      - run: apt-get update && apt-get -y install git unzip zlib1g-dev
-```
-
-Now we can actually check out our code, which will go in the working directory we specified earlier.
-
-```YAML
-...
-      - checkout
-```
-
-Next, we're going to run a pre-installed script called `docker-php-ext-install`. This script comes from the Docker image and was designed to install PHP extensions for anything that isn't available by default.
-
-We'll be using it to get ZIP support for Composer and PHP talking to MariaDB. Normally, we'd use the `RUN` command in a `Dockerfile`, but in this case, we have to run it manually:
-
-```YAML
-...
-      - run: docker-php-ext-install pdo pdo_mysql zip
-```
-
-We're going to be using Composer to install project dependencies, so let's install that next. Forgive the verbosity, but these are the official install instructions.
-
-```YAML
-...
-      - run:
-          name: Install Composer
-          command: |
-            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-            php -r "if (hash_file('SHA384', 'composer-setup.php') === 'aa96f26c2b67226a324c27919f1eb05f21c248b987e6195cad9690d5c1ff713d53020a02ac8c217dbf90a7eacc9d141d') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-            php composer-setup.php
-            php -r "unlink('composer-setup.php');"
-```
-
-Now that Composer has been installed, let's use it to install the project's dependencies, located in `composer.json`.
-
-```YAML
-...
-      - run: php composer.phar install
-```
-
-Next, let's initialize required database (DB) tables and seed it with initial data.
-
-```YAML
-...
-      - run:
-          name: Initialize Database
-          command: |
-            php artisan migrate:refresh
-            php artisan db:seed
-```
-
-Finally, let's run our tests using PHPUnit.
-
-```YAML
-...
-      - run: vendor/bin/phpunit
-```
-
-Nice! You just set up CircleCI for a Lumen app. Check out our [project’s build page](https://circleci.com/gh/circleci/cci-demo-lumen).
-
-If you have any questions, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.
+If you have any questions about the specifics of testing your PHP application, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -2,7 +2,7 @@
 layout: classic-docs
 title: "Language Guide: Python"
 short-title: "Python"
-description: "Overview and sample config for a Python project"
+description: "Building and Testing with Python on CircleCI 2.0"
 categories: [language-guides]
 order: 6
 ---

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -2,134 +2,46 @@
 layout: classic-docs
 title: "Language Guide: Ruby"
 short-title: "Ruby"
-description: "Overview and sample config for a Ruby project"
+description: "Building and Testing with Ruby and Rails on CircleCI 2.0"
 categories: [language-guides]
 order: 7
 ---
 
-## Overview
+## New to CircleCI 2.0?
 
-This guide will help you get started with a Ruby project on CircleCI. If you’re in a rush, just copy the sample configuration below into `.circleci/config.yml` in your project’s root directory and start building.
+If you're new to CircleCI 2.0, we recommend reading our [Project Walkthrough]({{ site.baseurl }}/2.0/project-walkthrough/) for a detailed explanation of our configuration using Python and Flask as an example.
 
-Otherwise, we recommend reading our [walkthrough](#config-walkthrough) for a detailed explanation of our configuration.
+## Quickstart: demo Ruby on Rails reference project
 
-## Sample Configuration
+We maintain a reference Ruby on Rails project to show how to build Ruby on CircleCI 2.0:
 
-```YAML
-version: 2
-jobs:
-  build:
-    docker:
-      - image: ruby:2.3
-      - image: postgres:9.4.1
-        environment:
-          POSTGRES_USER: root
+- <a href="https://github.com/CircleCI-Public/circleci-demo-ruby-rails"> target="_blank">Demo Ruby on Rails Project on GitHub</a>
+- <a href="https://circleci.com/gh/CircleCI-Public/circleci-demo-ruby-rails"> target="_blank">Demo Ruby on Rails Project building on CircleCI</a>
 
-    working_directory: ~/cci-demo-rails
-    steps:
-      - checkout
-      - run: apt-get update -qq && apt-get install -y build-essential nodejs
-      - run: bundle install
-      - run: bundle exec rake db:create db:schema:load --trace
-      - run: bundle exec rake db:migrate
-      - run: bundle exec rake test
-```
+In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-ruby-rails/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using CircleCI 2.0 with Python projects.
 
-## Get the Code
+## Pre-built CircleCI Docker images
 
-The configuration above is from a demo Ruby on Rails app, which you can access at [https://github.com/circleci/cci-demo-rails](https://github.com/circleci/cci-demo-rails).
+We recommend using a CircleCI pre-built image that comes pre-installed with tools that are useful in a CI environment. You can select the Python version you need from Docker Hub: <https://hub.docker.com/r/circleci/ruby/>. The demo project uses an official CircleCI image.
 
-Fork the project and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
+Database images for use as a secondary 'service' container are also available.
 
-Now we’re ready to build a `config.yml` from scratch.
+## Build the demo Ruby on Rails project yourself
+
+A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
+
+1. Fork the project on GitHub to your own account
+2. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to the project you just forked
+3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 ---
 
 ## Config Walkthrough
 
-We always start with the version.
+Details of the configuration steps will be updated soon. Please see the `.circleci/config.yml` file in the demo project to get started.
 
-```YAML
-version: 2
-```
+---
 
-Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deploy process. Our sample app only needs a `build` job, so everything else is going to live under that key.
+Success! You just set up CircleCI 2.0 for a Ruby on Rails app. Check out our [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-ruby-rails) to see how this looks when building on CircleCI.
 
-In each job, we specify a `working_directory`. In this sample config, we’ll name it after the project in our home directory.
-
-```YAML
-...
-jobs:
-  build:
-    working_directory: ~/cci-demo-rails
-```
-
-This path will be used as the default working directory for the rest of the `job` unless otherwise specified.
-
-Directly beneath `working_directory`, we can specify container images for the build under a `docker` key.
-
-```YAML
-...
-    docker:
-      - image: ruby:2.3
-      - image: postgres:9.4.1
-        environment:
-          POSTGRES_USER: root
-```
-
-We use 2 Docker images here: `ruby:2.3` as the primary build image and `postgres:9.4.1` as the database image.
-
-Now we’ll add several `steps` within the `build` job.
-
-First we check out the codebase.
-
-In our second step, we install NodeJS because Docker’s Ruby image doesn’t include it. This command will also install any tools/headers required to build native gems.
-
-```YAML
-...
-    steps:
-      - checkout
-      - run: apt-get update -qq && apt-get install -y build-essential nodejs
-```
-
-Now we have to install our actual dependencies for the project.
-
-```YAML
-...
-      - run: bundle install
-```
-
-Next, set up the DB.
-
-```YAML
-...
-      - run: bundle exec rake db:create db:schema:load --trace
-```
-
-Rails will read `config/database.yml` and create a test DB automatically with `db:create` task. Ensure that `POSTGRES_USER` env var matches a username specified in your `database.yml`.
-
-**(Optional)** If you want to create a DB manually, you can do so with `createdb` command. We are installing the postgresql package because we need the `createdb` command.
-
-```YAML
-      - run: |
-        apt-get update -qq; apt-get install -y postgresql
-        createdb -h localhost my_test_db
-```
-
-Run our migrations.
-
-```YAML
-...
-      - run: bundle exec rake db:migrate
-```
-
-Finally, run our tests.
-
-```YAML
-...
-      - run: bundle exec rake test
-```
-
-Nice! You just set up CircleCI for a Rails app. Check out our [project’s build page](https://circleci.com/gh/circleci/cci-demo-rails).
-
-If you have any questions, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.
+If you have any questions about the specifics of testing your Ruby application, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.


### PR DESCRIPTION
This fixes links to all the main language demos.

The language docs themselves have been simplified since they contained inaccurate and outdated information. We will expand the details in the docs over the coming days.

I'm hoping to get this merged on the principle that it's better to have limited but accurate information instead of extensive outdated information.