### PR TITLE
Fix spelling mistakes throughout remainder of 1.0 documentation

### DIFF
--- a/jekyll/_cci1/browser-debugging.md
+++ b/jekyll/_cci1/browser-debugging.md
@@ -147,7 +147,7 @@ Now you can run your integration tests from the command line and watch the brows
 ### VNC Viewer Recommendations
 
 Some of our customers have had some VNC clients perform poorly and
-others perform well.  Particuarly, on macOS, RealVNC produces a better
+others perform well.  Particularly, on macOS, RealVNC produces a better
 image than Chicken of the VNC.
 
 If you have had a good or bad experience with a VNC viewer,

--- a/jekyll/_cci1/ssh-between-build-containers.md
+++ b/jekyll/_cci1/ssh-between-build-containers.md
@@ -19,5 +19,5 @@ ssh node6
 ### Uses
 
 You can use this feature if you want to manually
-collect metadata, synchronise a certain operation across the fleet, or
+collect metadata, synchronize a certain operation across the fleet, or
 just transfer arbitrary data between parallel build containers.

--- a/jekyll/_cci1/troubleshooting-ios-and-OSX.md
+++ b/jekyll/_cci1/troubleshooting-ios-and-OSX.md
@@ -14,7 +14,7 @@ There are common problems you might run into during the initial setup of your CI
 ## Xcode Toolchain errors
 
 ### xcodebuild exit code 65
-There are plenty of reasons why exit code 65 could be thrown, as it is a general error returned for bad user input. Sometimes that is not the case though, since all your builds run in a container your builds also have to share system resources with other builds. Exit code 65 is mostly the issue of a lack of enough CPU power to launch the iOS simulator in time for the test to run once xcodebuild'S `test` action is called, and the tests simply time out.
+There are plenty of reasons why exit code 65 could be thrown, as it is a general error returned for bad user input. Sometimes that is not the case though, since all your builds run in a container your builds also have to share system resources with other builds. Exit code 65 is mostly the issue of a lack of enough CPU power to launch the iOS simulator in time for the test to run once xcodebuild's `test` action is called, and the tests simply time out.
 A way to mitigate this is to launch the iOS simulator as a part of your dependencies block in your CircleCI configuration file.
 
 


### PR DESCRIPTION
Similar to #1127, I read through the remainder of the 1.0 documentation today (specifically the Troubleshooting, Reference, Parallelism, and Privacy and Security sections) and found a few more spelling mistakes and thought I'd send a PR in that fixed them. See the commit history/diff for which specific words were corrected and in what files. 💃 