### PR TITLE
docs: minor typo

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -295,7 +295,7 @@ workflows:
               only: /.*/
       - deploy:
           requires:
-            - test
+            - build
           filters:
             tags:
               only: /^config-test.*/


### PR DESCRIPTION
We meant to reference the build job, not the test job in this workflow.

we might consider changing:

```
only: /^config-test.*/
```

to

```
only: /^v.*/
```

To represent an actual workflow of building and testing on every push, but only releasing on tags that start with `v` - as in: `v0.0.1`.