### PR TITLE
2.0 parallelism is only to be set via config.

### DIFF
--- a/jekyll/_data/api.yml
+++ b/jekyll/_data/api.yml
@@ -615,7 +615,7 @@ project_post:
   params:
     - {name: "revision", description: "The specific revision to build.  Default is null and the head of the branch is used. Cannot be used with tag parameter.", example: "f1baeb913288519dd9a942499cef2873f5b1c2bf"}
     - {name: "tag", description: "The tag to build. Default is null. Cannot be used with revision parameter.", example: "f1baeb913288519dd9a942499cef2873f5b1c2bf"}
-    - {name: "parallel", description: "The number of containers to use to run the build.  Default is null and the project default is used.", example: 4}
+    - {name: "parallel", description: "The number of containers to use to run the build.  Default is null and the project default is used.  This parameter is ignored for builds running on our 2.0 infrastructure.", example: 4}
     - {name: "build_parameters", description: "Additional environment variables to inject into the build environment.  A map of names to values.", example: "{\"JAVA_OPTS\": \"+Xms128m\"}"}
   body: |
     {


### PR DESCRIPTION
Respecting parallelism set via the API (or project settings) leads to
unexpectedly parallel jobs.

This is pending acceptance of PRs in other repos.