### PR TITLE
Using a private image on the `machine`

### DIFF
--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -35,3 +35,25 @@ jobs:
 ```
 
 
+Alternatively, you can utilize the `machine` executor to achieve the same thing:
+
+```
+version: 2
+jobs:
+  build:
+    machine: true
+    working_directory: ~/my_app
+    steps:
+      # Docker is preinstalled, along with docker-compose
+      - checkout
+
+      # start proprietary DB using private Docker image
+      - run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+          docker run -d --name db company/proprietary-db:1.2.3
+
+      # build and test application
+      - run: |
+          docker build -t my-app .
+          # assuming that our app expects to have DB on localhost
+          docker run --network container:db my-app test


### PR DESCRIPTION
It came to my attention we don't currently document the ability to use the `machine` executor for private images. We will also need to elaborate on the `executor-types.md` page.