### PR TITLE
Re-add missing context for interpolating env vars

### DIFF
--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -116,6 +116,9 @@ With the following to load it into your shell:
 ```
     environment:
        BASH_ENV: ~/.bashrc
+    steps:
+      run: echo 'export PATH=/path/to/foo/bin:$PATH' >> $BASH_ENV 
+      run: some_program_inside_bin
 ```
 
 - Search and replace the `hosts:` key, for example:


### PR DESCRIPTION
Some context was lost in the environment variable section at some point.  It was in this pull request earlier:

https://github.com/circleci/circleci-docs/pull/1065/files