### PR TITLE
add limitation to language-android.md

### DIFF
--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -15,6 +15,7 @@ There are some assumptions made in this guide:
 
 - We assume that your Android project is built with `gradle` (this is the default for projects created with [Android Studio](https://developer.android.com/studio).
 - We assume that your project is located in the root of your `git` repository, with the application located in a subfolder named `app`.
+- It is possible to run your tests, but loading the full emulator may not work.
 
 ## Sample Configuration
 


### PR DESCRIPTION
just a draft sentence about the emulator for https://github.com/circleci/circleci-docs/issues/1483
maybe this should also be mentioned in the docker images section (or only there)?