### PR TITLE
update circleci-docs/jekyll/_cci2/basics.md

### DIFF
--- a/jekyll/_cci2/basics.md
+++ b/jekyll/_cci2/basics.md
@@ -11,7 +11,7 @@ Document | Description
 ----|----------
 <a href="{{ site.baseurl }}/2.0/about-circleci/">Overview</a> | Overview of Continuous Integration (CI) with links to CircleCI case studies.
 <a href="{{ site.baseurl }}/2.0/jobs-steps/">Jobs and Steps</a> | How Jobs and Steps are used in a CircleCI 2.0 configuration.
-<a href="{{ site.baseurl }}/2.0/jobs-steps/">Workflows</a> | How to configure Workflows to increase the speed of your software development through faster feedback, shorter reruns, and more efficient use of resources.
+<a href="{{ site.baseurl }}/2.0/workflows/">Workflows</a> | How to configure Workflows to increase the speed of your software development through faster feedback, shorter reruns, and more efficient use of resources.
 <a href="{{ site.baseurl }}/2.0/faq/">FAQ</a> | Frequently asked questions about CircleCI 2.0.
 {: class="table table-striped"}
 


### PR DESCRIPTION
The link in the "Get started by learning about the basic concepts used in CircleCI." table for workflows was pointing to "job-steps"