### PR TITLE
Add redirect for multiple jobs page

### DIFF
--- a/jekyll/_cci2/defining-multiple-jobs.md
+++ b/jekyll/_cci2/defining-multiple-jobs.md
@@ -1,0 +1,7 @@
+---
+layout: classic-docs
+title: "CircleCI 2.0"
+redirect: /docs/2.0/workflows/
+---
+
+<h1>This page has moved. You should be automatically redirected, but if that didn't work you can <a href="/docs/2.0/workflows/">click here</a>.</h1> 


### PR DESCRIPTION
Reported on Twitter: https://twitter.com/nschloe/status/874900459194023936

The workflows PR removed this page. This adds a redirect to workflows from the removed page.

Merging to fix broken links from Google and internal search.