### PR TITLE
add note re: sudo to Heroku deployment info

### DIFF
--- a/jekyll/_cci2/deployment_integrations.md
+++ b/jekyll/_cci2/deployment_integrations.md
@@ -112,6 +112,8 @@ The built-in Heroku integration through the CircleCI UI is not implemented for C
      StrictHostKeyChecking no
      EOF
      ```
+***Note:*** *this script will need to be executed with `sudo` if running in a Docker container where the user is not `root` (for example, CircleCI's [convenience images](hub.docker.com/r/circleci)).*
+
 This file runs on CircleCI and configures everything Heroku needs to deploy the app. The second part creates a `.netrc` file and populates it with the API key and login details set previously.
 
 2. Install and authorize Heroku for the CircleCI account that owns the project. 

--- a/jekyll/_cci2/deployment_integrations.md
+++ b/jekyll/_cci2/deployment_integrations.md
@@ -112,7 +112,7 @@ The built-in Heroku integration through the CircleCI UI is not implemented for C
      StrictHostKeyChecking no
      EOF
      ```
-***Note:*** *this script will need to be executed with `sudo` if running in a Docker container where the user is not `root` (for example, CircleCI's [convenience images](hub.docker.com/r/circleci)).*
+***Note:*** *this script will need to be executed with `sudo` if running in a Docker container where the user is not `root` (for example, CircleCI's [convenience images](https://hub.docker.com/r/circleci)).*
 
 This file runs on CircleCI and configures everything Heroku needs to deploy the app. The second part creates a `.netrc` file and populates it with the API key and login details set previously.
 


### PR DESCRIPTION
@keybits added `sudo` to the Heroku script [back in September](https://github.com/circleci/circleci-docs/commit/d9d919f5deb1c828e609a8bb9ef6527cdd17e43c#diff-63f3e207b64870e2bf3183435fb4921b), most likely because many customers use our [convenience Docker images](https://hub.docker.com/r/circleci), where the user is `circleci` rather than `root`; however `sudo` was taken back out a month ago in a [community-submitted PR](https://github.com/circleci/circleci-docs/pull/1672), most likely because most vanilla Docker images *do* have `root` as their user. Hopefully this is a good compromise?