### PR TITLE
Change out base/generic Docker image tag recommendation.

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -21,7 +21,7 @@ jobs:
     docker:
       - image: buildpack-deps:trusty
 ```
-In this example, all steps run in the container created by the first image listed under the `build` job. To make the transition easy, CircleCI maintains convenience images on Docker Hub for popular languages. See [Using Pre-Built CircleCI Docker Images]({{ site.baseurl }}/2.0/circleci-images/) for the complete list of names and tags. If you need a Docker image that installs Docker and has Git, consider using `docker:17.05.0-ce-git`, which is an offical [Docker image](https://hub.docker.com/_/docker/).
+In this example, all steps run in the container created by the first image listed under the `build` job. To make the transition easy, CircleCI maintains convenience images on Docker Hub for popular languages. See [Using Pre-Built CircleCI Docker Images]({{ site.baseurl }}/2.0/circleci-images/) for the complete list of names and tags. If you need a Docker image that installs Docker and has Git, consider using `docker:stable-git`, which is an offical [Docker image](https://hub.docker.com/_/docker/).
 
 ## Using Multiple Docker Images
 It is possible to specify multiple images for your job. Specify multiple images if, for example, you need to use a database for your tests or for some other required service. **In a multi-image configuration job, all steps are executed in the container created by the first image listed**. All containers run in a common network and every exposed port will be available on `localhost` from a [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container).


### PR DESCRIPTION
We currently recommend the Docker image `docker:17.05.0-ce-git` as the base, generic, use this if you just need a basic Docker image with git support.

That version of Docker is no longer supported. Docker has a release cycle that includes longer, "stable" versions and intermediate release images. Very similar to the model Ubuntu uses.

The Docker Hub repo has a tag `docker:stable-git` that will move in between stable, longer supported releases only and not intermediate releases (which Docker 17.05 was).