### PR TITLE
hide the lxc docs in prep of sunsetting.

### DIFF
--- a/jekyll/_ccie/config.md
+++ b/jekyll/_ccie/config.md
@@ -4,6 +4,7 @@ section: enterprise
 title: "LXC-based Builder Configuration"
 category: [advanced-config]
 order: 6
+hide: true
 description: "Configuring the CircleCI Enterprise installation."
 ---
 

--- a/jekyll/_ccie/on-prem.md
+++ b/jekyll/_ccie/on-prem.md
@@ -4,6 +4,7 @@ section: enterprise
 title: "LXC-based Installation"
 category: [advanced-config]
 order: 5
+hide: true
 description: "How to install CircleCI Enterprise LXC on Ubuntu 14.04"
 ---
 


### PR DESCRIPTION
urls remain valid, but will no longer appear in the navigation