### PR TITLE
Update pytest docs for collecting test results

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -233,8 +233,8 @@ To add test metadata to a project that uses `pytest` you need to tell it to outp
           name: run tests
           command: |
             . venv/bin/activate
-            mkdir -p test-reports/junit
-            pytest --junitxml=test-reports/junit
+            mkdir test-reports
+            pytest --junitxml=test-reports/junit.xml
 
       - store_test_results:
           path: test-reports


### PR DESCRIPTION
pytest expects the --junitxml argument to be the file to store the results in, not a directory.