### PR TITLE
Update github-security-ssh-keys.md

### DIFF
--- a/jekyll/_cci1/github-security-ssh-keys.md
+++ b/jekyll/_cci1/github-security-ssh-keys.md
@@ -41,13 +41,13 @@ You can add a machine user's SSH key to your projects on CircleCI and use that k
 
 The main benefit of using a machine user's SSH key instead of a regular user's key is that you can lock down the machine user's access to just the repos that it _needs_ to access.
 
-Here are the steps to set a machine user's SSH key as a checkout key for your project.
+Here are the steps to set a machine user's SSH key as a checkout key for your project.  We recommend doing this in an incognito window, as you will have to sign out of your normal user's Github and CircleCI accounts.
 
 - First, you need to login to GitHub as the machine user.
 
 - Go to <https://circleci.com> and log in. GitHub will ask you to authorize CircleCI to access the machine user's account, so click on the **Authorize application** button.
 
-- Go to <https://circleci.com/add-projects> and follow the projects you want the machine user to have access to.
+- Click on "Projects" on the left and follow the projects you want the machine user to have access to.
 
 - Once followed, go to the **Project Settings > Checkout SSH keys** page and then click on the ***Authorize w/GitHub*** button. That gives us permission to create and upload SSH keys to GitHub on behalf of the machine user.
 


### PR DESCRIPTION
Remove link that's no longer valid with org-centric UI.  The link works, but takes me to a page that I can't add a project from.

Add suggestion about using incognito window since many users log out of only one site and get confused.