### PR TITLE
Add quotes to checksum parameter

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -14,7 +14,7 @@ Caching is one of the most effective ways to make jobs faster on CircleCI. Autom
     steps:
       -restore_cache:
          keys:
-           - m2-{{ checksum pom.xml }}
+           - m2-{{ checksum "pom.xml" }}
            - m2- # used if checksum fails
 ```
 {% endraw %}


### PR DESCRIPTION
Omitting the quotes seems to fail with something like:

    function "Dockerfile" not defined