### PR TITLE
Set paths correctly in the fastlane example

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -213,9 +213,9 @@ jobs:
   build-and-test:
     macos:
       xcode: "9.0"
-    working_directory: /Users/distiller/output
+    working_directory: /Users/distiller/project
     environment:
-      FL_OUTPUT_DIR: $CIRCLE_WORKING_DIRECTORY
+      FL_OUTPUT_DIR: /Users/distiller/project/output
       FASTLANE_LANE: test
     shell: /bin/bash --login -o pipefail
     steps:
@@ -228,16 +228,16 @@ jobs:
           command: cp $FL_OUTPUT_DIR/scan/report.junit $FL_OUTPUT_DIR/scan/results.xml
           when: always
       - store_artifacts:
-          path: /Users/distiller/output
+          path: /Users/distiller/project/output
       - store_test_results:
-          path: /Users/distiller/output/scan
+          path: /Users/distiller/project/output/scan
 
   adhoc:
     macos:
       xcode: "9.0"
-    working_directory: /Users/distiller/output
+    working_directory: /Users/distiller/project
     environment:
-      FL_OUTPUT_DIR: $CIRCLE_WORKING_DIRECTORY
+      FL_OUTPUT_DIR: /Users/distiller/project/output
       FASTLANE_LANE: adhoc
     shell: /bin/bash --login -o pipefail
     steps:
@@ -247,7 +247,7 @@ jobs:
           name: Fastlane
           command: bundle exec fastlane $FASTLANE_LANE
       - store_artifacts:
-          path: /Users/distiller/output
+          path: /Users/distiller/project/output
 
 workflows:
   version: 2


### PR DESCRIPTION
We noticed that the paths were set incorrectly in the fastlane example.
Fixing it here.