### PR TITLE
Top level v1 doc update

### DIFF
--- a/jekyll/_cci1/configuration.md
+++ b/jekyll/_cci1/configuration.md
@@ -5,6 +5,8 @@ categories: [getting-started,reference]
 description: How to configure CircleCI
 order: 30
 ---
+* Contents
+{:toc}
 
 CircleCI automatically infers settings from your code, so it's possible you won't need to add any custom configuration.
 

--- a/jekyll/_cci1/faq.md
+++ b/jekyll/_cci1/faq.md
@@ -7,6 +7,9 @@ description: Frequently Asked Questions
 order: 60
 ---
 
+* Contents
+{:toc}
+
 ## How do I subscribe to CircleCI announcements and get updates about new features and changes?
 
 We recommend that **all customers subscribe to the '[Announcements](https://discuss.circleci.com/c/announcements)' category** on our forums. You will get advance notice of important changes and new features.

--- a/jekyll/_cci1/index.md
+++ b/jekyll/_cci1/index.md
@@ -26,7 +26,7 @@ For some language versions, CircleCI provides demo applications, as follows:
 - **PHP 5 and later**, see the [PHP Guide]({{ site.baseurl }}/1.0/language-php/)
 - **Python 2.6.6 and later**, see the [Python Guide]({{ site.baseurl }}/1.0/language-python/)
 - **Ruby 1.8 and later**, see the [Ruby/Rails Guide]({{ site.baseurl }}/1.0/language-ruby-on-rails/) 
-- **Scala 0.13.11 and later**, see the [Scala Guide]({{ site.baseurl }}/1.0/scala/)
+- **Scala 0.13.11 and later**, see the [Scala Guide]({{ site.baseurl }}/1.0/language-scala/)
 
 Build projects in C, C#, C++, Clojure, Elixir, Erlang, Groovy, Haxe, Javascript, Perl, Rust, Scala and many more.
 

--- a/jekyll/_cci1/index.md
+++ b/jekyll/_cci1/index.md
@@ -17,18 +17,18 @@ For example, after a software repository on GitHub or Bitbucket is authorized an
 
 ## Programming Language Support
 
-For some language versions, CircleCI provides demo applications, as follows:  
+CircleCI 1.0 supports the use of any language version that is installable on Ubuntu 14.04. Additional versions may be installed at runtime, see the [Ubuntu 14.04 Trusty doc]({{ site.baseurl }}/1.0/build-image-trusty/#programming-languages) for the defaults. For some language versions, CircleCI provides demo applications, as follows:  
 
 - **Go 1.5.3**, see the [Golang Guide]({{ site.baseurl }}/1.0/language-go/)
 - **Haskell 7.4 and later**, see the [Haskell Guide]({{ site.baseurl }}/1.0/language-haskell/)
 - **Java JDK6 and later**, see the [Java Guide]({{ site.baseurl }}/1.0/language-java/)
 - **Node.js all versions**, see the [Node Guide]({{ site.baseurl }}/1.0/language-nodejs/)
 - **PHP 5 and later**, see the [PHP Guide]({{ site.baseurl }}/1.0/language-php/)
-- **Python 2.6.6 and later**, see the [Python Guide]({{ site.baseurl }}/1.0/language-python/)
+- **Python 2.x or 3.x**, see the [Python Guide]({{ site.baseurl }}/1.0/language-python/)
 - **Ruby 1.8 and later**, see the [Ruby/Rails Guide]({{ site.baseurl }}/1.0/language-ruby-on-rails/) 
 - **Scala 0.13.11 and later**, see the [Scala Guide]({{ site.baseurl }}/1.0/language-scala/)
 
-Build projects in C, C#, C++, Clojure, Elixir, Erlang, Groovy, Haxe, Javascript, Perl, Rust, Scala and many more.
+CircleCI works with projects written in C, C#, C++, Clojure, Elixir, Erlang, Groovy, Haxe, Javascript, Perl, Rust, Scala and many more!
 
 ## Continuous Deployment 
 

--- a/jekyll/_cci1/index.md
+++ b/jekyll/_cci1/index.md
@@ -20,13 +20,13 @@ For example, after a software repository on GitHub or Bitbucket is authorized an
 For some language versions, CircleCI provides demo applications, as follows:  
 
 - **Go 1.5.3**, see the [Golang Guide]({{ site.baseurl }}/1.0/language-go/)
-- **Haskell 7.4 and later**, see the [Haskell Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-haskell/)
-- **Java JDK6 and later**, see the [Java Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-java/)
-- **Node.js all versions**, see the [Node Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-nodejs/)
-- **PHP 5 and later**, see the [PHP Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-php/)
-- **Python 2.6.6 and later**, see the [Python Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-python/)
-- **Ruby 1.8 and later**, see the [Ruby/Rails Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-ruby-on-rails/) 
-- **Scala 0.13.11 and later**, see the [Scala Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/scala/)
+- **Haskell 7.4 and later**, see the [Haskell Guide]({{ site.baseurl }}/1.0/language-haskell/)
+- **Java JDK6 and later**, see the [Java Guide]({{ site.baseurl }}/1.0/language-java/)
+- **Node.js all versions**, see the [Node Guide]({{ site.baseurl }}/1.0/language-nodejs/)
+- **PHP 5 and later**, see the [PHP Guide]({{ site.baseurl }}/1.0/language-php/)
+- **Python 2.6.6 and later**, see the [Python Guide]({{ site.baseurl }}/1.0/language-python/)
+- **Ruby 1.8 and later**, see the [Ruby/Rails Guide]({{ site.baseurl }}/1.0/language-ruby-on-rails/) 
+- **Scala 0.13.11 and later**, see the [Scala Guide]({{ site.baseurl }}/1.0/scala/)
 
 Build projects in C, C#, C++, Clojure, Elixir, Erlang, Groovy, Haxe, Javascript, Perl, Rust, Scala and many more.
 

--- a/jekyll/_cci1/index.md
+++ b/jekyll/_cci1/index.md
@@ -5,39 +5,39 @@ title: "CircleCI 1.0 Documentation"
 permalink: /1.0/
 ---
 
-{% for category in site.data.categories %}
-{% if category.section == "cci1" %}
+CircleCI is a modern continuous integration and continuous delivery (CI/CD) platform. The hosted solution is available at <https://circleci.com/>. The [CircleCI Enterprise](https://circleci.com/enterprise/) solution is installable inside your private cloud or data center. Both are free to try for two weeks. If you are new to CircleCI, check out the [Getting Started with CircleCI]({{ site.baseurl }}/1.0/getting-started/).
 
-{% if category.index %}
-	{% assign catFile = category.index %}
-{% else %}
-	{% assign catFile = category.slug %}
-{% endif %}
+## Overview
 
-<div class="category-section">
-	<img src="{{ site.baseurl }}/assets/img/icons/{{ category.icon }}" class="logo" alt="Category Icon" />
-	<h2>{{ category.name }}</h2>
-	<ul class="list-unstyled">
-	{% assign docs_found = 0 %}
-	{% assign sortedDocs = site.cci1 | sort: 'order' %}
-	{% for doc in sortedDocs %}
-		{% if doc.categories contains category.slug and doc.slug != catFile and doc.hide != true %}
-			{% assign docs_found = docs_found | plus: 1 %}
-			{% if docs_found < 4 %}
-				{% if doc.short-title %}
-					<li class="{% if page.path contains doc.url %}active{% endif %}"><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.short-title }}</a></li>
-				{% else %}
-					<li><a href="{{ site.baseurl }}{{ doc.url }}">{{ doc.title }}</a></li>
-				{% endif %}
-			{% endif %}
-		{% endif %}
-	{% endfor %}
+CircleCI automates build, test, and deployment of software for mobile, enterprise, and web applications. 
 
-	{% if docs_found > 3 %}
-		{% assign more = docs_found | minus: 3 %}
-		<li><em><a href="{{ site.baseurl }}/1.0/{{ catFile }}/">{{ more }} more</a></em></li>
-	{% endif %}
-	</ul>
-</div>
-{% endif %}
-{% endfor %}
+![CircleCI Example Flow with GitHub]({{ site.baseurl }}/assets/img/docs/how_it_works.png)
+
+For example, after a software repository on GitHub or Bitbucket is authorized and added as a project to the circleci.com SaaS application, every new commit triggers a build and notification of success or failure through webhooks. CircleCI also supports Slack, HipChat, Campfire, Flowdock, and IRC notifications. Code coverage results are available from the details page for any project for which a reporting library is added.
+
+## Programming Language Support
+
+For some language versions, CircleCI provides demo applications, as follows:  
+
+- **Go 1.5.3**, see the [Golang Guide]({{ site.baseurl }}/1.0/language-go/)
+- **Haskell 7.4 and later**, see the [Haskell Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-haskell/)
+- **Java JDK6 and later**, see the [Java Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-java/)
+- **Node.js all versions**, see the [Node Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-nodejs/)
+- **PHP 5 and later**, see the [PHP Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-php/)
+- **Python 2.6.6 and later**, see the [Python Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-python/)
+- **Ruby 1.8 and later**, see the [Ruby/Rails Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/language-ruby-on-rails/) 
+- **Scala 0.13.11 and later**, see the [Scala Guide]({{ site.baseurl }} https://circleci.com/docs/1.0/scala/)
+
+Build projects in C, C#, C++, Clojure, Elixir, Erlang, Groovy, Haxe, Javascript, Perl, Rust, Scala and many more.
+
+## Continuous Deployment 
+
+CircleCI is able to automatically deploy code to various environments based on successful tests. The following continuous deployment mechanisms are integrated with CircleCI:
+
+* AWS CodeDeploy
+* AWS EC2 Container Service (ECS)
+* AWS S3
+* Google Container Engine (GKE)
+* Heroku
+* SSH
+

--- a/jekyll/_cci1/manually.md
+++ b/jekyll/_cci1/manually.md
@@ -6,6 +6,9 @@ description: Manual build setup
 order: 40
 ---
 
+* Contents
+{:toc}
+ 
 CircleCI is designed to set up most tests automatically because we infer your settings from your code.
 However, if you have an unusual setup or work in a framework that has no idiomatic way to set up your project, you'll need to set it up manually.
 Fortunately, this is a pretty straightforward procedure.


### PR DESCRIPTION
Just a little love for the 1.0 collection, using the landing page to provide the language versions and limited set of links, overview information, and adding TOCs to the long getting started docs