### PR TITLE
update 'executor-types' language w.r.t `machine` executor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Come back here when you're ready to start editing!
 
 ### Editing Docs Locally
 
-All docs live in folders named after the version of CircleCI. The only two you need to worry about are `jekyll_cci1` and `jekyll/_cci2`, for CircleCI Classic and CircleCI 2.0, respectively.
+All docs live in folders named after the version of CircleCI. The only two you need to worry about are `jekyll/_cci1` and `jekyll/_cci2`, for CircleCI Classic and CircleCI 2.0, respectively.
 
 1. Create a branch and switch to it:
 

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -115,7 +115,7 @@ jobs:
     machine: true
 ```
 
-The VM will run Ubuntu 14.04 with a few additional tools installed. It isn’t possible to specify other images. Refer to the [specification script for the VM](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh) for more information about additional tools.
+[You can specify one of two images for the VM](https://circleci.com/docs/2.0/configuration-reference/#machine), both running Ubuntu 14.04: a `circleci/classic:latest` (default) image with Docker version `17.03.0-ce`, or a `circleci/classic:edge` image with Docker Version `17.06.0-ce`, both with common language tools preinstalled. Refer to the [specification script for the VM](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh) for more information about additional tools.
 
 ### When To Use the Machine Executor?
 - Your application requires full access to OS resources.


### PR DESCRIPTION
bringing [Machine Executor Overview](https://circleci.com/docs/2.0/executor-types/#machine-executor-overview) text in line with info in [Writing Jobs with Steps](https://circleci.com/docs/2.0/configuration-reference/#machine)

also fixed a tiny typo in `contributing.md`