### PR TITLE
Add - checkout step to Heroku deployment docs

### DIFF
--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -151,6 +151,7 @@ This file runs on CircleCI and configures everything Heroku needs to deploy the 
          - image: my-image
        working_directory: /tmp/my-project  
        steps:
+         - checkout
          - run:
              name: Run setup script
              command: bash .circleci/setup-heroku.sh


### PR DESCRIPTION
The `- checkout` step was missing in the Heroku deployment docs steps. I'm only familiar with Heroku and use Heroku but I'd assume the checkout step needs to be added to the other deployment provider docs as well as they're missing too. 