### PR TITLE
Injected variables don't override project settings

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -116,7 +116,7 @@ export qux="{\"quux\": 1}"
 export list="[\"a\", \"list\", \"of\", \"strings\"]"
 ```
 
-Build parameters are exported as environment variables inside the build's containers and can be used by scripts/programs and commands in `circle.yml`. The injected environment variables may be used to influence the steps that are run during the build.
+Build parameters are exported as environment variables inside the build's containers and can be used by scripts/programs and commands in `circle.yml`. The injected environment variables may be used to influence the steps that are run during the build. It is important to note that injected environment variables will not override values defined in `circle.yml` nor in the project settings.
 
 You might want to inject environment variables with the `build_parameters` key to enable your functional tests to build against different targets on each run. For example, a run with a deploy step to a staging environment that requires functional testing against different hosts. It is possible to include `build_parameters` by sending a JSON body with `Content-type: application/json` as in the following example that uses `bash` and `curl` (though you may also use an HTTP library in your language of choice).
 


### PR DESCRIPTION
When triggering a build that contain injected environment variables with the same key as a variable defined in the project settings, the project settings will take precedence. This expectation should be noted in the documentation.

This has been my experience thus far, and would be delighted to learn this isn't the case, but it should be noted.