### PR TITLE
Bump ruby to latest 2.3.x patch level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.3.3
+      - image: circleci/ruby:2.3.5
     working_directory: ~/circleci-docs
     environment:
       - JEKYLL_ENV=production

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.3'
+ruby '2.3.5'
 
 gem 'jekyll', "~> 3.6.0"
 gem 'html-proofer', "~> 3.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ DEPENDENCIES
   jekyll (~> 3.6.0)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.5p376
 
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
There was a recent release with a number of security vulnerabilities:
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/