### PR TITLE
remove offensive android link

### DIFF
--- a/jekyll/_cci2/demo-apps.md
+++ b/jekyll/_cci2/demo-apps.md
@@ -13,7 +13,6 @@ Code that builds on Linux or iOS will generally build on CircleCI 2.0. We’ve c
 
 Language Guide | Framework | GitHub Repo Name
  ---------|-----------|-----------------
- [Android] | Gradle | [android-image](https://github.com/circleci/circleci-images/tree/master/android)
  [Android](https://github.com/CircleCI-Public/circleci-demo-react-native/blob/master/README.md) | React Native | [circleci-demo-react-native]
  [Clojure] | Luminus | [circleci-demo-clojure-luminus]
  [Elixir] | Phoenix | [circleci-demo-elixir-phoenix]


### PR DESCRIPTION
First link wasn't pointing to an actual demo application. Potential fix for #1937.