### PR TITLE
~/circleci/config.yml ➡️ ~/.circleci/config.yml

### DIFF
--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -45,7 +45,7 @@ You automatically *follow* any new project that you push to, subscribing you to 
 
 ## Validate Every Configuration Change
 
-To catch CircleCI config errors as you build your full `config.yml` file, it is possible create a git pre-commit hook to validate `~/circleci/config.yml` that, when pushing to git, will run the 
+To catch CircleCI config errors as you build your full `config.yml` file, it is possible create a git pre-commit hook to validate `~/.circleci/config.yml` that, when pushing to git, will run the 
 `circleci config validate` command that is available to every build. 
 
 See the [Using the CircleCI CLI]({{ site.baseurl }}/2.0/local-jobs/) document for complete information about the `circleci` command and then check out [this blog post](https://circleci.com/blog/circleci-hacks-validate-circleci-config-on-every-commit-with-a-git-hook/) about creating the Git hook.


### PR DESCRIPTION
I thought that the dot was missing, so I changed it to `~/.circleci/config.yml`.