### PR TITLE
Fix old config syntax in Ruby doc.

### DIFF
--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -187,8 +187,7 @@ steps:
   # ...
 
   # Run rspec in parallel
-  - type: shell
-    command: |
+  - run: |
       bundle exec rspec --profile 10 \
                         --format RspecJunitFormatter \
                         --out test_results/rspec.xml \


### PR DESCRIPTION
Fixing old syntax reported here: https://discuss.circleci.com/t/is-there-a-difference-between-run-vs-type-shell-steps/17022