### PR TITLE
Add a missing {% endraw %} tag

### DIFF
--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -234,6 +234,7 @@ steps:
     paths:
       - ~/.yarn-cache
 ```
+{% endraw %}
 
 Now we can setup our test database we'll use during the build.
 


### PR DESCRIPTION
This patch will fix an issue that `{% raw %}` is [rendered in the document](https://circleci.com/docs/2.0/language-ruby/).

![screenshot-2017-12-17 language guide ruby - circleci](https://user-images.githubusercontent.com/2227862/34077996-ab65fe9c-e354-11e7-9e61-e05a6ade21c3.png)