### PR TITLE
Add a vertical line to command of spec

### DIFF
--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -67,7 +67,7 @@ jobs:
       - run: bundle exec rake db:schema:load
 
       # Run rspec in parallel
-      - run:
+      - run: |
           bundle exec rspec --profile 10 \
                             --format RspecJunitFormatter \
                             --out test_results/rspec.xml \


### PR DESCRIPTION
If you write multiple command in yml, need a vertical line after `run:`.