### PR TITLE
Corrected command to get builder secret

### DIFF
--- a/jekyll/_ccie/faq.md
+++ b/jekyll/_ccie/faq.md
@@ -23,7 +23,7 @@ SSH into into the services box, and run the following:
 
 ```
 $ # To get the passphrase
-$ grep PASSPHRASE /etc/circle/generated
+$ circleci get-secret-token
 CIRCLE_SECRET_PASSPHRASE=xxxxxxxxxxxxxxxxxxxx
 $
 $ # To get private ip address


### PR DESCRIPTION
The prior command no longer worked due to a location change of where we save the secrets