### PR TITLE
Clarify whether the `ci/circle` Github check will ever run for a workflow

### DIFF
--- a/jekyll/_cci2/workflows-waiting-status.md
+++ b/jekyll/_cci2/workflows-waiting-status.md
@@ -7,11 +7,11 @@ categories: [troubleshooting]
 order: 1
 ---
 
-If you have implemented workflows on a branch in your GitHub repository, but the status check never completes, there may be  status settings in GitHub that you need to reset. For example, if you choose to protect your branches, you may need to deselect the status keys you expect from CircleCI, as follows:
+If you have implemented workflows on a branch in your GitHub repository, but the status check never completes, there may be  status settings in GitHub that you need to deselect. For example, if you choose to protect your branches, you may need to deselect the `ci/circleci` status key as this check refers to the default CircleCI 1.0 check, as follows:
 
 ![Uncheck GitHub Status Keys]({{ site.baseurl }}/assets/img/docs/github_branches_status.png)
 
-Having the `ci/circleci` checkbox enabled may prevent the status from showing as completed in GitHub because CircleCI posts statuses to Github with a key that includes the job by name.
+Having the `ci/circleci` checkbox enabled will prevent the status from showing as completed in GitHub when using a workflow because CircleCI posts statuses to Github with a key that includes the job by name.
 
 Refer to the [Orchestrating Workflows]({{ site.baseurl }}/2.0/workflows) document for examples and conceptual information.
 


### PR DESCRIPTION
The current version does not make it clear whether, when using a workflow, one should _ever_ expect the `ci/circleci` status check to return.

I think what is being said is that if you use a workflow you will only see `ci/circleci:job_name` checks, but since my expectation was that I might still see a `ci/circleci` check complete at the end of the process this document does not provide clarity, and I suspected my integration was faulty. Noncommittal language like "may prevent the status from showing as completed" (surely it _always_ will, for a workflow?) obscures what you need to do. The term "reset" (along with the annotations) also made me think I may need to turn branch protection or certain checks off then on again (which again I guess is not what was meant).

If something to the contrary was meant then that could be made clearer.