### PR TITLE
Identify the default elasticsearch version

### DIFF
--- a/jekyll/_cci1/installing-elasticsearch.md
+++ b/jekyll/_cci1/installing-elasticsearch.md
@@ -12,7 +12,7 @@ machine:
     - elasticsearch
 ```
 
-The default version of Elasticsearch is {{ site.data.trusty.versions.summary.elasticsearch }}.
+The default version of Elasticsearch is {{ site.data.trusty.versions.some.variable.thats.actually.bound.since.elasticsearch.isnt }}.
 If you need a custom version, you can download and start it from your build. To install 2.4.3, add the following to your `circle.yml`:
 
 ```

--- a/jekyll/_cci1/installing-elasticsearch.md
+++ b/jekyll/_cci1/installing-elasticsearch.md
@@ -12,7 +12,7 @@ machine:
     - elasticsearch
 ```
 
-The default version of Elasticsearch is {{ site.data.trusty.versions.some.variable.thats.actually.bound.since.elasticsearch.isnt }}.
+The default version of Elasticsearch is {{ site.data.trusty.versions-ubuntu-14_04-XXL.summary.elasticsearch }}.
 If you need a custom version, you can download and start it from your build. To install 2.4.3, add the following to your `circle.yml`:
 
 ```


### PR DESCRIPTION
The variable referenced by the source file (`site.data.trusty.versions.summary.elasticsearch`) apparently isn't bound, resulting in the absurd statement in the rendered page: 

"The default version of Elasticsearch is ."