### PR TITLE
Fix spelling mistakes throughout CCIE documentation

### DIFF
--- a/jekyll/_ccie/aws.md
+++ b/jekyll/_ccie/aws.md
@@ -23,7 +23,7 @@ The following step-by-step instructions will guide you through the process of in
 
 ## Setup Terraform
 
-(If you prefer to do this process manually or with different tools please see the [Manual Aws Instructions]({{site.baseurl}}/enterprise/aws-manual/).)
+(If you prefer to do this process manually or with different tools please see the [Manual AWS Instructions]({{site.baseurl}}/enterprise/aws-manual/).)
 
 1. Download the setup repo: `git clone https://github.com/circleci/enterprise-setup ccie && cd ccie`
 1. Open `terraform.tfvars` in your favorite text editor and input the

--- a/jekyll/_ccie/aws.md
+++ b/jekyll/_ccie/aws.md
@@ -27,7 +27,7 @@ The following step-by-step instructions will guide you through the process of in
 
 1. Download the setup repo: `git clone https://github.com/circleci/enterprise-setup ccie && cd ccie`
 1. Open `terraform.tfvars` in your favorite text editor and input the
-prerequities stated above in the required fields.
+prerequisites stated above in the required fields.
 1. Launch the Terraform stack:
 	- **Linux/Windows:** Please install [Terraform](https://www.terraform.io/downloads.html) yourself on Linux/Windows, then run `terraform apply` from the repo root.
 	- **OSX:** You can just run `bin/terraform apply` and follow the prompts.
@@ -62,8 +62,8 @@ where you should soon see an indication that the app has started like below.
 
 ## Using custom instance types
 
-The Terraform-based CircleCI installation currently only supports instance types with attached SSD storage. EBS-only volumes (**C4** / **M4**) will not work. The number of containers per machine below assume the defualt container size of 2CPU/4G. If you want to change those defaults, please see below.
+The Terraform-based CircleCI installation currently only supports instance types with attached SSD storage. EBS-only volumes (**C4** / **M4**) will not work. The number of containers per machine below assume the default container size of 2CPU/4G. If you want to change those defaults, please see below.
 
-* **M3**: The `m3.2xlarge` is a good choice if you only need a couple containers, as it is usually cheaper than comprable `c3` or `r3` instances. But the `m3.2xlarge` can only fit **3 containers**, and there are no larger `m3` instances. If you plan to use a larger fleet, we recommend `c3` instances.
+* **M3**: The `m3.2xlarge` is a good choice if you only need a couple containers, as it is usually cheaper than comparable `c3` or `r3` instances. But the `m3.2xlarge` can only fit **3 containers**, and there are no larger `m3` instances. If you plan to use a larger fleet, we recommend `c3` instances.
 * **C3**: The `c3` family is a less expensive choice for larger fleets. Since the `c3` instances have less memory than the `r3` instances, the number of containers we can fit on a machine is memory bound. The `c3.4xlarge` can fit **6 containers**, and the `c3.8xlarge` can fit **14 containers**.
 * **R3 (recommended)**: The `r3` family is a great choice if you're using memory intensive builds. They are especially good if you plan to increase the default memory allocation for each container. Because of noisy neighbor problems and resource contention, the excess memory of the `r3` family can can also sometimes speed up your builds without changing the default container allocation. The number of containers we can fit on an `r3` is CPU bound. Thus, we will put **3 containers** on an `r3.2slarge`, **7 containers** on an `r3.4xlarge`, and **15 containers** on an `r3.8xlarge`.

--- a/jekyll/_ccie/config.md
+++ b/jekyll/_ccie/config.md
@@ -104,7 +104,7 @@ You should then see improved performance between builds!
 
 ### Adjusting Builder Networking
 
-You can adjust which subnets containers use by setting the following enviroment variables:
+You can adjust which subnets containers use by setting the following environment variables:
 
 * `CIRCLE_CONTAINERS_SUBNET` - the subnet all containers will share, in CIDR notation.
 * `CIRCLE_CONTAINERS_SUBNET_MASK_LENGTH` - the size of the netmask for

--- a/jekyll/_ccie/docker-install.md
+++ b/jekyll/_ccie/docker-install.md
@@ -43,7 +43,7 @@ this access with iptables rules in a production setup. Please [contact us](mailt
 if you have questions.
 
 
-CircleCI Enterpise installation requires provisioning two types of machines:
+CircleCI Enterprise installation requires provisioning two types of machines:
 
 * Services box - an instance that is always-on and used as the web server.  The GitHub App domain name needs to map to this instance.
 * A pool of builder machines.  You can have a least one for normal operations, but you can provision as many builders as your scale demands.

--- a/jekyll/_ccie/gpu-configuration.md
+++ b/jekyll/_ccie/gpu-configuration.md
@@ -111,7 +111,7 @@ ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs:${LIBRARY_PATH}
 
 6.) 
 
-In your GPU Circle Project add the following under your enviroment variables
+In your GPU Circle Project add the following under your environment variables
 
 Name: `PATH`
 
@@ -135,7 +135,7 @@ See here for a working sample project
     
 ### LXC
 
-This is only supported in releases after ( 1.47.0 +). If you need help upgraging, please reachout to enterprise-support@circleci.com
+This is only supported in releases after ( 1.47.0 +). If you need help upgrading, please reach out to enterprise-support@circleci.com
 
 
 

--- a/jekyll/_ccie/logging.md
+++ b/jekyll/_ccie/logging.md
@@ -72,7 +72,7 @@ We are looking into providing first class support to integrate with Amazon Cloud
 
 ## Integrating with Syslog
 
-CirclecI Builders integrate with the `syslog` facility.  `Syslog` is a widely used standard for logging, and most agents integrate with it out of the box.  You can configure the builder machines to emit logs to the `syslog` facility by setting `CIRCLE_LOG_TO_SYSLOG` to `true` in the launch configuration:
+CircleCI Builders integrate with the `syslog` facility.  `Syslog` is a widely used standard for logging, and most agents integrate with it out of the box.  You can configure the builder machines to emit logs to the `syslog` facility by setting `CIRCLE_LOG_TO_SYSLOG` to `true` in the launch configuration:
 
 ```
 #!/bin/bash

--- a/jekyll/_ccie/on-prem.md
+++ b/jekyll/_ccie/on-prem.md
@@ -117,13 +117,13 @@ After ~20 minutes or so, you will have a fully running instance.  A fully operat
 * Few directories at `/mnt`, namely `/mnt/tmp`, `/mnt/slave-image`, `/mnt/box1`
 * Process log files at `/var/log/circle-builder/circle.log` without any exceptions.
 
-*NOTE*: The defualt container image is currently hosted on S3 US East.  Your download speed may vary depending on where your machines are.  Upcoming releases will use an CDN to manage the container image.
+*NOTE*: The default container image is currently hosted on S3 US East.  Your download speed may vary depending on where your machines are.  Upcoming releases will use an CDN to manage the container image.
 
 ## Advanced configuration
 
 ### Cloud Object Storage
 
-CircleCI Enterprise can optionally use cloud storage providers for storing large files and build related artifacts.  Using external object storage eases management and operationing of CircleCI (e.g. avoid filling disks in services box) and allows for faster builds.
+CircleCI Enterprise can optionally use cloud storage providers for storing large files and build related artifacts.  Using external object storage eases management and the operation of CircleCI (e.g. avoid filling disks in services box) and allows for faster builds.
 
 We currently support AWS S3, Google Cloud Storage, and Microsoft Azure.  If you have Swift/Ceph in house, or any other Object Storage, let us know.
 
@@ -156,7 +156,7 @@ The System Console Settings page will have fields for the AWS access key and sec
 
 #### b. Google Storage
 
-When running inside Google Cloud, we can use instance authentication (remember to permit instances to make Google Cloud API calls).  If running outside, you must export a Serivce Credentials file.  You can create a "Service account key" at https://console.cloud.google.com/apis/credentials, and choose JSON file format.
+When running inside Google Cloud, we can use instance authentication (remember to permit instances to make Google Cloud API calls).  If running outside, you must export a Service Credentials file.  You can create a "Service account key" at https://console.cloud.google.com/apis/credentials, and choose JSON file format.
 
 With credentials files, CircleCI will automatically create a Standard bucket in United States location.  You can create a bucket with a different configuration in the Google Console at: https://console.cloud.google.com/storage/browser .
 

--- a/jekyll/_ccie/proxy.md
+++ b/jekyll/_ccie/proxy.md
@@ -20,7 +20,7 @@ The proxy instructions must be done **before** installing CircleCI on fresh vm's
 
 
 ### EC2 Proxies
-If you are setting up your proxy through Amazon, please read this before preceeding: http://docs.aws.amazon.com/cli/latest/userguide/cli-http-proxy.html
+If you are setting up your proxy through Amazon, please read this before proceeding: http://docs.aws.amazon.com/cli/latest/userguide/cli-http-proxy.html
 
 You should also avoid proxying internal requests, especially for the services box. Run `export NO_PROXY=<services_box_ip>` to add it to the `NO_PROXY` rules.
 
@@ -58,7 +58,7 @@ EOF
 3.) sudo service replicated stop; sudo service replicated-agent stop; sudo service replicated-agent start; sudo service replicated start
 ```
 ####Corporate Proxies
-In some enviroments you might not have access to a `NO_PROXY` equivalent outside your network. In that case feel free to put all relevant outbound addresses into the `HTTP_PROXY` or `HTTPS_PROXY`and instead only add machines on the internal network to `NO_PROXY` such as the services, and builder box. 
+In some environments you might not have access to a `NO_PROXY` equivalent outside your network. In that case feel free to put all relevant outbound addresses into the `HTTP_PROXY` or `HTTPS_PROXY`and instead only add machines on the internal network to `NO_PROXY` such as the services, and builder box. 
 
 ### Installing CircleCI Services 
 
@@ -67,7 +67,7 @@ In some enviroments you might not have access to a `NO_PROXY` equivalent outside
 2.) sudo -E bash init-services.sh
 ```
 
-Note that this differs from the regular installation instructions by including the `-E` command with `sudo`. This allows the script to have access to the enviroment variables you exported above.
+Note that this differs from the regular installation instructions by including the `-E` command with `sudo`. This allows the script to have access to the environment variables you exported above.
 
 Also note that when the instructions ask you if you use a proxy, they will also prompt you for the address. It is **very important** that you input the proxy in the following format `<protocol>://<ip>:<port>`. If you are missing any part of that, then apt-get won't work correctly and the packages won't download. 
 
@@ -78,7 +78,7 @@ If for any reason you can't access the page the CircleCI Replicated console, but
 
 - External Network Calls
   - We use scripts to download initialization scripts, along with jars from Amazon S3. 
-    - `Curl` respects enviroment settings, but if you have whitelisted traffic from Amazon S3 you shouldn't have any problems.
+    - `Curl` respects environment settings, but if you have whitelisted traffic from Amazon S3 you shouldn't have any problems.
   - `awscli` tool to download container from S3. The same rules of `curl` apply here (i.e. dependent on S3 traffic and environment variable)
   
 

--- a/jekyll/_ccie/quick-start.md
+++ b/jekyll/_ccie/quick-start.md
@@ -13,7 +13,7 @@ For developers testing and deploying their code with CircleCI Enterprise, the
 experience extremely similar to using circleci.com, so much of the information in the
 [docs](https://circleci.com/docs/) and [support forum](https://discuss.circleci.com)
 for circleci.com are applicable. There are a few potentially
-confusing differences between CircleCI Enterpise and circleci.com though, so this guide
+confusing differences between CircleCI Enterprise and circleci.com though, so this guide
 provides a starting point specifically for users of Enterprise.
 
 Let's quickly cover a few of the first things you might want to try on CircleCI Enterprise. If you


### PR DESCRIPTION
Similar to #1127 and #1132, I'm reading through all of the CircleCI documentation as part of my training. While I was reading through the CCIE documentation, I found a few spelling mistakes and a couple of other things that I thought could be improved. See the commit history/diff for which specific words were corrected and in what files. 🧀 