### PR TITLE
Iynere test results workflows patch

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -9,7 +9,7 @@ order: 34
 
 *[Test]({{ site.baseurl }}/2.0/test/) > Collecting Test Metadata*
 
-CircleCI collects test metadata from XML files and uses it to provide insights into your build. This document describes how to configure CircleCI to output test metadata as XML for some common test runners and store reports with the `store_test_results` step. **Note:** This step is not supported with Workflows. To see test result as artifacts, upload them using the `store_artifacts` step. 
+CircleCI collects test metadata from XML files and uses it to provide insights into your build. This document describes how to configure CircleCI to output test metadata as XML for some common test runners and store reports with the `store_test_results` step. To see test result as artifacts, upload them using the `store_artifacts` step. 
 
 After configuring CircleCI to collect your test metadata, tests that fail most often appear in a list on the details page of   [Insights](https://circleci.com/build-insights) in the application to identify flaky tests and isolate recurring issues.  
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -690,7 +690,7 @@ There can be multiple `store_artifacts` steps in a job. Using a unique prefix fo
 
 ##### **`store_test_results`**
 
-Special step used to upload test results so they can be used for timing analysis. **Note** At this time the results are not shown as artifacts in the web UI. To see test result as artifacts please also upload them using **store_artifacts**. This key is **not** supported with Workflows.
+Special step used to upload test results so they can be used for timing analysis. **Note** At this time the results are not shown as artifacts in the web UI. To see test result as artifacts please also upload them using **store_artifacts**.
 
 Key | Required | Type | Description
 ----|-----------|------|------------

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -690,7 +690,7 @@ There can be multiple `store_artifacts` steps in a job. Using a unique prefix fo
 
 ##### **`store_test_results`**
 
-Special step used to upload test results so they can be used for timing analysis. **Note** At this time the results are not shown as artifacts in the web UI. To see test result as artifacts please also upload them using **store_artifacts**.
+Special step used to upload test results so they display in builds' Test Summary section and can be used for timing analysis. To also see test result as build artifacts, please use [the **store_artifacts** step]({{ site.baseurl }}/2.0/configuration-reference/#store_artifacts).
 
 Key | Required | Type | Description
 ----|-----------|------|------------

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -141,7 +141,7 @@ Not yet, but we are working on that functionality.
 Not yet, but we are working on that functionality.
 
 ### Can I use `store_test_results` with Workflows?
-This is next up on our roadmap to fix. Test timings are available for 2.0 but not with Workflows.
+You can use `store_test_results` in order to populate your builds' Test Summary section with your test results information, however [timing-based test-splitting]({{ site.baseurl }}/2.0/parallelism-faster-jobs/#splitting-patterns) will not work. This is next up on our roadmap to fix. Test timings data is available for 2.0 but not with Workflows.
  
 ### Can I use Workflows with CircleCI 1.0?
  

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -69,6 +69,8 @@ When the items are filepaths, the `filesize` option will weight the split by fil
 
 The `timings` split type uses historical timing data to weight the split. CircleCI automatically makes timing data from previous successful runs available inside your container in a default location so the CLI tool can discover them (`$CIRCLE_INTERNAL_TASK_DATA/circle-test-results`). Make sure you are using the [`store_test_results` key]({{ site.baseurl }}/2.0/configuration-reference/#store_test_results) to save your test timing data, otherwise there will not be any historical timing data available.
 
+***Note:** timing-based test splitting is not currently compatible with Workflows.*
+
 When splitting by `timings`, the tool will assume it’s splitting filenames. If you’re splitting classnames, you’ll need to specify that with the `--timings-type` flag, as in the following examples:
 
 `circleci tests glob "**/*.go" | circleci tests split --split-by=timings --timings-type=filename`


### PR DESCRIPTION
we were documenting the timing-based test-splitting + workflows issue slightly inaccurately—it's not that `store_test_results` doesn't work w/ workflows (it does—otherwise Test Summary wouldn't work at all); it's just that using `circleci tests split --split-by=timings` doesn't work w/ workflows. so really, the only place we need that note is on the Running Tests in Parallel page, imo at least...