### PR TITLE
Fix config error in config reference

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -66,7 +66,7 @@ Example:
 jobs:
   build:
     docker:
-      - buildpack-deps:trusty
+      - image: buildpack-deps:trusty
     environment:
       - FOO: "bar"
     parallelism: 3


### PR DESCRIPTION
Without it we raise this error during "Spin up Environment":

* json: cannot unmarshal string into Go struct field JobDescription.docker of type config.ContainerConfig