### PR TITLE
make HA language more explicit

### DIFF
--- a/jekyll/_cci2/high-availability.md
+++ b/jekyll/_cci2/high-availability.md
@@ -11,7 +11,7 @@ This document describes how to to set up a highly available CircleCI 2.0 install
 * TOC
 {:toc}
 
-## Prequisites
+## Prerequisites
 
 Before you configure an existing CircleCI installation for high availability, you must update your license by contacting the Customer Success Manager on your account or by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new). Configuring an existing CircleCI installation for HA without updating the license through the CircleCI customer success team is **not** supported.
 

--- a/jekyll/_cci2/high-availability.md
+++ b/jekyll/_cci2/high-availability.md
@@ -6,7 +6,7 @@ order: 20
 description: "Configuring High Availability for CircleCI 2.0"
 ---
 
-**NOTE: Your CircleCI license must include support for high-availability in order to use this configuration. Please contact your account manager if you have questions.**
+**Note: To use this configuration, your CircleCI license must include support for high availability. Please contact your Customer Success Manager if you'd like to set up a High Availability Installation on CircleCI 2.0.**
 
 This document describes how to to set up a highly available CircleCI 2.0 installation in the following sections:
 
@@ -255,7 +255,7 @@ docker logs -f frontend
 
 Regularly backup data mounted on EBS volumes using the following steps:
 
-1. To ensure that the disk is in a consistent state, stop the mongodb process (using `sudo service mongod stop` or another system-appropriate command) on one of the SECONDARY instances and wait for the process to completely stop. **NOTE:** stopping the replica outright has proven to be more reliable for consistent restores than using the db.fsyncLock() mechanism described in the mongo documentation. This is also an additional safeguard for consistent state on top of the journal files.
+1. To ensure that the disk is in a consistent state, stop the mongodb process (using `sudo service mongod stop` or another system-appropriate command) on one of the SECONDARY instances and wait for the process to completely stop. **Note:** stopping the replica outright has proven to be more reliable for consistent restores than using the db.fsyncLock() mechanism described in the mongo documentation. This is also an additional safeguard for consistent state on top of the journal files.
 2. Use the AWS console or CLI to generate and complete a snapshot.
 3. To rejoin the replica set as a SECONDARY, restart the mongodb  process with `sudo service mongod start`.
 4. The SECONDARY begins serving traffic after replication catches up.

--- a/jekyll/_cci2/high-availability.md
+++ b/jekyll/_cci2/high-availability.md
@@ -6,12 +6,14 @@ order: 20
 description: "Configuring High Availability for CircleCI 2.0"
 ---
 
-**Note: To use this configuration, your CircleCI license must include support for high availability. Please contact your Customer Success Manager if you'd like to set up a High Availability Installation on CircleCI 2.0.**
-
 This document describes how to to set up a highly available CircleCI 2.0 installation in the following sections:
 
 * TOC
 {:toc}
+
+## Prequisites
+
+Before you configure an existing CircleCI installation for high availability, you must update your license by contacting the Customer Success Manager on your account or by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new). Configuring an existing CircleCI installation for HA without updating the license through the CircleCI customer success team is **not** supported.
 
 ## Overview
 

--- a/jekyll/_cci2/high-availability.md
+++ b/jekyll/_cci2/high-availability.md
@@ -15,7 +15,7 @@ This document describes how to to set up a highly available CircleCI 2.0 install
 
 ## Prerequisites
 
-Before you configure an existing CircleCI installation for high availability, you must update your license by contacting an account manager or by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new). Configuring an existing CircleCI installation for HA without updating the license through the CircleCI customer success team is **not** supported.
+Before you configure an existing CircleCI installation for high availability, you must update your license by contacting our account team or by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new). Configuring an existing CircleCI installation for HA without updating the license through the CircleCI customer success team is **not** supported.
 
 The steps in this document also assume you have an existing CircleCI 2.0 Services machine and Builders in use. To configure your existing CircleCI 2.0 installation for high availability, you must export the databases currently in use on the Services machine to new AWS instances. This procedure uses three instances for the MongoDB replica set and a new AWS Auto Scaling group for PostgreSQL.
 

--- a/jekyll/_cci2/high-availability.md
+++ b/jekyll/_cci2/high-availability.md
@@ -6,6 +6,8 @@ order: 20
 description: "Configuring High Availability for CircleCI 2.0"
 ---
 
+High availability gives you the ability to replicate your CircleCI data and automate recovery from a single database instance failure, without downtime or service disruption.
+
 This document describes how to to set up a highly available CircleCI 2.0 installation in the following sections:
 
 * TOC
@@ -16,8 +18,6 @@ This document describes how to to set up a highly available CircleCI 2.0 install
 Before you configure an existing CircleCI installation for high availability, you must update your license by contacting an account manager or by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new). Configuring an existing CircleCI installation for HA without updating the license through the CircleCI customer success team is **not** supported.
 
 The steps in this document also assume you have an existing CircleCI 2.0 Services machine and Builders in use. To configure your existing CircleCI 2.0 installation for high availability, you must export the databases currently in use on the Services machine to new AWS instances. This procedure uses three instances for the MongoDB replica set and a new AWS Auto Scaling group for PostgreSQL.
-
-After completing these procedures, you should be familiar enough with MongoDB and PostgreSQL to manage the security, maintenance, and backups of these external databases. The benefit of completing this configuration is the ability to replicate your CircleCI data and to automate recovery from a single database instance failure without downtime or loss of services.
 
 ## MongoDB Instance Requirements
 

--- a/jekyll/_cci2/high-availability.md
+++ b/jekyll/_cci2/high-availability.md
@@ -13,7 +13,7 @@ This document describes how to to set up a highly available CircleCI 2.0 install
 
 ## Prerequisites
 
-Before you configure an existing CircleCI installation for high availability, you must update your license by contacting the Customer Success Manager on your account or by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new). Configuring an existing CircleCI installation for HA without updating the license through the CircleCI customer success team is **not** supported.
+Before you configure an existing CircleCI installation for high availability, you must update your license by contacting an account manager or by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new). Configuring an existing CircleCI installation for HA without updating the license through the CircleCI customer success team is **not** supported.
 
 The steps in this document also assume you have an existing CircleCI 2.0 Services machine and Builders in use. To configure your existing CircleCI 2.0 installation for high availability, you must export the databases currently in use on the Services machine to new AWS instances. This procedure uses three instances for the MongoDB replica set and a new AWS Auto Scaling group for PostgreSQL.
 

--- a/jekyll/_cci2/high-availability.md
+++ b/jekyll/_cci2/high-availability.md
@@ -15,11 +15,9 @@ This document describes how to to set up a highly available CircleCI 2.0 install
 
 Before you configure an existing CircleCI installation for high availability, you must update your license by contacting the Customer Success Manager on your account or by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new). Configuring an existing CircleCI installation for HA without updating the license through the CircleCI customer success team is **not** supported.
 
-## Overview
+The steps in this document also assume you have an existing CircleCI 2.0 Services machine and Builders in use. To configure your existing CircleCI 2.0 installation for high availability, you must export the databases currently in use on the Services machine to new AWS instances. This procedure uses three instances for the MongoDB replica set and a new AWS Auto Scaling group for PostgreSQL.
 
-The steps in this document assume you have an existing CircleCI 2.0 Services machine and Builders in use. To configure your existing CircleCI 2.0 installation for high availability, you must export the databases currently in use on the Services machine to new AWS instances. This procedure uses three instances for the MongoDB replica set and a new AWS instance ASG (Auto Scaling Group) for PostgreSQL.
-
-After completing these procedures, the security, maintenance, and backups of the external databases will require knowledge of MongoDB and PostgreSQL sufficient for your organization to own this responsibility and perform all related tasks. The benefit of completing this configuration is the ability to replicate your CircleCI data and to automate recovery from a single database instance failure without downtime or loss of services.
+After completing these procedures, you should be familiar enough with MongoDB and PostgreSQL to manage the security, maintenance, and backups of these external databases. The benefit of completing this configuration is the ability to replicate your CircleCI data and to automate recovery from a single database instance failure without downtime or loss of services.
 
 ## MongoDB Instance Requirements
 


### PR DESCRIPTION
Fixes #1956. Also makes "Note" capitalization consistent and removes dash from "high availability" phrase.