### PR TITLE
Update circleci-images.md

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -7,7 +7,7 @@ categories: [containerization]
 order: 20
 ---
 
-As a convenience, CircleCI maintains a number of Docker Images for popular languages with additional tooling that is useful when running your tests. All of the following images are published in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/), the Dockerfiles and other source code is available in the [repository on GitHub](https://github.com/circleci/circleci-images). 
+As a convenience, CircleCI maintains a number of Docker Images for popular languages with additional tooling that is useful when running your tests. All of the following images are published in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/), the source code is available in the [repository on GitHub](https://github.com/circleci/circleci-images) and the Dockerfiles are available as build artifacts in the [repository's production branch on CircleCI](https://circleci.com/gh/circleci/circleci-images/tree/production). 
 
 ## How to Get Started with Pre-Built Docker Images Video Tutorial
 <div class="screen">


### PR DESCRIPTION
it's no longer the case that we provide the Dockerfiles for our convenience images in the GitHub repository. it's unfortunate that the steps to view the Dockerfiles are a bit complicated, but hopefully this is clear enough ?