### PR TITLE
Fix example in migrating-from-1-2.md workflow doc

### DIFF
--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -78,18 +78,18 @@ Optionally configure workflows, using the following instructions:
 5. For jobs which must run sequentially depending on success of another job, add the `requires:` key with a nested list of jobs that must succeed for it to start. If you were using a `curl` command to start a job, Workflows enable you to remove the command and start the job by using the `requires:` key.
  
      ```
-      - <job_name>
+      - <job_name>:
           requires:
             - <job_name>
      ```
 6. For jobs which must run on a particular branch, add the `filters:` key with a nested `branches` and `only` key. For jobs which must not run on a particular branch, add the `filters:` key with a nested `branches` and `ignore` key.
  
      ```
-     - <job_name>
+     - <job_name>:
          filters:
            branches:
              only: master
-     - <job_name>
+     - <job_name>:
          filters:
            branches:
              ignore: master


### PR DESCRIPTION
Fix example in migrating-from-1-2.md workflow doc
Without the `:` it doesn't work