### PR TITLE
Update getting-started.md

### DIFF
--- a/jekyll/_cci1/getting-started.md
+++ b/jekyll/_cci1/getting-started.md
@@ -54,4 +54,6 @@ Add projects by clicking the Add Projects button on the Project page in the Circ
 Following a project subscribes you to email notifications and adds the project into your dashboard's project/branch picker. CircleCI users that push to a new project get automatically followed to the project. You can control which projects you follow (including following projects that you do not push to!) from the Projects > Add projects page.
 
 
+### I can't find my project to add
 
+If you're not seeing a project you'd like to build and it's not currently building on CircleCI, you should check your org in the top left corner of the CircleCI UI.  For instance, if the top left shows your user `myUser`, only Github projects belonging to `myUser` will be available under `Add Projects`.  If you want to build the Github project `myOrg/orgProject`, you would have to change your org on the UI to `myOrg`.


### PR DESCRIPTION
Add a note about finding the proper project owner in the org UI.  This is a common support issue: user can't find a project on the add projects page.