### PR TITLE
Improve CircleCI Images Docs

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -56,24 +56,24 @@ For both language and service images, CircleCI has extended the official Docker 
 
 The following packages are installed on every image with `apt-get`:
 
-- bzip2
-- ca-certificates
-- curl
-- git
-- gnupg
-- gzip
-- locales
-- mercurial
-- net-tools
-- netcat
-- openssh-client
-- parallel
-- sudo
-- tar
-- unzip
-- wget
-- xvfb
-- zip
+- [bzip2](https://packages.debian.org/stretch/bzip2)
+- [ca-certificates](https://packages.debian.org/stretch/ca-certificates)
+- [curl](https://packages.debian.org/stretch/curl)
+- [git](https://packages.debian.org/stretch/git)
+- [gnupg](https://packages.debian.org/stretch/gnupg)
+- [gzip](https://packages.debian.org/stretch/gzip)
+- [locales](https://packages.debian.org/stretch/locales)
+- [mercurial](https://packages.debian.org/stretch/mercurial)
+- [net-tools](https://packages.debian.org/stretch/net-tools)
+- [netcat](https://packages.debian.org/stretch/netcat)
+- [openssh-client](https://packages.debian.org/stretch/openssh-client)
+- [parallel](https://packages.debian.org/stretch/parallel)
+- [sudo](https://packages.debian.org/stretch/sudo)
+- [tar](https://packages.debian.org/stretch/tar)
+- [unzip](https://packages.debian.org/stretch/unzip)
+- [wget](https://packages.debian.org/stretch/wget)
+- [xvfb](https://packages.debian.org/stretch/xvfb)
+- [zip](https://packages.debian.org/stretch/zip)
 
 ### Other Packages
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -24,6 +24,7 @@ CircleCI maintains language images for the following languages:
 - [Clojure](#clojure)
 - [Elixir](#elixir)
 - [Go (Golang)](#go-golang)
+- [JRuby](#jruby)
 - [Node.js](#nodejs)
 - [OpenJDK (Java)](#openjdk)
 - [PHP](#php)

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -54,7 +54,7 @@ All convenience images have been extended with additional tools.
 
 ### APT Packages
 
-The following packages are installed on every image with `apt-get`:
+The following packages are installed with `apt-get` on every image:
 
 - [bzip2](https://packages.debian.org/stretch/bzip2)
 - [ca-certificates](https://packages.debian.org/stretch/ca-certificates)

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -16,7 +16,7 @@ CircleCI's pre-built Docker images fall into two categories: **language** images
 
 ### Language Images
 
-Language images are images for common programming languages, along with some common [pre-installed tools](#pre-installed-tools). These images should be listed first under the `docker` key in your configuration, thus becoming the [**primary container**]({{ site.baseurl }}/2.0/glossary/#primary-container) during execution.
+Language images are images for common programming languages, along with some common [pre-installed tools](#pre-installed-tools). A language image should be listed first under the `docker` key in your configuration, thus becoming the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.
 
 CircleCI maintains language images for the following languages:
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -8,7 +8,7 @@ order: 20
 ---
 *[Reference]({{ site.baseurl }}/2.0/reference/) > Pre-Built CircleCI Docker Images*
 
-As a convenience, CircleCI maintains a number of Docker Images for popular languages with additional tooling that is useful when running your tests. All of the following images are published in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/), the source code is available in the [repository on GitHub](https://github.com/circleci/circleci-images) and the Dockerfiles are available as build artifacts in the [repository's production branch on CircleCI](https://circleci.com/gh/circleci/circleci-images/tree/production). 
+For convenience, CircleCI maintains several Docker images. These images are extensions of official Docker images and include tooling that is especially useful for CI/CD. All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/). The source code and Dockerfiles for these images are available in this [GitHub repository](https://github.com/circleci/circleci-images).
 
 ## How to Get Started with Pre-Built Docker Images Video Tutorial
 <div class="screen">

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -79,7 +79,7 @@ The following packages are installed on every image with `apt-get`:
 
 The following packages are installed via cURL or other means:
 
-- Docker client
+- [Docker client](https://docs.docker.com/install/)
 - [Docker Compose](https://docs.docker.com/compose/overview/)
 - [dockerize](https://github.com/jwilder/dockerize)
 - [jq](https://stedolan.github.io/jq/)

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -16,7 +16,7 @@ CircleCI's pre-built Docker images fall into two categories: **language** images
 
 ### Language Images
 
-Language images are images for common programming languages, along with some common tools pre-installed. These images should be listed first under the `docker` key in your configuration, thus becoming the [**primary container**]({{ site.baseurl }}/2.0/glossary/#primary-container) during execution.
+Language images are images for common programming languages, along with some common [pre-installed tools](#pre-installed-tools). These images should be listed first under the `docker` key in your configuration, thus becoming the [**primary container**]({{ site.baseurl }}/2.0/glossary/#primary-container) during execution.
 
 CircleCI maintains language images for the following languages:
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -10,6 +10,26 @@ order: 20
 
 For convenience, CircleCI maintains several Docker images. These images are extensions of official Docker images and include tools that are especially useful for CI/CD. All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/). The source code and Dockerfiles for these images are available in this [GitHub repository](https://github.com/circleci/circleci-images).
 
+## Image Types
+
+CircleCI's pre-built Docker images fall into two categories: **language** images and **service** images.
+
+### Language Images
+
+Language images are images for common programming languages, along with common tools pre-installed. These images should be listed first under the `docker` key in your configuration, thus becoming the [**primary container**]({{ site.baseurl }}/2.0/glossary/#primary-container) during execution.
+
+CircleCI maintains language images for the following images:
+
+- [Android](#android)
+- [Clojure](#clojure)
+- [Elixir](#elixir)
+- [Go (Golang)](#go-golang)
+- [Node.js](#nodejs)
+- [OpenJDK (Java)](#openjdk)
+- [PHP](#php)
+- [Python](#python)
+- [Ruby](#ruby)
+
 ## How to Get Started with Pre-Built Docker Images Video Tutorial
 <div class="screen">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -48,6 +48,44 @@ CircleCI maintains service images for the following services:
     <iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>
 </div>
 
+## Pre-installed Tools
+
+For both language and service images, CircleCI has extended the official Docker images with additional tools.
+
+### APT Packages
+
+The following packages are installed on every image with `apt-get`:
+
+- bzip2
+- ca-certificates
+- curl
+- git
+- gnupg
+- gzip
+- locales
+- mercurial
+- net-tools
+- netcat
+- openssh-client
+- parallel
+- sudo
+- tar
+- unzip
+- wget
+- xvfb
+- zip
+
+### Other Packages
+
+The following packages are installed via cURL or other means:
+
+- Docker client
+- [Docker Compose](https://docs.docker.com/compose/overview/)
+- [dockerize](https://github.com/jwilder/dockerize)
+- [jq](https://stedolan.github.io/jq/)
+
+## Image Variants
+
 **Note:** CircleCI maintains variants, which can be added to the main image name as follows:
 
 - `-browsers`: Includes browsers and libraries normally used for windowing.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -50,7 +50,7 @@ CircleCI maintains service images for the following services:
 
 ## Pre-installed Tools
 
-For both language and service images, CircleCI has extended the official Docker images with additional tools.
+CircleCI has extended all convenience images with additional tools
 
 ### APT Packages
 
@@ -77,7 +77,7 @@ The following packages are installed on every image with `apt-get`:
 
 ### Other Packages
 
-The following packages are installed via cURL or other means:
+The following packages are installed via `curl` or other means:
 
 - [Docker client](https://docs.docker.com/install/)
 - [Docker Compose](https://docs.docker.com/compose/overview/)

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -12,7 +12,7 @@ For convenience, CircleCI maintains several Docker images. These images are exte
 
 ## How to Get Started with Pre-Built Docker Images Video Tutorial
 <div class="screen">
-<iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>
 </div>
 
 ## Available Images

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -94,6 +94,7 @@ The following packages are installed via cURL or other means:
 **Note:** If you choose to use the `latest` tag the image may change unexpectedly and create surprising results.
 <hr>
 
+{% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}
 
 ### {{ image[1].name }} 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -8,7 +8,7 @@ order: 20
 ---
 *[Reference]({{ site.baseurl }}/2.0/reference/) > Pre-Built CircleCI Docker Images*
 
-For convenience, CircleCI maintains several Docker images. These images are extensions of official Docker images and include tooling that is especially useful for CI/CD. All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/). The source code and Dockerfiles for these images are available in this [GitHub repository](https://github.com/circleci/circleci-images).
+For convenience, CircleCI maintains several Docker images. These images are extensions of official Docker images and include tools that are especially useful for CI/CD. All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/). The source code and Dockerfiles for these images are available in this [GitHub repository](https://github.com/circleci/circleci-images).
 
 ## How to Get Started with Pre-Built Docker Images Video Tutorial
 <div class="screen">

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -12,7 +12,7 @@ For convenience, CircleCI maintains several Docker images. These images are exte
 
 ## Image Types
 
-CircleCI's pre-built Docker images fall into two categories: **language** images and **service** images.
+CircleCI's pre-built Docker images fall into two categories: **language** images and **service** images. All images add a `circleci` user as a system user.
 
 ### Language Images
 
@@ -50,7 +50,7 @@ CircleCI maintains service images for the following services:
 
 ## Pre-installed Tools
 
-CircleCI has extended all convenience images with additional tools
+All convenience images have been extended with additional tools.
 
 ### APT Packages
 
@@ -86,12 +86,20 @@ The following packages are installed via `curl` or other means:
 
 ## Image Variants
 
-**Note:** CircleCI maintains variants, which can be added to the main image name as follows:
+CircleCI maintains variants of convenience images. These can be created by adding optional suffixes to the end of image tags.
 
-- `-browsers`: Includes browsers and libraries normally used for windowing.
-- `-node`: Includes Node.js in addition to the core language for polyglot applications.
+**Note:** If you choose to use the `latest` tag, the image may change unexpectedly and create surprising results.
 
-**Note:** If you choose to use the `latest` tag the image may change unexpectedly and create surprising results.
+### Language Image Variants
+
+- `-node`: includes Node.js for polyglot applications
+- `-browsers`: includes Java 8, PhantomJS, Firefox, and Chrome
+- `-node-browsers`: a combination of the `-node` and `-browsers` variants
+
+### Service Image Variants
+
+- `-ram`: variants that use the RAM volume to speed up builds
+
 <hr>
 
 {% assign images = site.data.docker-image-tags | sort %}

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -16,9 +16,9 @@ CircleCI's pre-built Docker images fall into two categories: **language** images
 
 ### Language Images
 
-Language images are images for common programming languages, along with common tools pre-installed. These images should be listed first under the `docker` key in your configuration, thus becoming the [**primary container**]({{ site.baseurl }}/2.0/glossary/#primary-container) during execution.
+Language images are images for common programming languages, along with some common tools pre-installed. These images should be listed first under the `docker` key in your configuration, thus becoming the [**primary container**]({{ site.baseurl }}/2.0/glossary/#primary-container) during execution.
 
-CircleCI maintains language images for the following images:
+CircleCI maintains language images for the following languages:
 
 - [Android](#android)
 - [Clojure](#clojure)

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -31,24 +31,22 @@ CircleCI maintains language images for the following languages:
 - [Python](#python)
 - [Ruby](#ruby)
 
+### Service Images
+
+Service images are images for services like databases. These images should be listed _after_ language images so they become secondary service containers.
+
+CircleCI maintains service images for the following services:
+
+- [buildpack-deps](#buildpack-deps)
+- [MariaDB](#mariadb)
+- [MongoDB](#mongodb)
+- [MySQL](#mysql)
+- [PostgreSQL](#postgresql)
+
 ## How to Get Started with Pre-Built Docker Images Video Tutorial
 <div class="screen">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>
 </div>
-
-## Available Images
-
-{% assign images = site.data.docker-image-tags | sort %}
-
-**Note:** The language images are to be used as your primary container listed first in your `config.yml` file. The database images are best used as a secondary service container, in which case, list after the primary container image in your `config.yml` file.
-
-<ul class="list-2cols">
-{% for image in images %}
-<li markdown="1">
-[{{ image[1].name }}](#{{ image[1].name | kramdown_generate_id }})
-</li>
-{% endfor %}
-</ul>
 
 **Note:** CircleCI maintains variants, which can be added to the main image name as follows:
 


### PR DESCRIPTION
This is a reworking of the beginning sections of the "Pre-built CircleCI Docker Images" article. It adds:

- a revised overview
- distinctions between **language** images and **service** images
- lists of tools pre-installed on every image
- explanations of image variants

Fixes #2009 and #2012.