### PR TITLE
WIP: ios changes

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -35,6 +35,8 @@ Virtual Environment | `docker` | `machine`
 
 <sup>(1)</sup> Requires using [Remote Docker][building-docker-images].
 
+It is also possible to use the `macos` executor type with `xcode`, see the [iOS Project Tutorial]({{ site.baseurl }}/2.0/ios-tutorial/) to get started.
+
 ### Using Docker
 
 The `docker` key defines Docker as the underlying technology to run your jobs using Docker Containers. Containers are an instance of the Docker Image you specify and the first image listed in your configuration is the primary container image in which all steps run.

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -42,7 +42,7 @@ If you'd like to completely revert to 1.0 configuration, simply replace `.circle
 
 - **Android:** Refer to [Android Language Guide]({{ site.baseurl }}/2.0/language-android/) for instructions.
 
-- **iOS:** Refer to the [iOS Project Tutorial]({{ site.baseurl }}/1.0/ios-tutorial) to get started.
+- **iOS:** Refer to the [iOS Project Tutorial]({{ site.baseurl }}/2.0/ios-tutorial) to get started.
 
 - **Windows:** We do not yet support building and testing Windows applications.
 

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -42,7 +42,7 @@ If you'd like to completely revert to 1.0 configuration, simply replace `.circle
 
 - **Android:** Refer to [Android Language Guide]({{ site.baseurl }}/2.0/language-android/) for instructions.
 
-- **iOS:** Building iOS apps is not yet supported on CircleCI 2.0. Please refer to our documentation for [Getting Started with iOS on 1.0]({{ site.baseurl }}/1.0/ios-getting-started/) until 2.0 support is available.
+- **iOS:** Refer to the [iOS Project Tutorial]({{ site.baseurl }}/1.0/ios-tutorial) to get started.
 
 - **Windows:** We do not yet support building and testing Windows applications.
 

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -207,12 +207,11 @@ workflows:
 ```
 {% endraw %}
 
-<!---
-## Sample configuration with multiple executor types (macOS + Docker)
+## Sample Configuration with Multiple Executor Types (macOS + Docker)
 
 It is possible to use multiple [executor types](https://circleci.com/docs/2.0/executor-types/)
 in the same workflow. In the following example each push of an iOS
-project will be built on macO , and additional iOS tools
+project will be built on macOS, and additional iOS tools
 ([SwiftLint](https://github.com/realm/SwiftLint) and
 [Danger](https://github.com/danger/danger))
 will be run in Docker.
@@ -223,8 +222,7 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode:
-        version: "9.0"
+      xcode: "9.0"
 
     steps:
       - checkout
@@ -279,4 +277,3 @@ workflows:
       - build-and-test
 ```
 {% endraw %}
--->

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -28,6 +28,8 @@ title: CircleCI Documentation
 		<li>
 			<p><a href="/docs/2.0/language-android/">Android Language Guide</a></p></li>
 		<li>
+			<p><a href="/docs/2.0/ios-tutorial/">iOS Project Tutorial</a></p></li>
+		<li>
 			<p><a href="/docs/2.0/language-clojure/">Clojure Language Guide (v1.2.0 and later)</a></p></li>
     <li>
 	    <p><a href="/docs/2.0/language-elixir/">Elixir Language Guide (v1.2 and later)</a></p></li>


### PR DESCRIPTION
For the executor-types.md doc, should we add a compelte section for the macos executor type with information about available xcode versions/updates, etc? I just added a link in that document for now, but we might want to make a complete section for this third executor type to make this difference clear to customers?