### PR TITLE
Add a video walkthrough of the single-box install

### DIFF
--- a/jekyll/_ccie/single-box.md
+++ b/jekyll/_ccie/single-box.md
@@ -84,6 +84,10 @@ You will also need to open ports 64535-65535 to let developers optionally SSH in
 (Note: Final startup of the app can take some time as the "circleci/build-image" Docker image is downloaded.)</li>
 </ol>
 
+<p style="font-size: 20px; text-align: center"><strong>A short video walkthrough of the entire install process on AWS:</strong></p>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/m4plGZmZkj4" frameborder="0" allowfullscreen style="display: block; margin: 20px auto;"></iframe>
+
 ## On Other Platforms
 
 It is also possible to install a trial of CircleCI Enterprise on a single VM on other cloud providers,


### PR DESCRIPTION
Here's what it looks like in place:

<img width="928" alt="screen shot 2017-05-25 at 4 47 46 pm" src="https://cloud.githubusercontent.com/assets/2081889/26475125/6739b876-416a-11e7-9f83-7545da7d9ee4.png">
