### PR TITLE
Specify language for code block

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -485,7 +485,7 @@ In the case of `checkout`, the step type is just a string with no additional att
 
 **Note:** CircleCI does not check out submodules. If your project requires submodules, add `run` steps with appropriate commands as shown in the following example:
 
-```
+``` YAML
 - checkout
 - run: git submodule sync
 - run: git submodule update --init


### PR DESCRIPTION
It was auto-recognized as a diff and so highlighted in red, because all lines started with a dash.