### PR TITLE
Remove the Version stanza from the macOS 2.0 example

### DIFF
--- a/jekyll/_cci2/ios-migrating-from-1-2.md
+++ b/jekyll/_cci2/ios-migrating-from-1-2.md
@@ -47,8 +47,7 @@ jobs:
 
     # Specify the Xcode version to use.
     macos:
-      xcode:
-        version: "8.3.3"
+      xcode: "8.3.3"
 
     # Define the steps required to build the project.
     steps:
@@ -86,8 +85,7 @@ jobs:
 
   deploy:
     macos:
-      xcode:
-        version: 8.3.3
+      xcode: "8.3.3"
 
     steps:
       - checkout
@@ -184,13 +182,11 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode:
-        version: "8.3.3"
+      xcode: "8.3.3"
 ...
   deploy:
     macos:
-      xcode:
-        version: 8.3.3
+      xcode: "8.3.3"
 ...
 ```
 
@@ -376,8 +372,7 @@ jobs:
   ...
   deploy:
     macos:
-      xcode:
-        version: 8.3.3
+      xcode: 8.3.3
 
     steps:
       - checkout


### PR DESCRIPTION
We recently updated the macOS 2.0 config, and we need to reflect the change in the docs.