### PR TITLE
Add temporary support info page

### DIFF
--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -25,6 +25,6 @@ title: CircleCI Documentation
 		<p>We welcome your feedback, questions and feature requests on our community forums - <a href="https://discuss.circleci.com/">Discuss</a>. Searching the forums is a great way to find solutions to specific issues not covered by the docs.</p>
 </div>
 <div class="category-section">
-	<h2><a href="https://circleci.com/support/premium-support/">Support</a></h2>
-		<p>Engineering support is available for customers on paid plans. You can submit a ticket from within the application by clicking the question mark icon at the bottom right of the screen.</p>
+	<h2><a href="https://circleci.com/docs/support/">Support</a></h2>
+		<p>CircleCI offers a range of support options to suit your needs. <a href="https://circleci.com/docs/support/">Read more about the support options available to you and how to contact the Support Team</a>.</p>
 </div>

--- a/jekyll/support.html
+++ b/jekyll/support.html
@@ -1,0 +1,43 @@
+---
+layout: classic-docs
+page-type: homepage
+title: Get Support
+---
+
+<h1><strong>Help and Support Resources for CircleCI</strong></h1>
+
+<div class="category-section">
+    <h2><strong>Contact our Support Team</strong></h2>
+        <p>Engineering support is available for all customers on paid plans.
+        Submit a ticket from within the application by clicking the 'question mark' icon at the bottom right of the screen. If you're unable to access the application, email <a href="mailto:support@circleci.com">support@circleci.com</a>.
+        <p><a href="#support-info">Read more about our Support service</a></p>
+</div>
+<div class="category-section">
+    <h2><strong><a href="https://discuss.circleci.com/">Community Forum - Discuss</a></strong></h2>
+        <p>All customers, whether on free or paid plans, have access to our Community Forum. Please search Discuss before contacting support as many common problems have solutions posted there.</p>
+        <p>The forum has an <a href="https://discuss.circleci.com/announcments/">Announcements</a> category that you can subscribe to for important news and updates.</p>
+</div>
+<div class="category-section">
+    <h2><strong><a href="https://circleci.com/support/premium-support/">Premium Support</a></strong></h2>
+        <p>For teams who need predictably rapid response times on their support tickets and preferential escalation of critical issues, we offer Premium Support packages with guaranteed response times and access to our Success Engineers.</p>
+</div>
+<div class="category-section">
+    <h2><strong><a href="/docs/">Documentation</a></strong></h2>
+        <p>Documentation is arranged in sections for <a href="https://circleci.com/docs/1.0/">CircleCI 1.0</a>, <a href="https://circleci.com/docs/2.0/">CircleCI 2.0</a>, <a href="https://circleci.com/docs/enterpsie/">Enterprise</a> 'Behind the Firewall', and <a href="https://circleci.com/docs/api/">API</a>. There is a search bar at the top of each documantation page which searches the current section.</p>
+        <p>Use the dropdown selector in the left sidebar to choose a section.</p>
+</div>
+<div class="category-section">
+    <h2><strong><a href="https://circleci.com/changelog/">Changelog</a></strong></h2>
+        <p>The changelog lists significant updates to our platform. It can be useful to check and see if a recent update could be the cause of a problem.</p>
+</div>
+<div class="category-section">
+    <h2><strong><a href="https://status.circleci.com/">CircleCI Status</a></strong></h2>
+        <p>You can check the status of our service and our partners on the status page. We also report incidents using a banner in the application while an event is current.</p>
+</div>
+
+<h2 id="support-info"><strong>Support Helpdesk Information</strong></h2>
+
+<p>All customers on paid plans have access to engineering support via our helpdesk.</p>
+<p>We aim to respond to urgent issues within 24 hours, and all other issues as soon as we’re able.</p>
+<p>Support operations are round-the-clock, Monday - Friday. Over weekends and US public holidays we check in on tickets for any urgent issues, but otherwise we'll respond once we're back at work.</p>
+<p>We use an email ticket system. Our application is able to send additional information about your pojects and builds if you submit a ticket using the widget in the application from a screen where you're seeing a problem.</p>


### PR DESCRIPTION
This adds a temporary page at `/docs/support/` that will eventually be hosted on 'outer'. It will be linked from new item labelled 'Get Support' in this menu from the top bar:

![image](https://user-images.githubusercontent.com/809823/27690994-b0634842-5cda-11e7-8a76-03a81b405f50.png)

Reason: Currently customers are unsure how to contact support since the 'middle way' for paid plans is not linked anywhere.

When the 'outer' team have created a page based on this one it will be removed.