### PR TITLE
Fix doc boog where rspec formatter missing from config

### DIFF
--- a/jekyll/_cci1/parallel-manual-setup.md
+++ b/jekyll/_cci1/parallel-manual-setup.md
@@ -109,7 +109,7 @@ command like this to include the RSpec Junit formatter:
 ```
 test:
   override:
-    - bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec.xml:
+    - bundle exec rspec --format progress --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec.xml:
         parallel: true
         files:
           - spec/unit/sample.rb   # can be a direct path to file

--- a/jekyll/_cci1/test-metadata.md
+++ b/jekyll/_cci1/test-metadata.md
@@ -195,7 +195,7 @@ And modify your test command to this:
 ````
 test:
   override:
-    - RAILS_ENV=test bundle exec rspec -r rspec_junit_formatter --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
+    - bundle exec rspec --format progress --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec.xml
 ````
 
 ### <a name="minitest"></a> Minitest


### PR DESCRIPTION
Originally pointed out here by @conwayje:
https://discuss.circleci.com/t/metadata-collection-parallelization-leads-to-time-out-for-rspec/12720

Unless you specify a formatter which actually outputs to STDOUT, which junit formatter doesnt,
your rspec command will eventually be killed if it takes longer than 10 minutes (without output).

Also, this patch addresses unnecessary require and instructions for rspec_junit_formatter gem