### PR TITLE
Fix spelling mistakes throughout 1.0 documentation

### DIFF
--- a/jekyll/_cci1/build-image-macos.md
+++ b/jekyll/_cci1/build-image-macos.md
@@ -11,7 +11,7 @@ To change a project from building on Linux to building on macOS you can go to
 'Project Settings' -> 'Build Environment', and enable the 'Build OS X project'
 setting.
 
-**NOTE: To apply the new setting, you will need to trigger a new build by pushing a commit to GitHub or Bitbucket. Rebuilding a previous build will re-use all settings from the previous build, including the Build Envirnonment.**
+**NOTE: To apply the new setting, you will need to trigger a new build by pushing a commit to GitHub or Bitbucket. Rebuilding a previous build will re-use all settings from the previous build, including the Build Environment.**
 
 ## Selecting Xcode Version and Operating System
 

--- a/jekyll/_cci1/continuous-deployment-with-aws-codedeploy.md
+++ b/jekyll/_cci1/continuous-deployment-with-aws-codedeploy.md
@@ -111,7 +111,7 @@ key starts with `my-app`.
 CircleCI also needs to be able to create application revisions, trigger
 deployments and get deployment status. If your application is called `my-app`
 and your account ID is `80398EXAMPLE` then the following policy snippet gives
-us sufficient accesss:
+us sufficient access:
 
     {
       "Version": "2012-10-17",

--- a/jekyll/_cci1/ios-builds-on-os-x.md
+++ b/jekyll/_cci1/ios-builds-on-os-x.md
@@ -317,7 +317,7 @@ your organization's settings page.
 
 ![](  {{ site.baseurl }}/assets/img/docs/fabric-org-settings-page.png)
 
-Click on your organisation (CircleCI in the image above), and click on
+Click on your organization (CircleCI in the image above), and click on
 the API key and Build Secret links to reveal the items.
 
 ![](  {{ site.baseurl }}/assets/img/docs/fabric-api-creds-page.png)

--- a/jekyll/_cci1/ios-code-signing.md
+++ b/jekyll/_cci1/ios-code-signing.md
@@ -53,7 +53,7 @@ The keychain that CircleCI creates is named `circle.keychain`, and the
 password is `circle`. This keychain is unlocked for the duration of the
 build, and it is added to the default search path. Any P12 certificates
 or provisioning profiles that you have uploaded are added to this keychain
-before your build begins. Any futher credentials that you add to this
+before your build begins. Any further credentials that you add to this
 keychain will be available to Xcode.
 
 ### 1. Install Fastlane tools locally

--- a/jekyll/_cci1/ios-getting-started.md
+++ b/jekyll/_cci1/ios-getting-started.md
@@ -110,9 +110,9 @@ This keychain is also added to the Xcode search path, so any credentials stored 
 
 To use your provisioning profile with your CircleCI builds, you need to upload the `.mobileprovision` file on the **Project Settings** > **OS X Code Signing** page. Any provisioning profiles will automatically be added to the `circle.keychain` at the start of the build.
 
-## Customising your build
+## Customizing your build
 
-Although our inference will work for many cases, some teams may want to customise their build process to use custom tools or run their own scripts. This is done using the `circle.yml` file.
+Although our inference will work for many cases, some teams may want to customize their build process to use custom tools or run their own scripts. This is done using the `circle.yml` file.
 
 If you wish to see a more detailed guide to the format, take a look at our [configuration sample]( {{ site.baseurl }}/1.0/config-sample/).
 

--- a/jekyll/_cci1/ios-getting-started.md
+++ b/jekyll/_cci1/ios-getting-started.md
@@ -14,7 +14,7 @@ By default, we build projects on Linux, so you’ll need to enable macOS for you
 
 ## Assumptions and prerequisites
 
-For our infererence to test your Xcode project, we check for and validate the presence of:
+For our inference to test your Xcode project, we check for and validate the presence of:
 
 - an Xcode workspace/project
 - with at least one shared scheme

--- a/jekyll/_cci1/language-php.md
+++ b/jekyll/_cci1/language-php.md
@@ -11,7 +11,7 @@ help PHP developers test and deploy their code. We can generally infer
 most of your dependencies and test commands, but we also provide custom
 configuration via a `circle.yml` file checked into your repo's root directory. 
 The examples here referring to PHP filepaths are for the Ubuntu 14.04 and newer 
-images. This image is not default but can be choosen in Project Settings -> 
+images. This image is not default but can be chosen in Project Settings -> 
 Build Environment. For Ubuntu 12.04, replace `/opt/circleci/php` with 
 `~/.phpenv/versions` in the examples.
 

--- a/jekyll/_cci1/language-ruby-on-rails.md
+++ b/jekyll/_cci1/language-ruby-on-rails.md
@@ -57,7 +57,7 @@ dependencies:
     - bundle exec rake assets:precompile
 ```
 
-The default inferred step for Bundler is `bundle check || bundle install`. For reasons, we use `check` prior to `install` in order to skip unnecessary steps inherited from the `bundle install` command when all depedencies are cached or otherwise already installed and available on the system.
+The default inferred step for Bundler is `bundle check || bundle install`. For reasons, we use `check` prior to `install` in order to skip unnecessary steps inherited from the `bundle install` command when all dependencies are cached or otherwise already installed and available on the system.
 
 ### Databases
 


### PR DESCRIPTION
I've been reading through the Getting Started, Build Images, Languages, Mobile Platforms and How-To sections of the 1.0 documentation as part of my training. I noticed a few spelling mistakes while reading through the documents and thought I'd contribute to fix them. See the commit history/diff for which specific words were corrected and in what files. 😸 