### PR TITLE
fix typo in add ssh keys syntax

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -143,7 +143,7 @@ In this example, the GitHub repository is `https://github.com/you/test-repo` and
 4. In you config.yml, you can refer to the key with the following:
 ```
 steps:
-  - add-ssh-keys:
+  - add_ssh_keys:
       fingerprints:
         - "SO:ME:FIN:G:ER:PR:IN:T"
 ```


### PR DESCRIPTION
https://github.com/circleci/circleci-docs/issues/1767