### PR TITLE
Emphasizing need for tag filters on dependent jobs

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -296,6 +296,8 @@ workflows:
               ignore: /.*/
 ```
 
+**Note:** The `build` job **must** also have a `filters` `tags` section, as it is a transient dependency of the `deploy` job.
+
 The following example runs
 
 1. `build` and `test` jobs for all branches and only `config-test.*` tags.


### PR DESCRIPTION
Added a note below the example config to stress the need for a tag filters section on job dependencies. Although this requirement is clearly stated at the top of the `Git Tag Job Execution` section - probably a good idea to re-iterate this concept within the example.