### PR TITLE
Fix index links

### DIFF
--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -15,7 +15,7 @@ Code that builds on Linux will generally build on CircleCI 2.0. For some languag
 - **Elixir 1.2 and later**, see the [Elixir Language Guide]({{ site.baseurl }}/2.0/language-elixir/)
 - **Go 1.7 and later**, see the [Go Language Guide]({{ site.baseurl }}/2.0/language-go/)
 - **Java 8 and later**, see the [Java Language Guide]({{ site.baseurl }}/2.0/language-java/)
-- **Node.js 4 and later**, see the [JavaScript Language Guide]({ site.baseurl }}/2.0/language-javascript/)
+- **Node.js 4 and later**, see the [JavaScript Language Guide]({{ site.baseurl }}/2.0/language-javascript/)
 - **PHP 5 and later**, see the [PHP Language Guide]({{ site.baseurl }}/2.0/language-php/)
 - **Python 2 and later**, see the [Python Language Guide]({{ site.baseurl }}/2.0/language-python/)
 - **Ruby 2 and later**, see the [Ruby and Rails]({{ site.baseurl }}/2.0/language-ruby/) 
@@ -26,7 +26,7 @@ Build projects in C, C#, C++, Clojure, Elixir, Erlang, Go, Groovy, Haskell, Haxe
 
 CircleCi 2.0 includes infrastructure upgrades for faster performance that reduce overall time to build, test, and deploy for all platforms at scale. See the [Migration FAQ]({{ site.baseurl }}/2.0/faq/) for answers to common questions about the Beta.
 
-CircleCI 2.0 gives you greater control with new configuration keys in 2.0 enable you to break up monolithic builds into separate Jobs and Steps. See [Migrating from 1.0 to 2.0]({{ site.baseurl }}/2.0/migrate-1-2/) for information about the new keys, then head over to the [2.0 Project Tutorial]({{ site.baseurl }}/2.0/project-walkthrough/).
+CircleCI 2.0 gives you greater control with new configuration keys in 2.0 enable you to break up monolithic builds into separate Jobs and Steps. See [Migrating from 1.0 to 2.0]({{ site.baseurl }}/2.0/migrating-from-1-2/) for information about the new keys, then head over to the [2.0 Project Tutorial]({{ site.baseurl }}/2.0/project-walkthrough/).
 
 First-class container support is also implemented in 2.0 to give you more control over your build environment and access to native Docker features.
 

--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -5,43 +5,30 @@ description: "Landing page for CircleCI 2.0"
 permalink: /2.0/
 ---
 
-Welcome to CircleCI 2.0 Beta! The Beta release of CircleCI 2.0 includes many improvements for faster performance and greater control. 
+Welcome to CircleCI 2.0 Beta! The Beta release of CircleCI 2.0 includes many improvements for faster performance and greater control. If you are new to CircleCI, check out the [Overview]({{ site.baseurl }}/2.0/about-circleci) for how it works and then use the [Hello World]({{ site.baseurl }}/2.0/hello-world) doc to start your first project build.
 
 ## Programming Language Support
 
-Code that builds on Linux will generally build on CircleCI 2.0. For some language versions, CircleCI provides demo applications and Docker images for primary container use, as follows: 
+Code that builds on Linux will generally build on CircleCI 2.0. For some language versions, CircleCI provides demo applications with YAML file templates and instructions: 
 
-- **Clojure 1.8 and later**, see <https://github.com/CircleCI-Public/circleci-demo-clojure-luminus> and <https://hub.docker.com/r/circleci/clojure>
-- **Go 1.7 and later**, see <https://github.com/CircleCI-Public/circleci-demo-go> and <https://hub.docker.com/r/circleci/golang>
-- **Java 8 and later**, see <https://github.com/CircleCI-Public/circleci-demo-java-spring> and <https://hub.docker.com/r/circleci/openjdk>
-- **Node.js 4 and later**, see <https://github.com/CircleCI-Public/circleci-demo-javascript-express> and <https://hub.docker.com/r/circleci/node>
-- **PHP 5 and later**, see <https://github.com/CircleCI-Public/circleci-demo-php-laravel> and <https://hub.docker.com/r/circleci/php>
-- **Python 2 and later**, see <https://github.com/CircleCI-Public/cci-demo-python-flask> or <https://github.com/CircleCI-Public/circleci-demo-python-django> and <https://hub.docker.com/r/circleci/python>
-- **Ruby 2 and later**, see <https://github.com/CircleCI-Public/circleci-demo-ruby-rails> and <https://hub.docker.com/r/circleci/ruby> 
-
-In addition, CircleCI provides Docker database images for use as a secondary service container:
-
-- **MongoDB 3 and later**, see <https://hub.docker.com/r/circleci/mongo>
-- **MySQL 5 and later**, see <https://hub.docker.com/r/circleci/mysql>
-- **PostgreSQL 9 and later**, see <https://hub.docker.com/r/circleci/postgres>
+- **Clojure 1.8 and later**, see the [Clojure Language Guide]({{ site.baseurl }}/2.0/language-clojure/)
+- **Elixir 1.2 and later**, see the [Elixir Language Guide]({{ site.baseurl }}/2.0/language-elixir/)
+- **Go 1.7 and later**, see the [Go Language Guide]({{ site.baseurl }}/2.0/language-go/)
+- **Java 8 and later**, see the [Java Language Guide]({{ site.baseurl }}/2.0/language-java/)
+- **Node.js 4 and later**, see the [JavaScript Language Guide]({ site.baseurl }}/2.0/language-javascript/)
+- **PHP 5 and later**, see the [PHP Language Guide]({{ site.baseurl }}/2.0/language-php/)
+- **Python 2 and later**, see the [Python Language Guide]({{ site.baseurl }}/2.0/language-python/)
+- **Ruby 2 and later**, see the [Ruby and Rails]({{ site.baseurl }}/2.0/language-ruby/) 
 
 Build projects in C, C#, C++, Clojure, Elixir, Erlang, Go, Groovy, Haskell, Haxe, Java, Javascript, Node.js, Perl, PHP, Python, Ruby, Rust, Scala and many more. 
 
-## Faster Performance with 2.0
+## Features
 
-- Infrastructure upgrades resulting in significant performance improvements that reduce overall time to build, test, and deploy for all platforms at scale. [Join the CircleCI 2.0 Beta](https://circleci.com/beta-access/) to access the latest features. 
+CircleCi 2.0 includes infrastructure upgrades for faster performance that reduce overall time to build, test, and deploy for all platforms at scale. See the [Migration FAQ]({{ site.baseurl }}/2.0/faq/) for answers to common questions about the Beta.
 
-- Caching of images, source code, dependencies, custom caches, and save/restore points throughout jobs for increased speed. See [Caching in CircleCI]({{ site.baseurl }}/2.0/caching/) for details.
+CircleCI 2.0 gives you greater control with new configuration keys in 2.0 enable you to break up monolithic builds into separate Jobs and Steps. See [Migrating from 1.0 to 2.0]({{ site.baseurl }}/2.0/migrate-1-2/) for information about the new keys, then head over to the [2.0 Project Tutorial]({{ site.baseurl }}/2.0/project-walkthrough/).
 
-## Greater Control with 2.0
-
-- Implementation of first-class Docker support for nearly all public Docker images, layer caching, compose, public or private registries, and runtime metrics. See [Using Docker Compose]({{ site.baseurl }}/2.0/docker-compose/) for the steps.
-
-- Availability of *CircleCI Images* on Docker Hub that include pre-installed dependencies, test tools, Git, and SSH to save  time getting started with the most popular languages and databases. See the [CircleCI Images]({{ site.baseurl }}/2.0/circleci-images/) document for an overview of the available images and how to add them to the `config.yml` file. 
-
-- Ability to create custom images or compose multiple images together to minimize build failures related to unexpected image updates. See [Building Custom Images for Docker Executor]({{ site.baseurl }}/2.0/custom-images/) for instructions.
-
-- Increased flexibility of CPU and RAM limits for premium users. 
+First-class container support is also implemented in 2.0 to give you more control over your build environment and access to native Docker features.
 
 We’re thrilled to have you here. Happy building!
 


### PR DESCRIPTION
point language links to language guides as Nathan suggested, point other links to the get started and migration documents, fix up the text