### PR TITLE
Update location of test timing data.

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -65,7 +65,7 @@ When the items are filepaths, the `filesize` option will weight the split by fil
 
 `circleci tests glob "**/*.go" | circleci tests split --split-by=filesize`
 
-The `timings` split type uses historical timing data to weight the split. CircleCI automatically makes timing data from previous runs available inside your container in a default location so the CLI tool can discover them (`/.circleci-task-data/circle-test-results/`).
+The `timings` split type uses historical timing data to weight the split. CircleCI automatically makes timing data from previous runs available inside your container in a default location so the CLI tool can discover them (`$CIRCLE_INTERNAL_TASK_DATA/circle-test-results/results.json`).
 
 When splitting by `timings`, the tool will assume it’s splitting filenames. If you’re splitting classnames, you’ll need to specify that with the `--timings-type` flag, as in the following examples:
 


### PR DESCRIPTION
The previous suggestion to check in `/.circleci-task-data/circle-test-results/` doesn't seem to be correct as it never exists (and appears to be incorrect anyway as I wouldn't expect the data to be mounted in the root of the drive).

Judging by the environment variable `CIRCLE_INTERNAL_TASK_DATA` and the actual discovery of a `results.json` in this corrected path with the timing information, I believe this is correct.