### PR TITLE
Clarify workflow filter specification

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -714,8 +714,8 @@ Branches can have the keys `only` and `ignore` which either map to a single stri
 Key | Required | Type | Description
 ----|-----------|------|------------
 branches | N | Map | A map defining rules for execution on specific branches
-only | N | String | A branch name
-ignore | N | String | A branch name
+only | N | String, or List of Strings | Either a single branch specifier, or a list of branch specifiers
+ignore | N | String, or List of Strings | Either a single branch specifier, or a list of branch specifiers
 {: class="table table-striped"}
 
 ###### *Example*

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -197,7 +197,9 @@ workflows:
       - test_dev:
           filters:
             branches:
-              only: dev
+              only:
+                - dev
+                - /user-.*/
       - test_stage:
           filters:
             branches:
@@ -205,7 +207,7 @@ workflows:
       - test_pre-prod:
           filters:
             branches:
-              only: pre-prod
+              only: /pre-prod(?:-.+)?$/
 ```
 
 In the example, `filters` is set with the `branches` key and the `only` key with the branch name. Any branches that match the value of `only` will run the job. Branches matching the value of `ignore` will not run the job.


### PR DESCRIPTION
Mention both options for specifying branch filters.

Update the workflows example config to include both variants.