### PR TITLE
[CIRCLE-5502] Support specifying machine images

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -65,6 +65,21 @@ Let’s break down what’s happening during this build’s execution:
 3. All docker-related commands are also executed in your primary container, but building/pushing images and running containers happens in the remote Docker Engine.
 4. We use project environment variables to store credentials for Docker Hub.
 
+## Docker version
+
+If your build requires a specific docker image, you can set it as an `image` attribute:
+
+```YAML
+      - setup_remote_docker:
+          version: 17.05.0-ce
+```
+
+The currently supported versions are:
+
+* `17.03.0-ce` (default)
+* `17.05.0-ce`
+* `17.06.0-ce`
+
 ## Separation of Environments
 The job and [remote docker]({{ site.baseurl }}/2.0/glossary/#remote-docker) run in  separate environments. Therefore, Docker or Machine containers cannot directly communicate with the containers running in remote docker.
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -143,7 +143,8 @@ The usage of the [machine executor]({{ site.baseurl }}/2.0/executor-types) is co
 
 Key | Required | Type | Description
 ----|-----------|------|------------
-enabled | Y | Boolean | This must be true in order to enable the `machine` executor.
+enabled | N | Boolean | This must be true in order to enable the `machine` executor.  Is required if no other value is specified
+image | N | String | The image to use (default: `circleci/classic:latest`)
 {: class="table table-striped"}
 
 As a shorthand, you can set the `machine` key to `true`.
@@ -162,6 +163,22 @@ jobs:
   build:
     machine: true
 ```
+
+CircleCI supports multiple machine images that can be specified in `image` field:
+
+* `circleci/classic:latest` (default) - an Ubuntu Trusty-based image with Docker `17.03.0-ce` along with common language tools found in CircleCI 1.0 build image.  The `latest` channel provides the latest tested images, changes to the channel are announced at least a week in advance.
+* `circleci/classic:edge` - an Ubuntu Trusty-based image with Docker `17.06.0-ce` along with common language tools found in CircleCI 1.0 build image.  The `edge` channel provides release candidates that will eventually.
+
+So you can set the following to use Docker `17.06.0-ce`:
+
+```YAML
+jobs:
+  build:
+    machine:
+      image: circleci/classic:edge
+```
+
+*Coming soon*: Capability to pin the image version and documentation of the actual content of each released image.
 
 ### **`branches`**
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -167,7 +167,7 @@ jobs:
 CircleCI supports multiple machine images that can be specified in `image` field:
 
 * `circleci/classic:latest` (default) - an Ubuntu Trusty-based image with Docker `17.03.0-ce` along with common language tools found in CircleCI 1.0 build image.  The `latest` channel provides the latest tested images, changes to the channel are announced at least a week in advance.
-* `circleci/classic:edge` - an Ubuntu Trusty-based image with Docker `17.06.0-ce` along with common language tools found in CircleCI 1.0 build image.  The `edge` channel provides release candidates that will eventually.
+* `circleci/classic:edge` - an Ubuntu Trusty-based image with Docker `17.06.0-ce` along with common language tools found in CircleCI 1.0 build image.  The `edge` channel provides release candidates that will eventually be promoted to `classic:latest`.
 
 So you can set the following to use Docker `17.06.0-ce`:
 
@@ -177,8 +177,6 @@ jobs:
     machine:
       image: circleci/classic:edge
 ```
-
-*Coming soon*: Capability to pin the image version and documentation of the actual content of each released image.
 
 ### **`branches`**
 


### PR DESCRIPTION
We are starting to support to support specifying different non-default images, primarily to allow different versions of docker - a highly requested feature.

Will follow up with more documentation explaining our machine image management (e.g. announcements, deprecation policy, image content) as well as expected SLA for providing support once a Docker release is made.

This PR is to provide a soft-launch of the feature.