### PR TITLE
enquote xcode version number

### DIFF
--- a/jekyll/_cci2/ios-tutorial.md
+++ b/jekyll/_cci2/ios-tutorial.md
@@ -85,13 +85,13 @@ version: 2
 jobs:
   test:
     macos:
-      xcode: 9.0
+      xcode: "9.0"
     steps:
       - checkout
       - run: swift test
   deploy:
     macos:
-      xcode: 9.0
+      xcode: "9.0"
     steps:
       - checkout
       - deploy:


### PR DESCRIPTION
Xcode version number needs to be quoted as a string, or this example will fail.