### PR TITLE
DLC is now supported on machine executor

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -28,7 +28,7 @@ Virtual Environment | `docker` | `machine`
  Full root access | No | Yes
  Run multiple databases | No | Yes
  Run multiple versions of the same software | No | Yes
- Layer caching | Yes | No
+ Layer caching | Yes | Yes
  Run privileged containers | No | Yes
  Use docker compose with volumes | No | Yes
 {: class="table table-striped"}


### PR DESCRIPTION
Updating to reflect that we now support layer caching on machine executor

https://circleci.com/docs/2.0/docker-layer-caching/#nav-button