### PR TITLE
Fix order of format statements, resolves error "Message: Content is not allowed in prolog"

### DIFF
--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -191,8 +191,8 @@ steps:
     command: |
       bundle exec rspec --profile 10 \
                         --format RspecJunitFormatter \
-                        --format progress \
                         --out test_results/rspec.xml \
+                        --format progress \
                         $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
     
   # Save test results for timing analysis


### PR DESCRIPTION
The `--out test_results/rspec.xml` needs to follow the `--format RspecJunitFormatter`, not the `--format progress` command, otherwise, the rspec.xml file will have the non-xml contents written to it, and the test-output seen in the UI will be the XML format.

This will result in a "Test Summary" saying:
> The following errors were encountered parsing test results:
> rspec.xmlParseError at [row,col]:[2,1] Message: Content is not allowed in prolog