### PR TITLE
Fix the command to run a test in Firebase Test Lab

### DIFF
--- a/jekyll/_cci1/firebase-test-lab.md
+++ b/jekyll/_cci1/firebase-test-lab.md
@@ -80,7 +80,7 @@ CircleCI.
 ```
 test:
   override:
-    - echo "y" | sudo /opt/google-cloud-sdk/bin/gcloud beta test android run --app app/build/outputs/apk/app-debug.apk --test app/build/outputs/apk/app-debug-test-unaligned.apk --results-bucket cloud-test-<PROJECT-ID>
+    - echo "y" | sudo /opt/google-cloud-sdk/bin/gcloud beta firebase test android run --app app/build/outputs/apk/app-debug.apk --test app/build/outputs/apk/app-debug-test-unaligned.apk --results-bucket cloud-test-<PROJECT-ID>
   post:
     - sudo /opt/google-cloud-sdk/bin/gsutil -m cp -r -U `sudo /opt/google-cloud-sdk/bin/gsutil ls gs://cloud-test-circle-ctl-test | tail -1` $CIRCLE_ARTIFACTS/ | true
 ```


### PR DESCRIPTION
For the latest version of `gcloud`, need to specify `firebase` group to invoke a test in Firebase Test Lab.
The documentation is [here](https://cloud.google.com/sdk/gcloud/reference/beta/firebase/test/android/run)