### PR TITLE
Fix up some example macOS config.yml 

### DIFF
--- a/jekyll/_cci2/building-xcode-projects.md
+++ b/jekyll/_cci2/building-xcode-projects.md
@@ -6,49 +6,36 @@ description: Using a macOS Build Image
 changefreq: "weekly"
 ---
 
-This document describes how to specify an Xcode project and use a macOS or OSX image for your build environment in the following sections:
+This document describes how to specify an Xcode project and use a macOS image for your build environment in the following sections:
 
 * TOC
 {:toc}
 
 ## Overview of CircleCI 2.0 macOS Images
 
-CircleCI maintains a manifest of the software installed on the available OSX and macOS build images. This manifest includes the version of the software components including the operating system, Xcode, Python, and Ruby, for example.
+CircleCI maintains a manifest of the software installed on the available macOS build images. This manifest includes the version of the software components including the operating system, Xcode, Python, and Ruby, for example.
 
-* [Xcode version 9.0 Beta 2 and later (macOS 10.12 Sierra)](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-145/index.html).
-* [Xcode version 8.3.3 and later (macOS 10.12 Sierra)](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-146/index.html).
+* [Xcode version 9.0 (macOS 10.12 Sierra)](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-145/index.html).
+* [Xcode version 8.3.3 (macOS 10.12 Sierra)](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-146/index.html).
 
 ## Supported Xcode Versions
 
-To allow CircleCI to upgrade Xcode to the latest point-release without requiring you to change your `config.yml`, specify the version of Xcode that you would like to build by specifying the `major.minor` version. CircleCI will automatically ensure that the correct version of Xcode is selected.
-
 The currently available Xcode versions are:
 
-* `9.0`: Xcode 9.0 Beta 2 (Build 16F73)
-* `8.3`: Xcode 8.3.2 (Build 8E2002)
+* `9.0`: Xcode 9.0 (Build 9A235)
 * `8.3.3`: Xcode 8.3.3 (Build 8E3004b)
-* `8.3.2`: Xcode 8.3.2 (Build 8E2002)
-* `8.3.1`: Xcode 8.3.1 (Build 8E1000a)
-* `8.2`: Xcode 8.2.1 (Build 8C1002)
-* `8.1`: Xcode 8.1 (Build 8B62)
-* `8.0`: Xcode 8.0 (Build 8A218a)
-* `7.3`: Xcode 7.3 (Build 7D175)
-* `7.2`: Xcode 7.2 (Build 7C68)
-* `7.1`: Xcode 7.1 (Build 7B91b)
-* `7.0`: Xcode 7.0 (Build 7A220)
 
 ## Specifying the macOS Build Environment
 
-1. Specify the name and version of the build image and Xcode in your `.circleci/config.yml` file. For example, to build on macOS with Xcode `8.2.1`, add the following:
+1. Specify the name and version of the build image and Xcode in your `.circleci/config.yml` file. For example, to build on macOS with Xcode `8.3.3`, add the following:
 
 ```
 jobs:
   build:
     macos:
-      xcode:
-        version: "8.2"
+      xcode: "8.3.3"
 ```
 
-2. Start a new run by pushing a new commit to GitHub or Bitbucket. 
+2. Start a new run by pushing a new commit to GitHub or Bitbucket.
 
 

--- a/jekyll/_cci2/ios-tutorial.md
+++ b/jekyll/_cci2/ios-tutorial.md
@@ -21,7 +21,7 @@ The following sections walk through how to write Jobs and Steps that use `xcodeb
 - Add your project to CircleCI, see [Hello World]( {{ site.baseurl }}/2.0/hello-world/)
 - This tutorial assumes you have an Xcode workspace for your project with at least one shared scheme and that the selected scheme has a test action. If you do not already have a shared scheme, you can add this in Xcode by completing the following steps:
 
-1. Open your Xcode workspace or project. 
+1. Open your Xcode workspace or project.
 2. Use the scheme selector to open the Manage Schemes dialogue box as shown in the following image.
 ![Xcode Scheme Selector](  {{ site.baseurl }}/assets/img/docs/ios-getting-started-scheme-selector.png)
 3. In the manage schemes dialog, select the scheme you wish to build, and ensure that the Shared checkbox is enabled.
@@ -52,10 +52,6 @@ jobs:
 
 Refer to <https://codesigning.guide/> for details.
 
-## Using A Provisioning Profile
-
-To use your provisioning profile with your CircleCI builds, upload the `.mobileprovision` file on the Project Settings > OS X Code Signing page. Provisioning profiles are automatically added to the `circle.keychain` at the start of the build.
-
 To further customize your build process to use custom tools or run your own scripts, use the `config.yml` file, see the [Sample 2.0 config.yml]( {{ site.baseurl }}/2.0/sample-config/) document for customizations.
 
 ## Installing Dependencies
@@ -65,10 +61,11 @@ To install dependencies from homebrew, for example, use a `run` step with the ap
 ```
     steps:
       - run:
-          name: homebrew dependencies
-          command: |
-            - brew install kylef/formulae/swiftenv
-            - swiftenv install 3.0
+          name: Install Homebrew Dependencies
+          command: brew install yarn
+      - run:
+          name: Install Node Dependencies
+          command: yarn install
 ```
 
 ## Running Tests
@@ -88,16 +85,18 @@ To deploy your application with CircleCI using [Gym](https://github.com/fastlane
 version: 2
 jobs:
   test:
-    machine:
-      enabled: true
-      xcode:
-        version: 8.0
+    macos:
+      xcode: 9.0
     steps:
+      - checkout
       - run: swift test
   deploy:
+    macos:
+      xcode: 9.0
     steps:
+      - checkout
       - deploy:
-          name: Maybe Deploy
+          name: Deploy
           command: fastlane release_appstore
 
 workflows:

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -12,7 +12,7 @@ order: 2
 
 The CircleCI 2.0 configuration introduces a new key for `version: 2`. This new key enables you to try 2.0 while continuing to build on 1.0. That is, you can still use 1.0 on some projects while using 2.0 on others. New keys for `jobs:` and `steps:` enable greater control and provide a framework for workflows and status on each phase of a run to report more frequent feedback.
 
-The following sections provide a sample `.circleci/config.yml` with an overview of Jobs and Steps, changes to keys from 1.0, new keys that are nested inside Steps and new keys for Workflows. 
+The following sections provide a sample `.circleci/config.yml` with an overview of Jobs and Steps, changes to keys from 1.0, new keys that are nested inside Steps and new keys for Workflows.
 
 ## Jobs Overview
 
@@ -30,7 +30,7 @@ Steps are a collection of executable commands which are run during a job. The `s
 
 ## Sample Configuration with Sequential Workflow
 
-Following is a sample 2.0 `.circleci/config.yml` file. 
+Following is a sample 2.0 `.circleci/config.yml` file.
 
 {% raw %}
 ```
@@ -41,7 +41,7 @@ jobs:
     # The primary container is an instance of the first list image listed. Your build commands run in this container.
     docker:
       - image: circleci/node:4.8.2
-    # The secondary container is an instance of the second listed image which is run in a common network where ports exposed on the primary container are available on localhost.   
+    # The secondary container is an instance of the second listed image which is run in a common network where ports exposed on the primary container are available on localhost.
       - image: mongo:3.4.4
     steps:
       - checkout
@@ -59,7 +59,7 @@ jobs:
             - node_modules
   test:
     docker:
-      - image: circleci/node:4.8.2  
+      - image: circleci/node:4.8.2
       - image: mongo:3.4.4
     steps:
       - checkout
@@ -75,7 +75,7 @@ jobs:
       - store_artifacts:
           path: coverage
           prefix: coverage
-      
+
 workflows:
   version: 2
   build_and_test:
@@ -245,8 +245,7 @@ jobs:
 
     # Specify the Xcode version to use.
     macos:
-      xcode:
-        version: "8.3.3"
+      xcode: "8.3.3"
 
     # Define the steps required to build the project.
     steps:
@@ -284,8 +283,7 @@ jobs:
 
   deploy:
     macos:
-      xcode:
-        version: 8.3.3
+      xcode: 8.3.3
 
     steps:
       - checkout
@@ -321,9 +319,10 @@ workflows:
           filters:
             branches:
               only: master
-              ```
-              
-## Sample Linux and macOS Configuration File     
+
+```
+
+## Sample Linux and macOS Configuration File
 
 ```version: 2
 jobs:
@@ -339,8 +338,7 @@ jobs:
 
   xcode_nine:
     macos:
-      xcode:
-        version: "9.0"
+      xcode: "9.0"
     steps:
       - checkout
       - attach_workspace:
@@ -356,8 +354,7 @@ jobs:
 
   xcode_eight_three_three:
     macos:
-      xcode:
-        version: "8.3.3"
+      xcode: "8.3.3"
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
Hi @michelle-luna, I've made some quick updates targeting your mobile docs branch.

The changes are mostly about the new `config.yml` syntax, and limiting the examples to xcode `9.0` and `8.3.3`.

We also do not have support for running builds by specifying only the `x.y` build number at present, so I have removed that advice.