### PR TITLE
replace cache keys with more generic example

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -218,14 +218,14 @@ The following example demonstrates how to use `restore_cache` and `save_cache` t
       
       - restore_cache:
           keys:
-            - asset-cache-{{ arch }}-{{ .Branch }}-{{ checksum "VERSION" }}
+            - asset-cache-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
             - asset-cache-{{ arch }}-{{ .Branch }}
             - asset-cache
             
       - run: bundle exec rake assets:precompile
       
       - save_cache:
-          key: asset-cache-{{ arch }}-{{ .Branch }}-{{ checksum "VERSION" }}
+          key: asset-cache-{{ arch }}-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - public/assets
             - tmp/cache/assets/sprockets


### PR DESCRIPTION
Fixes #2073 

@zzak I've added you here because I based the caching changes on one of your [workflows examples](https://github.com/CircleCI-Public/circleci-demo-workflows/blob/fan-in-fan-out/.circleci/config.yml).