### PR TITLE
Fix old config syntax in Ruby doc.

### DIFF
--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -67,8 +67,7 @@ jobs:
       - run: bundle exec rake db:schema:load
 
       # Run rspec in parallel
-      - type: shell
-        command: |
+      - run:
           bundle exec rspec --profile 10 \
                             --format RspecJunitFormatter \
                             --out test_results/rspec.xml \


### PR DESCRIPTION
Part 2. Found a second instance of old syntax.