### PR TITLE
[CIRCLE-6879] Link to the React Native sample app

### DIFF
--- a/jekyll/_cci2/demo-apps.md
+++ b/jekyll/_cci2/demo-apps.md
@@ -23,6 +23,7 @@ Language Guide | Framework | GitHub Repo Name
 [PHP] | Laravel | [circleci-demo-php-laravel]
 [Python] | Django | [circleci-demo-python-django]
 [Python] | Flask | [circleci-demo-python-flask]
+React Native | React Native | [circleci-demo-react-native]
 [Ruby and Rails] | Rails | [circleci-demo-ruby-rails]
 {: class="table"}
 
@@ -46,4 +47,5 @@ Language Guide | Framework | GitHub Repo Name
 [circleci-demo-php-laravel]: https://github.com/CircleCI-Public/circleci-demo-php-laravel
 [circleci-demo-python-django]: https://github.com/CircleCI-Public/circleci-demo-python-flask
 [circleci-demo-python-flask]: https://github.com/CircleCI-Public/circleci-demo-python-flask
+[circleci-demo-react-native]: https://github.com/CircleCI-Public/circleci-demo-react-native
 [circleci-demo-ruby-rails]: https://github.com/CircleCI-Public/circleci-demo-ruby-rails

--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -110,3 +110,10 @@ We have a different Docker image for each [Android API level](https://source.and
 Our Android Docker images are currently tagged with the suffix `-alpha`. This is to indicate the images are currently under development and might change in backwards incompatible ways from week to week.
 
 If you have any questions, head over to our [community forum](https://discuss.circleci.com/) for support from us and other users.
+
+## React Native projects
+
+React Native projects can be built on CircleCI 2.0 using Linux, Android
+and macOS capabilities. Please check out [this example React Native
+application](https://github.com/CircleCI-Public/circleci-demo-react-native)
+on GitHub for a full example of a React Native project.

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -580,6 +580,13 @@ workflows:
 ```
 {% endraw %}
 
+## React Native projects
+
+React Native projects can be built on CircleCI 2.0 using `macos` and
+`docker` executor types. Please check out [this example React Native
+application](https://github.com/CircleCI-Public/circleci-demo-react-native)
+on GitHub for a full example of a React Native project.
+
 ## Example Application on GitHub
 
 See the [`circleci-demo-ios` GitHub repository](https://github.com/CircleCI-Public/circleci-demo-ios)


### PR DESCRIPTION
Link to the [React Native sample app](https://github.com/CircleCI-Public/circleci-demo-react-native)
in various doc sections.