### PR TITLE
Need to add heroku remote to git

### DIFF
--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -161,6 +161,7 @@ This file runs on CircleCI and configures everything Heroku needs to deploy the 
          - run:
              name: Deploy Master to Heroku
              command: |
+               heroku git:remote -a HEROKU_APP_NAME
                git push --force git@heroku.com:$HEROKU_APP_NAME.git HEAD:refs/heads/master
                heroku run python manage.py deploy
                heroku restart


### PR DESCRIPTION
I tried to deploy to heroku, and it did not work.
I found the solution adding `heroku git:remote -a jiayuan-example`.