### PR TITLE
Update migrating-from-1-2.md

### DIFF
--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -111,11 +111,9 @@ Optionally configure workflows, using the following instructions:
     PATH: "/path/to/foo/bin:$PATH"
 ```
 
-With the following to load it into your shell:
+With the following to load it into your shell (the file $BASH_ENV already exists and has a random name in /tmp):
 
 ```
-    environment:
-       BASH_ENV: ~/.bashrc
     steps:
       run: echo 'export PATH=/path/to/foo/bin:$PATH' >> $BASH_ENV 
       run: some_program_inside_bin


### PR DESCRIPTION
As per Mahmood's comment, setting a new $BASH_ENV value is unnecessary:

https://github.com/circleci/circleci-docs/pull/1065/files#r118388801