### PR TITLE
Android: Clarify "emulator not supported"

### DIFF
--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -18,7 +18,7 @@ There are some assumptions made in this guide:
 - We assume that your Android project is built with `gradle` (this is the default for projects created with [Android Studio](https://developer.android.com/studio).
 - We assume that your project is located in the root of your `git` repository, with the application located in a subfolder named `app`.
 
-Running the Android emulator is not currently supported on CircleCI 2.0. To run emulator tests from a job, consider using an external service like [Firebase Test Lab](https://firebase.google.com/docs/test-lab). To do this, you can use the [gcloud command line](https://firebase.google.com/docs/test-lab/command-line). Google Cloud tools are preinstalled in our Android Docker images, which you can find on [GitHub](https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/android/images) or [Docker Hub](https://hub.docker.com/r/circleci/android/tags).
+Running the Android emulator is not currently supported on CircleCI 2.0: The Android emulator requires KVM on Linux, and we can’t provide it. To run emulator tests from a job, consider using an external service like [Firebase Test Lab](https://firebase.google.com/docs/test-lab). To do this, you can use the [gcloud command line](https://firebase.google.com/docs/test-lab/command-line). Google Cloud tools are preinstalled in our Android Docker images, which you can find on [GitHub](https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/android/images) or [Docker Hub](https://hub.docker.com/r/circleci/android/tags).
 
 ## Sample Configuration
 


### PR DESCRIPTION
It was unclear at first reading what "not supported" meant:

- Explicitly blacklisted, so don't even try?
- Not supported out of the box, but feel free to yak-shave?
- Not technically possible?

Language from the 1.0 docs clarifies that the correct choice is
"not technically possible," due to virtualization issues.

The language added is drawn from:
https://github.com/circleci/circleci-docs/blob/9b8e6b6fd055ca78ec20b558589f7f0bd1dfdb1b/jekyll/_cci1/android.md#starting-the-android-emulator