### PR TITLE
Fix mistype in workflow example

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -116,7 +116,7 @@ workflows:
   version: 2
   build_accept_deploy:
     jobs:
-      - build:
+      - build
       - acceptance_test_1:
           requires:
             - build


### PR DESCRIPTION
Seems like job with no config should be without colon. I was getting parsing error until removed trailing colon:
`* error parsing config: yaml: line 100: mapping values are not allowed in this context`
part of failing config example (lines 95-105):
```
workflows:
  version: 2
  build_and_deploy:
    jobs:
      - build:
      - publish_api_client:
          requires:
            - build
          filters:
            branches:
              only: master
```