### PR TITLE
Clarify jobs/workflows caching example

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -37,9 +37,17 @@ The dependencies that are most important to cache during a job are the libraries
 
 Tools that are not explicitly required for your project are best stored on the Docker image. The Docker image(s) pre-built by CircleCI have tools preinstalled that are generic for building projects using the language the image is focused on. For example the `circleci/ruby:2.4.1` image has useful tools like git, openssh-client, and gzip preinstalled.  
 
-## Writing to the Cache
- 
-Cache is written in chronological order. Consider a workflow of Job1 -> Job2 -> Job3. If Job1 and Job3 write to the same cache key, a rerun of Job2 may use the changes written by Job3 because Job2 ran last. That is, any job that runs inside a project will always use the latest write. For example, when you increment versions of a Gem package, the `~/.gem` contains both the old and new versions and the cache is made more useful by the addition of data.
+## Writing to the Cache in Workflows
+
+Jobs in one workflow can share caches.  Note that this makes it possibile to create race conditions in caching across different jobs in workflows.
+
+Cache is immutable on write: once a cache is written for a particular key like `node-cache-master`, it cannot be written to again. Consider a workflow of 3 jobs, where Job3 depends on Job1 and Job2: {Job1, Job2} -> Job3.  They all read and write to the same cache key.
+
+In a run of the workflow, Job3 may use the cache written by Job1 or Job2.  Since caches are immutable, this would be whichever job saved its cache first.  This is usually undesireable because the results aren't deterministic--part of the result depends on chance.  You could make this workflow deterministic by changing the job dependencies: make Job1 and Job2 write to different caches and Job3 loads from only one, or ensure there can be only one ordering: Job1 -> Job2 ->Job3.
+
+There are more complex cases, where jobs can save using a dynamic key like `node-cache-{{ checksum "package.json" }}` and restore using a partial key match like `node-cache-`.  The possibility for a race condition still exists, but the details may change.  For instance, the downstream job uses the cache from the upstream job to run last.
+
+Another race condition is possible when sharing caches between jobs. Consider a workflow with no dependency links: Job1 and Job2.  Job2 uses the cache saved from Job1.  Job2 could sometimes successfully restore a cache, and sometimes report no cache is found, even when Job1 reports saving it.  Job2 could also load a cache from a previous workflow.  If this happens, this means Job2 tried to load the cache before Job1 saved it.  This can be resolved by creating a workflow dependency: Job1 -> Job2.  This would force Job2 to wait until Job1 has finished running.
 
 ## Restoring Cache
 


### PR DESCRIPTION
Addressing 2 issues:

1.  Old example implies caches are re-writeable: 

> Cache is written in chronological order. Consider a workflow of Job1 -> Job2 -> Job3. If Job1 and Job3 write to the same cache key, a rerun of Job2 may use the changes written by Job3 because Job2 ran last.

I reworked this example to emphasize that workflow jobs can share caches, and a race condition to be aware of.

2. Added an example of another kind of job cache race condition: a cache not yet existing when it's requested.  This came up in this ticket:

https://circleci.zendesk.com/agent/tickets/23696/events

Let me know if 1) changed the intent of the original doc too much and I can cut that part out.