### PR TITLE
Add circleci prefix to images

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -43,7 +43,7 @@ As a convenience, CircleCI maintains a number of Docker Images for popular langu
 
 **Usage:** Add the following under `docker:` in your config.yml:  
 
-`- image: {{ image[0] }}:[TAG]`
+`- image: circleci/{{ image[0] }}:[TAG]`
 
 **Latest Tags:** <small>(view all available tags on [Docker Hub](https://hub.docker.com/r/circleci/{{ image[0] }}/tags/))</small>
 


### PR DESCRIPTION
I tried to install PostgreSQL with `- image: postgres:10.1-postgis`. It failed. What worked for me was `- image: circleci/postgres:10.1-postgis`. I assume, the other images work the same way.