### PR TITLE
Update beta-banner.html

### DIFF
--- a/jekyll/_includes/beta-banner.html
+++ b/jekyll/_includes/beta-banner.html
@@ -1,3 +1,3 @@
 <div class="alert alert-warning" role="alert">
-  <p><strong>Please Note:</strong> CircleCI 2.0 is currently in Beta. <a class="alert-link" href="https://circleci.com/beta-access/">Start building today</a> to use our latest features. During the Beta we'll be updating the documentation regularly, so <a href="https://github.com/circleci/circleci-docs/pulse#merged-pull-requests">watch for updates</a>. Questions about using 2.0 are welcome on <a class="alert-link" href="https://discuss.circleci.com/c/circleci-2-0">Discuss</a>.</p>
+  <p><strong>Please Note:</strong> CircleCI 2.0 is currently in Beta. During the Beta we'll be updating the documentation regularly, so <a href="https://github.com/circleci/circleci-docs/pulse#merged-pull-requests">watch for updates</a>. Questions about using 2.0 are welcome on <a class="alert-link" href="https://discuss.circleci.com/c/circleci-2-0">Discuss</a>.</p>
 </div>


### PR DESCRIPTION
Remove circular link back to the new 'explore the docs' CTA