### PR TITLE
Added notes regarding submodules

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -473,8 +473,7 @@ In the case of `checkout`, the step type is just a string with no additional att
 - checkout
 ```
 
-Currently, we don't check out submodules.
-If your project requires that, add the appropriate commands.
+**Note:** CircleCI does not check out submodules. If your project requires submodules, add `run` steps with appropriate commands as shown in the following example:
 
 ```
 - checkout:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -473,6 +473,15 @@ In the case of `checkout`, the step type is just a string with no additional att
 - checkout
 ```
 
+Currently, we don't check out submodules.
+If your project requires that, add the appropriate commands.
+
+```
+- checkout:
+- run: git submodule sync
+- run: git submodule update --init
+```
+
 <a name="save_cache"/>
 ##### **`save_cache`**
 


### PR DESCRIPTION
We do not automatically checkout git submodules. This causes confusion to customers who use them. While this is documented in the 1.0 docs https://circleci.com/docs/1.0/manually/#checkout it is completely missing from 2.0. Correcting this.