### PR TITLE
adding script tags to proper location

### DIFF
--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -26,6 +26,10 @@
 		</div><!-- .article-container -->
 	</div><!-- .main-body -->
 	{% include global-footer.html %}
+	<script src="{{ "/assets/js/vendor.min.js" | prepend: site.baseurl }}" type="text/javascript"></script>
+  <script src="{{ "/assets/js/site.min.js" | prepend: site.baseurl }}" type="text/javascript"></script>
+  <script src="{{ "/assets/js/jquery.cookie.min.js" | prepend: site.baseurl }}" type="text/javascript" ></script>
+  <script src="{{ "/assets/js/jquery.navgoco.min.js" | prepend: site.baseurl }}" type="text/javascript"></script>
 	<script src="{{ site.baseurl }}/assets/js/main.js" type="text/javascript"></script>
 	<script src="{{ site.baseurl }}/assets/js/nav.js" type="text/javascript"></script>
 	<script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>


### PR DESCRIPTION
see ticket: https://circleci.atlassian.net/browse/CIRCLE-8444

This PR addresses the problem by re-adding the js tags that where removed when the footer was changed. (I accidentally removed the tags - doing so because they were improperly placed at the bottom of the footer tag instead of in the site layout).