### PR TITLE
Fix branding for GitHub.

### DIFF
--- a/jekyll/_ccie/docker-install.md
+++ b/jekyll/_ccie/docker-install.md
@@ -62,7 +62,7 @@ If you are configuring network security, please ensure you whitelist the followi
 | Administrators              | 22                      | SSH                    |
 | Administrators              | 8800                    | Admin Console          |
 | Builder Boxes               | all traffic / all ports | Internal Communication |
-| Github (Enterprise or .com) | 80, 443                 | Incoming Webhooks      |
+| GitHub (Enterprise or .com) | 80, 443                 | Incoming Webhooks      |
 
 Once the machine is up, you can ssh in as root (or ubuntu) and run the following:
 

--- a/jekyll/_ccie/on-prem.md
+++ b/jekyll/_ccie/on-prem.md
@@ -22,7 +22,7 @@ CircleCI deployment environment is required to have the following:
 
 * Ubuntu Trusty 14.04 instances.  To import the instances into your environment, you can import the image from [Ubuntu Cloud releases](https://cloud-images.ubuntu.com/releases/14.04.4/release/) or plain [Ubuntu ISOs](http://releases.ubuntu.com/14.04/).  Your probably need the appropriate image named `ubuntu-14.04-server-cloudimg-amd64` for your private cloud environment.
 * Access to GitHub Enterprise instance.  If running in separate networks, ensure that GitHub Enterprise and CircleCI Enterprise server are whitelisted in the firewall, or VPN connections are setup.
-* For ideal setup, CircleCI builders require a second volume, preferrably local SSD volumes.  This speeds up build runs with maximum effectiveness.
+* For ideal setup, CircleCI builders require a second volume, preferably local SSD volumes.  This speeds up build runs with maximum effectiveness.
 
 ### 2. GitHub App Client ID/Secret
 
@@ -38,7 +38,7 @@ For test installations, you may punt on this step until you spin up the machines
 
 ## Installation
 
-CircleCI Enterpise installation requires provisioning two types of machines:
+CircleCI Enterprise installation requires provisioning two types of machines:
 
 * Services box - an instance that is always-on and used as the web server.  The GitHub App domain name needs to map to this instance.
 * A pool of builder machines.  You can have a least one for normal operations, but you can provision as many builders as your scale demands.
@@ -58,7 +58,7 @@ If you are configuring network security, please ensure you whitelist the followi
 | Administrators              | 22                      | SSH                    |
 | Administrators              | 8800                    | Admin Console          |
 | Builder Boxes               | all traffic / all ports | Internal Communication |
-| Github (Enterprise or .com) | 80, 443                 | Incoming Webhooks      |
+| GitHub (Enterprise or .com) | 80, 443                 | Incoming Webhooks      |
 
 Once the machine is up, you can ssh in as root (or ubuntu) and run the following:
 
@@ -192,7 +192,7 @@ If your network is setup differently, you can set the following environment vari
 
 ### No second volume for builders
 
-We strongly recommend using second volumes, preferrably backed by SSD disks, for running builds.  If your cloud installation doesn't support attaching second volumes - we can use loopback devices backed by sparse files:
+We strongly recommend using second volumes, preferably backed by SSD disks, for running builds.  If your cloud installation doesn't support attaching second volumes - we can use loopback devices backed by sparse files:
 
 ```bash
 $ sudo truncate -s 80G /tmp/sparse-file.img

--- a/jekyll/_ccie/overview.md
+++ b/jekyll/_ccie/overview.md
@@ -7,7 +7,7 @@ order: 1
 description: "High-level overview of the CircleCI Enterprise Installation process."
 ---
 
-This article provides a platform-independant overview of CircleCI Enterprise. CircleCI Enterprise matches the experience of <https://circleci.com> but runs behind your organization's firewall, allowing your code, builds, and production hosts to be inaccessible outside of your network.
+This article provides a platform-independent overview of CircleCI Enterprise. CircleCI Enterprise matches the experience of <https://circleci.com> but runs behind your organization's firewall, allowing your code, builds, and production hosts to be inaccessible outside of your network.
 
 We are constantly working on making the installation process as smooth as possible and expanding the administrative tooling.  We appreciate your feedback on ways to make CircleCI Enterprise easier and more valuable for you and your team, so please contact us at <enterprise-support@circleci.com> with any suggestions.
 
@@ -15,12 +15,12 @@ We are constantly working on making the installation process as smooth as possib
 ### Installation Steps
 
 Once you have all of the prerequisites in place, you can either [follow the detailed
-installation steps for AWS]({{site.baseurl}}/enterprise/aws/), or [for enviroments not on AWS]({{site.baseurl}}/enterprise/docker-install/).
+installation steps for AWS]({{site.baseurl}}/enterprise/aws/), or [for environments not on AWS]({{site.baseurl}}/enterprise/docker-install/).
 
 
 ## Architecture
 
-At a high level, CircleCI Enteprise has two kinds of instances that it needs in order to run: the services box and builder boxes.
+At a high level, CircleCI Enterprise has two kinds of instances that it needs in order to run: the services box and builder boxes.
 
 ![A Diagram of the CircleCI Architecture]({{site.baseurl}}/assets/img/docs/enterprise-network-diagram.png)
 
@@ -35,7 +35,7 @@ The first is a services box which contains the CircleCI frontend and all interna
 | Administrators              | 22                      | SSH                    |
 | Administrators              | 8800                    | Admin Console          |
 | Builder Boxes               | all traffic / all ports | Internal Communication |
-| Github (Enterprise or .com) | 80, 443                 | Incoming Webhooks      |
+| GitHub (Enterprise or .com) | 80, 443                 | Incoming Webhooks      |
 
 #### The Builder Boxes
 ---
@@ -50,7 +50,7 @@ Our Builder Boxes handle running your builds, and store no state themselves. Eac
 | Services Box                     | all traffic / all ports | Internal Communication                                         |
 | Builder Boxes (including itself) | all traffic / all ports | Internal Communication                                         |
 
-#### Github
+#### GitHub
 ---
 
 | Source        | Ports   | Use          |

--- a/jekyll/_ccie/troubleshooting-install.md
+++ b/jekyll/_ccie/troubleshooting-install.md
@@ -10,7 +10,7 @@ published: true
 
 #### "Test GitHub Authentication" is failing
 
-This means that the GitHub Enterprise server is not returning the intermediate SSL certificates. Check your Github Enterprise instance with <https://www.ssllabs.com/ssltest/analyze.html> - it may report some missing intermediate certs. You can use tools like <https://whatsmychaincert.com/> to get the full certificate chain for your server.
+This means that the GitHub Enterprise server is not returning the intermediate SSL certificates. Check your GitHub Enterprise instance with <https://www.ssllabs.com/ssltest/analyze.html> - it may report some missing intermediate certs. You can use tools like <https://whatsmychaincert.com/> to get the full certificate chain for your server.
 
 
 #### "Verify TLS Settings" is failing

--- a/jekyll/_ccie/upgrade-to-GA.md
+++ b/jekyll/_ccie/upgrade-to-GA.md
@@ -20,7 +20,7 @@ Once on the GA version, future updates to the newest release are simple to perfo
 Briefly, in two ways:
 
 1. iOS builds will be down for approximately 10 minutes, up to an hour if there are any errors in reconnecting. 
-2. This upgrade does not preserve user / project follow settings, so your end users will need to log back into the system once it is up and running and re-follow the projects the care about. All UI settings and configuration for those projects will be preserved (including environent variables). So once an admin of a particular Github Org refollows the project on CircleCI, the webhooks will reconnect and builds will start right where they left off. This can be done before killing the old installation, resulting in 0 downtime.
+2. This upgrade does not preserve user / project follow settings, so your end users will need to log back into the system once it is up and running and re-follow the projects the care about. All UI settings and configuration for those projects will be preserved (including environment variables). So once an admin of a particular GitHub Org refollows the project on CircleCI, the webhooks will reconnect and builds will start right where they left off. This can be done before killing the old installation, resulting in 0 downtime.
 
 ### Step 1. Preserving your settings
 
@@ -30,7 +30,7 @@ If you have iOS, you will also need access to the public/private key pair and IP
 
 ### Step 2. Setting up your new CircleCI
 
-Next you'll want to setup a new installation of CircleCI, following the doc here: <https://enterprise-docs.circleci.com/getting-started/aws/>. In order to prevent downtime, we recommend setting up a new Github Application as well. 
+Next you'll want to setup a new installation of CircleCI, following the doc here: <https://enterprise-docs.circleci.com/getting-started/aws/>. In order to prevent downtime, we recommend setting up a new GitHub Application as well. 
 
 If you have any iOS resources, you'll also want to launch an iOS builder (Step 1 of the iOS install process: <https://enterprise-docs.circleci.com/ios-install/>
 
@@ -39,7 +39,7 @@ If you have any iOS resources, you'll also want to launch an iOS builder (Step 1
 There are two things you need to do to get your new CircleCI back up and running:
 
 1. Import the settings you exported in step 1: <https://enterprise-docs.circleci.com/resources/export-import-projects/>.
-2. Migrate repos over. Have an admin for each project refollow the repo with the new CirclCI, so that the webhooks are reattached. Once they follow it on the new CircleCI, both installtions will be submitting commit statuses. If you would like to prevent this, you can delete the webhook for the old CircleCI installation manually. ***If you do not want to deal with the possibility of the two CircleCI installtions overwriting each other's commit statuses, you can perfomr this step after shutting down your old installation, but that will result in brief downtime***
+2. Migrate repos over. Have an admin for each project refollow the repo with the new CircleCI, so that the webhooks are reattached. Once they follow it on the new CircleCI, both installations will be submitting commit statuses. If you would like to prevent this, you can delete the webhook for the old CircleCI installation manually. ***If you do not want to deal with the possibility of the two CircleCI installtions overwriting each other's commit statuses, you can perfomr this step after shutting down your old installation, but that will result in brief downtime***
 
 ### Step 4. [DOWNTIME] Destroy the old CircleCI and finish the iOS installation
 

--- a/jekyll/_data/api.yml
+++ b/jekyll/_data/api.yml
@@ -492,7 +492,7 @@ project_build_cache:
 
 "user/ssh-key":
   method: "POST"
-  description: "Adds a CircleCI key to your Github User account."
+  description: "Adds a CircleCI key to your GitHub User account."
 
 "user/heroku-key":
   method: "POST"


### PR DESCRIPTION
This PR was meant to fix versions of the word GitHub to it's proper form. This PR does this, but also caught several spelling errors along the way.