### PR TITLE
Fix yaml syntax error at sync git submodule

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -479,7 +479,7 @@ In the case of `checkout`, the step type is just a string with no additional att
 **Note:** CircleCI does not check out submodules. If your project requires submodules, add `run` steps with appropriate commands as shown in the following example:
 
 ```
-- checkout:
+- checkout
 - run: git submodule sync
 - run: git submodule update --init
 ```


### PR DESCRIPTION
Just remove `:` because of yaml syntax error.