### PR TITLE
[CIRCLE-6790] Update IAM policy document

### DIFF
--- a/jekyll/_cci2/aws.md
+++ b/jekyll/_cci2/aws.md
@@ -87,6 +87,7 @@ Have available the following information and policies before starting the Previe
                 "iam:*",
                 "ec2:StartInstances",
                 "ec2:RunInstances",
+                "ec2:TerminateInstances",
                 "ec2:Describe*",
                 "ec2:CreateTags",
                 "ec2:AuthorizeSecurityGroupEgress",
@@ -100,6 +101,7 @@ Have available the following information and policies before starting the Previe
                 "ec2:DescribeSecurityGroups",
                 "ec2:RevokeSecurityGroupEgress",
                 "ec2:RevokeSecurityGroupIngress",
+                "ec2:ModifyNetworkInterfaceAttribute",
                 "cloudwatch:*",
                 "autoscaling:DescribeAutoScalingGroups",
                 "iam:GetUser"


### PR DESCRIPTION
The policy does not work in the current state. Including these two additional permissions will allow users to use our recommended IAM policy to install CircleCI Server on AWS with terraform.