### PR TITLE
Update configuration-reference.md

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -197,16 +197,16 @@ jobs:
 
 CircleCI supports multiple machine images that can be specified in the `image` field:
 
-* `circleci/classic:latest` (default) - an Ubuntu version `14.04` image that includes Docker version `17.03.0-ce` along with common language tools found in CircleCI 1.0 build image.  The `latest` channel provides the latest tested images, changes to the channel are [announced](https://discuss.circleci.com/t/how-to-subscribe-to-announcements-and-notifications-from-circleci-email-rss-json/5616) at least a week in advance.
-* `circleci/classic:edge` - an Ubuntu version `14.04` image with Docker version `17.06.1-ce` along with common language tools found in CircleCI 1.0 build image.  The `edge` channel provides release candidates that will eventually be promoted to `classic:latest`.
-* `circleci/classic:201703-01` is docker 17.03.0-ce
-* `circleci/classic:201707-01` is docker 17.06.0-ce
-* `circleci/classic:201708-01` is docker 17.06.1-ce
-* `circleci/classic:201709-01` is docker 17.07.0-ce
+* `circleci/classic:latest` (default) - an Ubuntu version `14.04` image that includes Docker version `17.03.0-ce` and docker-compose version `1.9.0`, along with common language tools found in CircleCI 1.0 build image.  The `latest` channel provides the latest tested images, changes to the channel are [announced](https://discuss.circleci.com/t/how-to-subscribe-to-announcements-and-notifications-from-circleci-email-rss-json/5616) at least a week in advance.
+* `circleci/classic:edge` - an Ubuntu version `14.04` image with Docker version `17.06.0-ce` and docker-compose version `1.14.0`, along with common language tools found in CircleCI 1.0 build image.  The `edge` channel provides release candidates that will eventually be promoted to `classic:latest`.
+* `circleci/classic:201703-01` – docker 17.03.0-ce, docker-compose 1.9.0
+* `circleci/classic:201707-01` – docker 17.06.0-ce, docker-comopse 1.14.0
+* `circleci/classic:201708-01` – docker 17.06.1-ce, docker-compose 1.14.0
+* `circleci/classic:201709-01` – docker 17.07.0-ce, docker-compose 1.14.0
 
 You can use one of the `year-month` versioned images to pin the version used by your jobs. Please [subscribe to our Announcements](https://discuss.circleci.com/t/how-to-subscribe-to-announcements-and-notifications-from-circleci-email-rss-json/5616) to be notified when new images are released.
 
-**Example:** use an Ubuntu version `14.04` image with Docker `17.06.1-ce`:
+**Example:** use an Ubuntu version `14.04` image with Docker `17.06.1-ce` and docker-compose `1.14.0`:
 
 ```YAML
 jobs:


### PR DESCRIPTION
added corresponding docker-compose version info to machine image info (double-checked everything here: https://circleci.com/workflow-run/7c38ff97-807f-4fda-bf83-7e26abc583c5)

important b/c folks want to know how they can use healthcheck, among other things, which is only available in docker-compose 1.10 & above: https://github.com/docker/compose/releases/tag/1.10.0