### PR TITLE
Restructure config sections

### DIFF
--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -4,7 +4,7 @@ title: "Uploading Build Artifacts"
 short-title: "Uploading Build Artifacts"
 description: "Example of uploading artifacts created during a build"
 categories: [configuring-jobs]
-order: 60
+order: 70
 ---
 
 Sometimes, you'll want to upload artifacts created during builds so you can view them later. The following is an example of how to do that:

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -1,21 +1,16 @@
 ---
 layout: classic-docs
-title: "Building Docker Images on CircleCI 2.0"
-short-title: "Building Docker Images"
+title: "Building Custom Docker Images"
+short-title: "Building Custom Docker Images"
 description: "How to build Docker images and access remote services"
-categories: [deploying]
-order: 20
+categories: [virtualization]
+order: 30
 ---
 
-## Overview
-As part of your build you might want to build Docker images for deploying elsewhere or for further testing. This document explains how to do that on CircleCI 2.0.
-
-For security reasons, the [Docker Executor]({{ site.baseurl }}/2.0/executor-types/#docker-executor) doesn’t allow building Docker images within a [job space][job-space].
-
-To help users build, run, and publish new images, we’ve introduced a special feature which creates a separate environment for each build. This environment is remote, fully-isolated and has been configured to execute Docker commands.
+This document explains how to build Docker images for deploying elsewhere or for further testing. To do so, you must use a special key which creates a separate environment for each build for security. This environment is remote, fully-isolated and has been configured to execute Docker commands.
 
 ## Configuration
-If your build requires `docker` or `docker-compose` commands, you’ll need to add a special step into your `.circleci/config.yml`:
+If your build requires `docker` or `docker-compose` commands, add the `setup_remote_docker` step into your `.circleci/config.yml`:
 
 ```YAML
 jobs:
@@ -71,7 +66,7 @@ Let’s break down what’s happening during this build’s execution:
 4. We use project environment variables to store credentials for Docker Hub.
 
 ## Separation of Environments
-Since the [job space][job-space] and [remote docker]({{ site.baseurl }}/2.0/glossary/#remote-docker) are separated environments, there's one caveat: containers running in your job space can’t directly communicate with containers running in remote docker.
+The job and [remote docker]({{ site.baseurl }}/2.0/glossary/#remote-docker) run in  separate environments. Therefore, Docker or Machine containers cannot directly communicate with the containers running in remote docker.
 
 ### Accessing Services
 It’s impossible to start a service in remote docker and ping it directly from a primary container (and vice versa). To solve that, you’ll need to interact with a service from remote docker, as well as through the same container:
@@ -116,8 +111,6 @@ In the same way, if your application produces some artifacts that need to be sto
     # once application container finishes we can copy artifacts directly from it
     docker cp app:/output /path/in/your/job/space
 ```
-
-If you have any questions, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.
 
 [job-space]: {{ site.baseurl }}/2.0/glossary/#job-space
 [primary-container]: {{ site.baseurl }}/2.0/glossary/#primary-container

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -3,7 +3,7 @@ layout: classic-docs
 title: "Building Custom Docker Images"
 short-title: "Building Custom Docker Images"
 description: "How to build Docker images and access remote services"
-categories: [virtualization]
+categories: [deploying]
 order: 30
 ---
 

--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -1,11 +1,12 @@
 ---
 layout: classic-docs
-title: "Caching For Faster Jobs"
-short-title: "Caching"
-description: "Caching strategies to increase build speeds"
+title: "Caching Dependencies and Source Code"
+short-title: "Caching Dependencies and Source Code"
+description: "Caching Dependencies and Source Code"
 categories: [configuring-jobs]
-order: 20
+order: 50
 ---
+
 
 Caching is one of the most effective ways to make jobs faster on CircleCI. To get the best performance can take a bit of planning and fine tuning. There is an art to effective caching. This document gives you strategies to optimise caching to speed up your jobs.
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -1,15 +1,15 @@
 ---
 layout: classic-docs
-title: "CircleCI Images"
-short-title: "CircleCI Images"
+title: "Using Pre-Built CircleCI Docker Images"
+short-title: "Using Pre-Built CircleCI Docker Images"
 description: "Listing of available images maintained by CircleCI"
-categories: [reference]
-order: 1
+categories: [virtualization]
+order: 20
 ---
 
-CircleCI maintains a number of Docker images that are, generally, supersets of official images for popular languages with additional tooling useful when running your tests. 
+CircleCI maintains a number of Docker Images for popular languages with additional tooling that is useful when running your tests. 
 
-For many of them we also have the following variants, which can be used by adding the suffix to the main image name (each of which is listed in the tags for each image below, when available):
+For many of them CircleCI maintains the following variants, which can be used by adding the suffix to the main image name (each of which is listed in the tags for each image below, when available):
 
 {% for variant in site.data.circleci_images.variants %}
 * `-{{ variant[0] }}`: {{ variant[1] }}
@@ -17,7 +17,7 @@ For many of them we also have the following variants, which can be used by addin
 
 All of the following images are published in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/). 
 
-NOTE: We strongly recommend that you lock your image to a particular tag to avoid unwanted changes (the available tags for each image are listed below and available on each images Docker Hub page). If you choose to use the `latest` tag the image may change unexpectedly and create surprising results.
+**Note:** It is important to lock your image to a particular tag to avoid unwanted changes (the available tags for each image are listed below and available on each images Docker Hub page). If you choose to use the `latest` tag the image may change unexpectedly and create surprising results.
 
 <!-- TODO: Sort this -->
 {% assign images = site.data.circleci_images.images %}
@@ -27,7 +27,7 @@ NOTE: We strongly recommend that you lock your image to a particular tag to avoi
 
 ## Available Images
 
-**Note:** The 'language' images would usually be used as your 'primary' container. The 'database' images are best used as a secondary 'service' container.
+**Note:** The language images are to be used as your primary container listed first in your `config.yml` file. The database images are best used as a secondary service container, in which case, list after the primary container image in your `config.yml` file.
 
 {% for image in images %}
 * [{{ image[1].name }}](#{{ image[1].name | kramdown_generate_id }})
@@ -46,4 +46,5 @@ NOTE: We strongly recommend that you lock your image to a particular tag to avoi
 <hr>
 {% endfor %}
  
+
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -3,21 +3,13 @@ layout: classic-docs
 title: "Using Pre-Built CircleCI Docker Images"
 short-title: "Using Pre-Built CircleCI Docker Images"
 description: "Listing of available images maintained by CircleCI"
-categories: [virtualization]
+categories: [containerization]
 order: 20
 ---
 
-CircleCI maintains a number of Docker Images for popular languages with additional tooling that is useful when running your tests. 
+As a convenience, CircleCI maintains a number of Docker Images for popular languages with additional tooling that is useful when running your tests. All of the following images are published in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/). 
 
-For many of them CircleCI maintains the following variants, which can be used by adding the suffix to the main image name (each of which is listed in the tags for each image below, when available):
 
-{% for variant in site.data.circleci_images.variants %}
-* `-{{ variant[0] }}`: {{ variant[1] }}
-{% endfor %}
-
-All of the following images are published in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/). 
-
-**Note:** It is important to lock your image to a particular tag to avoid unwanted changes (the available tags for each image are listed below and available on each images Docker Hub page). If you choose to use the `latest` tag the image may change unexpectedly and create surprising results.
 
 <!-- TODO: Sort this -->
 {% assign images = site.data.circleci_images.images %}
@@ -33,6 +25,16 @@ All of the following images are published in the [CircleCI org on Docker Hub](ht
 * [{{ image[1].name }}](#{{ image[1].name | kramdown_generate_id }})
 {% endfor %}
 
+
+
+
+**Note:** CircleCI maintains variants, which can be added to the main image name as follows:
+
+{% for variant in site.data.circleci_images.variants %}
+* `-{{ variant[0] }}`: {{ variant[1] }}
+{% endfor %}
+
+**Note:** If you choose to use the `latest` tag the image may change unexpectedly and create surprising results.
 <hr>
 
 {% for image in images %}

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1,13 +1,15 @@
 ---
 layout: classic-docs
-title: "Configuration Reference"
-short-title: "Configuration"
+title: "Writing Jobs with Steps"
+short-title: "Writing Jobs with Steps"
 description: "Reference for .circleci/config.yml"
-categories: [reference]
-order: 0
+categories: [configuring-jobs]
+order: 20
 ---
 
-This document is a reference for `.circleci/config.yml` which describes jobs and steps to build/test/deploy your project. The presence of this file indicates that you want to use the 2.0 infrastructure. This allows you to test 2.0 builds on a separate branch, leaving any existing configuration in the old `circle.yml` style unaffected and running on the CircleCI 1.0 infrastructure in branches that do not contain `.circleci/config.yml`.
+This document describes how to write jobs and steps to build, test, and deploy your project. The presence of a `.circleci/config.yml` file in your CircleCI-authorized repository branch indicates that you want to use the 2.0 infrastructure. 
+
+If you already have a CircleCI 1.0 configuration, the `config.yml` file allows you to test 2.0 builds on a separate branch, leaving any existing configuration in the old `circle.yml` style unaffected and running on the CircleCI 1.0 infrastructure in branches that do not contain `.circleci/config.yml`.
 
 You can see a complete `config.yml` in our [full example](#full-example).
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -100,7 +100,7 @@ For [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) (lis
 
 The `environment` settings apply to all commands run in this executor, not just the initial `command`. The `environment` here has higher precedence over setting it in the job map above.
 
-You can specify image versions using tags or digest. You can use any public images from any public Docker registry (defaults to Docker Hub). Learn more about [specifying images]({{ site.baseurl }}/2.0/executor-types/#specifying-images).
+You can specify image versions using tags or digest. You can use any public images from any public Docker registry (defaults to Docker Hub). Learn more about [specifying images]({{ site.baseurl }}/2.0/executor-types).
 
 Example:
 
@@ -125,7 +125,7 @@ jobs:
 #### **`machine`**
 {:.no_toc}
 
-The usage of the [machine executor]({{ site.baseurl }}/2.0/executor-types/#machine-executor) is configured by using the `machine` key, which takes a map:
+The usage of the [machine executor]({{ site.baseurl }}/2.0/executor-types) is configured by using the `machine` key, which takes a map:
 
 Key | Required | Type | Description
 ----|-----------|------|------------

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -107,7 +107,7 @@ In order to let CircleCI use your custom image you need to place it in a public 
 
 ### Public or private images?
 
-Please note that in order to use an image with our [Docker Executor]({{ site.baseurl }}/2.0/executor-types/#docker-executor) you'll have to have a public repository. If you want to keep your image private please [read about using private images and repositories]({{ site.baseurl }}/2.0/private-images/).
+Please note that in order to use an image with our [Docker Executor]({{ site.baseurl }}/2.0/executor-types) you'll have to have a public repository. If you want to keep your image private please [read about using private images and repositories]({{ site.baseurl }}/2.0/private-images/).
 
 ### Using different Docker registries
 
@@ -127,7 +127,7 @@ In this case we are using `-t` key to specify the name and tag of our new image:
 
 - `circleci` - our account in Docker Hub
 - `cci-demo-docker-primary` - repository name
-- `0.0.1` - tag (version) of the image. Always update the tag if you change something in a `Dockerfile` otherwise you might have unpredictable results ([read more]({{ site.baseurl }}/2.0/executor-types/#avoid-mutable-tags))
+- `0.0.1` - tag (version) of the image. Always update the tag if you change something in a `Dockerfile` otherwise you might have unpredictable results ([read more]({{ site.baseurl }}/2.0/executor-types))
 
 ### Pushing the image to the registry
 

--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -3,7 +3,7 @@ layout: classic-docs
 title: "Installing and Using docker-compose"
 short-title: "Installing and Using docker-compose"
 description: "How to enable docker-compose in your primary container"
-categories: [virtualization]
+categories: [deploying]
 order: 40
 ---
 

--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -1,19 +1,18 @@
 ---
 layout: classic-docs
-title: "Using docker-compose"
-short-title: "Using docker-compose"
+title: "Installing and Using docker-compose"
+short-title: "Installing and Using docker-compose"
 description: "How to enable docker-compose in your primary container"
-categories: [docker]
-order: 2
+categories: [virtualization]
+order: 40
 ---
 
-If you use `docker-compose`, you can use it in CircleCI 2.0 as well using the [Remote Docker Environment]({{ site.baseurl }}/2.0/building-docker-images/). We've prepared an [example project](https://github.com/circleci/cci-demo-docker/tree/docker-compose) to demonstrate it.
+To use `docker-compose`, you must install it in your [primary container][primary-container] using one of the following methods:
 
-You can use the [full config file](https://github.com/circleci/cci-demo-docker/blob/docker-compose/.circleci/config.yml) as a template for your own projects. Here, we'll just cover the relevant parts.
+- Pre-install it in your custom image by using the instructions in [Building Custom Docker Images]({{ site.baseurl }}/2.0/building-docker-images/).
+- Install it during the job execution with the Remote Docker Environment activated by adding the following to your `config.yml` file:
 
-In order to use `docker-compose`, you'll need to have it in your [primary container][primary-container]. You can either pre-install it in your custom image (recommended) or install it during the job's execution:
-
-``` YAML
+``` 
 - run:
     name: Install Docker Compose
     command: |
@@ -22,25 +21,25 @@ In order to use `docker-compose`, you'll need to have it in your [primary contai
       chmod +x /usr/local/bin/docker-compose
 ```
 
-To activate the Remote Docker Environment, you need use [this special step]({{ site.baseurl }}/2.0/building-docker-images/):
+Then, to activate the Remote Docker Environment, you must add the `setup_remote_docker` step:
 
-``` YAML
+```
 - setup_remote_docker
 ```
 
-After that, you can use `docker-compose` as usual. You can build images:
+This enables you to add `docker-compose` commands to build images:
 
-``` YAML
+``` 
 docker-compose build
 ```
 
-Or run the whole system:
+Or to run the whole system:
 
-``` YAML
+``` 
 docker-compose up -d
 ```
 
-In our example, we start the whole system, then verify that it's running and responding to requests:
+In the following example, the whole system starts, then verifies it is running and responding to requests:
 
 ``` YAML
       - run:
@@ -52,8 +51,8 @@ In our example, we start the whole system, then verify that it's running and res
               appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:8080/contacts/test
 ```
 
-Note that, to interact with a running service, we don't just `curl` it from the [primary-container][primary-container], but instead use docker and a container running in the service's network. This is because your primary container and Remote Docker live in [separate environments]({{ site.baseurl }}/2.0/building-docker-images/#separation-of-environments) and can't communicate directly.
+**Note**: To interact with a running service, use docker and a container running in the service's network. This is because your primary container and Remote Docker live in separate environments and can't communicate directly.
 
-If you have any questions, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.
+See the [Example docker-compose Project](https://github.com/circleci/cci-demo-docker/tree/docker-compose) on GitHub for a demonstration and use the [full configuration file](https://github.com/circleci/cci-demo-docker/blob/docker-compose/.circleci/config.yml) as a template for your own projects. 
 
 [primary-container]: {{ site.baseurl }}/2.0/glossary/#primary-container

--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -1,10 +1,10 @@
 ---
 layout: classic-docs
-title: "Docker Layer Caching"
-short-title: "Docker Layer Caching"
+title: "Enabling Docker Layer Caching"
+short-title: "Enabling Docker Layer Caching"
 description: "How to reuse unchanged cache layers to reduce build time"
-categories: [docker]
-order: 5
+categories: [virtualization]
+order: 45
 ---
 
 {% include beta-premium-feature.html feature='Docker Layer Caching' %}

--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -3,7 +3,7 @@ layout: classic-docs
 title: "Enabling Docker Layer Caching"
 short-title: "Enabling Docker Layer Caching"
 description: "How to reuse unchanged cache layers to reduce build time"
-categories: [virtualization]
+categories: [configuration]
 order: 45
 ---
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -1,11 +1,29 @@
 ---
 layout: classic-docs
-title: "CircleCI 2.0 Environment Variables"
-short-title: "Environment Variables"
+title: "Using CircleCI Environment Variables"
+short-title: "Using CircleCI Environment Variables"
 description: "A list of supported environment variables in CircleCI 2.0"
-categories: [reference]
-order: 1
+categories: [configuring-jobs]
+order: 40
 ---
+
+CircleCI exports the environment variables in this document during each build, which are
+useful for more complex testing or deployment. Ideally, you will not have code which behaves differently in CI. But for the cases when it is necessary, CircleCI sets two environment variables which you can test:
+
+`CIRCLECI`
+
+true
+
+`CI`
+
+true
+
+CircleCI uses Bash, which follows the POSIX naming convention for environment variables. Uppercase and lowercase letters, digits, and the underscore are allowed. With the added rule that the first character must be a letter.
+
+## Build Details
+
+CircleCI publishes the details of the currently running build in this list of variables:
+
 
 **CI**
 

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -1,14 +1,14 @@
 ---
 layout: classic-docs
-title: "Configuring Test Machine Images"
-short-title: "Configuring Test Machine Images"
+title: "Specifying Container Images"
+short-title: "Specifying Container Images"
 description: "Overviews of the docker and machine executor types"
-categories: [virtualization]
+categories: [containerization]
 order: 10
 ---
 [building-docker-images]: {{ site.baseurl }}/2.0/building-docker-images/
 
-This version of CircleCI enables you to configure test machines to use a Docker Image instead of using the full Linux OS. This change increases performance by building only what is required for your application, but it means selecting a new image in your `.circleci/config.yml` file as follows: 
+This version of CircleCI enables you to use Docker Images instead of using the full Linux OS container. This change increases performance by building only what is required for your application, and it requires selecting an image in your `.circleci/config.yml` file, for example: 
 ```
 jobs:
   build:
@@ -102,7 +102,7 @@ jobs:
     machine: true
 ```
 
-The VM will run Ubuntu 14.04 with a few additional tools installed. It isn’t possible to specify other images.
+The VM will run Ubuntu 14.04 with a few additional tools installed. It isn’t possible to specify other images. Refer to the [specification script for the VM](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh) for more information about additional tools.
 
 ### When To Use the Machine Executor?
 - Your application requires full access to OS resources

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -15,9 +15,15 @@ jobs:
     docker:
       - image: buildpack-deps:trusty
 ```
-Nearly all of the public images on Docker Hub and Docker Registry are supported by default when you specify the `docker:` key in your `config.yml` file. **Note:** If you want to work with private images/registries, please refer to [Remote Docker][building-docker-images].  
+To make the transition easy, CircleCI maintains convenience images on Docker Hub for popular languages. See [Using Pre-Built CircleCI Docker Images]({{ site.baseurl }}/2.0/circleci-images/) for the complete list of names and tags.    
 
-Docker Images may be specified in two ways, by referring to the image name and version tag on Docker Hub or by using the URL to an image in a registry:
+Docker Images may be specified in three ways, by the image name and version tag on Docker Hub or by using the URL to an image in a registry:
+
+### Public Convenience Images on Docker Hub
+  - `name:tag`
+    - `circleci/node:7.10-browsers`
+  - `name@digest`
+    - `redis@sha256:34057dd7e135ca41...`
 
 ### Public Images on Docker Hub
   - `name:tag`
@@ -30,6 +36,8 @@ Docker Images may be specified in two ways, by referring to the image name and v
     - `gcr.io/google-containers/busybox:1.24`
   - `image_full_url@digest`
     - `gcr.io/google-containers/busybox@sha256:4bdd623e848417d9612...`
+
+Nearly all of the public images on Docker Hub and Docker Registry are supported by default when you specify the `docker:` key in your `config.yml` file. If you want to work with private images/registries, please refer to [Remote Docker][building-docker-images].
 
 ### Docker and Machine Comparison
 

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -1,18 +1,43 @@
 ---
 layout: classic-docs
-title: "Choosing an Executor Type"
-short-title: "Executor Types"
+title: "Configuring Test Machine Images"
+short-title: "Configuring Test Machine Images"
 description: "Overviews of the docker and machine executor types"
-categories: [configuring-jobs]
-order: 0
+categories: [virtualization]
+order: 10
 ---
 [building-docker-images]: {{ site.baseurl }}/2.0/building-docker-images/
 
-An executor defines an underlying technology to run your job. Currently, we provide two options: `docker` and `machine`.
+This version of CircleCI enables you to configure test machines to use a Docker Image instead of using the full Linux OS. This change increases performance by building only what is required for your application, but it means selecting a new image in your `.circleci/config.yml` file as follows: 
+```
+jobs:
+  build:
+    docker:
+      - image: buildpack-deps:trusty
+```
+Nearly all of the public images on Docker Hub and Docker Registry are supported by default when you specify the `docker:` key in your `config.yml` file. **Note:** If you want to work with private images/registries, please refer to [Remote Docker][building-docker-images].  
+
+Docker Images may be specified in two ways, by referring to the image name and version tag on Docker Hub or by using the URL to an image in a registry:
+
+### Public Images on Docker Hub
+  - `name:tag`
+    - `alpine:3.4`
+  - `name@digest`
+    - `redis@sha256:54057dd7e125ca41...`
+
+### Public Docker Registries
+  - `image_full_url:tag`
+    - `gcr.io/google-containers/busybox:1.24`
+  - `image_full_url@digest`
+    - `gcr.io/google-containers/busybox@sha256:4bdd623e848417d9612...`
+
+### Docker and Machine Comparison
+
+The `docker` key defines Docker as the underlying technology to run your jobs using Docker Containers. Containers are an instance of the Docker Image you specify and the first image listed in your configuration is the primary container image in which all steps run. CircleCI also provides a `machine` option.
 
 Like any set of choices, there are tradeoffs to using one over the other. Here’s a basic comparison:
 
- Executor | `docker` | `machine`
+Virtual Environment | `docker` | `machine`
 ----------|----------|----------
  Start time | Instant | 30-60 sec
  Clean environment | Yes | Yes
@@ -21,22 +46,29 @@ Like any set of choices, there are tradeoffs to using one over the other. Here�
  Full control over job environment | No | Yes
 {: class="table table-striped"}
 
-<sup>(1)</sup> With [Remote Docker][building-docker-images].
+<sup>(1)</sup> Requires using [Remote Docker][building-docker-images].
 
-## Docker Executor
-When you choose the `docker` executor, your job will run in a Docker container. You can specify the container image in `.circleci/config.yml`:
+### Docker Benefits
+Docker also has built-in image caching and enables you to build, run, and publish Docker images via [Remote Docker][building-docker-images]. Consider the requirements of your application as well. If the following are true for your application, Docker may be the right choice:
+ 
+- Your application is self-sufficient
+- Your application requires additional services to be tested
+- Your application is distributed as a Docker Image (requires using [Remote Docker][building-docker-images])
+- You want to use `docker-compose` (requires using [Remote Docker][building-docker-images])
 
-```YAML
-jobs:
-  build:
-    docker:
-      - image: buildpack-deps:trusty
+### Docker Limitations
+Choosing Docker limits your runs to what is possible from within a Docker container (including our [Remote Docker][building-docker-images] feature). For instance, if you require low-level access to the network or need to mount external volumes check out the `machine` executor below.
+
+### Docker Image Best Practices
+
+- We strongly discourage using mutable tags like `latest` or `1` as the image version in your `config.yml file`. Mutable tags often lead to unexpected changes in your job environment.  CircleCI cannot guarantee that mutable tags will return an up-to-date version of an image. You could specify `alpine:latest` and actually get a stale cache from a month ago. Instead, we recommend using precise image versions or digests, like `redis:3.2.7` or `redis@sha256:95f0c9434f37db0a4f...` as shown in the examples.
+
+- If you experience increases in your run times due to installing additional tools during execution, we recommend using the [Building Custom Docker Images Documentation]({{ site.baseurl }}/2.0/custom-images/) to create a custom image with tools that are pre-loaded in the container to meet the job requirements.
+
+### Using Multiple Docker Images
+It is possible to specify multiple images. When you do so, all containers run in a common network. Every exposed port will be available on `localhost` from a [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container).
+
 ```
-
-### Multiple Images
-It’s also possible to specify multiple images. When you do this, all containers will run in a common network. Every exposed port will be available on `localhost` from a [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container).
-
-```YAML
 jobs:
   build:
     docker:
@@ -53,59 +85,16 @@ jobs:
       - run: sleep 5 && nc -vz localhost 27017
 ```
 
-In a multi-image configuration job, steps are executed in the first container listed (main container).
+In a multi-image configuration job, steps are executed in the first container listed.
 
 More details on the Docker Executor are available [here]({{ site.baseurl }}/2.0/configuration-reference/).
 
-### Specifying Images
-Only public images on Docker Hub and Docker Registry are supported. If you want to work with private images/registries, please refer to [Remote Docker][building-docker-images].
-
-Images for the Docker Executor can be specified in a few ways:
-
-#### Public Images on Docker Hub
-  - `name:tag`
-    - `alpine:3.4`
-  - `name@digest`
-    - `redis@sha256:54057dd7e125ca41...`
-
-#### Public Docker Registries
-  - `image_full_url:tag`
-    - `gcr.io/google-containers/busybox:1.24`
-  - `image_full_url@digest`
-    - `gcr.io/google-containers/busybox@sha256:4bdd623e848417d9612...`
-
-### When To Use The Docker Executor?
-- your application is self-sufficient
-- your application requires additional services to be tested
-- your application is distributed as a Docker Image (requires using [Remote Docker][building-docker-images])
-- you want to use `docker-compose` (requires using [Remote Docker][building-docker-images])
-
-### Advantages
-- Fastest way to start a job
-- Use any custom image for a job environment
-- Built-in image caching
-- Build, run, and publish Docker images via [Remote Docker][building-docker-images]
-
-### Limitations
-- Limited by what is possible from within a Docker container (including our [Remote Docker][building-docker-images] feature). For instance, if you require low-level access to the network or need to mount external volumes checkout the `machine` executor below.
-
-### Best Practices
-
-#### Avoid Mutable Tags
-We strongly discourage using mutable tags like `latest` or `1`. Mutable tags often lead to unexpected changes in your job environment.
-
-We also can’t guarantee that mutable tags will return an up-to-date version of an image. You could specify `alpine:latest` and actually get a stale cache from a month ago.
-
-Instead, we recommend using precise image versions or digests, like `redis:3.2.7` or `redis@sha256:95f0c9434f37db0a4f...`.
-
-#### Use Custom Images
-If you find yourself incurring undue increases in your run times due to installing additional tools during execution, we recommend [making custom images]({{ site.baseurl }}/2.0/custom-images/) that meet the job’s requirements, so the container will have such tools pre-loaded.
 
 ## Machine Executor
 
 **Potential Premium Feature Notice: During the CircleCI 2.0 Beta we are providing early access, for no additional charge, to features (including Machine Executor) that may be available for additional fees after the Beta. We welcome your [feedback](https://discuss.circleci.com/c/circleci-2-0/feedback) on this and all other aspects of CircleCI 2.0.**
 
-When you choose the `machine` executor, your job will run in a dedicated, ephemeral Virtual Machine (VM). To use the machine executor, simply set the `machine` key to `true` in `.circleci/config.yml`:
+When you choose the `machine` key, your job will run in a dedicated, ephemeral Virtual Machine (VM). To use the machine executor, simply set the `machine` key to `true` in `.circleci/config.yml`:
 
 ```YAML
 jobs:
@@ -124,4 +113,6 @@ The VM will run Ubuntu 14.04 with a few additional tools installed. It isn’t p
 ### Limitations
 - Takes additional time to create VM
 - Only the default image is supported; your job may require additional provisioning.
+
+
 

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -81,7 +81,7 @@ myUsername/couchdb:1.6.1
 
 ## Can I use the `latest` tag when specifying image versions?
 
-We highly recommend that you don’t. For more context, read about why we think you should [Avoid Mutable Tags]({{ site.baseurl }}/2.0/executor-types/#avoid-mutable-tags).
+We highly recommend that you don’t. For more context, read about why we think you should [Avoid Mutable Tags]({{ site.baseurl }}/2.0/executor-types).
 
 ## How can I set the timezone in Docker images?
 

--- a/jekyll/_cci2/local-jobs.md
+++ b/jekyll/_cci2/local-jobs.md
@@ -1,77 +1,49 @@
 ---
 layout: classic-docs
-title: "Running Jobs Locally"
-short-title: "Running Jobs Locally"
-description: "Why and how to run local jobs"
+title: “Using the CircleCI Command Line Interface (CLI)“
+short-title: "Using the CircleCI Command Line Interface (CLI)"
+description: “How to run local jobs with the CLI“
 categories: [configuring-jobs]
-order: 30
+order: 10
 ---
 
-The **CircleCI CLI** reproduces the CircleCI environment locally and runs jobs as if they were running on CircleCI. The tool enables better debugging and faster configuration.
+The following sections describe useful tools for validating and debugging your configuration.
 
-## Common Use Cases
+## CircleCI Command Line Interface (CLI) Overview
 
-### Debugging Configuration Syntax
+The `circleci` commands enable you to reproduce the CircleCI environment locally and run jobs as if they were running on the hosted application for more efficient debugging and configuration in the initial setup phase. 
 
-Getting the syntax correct for your `config.yml` file can take a few iterations. Instead of having to push a commit and run a job on CircleCI to test this, local builds allow you to experiment locally since they only build what’s currently on your file system.
+You can also run `circleci` commands in your `config.yml` file for jobs that use the primary container image. This is particularly useful for globbing or splitting tests among containers.
 
-Note that local jobs don’t cache dependencies. You may want to comment out dependency sections if you’re testing YAML syntax. Or use the `--config` flag to specify a local `config.yml` that doesn’t pull in large dependencies.
+### Installing the CLI Locally 
 
-### Troubleshooting Container Configurations
+1. Install and configure Docker by using the [docker installation instructions](https://docs.docker.com/engine/installation/).
 
-Jobs have several containers that need to “talk” to each other. If you have a PostgreSQL container, you can quickly try different settings to ensure your job can connect and create the relevant database with correct permissions on the correct port. Or you might be using a pre-built container, but you’re unsure if it has all the services you need, or if they're running in the way you hope.
+2. To install the CLI, run the following command:
 
-Local jobs allow you to quickly retry configurations such as connecting on different ports or with different users.
-
-### Testing a New Project
-
-Imagine you’re a new developer on a team. It could take some time to figure out how to build and test an application.
-
-If the project has been configured to run on CircleCI, you can clone the repo, install the CircleCI CLI and run `circleci build`. This is a great way to get set up quickly with the same environment as your team.
-
-## Requirements
-
-To use the CircleCI CLI, you’ll need to install and configure Docker. Please follow the [docker installation instructions](https://docs.docker.com/engine/installation/).
-
-## Installation
-
-To install the CLI, run:
-
-```Bash
-curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && chmod +x /usr/local/bin/circleci
+```
+$ curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && chmod +x /usr/local/bin/circleci
 ```
 
-(If the current user doesn't have write permissions for `/usr/local/bin`, you might need to run the above commands with `sudo`.)
+The CLI is downloaded to the `/usr/local/bin/circleci` directory. If you do not have write permissions for `/usr/local/bin`, you might need to run the above commands with `sudo`. The CLI automatically checks for updates and will prompt you if one is available. 
 
-## Usage
+### Validating 2.0 YAML Syntax
 
-Calling `circleci` without any options displays usage information:
-
-```Bash
-$ circleci
-The CLI tool to be used in CircleCI.
-
-Usage:
-  circleci [flags]
-  circleci [command]
-
-Available Commands:
-  build       run a full build locally
-  config      validate and update configuration files
-  tests       collect and split files with tests
-  version     output version info
-
-Flags:
-  -c, --config string   config file (default is .circleci/config.yml)
-      --taskId string   TaskID
-      --verbose         emit verbose logging output
-
-Use "circleci [command] --help" for more information about a command.
+1. Type `circleci` with one of six available commands (`build`, `config`, `help`, `step`, `tests`, and `version`) followed by a valid flag. For example:
 ```
+$ circleci config validate -c .circleci/config.yml
+```
+The config validate command checks your local config.yml file for syntax errors.
 
-## Updating
+**Note**: Local jobs don’t cache dependencies. You may want to comment out dependency sections if you are testing YAML syntax. Or, as in this example, use the `-c` flag to specify a local `config.yml` file that doesn’t pull in large dependencies.
 
-The CLI tool automatically checks for updates and will prompt you if one is available.
+### Troubleshooting Container Configurations Locally
+
+Test locally to quickly retry configurations such as connecting on different ports or with different users. Jobs often have several containers that need to “talk” to each other. For example, you might want to locally test that a job can connect and create the relevant database with correct permissions on the correct port for a PostgreSQL container. Or you might be using a pre-built container, but you’re unsure if it has all the services you need, or if they're running in the way you hope.
+
+### Cloning and Building an Environment Locally
+
+If a project has been configured to run on CircleCI, you can simply clone the repo and run the `circleci build` command to get set up quickly with the same environment as your team.
 
 ## Limitations
 
@@ -99,4 +71,4 @@ We plan to remove this limitation in a future update.
 
 ## Using the CircleCI CLI non-locally
 
-The CircleCI CLI is available in all CircleCI environments. For example, check out [Parallelism for Faster Jobs]({{ site.baseurl }}/2.0/parallelism-faster-jobs/) to see how you use the tool to manage paralellism in a remote hosted environment.
+The CircleCI CLI is available in all CircleCI environments. For example, check out [Merging and Splitting Tests]({{ site.baseurl }}/2.0/parallelism-faster-jobs/) for examples of using `circleci` commands in your `config.yml` file with a  remote hosted environment.

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -1,21 +1,21 @@
 ---
 layout: classic-docs
-title: "Parallelism with CircleCI CLI"
-short-title: "Parallelism for Faster Jobs"
+title: "Merging and Splitting Tests"
+short-title: "Merging and Splitting Tests"
 description: "How to run tests in parallel"
 categories: [configuring-jobs]
-order: 50
+order: 60
 ---
 
-One of the most powerful features of CircleCI is the ability to run your tests in parallel. In CircleCI 2.0 you manage this parallelism with a CLI tool called `circleci`. We inject this agent into the primary job container so the `circleci` command is always available in container `0`.
+One of the most powerful features of CircleCI is the ability to run your tests in parallel. This section describes how to use `circleci` commands in your `config.yml` file to merge and split tests with the hosted CircleCI CLI for faster builds. 
 
-Access help by running `circleci tests help` or see below for descriptions of your options.
+Use the circle tests glob command to specify multiple globs to merge using a pattern, for example: 
+	`circleci tests glob "tests/unit/*.java" "tests/functional/*.java"`
 
-- This tool is available on circleci.com and within the [local CircleCI CLI](/docs/2.0/local-jobs/).
-- You can specify multiple globs.  This is pretty common for test suites in 1.0.  For example: `circleci tests glob "tests/unit/*.java" "tests/functional/*.java"`
-- As you migrate from 1.0 to 2.0, it's worthwhile to manually check that your globs pick up exactly what you want and nothing else.  `circleci tests glob` scans the filesystem based on the globs you pass it and returns plain text in Bash.  So you can do check your glob results by adding a line like the following:
+In your `config.yml` file, check your glob results by using the `circleci tests glob` command, for example:
 
-```YAML
+```
+run:
 - type: shell
   command: |
   # Print all files in one line
@@ -24,11 +24,9 @@ Access help by running `circleci tests help` or see below for descriptions of yo
   circleci tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo
 ```
 
-## Commands
+### Supported Globbing Patterns
 
-### Globbing
-
-Supported patterns:
+The following patterns are used to glob files.
 
 - `*`: matches any sequence of characters (excluding path separators)
 - `**`: matches any sequence of characters (including path separators)
@@ -36,71 +34,60 @@ Supported patterns:
 - `[abc]`: matches any character (excluding path separators) against characters in braces
 - `{foo,bar,...}`: matches a sequence of characters if any of the alternatives in braces matches
 
+For example:
+
 `circleci tests glob "**/*.java"`
 
-### Splitting
+### Splitting Patterns
 
-`circleci` can be used to split a list of test files or classnames when running parallel builds on 2.0.
+The `circleci` CLI can be used to split a list of test files or classnames when running parallel builds on 2.0. The CLI uses the environment to look up the total number of containers, along with the current container index. Then, it uses deterministic splitting algorithms to return a distinct subset of the input filenames or classnames on each container.
 
-The tool uses the environment to look up the total number of containers, along with the current container index. Then, the tool uses deterministic splitting algorithms to return a distinct subset of the input filenames or classnames on each container.
+The list of items to split can be provided via standard input or as a file argument, as follows:
 
-The list of items to split can be provided via standard input or as a file argument.
+- Piping: `circleci tests glob test/**/*.java | circleci tests split`
+- `stdin` redirection: `circleci tests split < /path/to/items/to/split`
+- Process substitution: `circleci tests split <(circleci tests glob test/**/*.java)`
+- From file: `circleci tests split test_filenames.txt`
 
-- piping: `circleci tests glob test/**/*.java | circleci tests split`
-- stdin redirection: `circleci tests split < /path/to/items/to/split`
-- process substitution: `circleci tests split <(circleci tests glob test/**/*.java)`
-- from file: `circleci tests split test_filenames.txt`
+By default, it is assumed that the items being split are filenames and should be split by name. However, the tool can also split by file size or may use historical data to split by test runtimes.
 
-By default, it’s assumed that the items being split are filenames and should be split by name. However, the tool can also split by filesize or use historical data to split by test runtimes.
-
-#### Controlling splits
-Items can be split by `name`, `filesize` (for filepaths), or `timings` (when run on CircleCI).
-
-##### **name**
-This is the default and splits items alphabetically.
+Items can be split by `name`, `filesize` (for filepaths), or `timings` (when run on CircleCI). Splitting by name is the default and splits items alphabetically, for example:
 
 `circleci tests glob "**/*.go" | circleci tests split`
 
-##### **filesize**
-When the items are filepaths, this option will weight the split by filesize.
+When the items are filepaths, the `filesize` option will weight the split by file size, for example:
 
 `circleci tests glob "**/*.go" | circleci tests split --split-by=filesize`
 
-##### **timings**
-This split type uses historical timing data to weight the split. CircleCI automatically makes timing data from previous runs available inside your container in a default location so the CLI tool can discover them (`/.circleci-task-data/circle-test-results/`).
+The `timings` split type uses historical timing data to weight the split. CircleCI automatically makes timing data from previous runs available inside your container in a default location so the CLI tool can discover them (`/.circleci-task-data/circle-test-results/`).
 
-When splitting by `timings`, the tool will assume it’s splitting filenames. If you’re splitting classnames, you’ll need to specify that with the `--timings-type` flag.
+When splitting by `timings`, the tool will assume it’s splitting filenames. If you’re splitting classnames, you’ll need to specify that with the `--timings-type` flag, as in the following examples:
 
 `circleci tests glob "**/*.go" | circleci tests split --split-by=timings --timings-type=filename`
 
 `cat my_java_test_classnames | circleci tests split --split-by=timings --timings-type=classname`
 
-#### Additional flags
+The following additional flags are supported:
 - `--index`: set the container index for this invocation of `circleci tests split`
 - `--total`: set the total number of containers to consider
-- `--show-counts`: print test file or test class counts to stderr (default false).  Useful for debugging unexpected balance issues.
 
 When running on CircleCI, these values will be automatically picked up from environment variables.
 
-## Balancing libraries
+### Balancing Libraries
 
 The following libraries have built-in support for the CircleCI environment variables:
 
 {% include third-party-info.html app='Knapsack'%}
 
-* [Knapsack](https://github.com/ArturT/knapsack) - deterministic test suite split
+* [Knapsack](https://github.com/ArturT/knapsack) - Deterministic test suite split. A ruby gem for Knapsack will automatically divide your tests between parallel CI nodes, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber, Minitest, Spinach and Turnip.
 
-    A ruby gem for that will automatically divide your tests between parallel CI nodes, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber, Minitest, Spinach and Turnip.
-
-```YAML
+```
 - run: bundle exec rake knapsack:rspec
 ```
 
-* [Knapsack Pro](https://github.com/KnapsackPro/knapsack_pro-ruby) - dynamic optimal test suite split
+* [Knapsack Pro](https://github.com/KnapsackPro/knapsack_pro-ruby) - Dynamic optimal test suite split. Knapsack Pro is a more advanced version of knapsack gem. It has automated recording of tests time execution across branches, commits and it can distribute tests across parallel CI nodes with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split.
 
-    Is more advanced version of knapsack gem. Knapsack Pro has automated recording of tests time execution across branches, commits and it can distribute tests across parallel CI nodes with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split.
-
-```YAML
+```
 # some tests that are not balanced and executed only on first CI node
 - run: case $CIRCLE_NODE_INDEX in 0) npm test ;; esac
 

--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -1,17 +1,17 @@
 ---
 layout: classic-docs
-title: "Using Private Images and Docker Registries"
+title: "Using Private Images"
 short-title: "Using Private Images"
 description: "How to use private images with the Remote Docker Environment"
-categories: [docker]
-order: 1
+categories: [virtualization]
+order: 50
 ---
 
-Using private images isn’t directly supported by the [Docker Executor]({{ site.baseurl }}/2.0/executor-types/#docker-executor). However, you _can_ use the [Remote Docker Environment]({{ site.baseurl }}/2.0/building-docker-images/).
+To use private images, you must activate the Remote Docker Environment with the `setup_remote_docker` step in your `config.yml` file.
 
-If your application requires a proprietary DB for testing, for example:
+The following is an example of an application that requires a private image called `proprietary-db` for testing:
 
-```YAML
+```
 version: 2
 jobs:
   build:
@@ -25,7 +25,7 @@ jobs:
       # start proprietary DB using private Docker image
       - run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASS
-          docker run -d --name db company/proprietery-db:1.2.3
+          docker run -d --name db company/proprietary-db:1.2.3
 
       # build and test application
       - run: |
@@ -34,4 +34,4 @@ jobs:
           docker run --network container:db my-app test
 ```
 
-If you have any questions, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.
+

--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -1,10 +1,10 @@
 ---
 layout: classic-docs
-title: "SSH Access to Jobs"
-short-title: "SSH Access to Jobs"
+title: "Debugging Jobs Over SSH"
+short-title: "Debugging Jobs Over SSH"
 description: "How to access a build container using SSH on CircleCI 2.0"
 categories: [configuring-jobs]
-order: 40
+order: 70
 ---
 
 Often the best way to troubleshoot problems is to SSH into a build container and inspect 
@@ -12,29 +12,24 @@ things like log files, running processes, and directory paths.
 
 CircleCI 2.0 gives you the option to access all jobs via SSH.
 
-To start a build with SSH enabled, select the 'Rebuild with SSH' option from
+1. To start a build with SSH enabled, select the 'Rebuild with SSH' option from
 the 'Rebuild' dropdown menu:
-
 ![Rebuild with SSH](  {{ site.baseurl }}/assets/img/docs/rebuild-ssh-dropdown.png)
 
-To see the connection details, expand the 'Enable SSH' section in the build output where you will see the SSH command needed to connect:
-
-![SSH connection details](https://circleci-discourse.s3.amazonaws.com/optimized/2X/5/57f50e26ec245d0373c4265ec4375641553bdbdb_1_690x295.png)
-
-The details are displayed again in the 'Wait for SSH' section at the end of the job:
-
+2. To see the connection details, expand the 'Enable SSH' section in the build output where you will see the SSH command needed to connect:
+![SSH connection details](https://circleci-discourse.s3.amazonaws.com/optimized/2X/5/57f50e26ec245d0373c4265ec4375641553bdbdb_1_690x295.png)	
 ![SSH connection details](https://circleci-discourse.s3.amazonaws.com/optimized/2X/5/514e8aec3e8017dac8e8d401d22432026b473161_1_690x281.png)
 
-Now you can SSH to the running build (using the same SSH key
+     The details are displayed again in the 'Wait for SSH' section at the end of the job.
+
+3. SSH to the running build (using the same SSH key
 that you use for GitHub or Bitbucket) to perform whatever troubleshooting
 you need to.
 
 The build VM will remain available for **30 minutes after the build finishes running**
 and then automatically shut down. (Or you can cancel it.)
 
-## Parallelism and SSH Builds
-
-If your build has parallel steps, we launch more than one VM
+**Note**: If your build has parallel steps, CircleCI launches more than one VM
 to perform them. Thus, you'll see more than one 'Enable SSH' and
 'Wait for SSH' section in the build output.
 
@@ -125,13 +120,9 @@ debug1: Offering RSA public key: ...
 Make sure that the key which GitHub accepted (in our
 example, /Users/me/.ssh/id_rsa_github) was also offered to CircleCI.
 
-If it was not offered, you can specify it via the -i command-line
+If it was not offered, you can specify it via the `-i` command-line
 argument to SSH. For example:
 
 ```
 $ ssh -i /Users/me/.ssh/id_rsa_github -p 64784 ubuntu@54.224.97.243
 ```
-
-### Nope, still broken
-
-Please [contact us](mailto:support@circleci.com) with details of what you tried and our support team will assist you.

--- a/jekyll/_data/categories.yml
+++ b/jekyll/_data/categories.yml
@@ -95,12 +95,16 @@
   name: "Migration"
 
 - section: cci2
-  slug: language-guides
-  name: "Language Guides"
+  slug: virtualization
+  name: "Virtualization"
 
 - section: cci2
   slug: configuring-jobs
-  name: "Configuring Jobs"
+  name: "Configuration"
+
+- section: cci2
+  slug: language-guides
+  name: "Language Guides"
 
 - section: cci2
   slug: docker

--- a/jekyll/_data/categories.yml
+++ b/jekyll/_data/categories.yml
@@ -95,8 +95,8 @@
   name: "Migration"
 
 - section: cci2
-  slug: virtualization
-  name: "Virtualization"
+  slug: containerization
+  name: "Containerization"
 
 - section: cci2
   slug: configuring-jobs
@@ -112,7 +112,7 @@
 
 - section: cci2
   slug: deploying
-  name: "Deploying"
+  name: "Deployment"
 
 - section: cci2
   slug: reference


### PR DESCRIPTION
This wad adds a new category for Virtualization and changes Configuring Jobs to Configuration. The goal of the structure is to help a new person understand virtualization in 2.0 and their options first then to start at the beginning with configuration. I also retitled many articles to make them more meaningful and action-oriented.

Virtualization:
-Executor Types -> Configuring Test Machine Images
-CircleCI Images -> Using Pre-Built CircleCI Docker Images
-Building Custom Docker Images
-Using docker-compose -> Installing and Using docker-compose
-Docker Layer Caching-> Enabling Docker Layer Caching
-Using Private Images

Configuration:
-Running Jobs Locally -> Using the CircleCI Command Line Interface (CLI)
-Configuration Reference-> Writing Jobs with Steps 
-Environment Variables -> Using CircleCI Environment Variables
-Caching -> Caching Dependencies and Source Code
-Parallelism for Faster Jobs -> Merging and Splitting Tests
-Uploading Build Artifacts
-SSH Access to Jobs -> Debugging Jobs Over SSH
-Defining Multiple Jobs