### PR TITLE
Clarify env var template for caching.md

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -110,7 +110,7 @@ Template | Description
 {% raw %}`{{ .Branch }}`{% endraw %} | The VCS branch currently being built.
 {% raw %}`{{ .BuildNum }}`{% endraw %} | The CircleCI build number for this build.
 {% raw %}`{{ .Revision }}`{% endraw %} | The VCS revision currently being built.
-{% raw %}`{{ .Environment.variableName }}`{% endraw %} | The environment variable `variableName`.
+{% raw %}`{{ .Environment.variableName }}`{% endraw %} | The environment variable `variableName`, supports any environment  variable supplied by CircleCI, **not** any arbitrary environment variable.
 {% raw %}`{{ checksum "filename" }}`{% endraw %} | A base64 encoded SHA256 hash of the given filename's contents, so that a new cache key is generated if the file changes. This should be a file committed in your repo. Consider using dependency manifests, such as `package.json`, `pom.xml` or `project.clj`. The important factor is that the file does not change between `restore_cache` and `save_cache`, otherwise the cache will be saved under a cache key that is different from the file used at `restore_cache` time.
 {% raw %}`{{ epoch }}`{% endraw %} | The number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC), also known as POSIX or Unix epoch.
 {% raw %}`{{ arch }}`{% endraw %} | The OS and CPU information.  Useful when caching compiled binaries that depend on OS and CPU architecture, for example, `darwin amd64` versus `linux i386/32-bit`.


### PR DESCRIPTION
The env var template in configuration-reference.md is clarified, but caching.md is not clarified.

See ticket: https://discuss.circleci.com/t/cannot-use-circle-yml-environment-variables-in-cache-keys/10994
See commit: https://github.com/circleci/circleci-docs/commit/908d080a3ecf98915e7a718c662baaff7b64b019