### PR TITLE
Add details about changed environment variable behavior in 2.0

### DIFF
--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -9,12 +9,9 @@ order: 15
 
 *[2.0]({{ site.baseurl }}/2.0/) > Migrating from 1.0 to 2.0*
 
-This document provides a starting point for migrating from CircleCI 1.0 to 2.0.
-The migration process may not end with this document,
-but the goal is to replace most configuration keys with the new syntax.
+This document will give you a starting place for migrating from CircleCI 1.0 to 2.0 by using a copy of your existing 1.0 configuration file and replacing the old keys with the new keys if equivalents exist. The migration process may not end with this document, but the goal is to get the majority of keys replaced with the equivalent syntax nesting and to help you get started with adding new functionality.
 
-If you do not have a `circle.yml` file,
-start from scratch by referring to the [Sample 2.0 `config.yml` File]({{ site.baseurl }}/2.0/sample-config/).
+If you do not have a `circle.yml` file, refer to the [Sample 2.0 `config.yml` File]({{ site.baseurl }}/2.0/sample-config) to get started from scratch.
 
 * Contents
 {:toc}

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -84,6 +84,20 @@ If you already have a `circle.yml` file, the following sections describe how to 
 
 ## Environment Variables
 
+To set environment variables for all commands in a build,
+set environment variables for a [job]({{ site.baseurl }}/2.0/glossary/#job)
+by using the `environment` key in the associated job.
+
+```yaml
+version: 2.0
+jobs:
+  build:
+    docker:
+      - image: buildpack-deps:trusty
+    environment:
+      - FOO: "bar"
+```
+
 To set environment variables for all commands in a container,
 use the `environment` key in the corresponding `image`.
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -113,7 +113,37 @@ jobs:
           POSTGRES_DB: conductor_test
 ```
 
-Environment variables set at the `machine` level in CircleCI 1.0 should be set in the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container).
+To set environment variables for a single command,
+use the `environment` key in the associated `run` [step]({{ site.baseurl }}/2.0/glossary/#step).
+
+```yaml
+version: 2.0
+jobs:
+  build:
+    docker:
+      - image: smaant/lein-flyway:2.7.1-4.0.3
+    steps:
+      - checkout
+      - run:
+          name: Run migrations
+          command: sql/docker-entrypoint.sh sql
+          environment:
+            DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
+```
+
+**Note:** CircleCI 2.0 does not support interpolation of environment variables.
+All defined values are treated literally.
+A workaround is to export the environment variable within a command.
+
+```yaml
+- run:
+    command: |
+      export PATH=/go/bin:$PATH
+      go-get ...
+```
+
+For more information,
+see the CircleCI 2.0 document [Using Environment Variables]({{ site.baseurl }}/2.0/env-vars/).
 
 ## Steps to Configure Workflows
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -80,7 +80,26 @@ If you already have a `circle.yml` file, the following sections describe how to 
      
 7. (Optional) Add  the `add_ssh_keys` step with fingeprint to enable SSH into builds, see the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#add_ssh_keys) for details.
 
-8. Validate your YAML at <http://codebeautify.org/yaml-validator> to check the changes. 
+8. Validate your YAML at <http://codebeautify.org/yaml-validator> to check the changes.
+
+## Environment Variables
+
+To set environment variables for all commands in a container,
+use the `environment` key in the corresponding `image`.
+
+```yaml
+version: 2.0
+jobs:
+  build:
+    docker:
+      - image: smaant/lein-flyway:2.7.1-4.0.3
+      - image: circleci/postgres:9.6
+        environment:  # environment variables for database container
+          POSTGRES_USER: conductor
+          POSTGRES_DB: conductor_test
+```
+
+Environment variables set at the `machine` level in CircleCI 1.0 should be set in the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container).
 
 ## Steps to Configure Workflows
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -84,7 +84,9 @@ If you already have a `circle.yml` file, the following sections describe how to 
 
 ## Environment Variables
 
-To set environment variables for all commands in a build,
+CircleCI 2.0 allows you to set environment variables at several scope levels.
+
+To set environment variables **for all commands in a build**,
 set environment variables for a [job]({{ site.baseurl }}/2.0/glossary/#job)
 by using the `environment` key in the associated job.
 
@@ -98,7 +100,7 @@ jobs:
       - FOO: "bar"
 ```
 
-To set environment variables for all commands in a container,
+To set environment variables **for all commands in a container**,
 use the `environment` key in the associated `image`.
 
 ```yaml
@@ -113,7 +115,7 @@ jobs:
           POSTGRES_DB: conductor_test
 ```
 
-To set environment variables for a single command,
+To set environment variables **for a single command**,
 use the `environment` key in the associated `run` [step]({{ site.baseurl }}/2.0/glossary/#step).
 
 ```yaml
@@ -133,6 +135,7 @@ jobs:
 
 **Note:** CircleCI 2.0 does not support interpolation of environment variables.
 All defined values are treated literally.
+
 One workaround is to export the required variable within a command.
 
 ```yaml

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -99,7 +99,7 @@ jobs:
 ```
 
 To set environment variables for all commands in a container,
-use the `environment` key in the corresponding `image`.
+use the `environment` key in the associated `image`.
 
 ```yaml
 version: 2.0
@@ -108,7 +108,7 @@ jobs:
     docker:
       - image: smaant/lein-flyway:2.7.1-4.0.3
       - image: circleci/postgres:9.6
-        environment:  # environment variables for database container
+        environment:
           POSTGRES_USER: conductor
           POSTGRES_DB: conductor_test
 ```

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -133,7 +133,7 @@ jobs:
 
 **Note:** CircleCI 2.0 does not support interpolation of environment variables.
 All defined values are treated literally.
-A workaround is to export the environment variable within a command.
+One workaround is to export the required variable within a command.
 
 ```yaml
 - run:

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -120,7 +120,7 @@ To increase the speed of your software development through faster feedback, shor
            branches:
              ignore: master
      ```     
-6. Validate your YAML again at <http://codebeautify.org/yaml-validator> to check that it is well-formed. 
+6. Validate your YAML again at <http://codebeautify.org/yaml-validator> to check that it is well-formed.
 
 ## Search and Replace Deprecated 2.0 Keys
 
@@ -135,7 +135,7 @@ To increase the speed of your software development through faster feedback, shor
 
 ```
     environment:
-    PATH: "/path/to/foo/bin:$PATH"
+      PATH: "/path/to/foo/bin:$PATH"
 ```
 
 With the following to load it into your shell (the file $BASH_ENV already exists and has a random name in /tmp):

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -9,9 +9,12 @@ order: 15
 
 *[2.0]({{ site.baseurl }}/2.0/) > Migrating from 1.0 to 2.0*
 
-This document will give you a starting place for migrating from CircleCI 1.0 to 2.0 by using a copy of your existing 1.0 configuration file and replacing the old keys with the new keys if equivalents exist. The migration process may not end with this document, but the goal is to get the majority of keys replaced with the equivalent syntax nesting and to help you get started with adding new functionality.
+This document provides a starting point for migrating from CircleCI 1.0 to 2.0.
+The migration process may not end with this document,
+but the goal is to replace most configuration keys with the new syntax.
 
-If you do not have a `circle.yml` file, refer to the [Sample 2.0 `config.yml` File]({{ site.baseurl }}/2.0/sample-config) to get started from scratch.
+If you do not have a `circle.yml` file,
+start from scratch by referring to the [Sample 2.0 `config.yml` File]({{ site.baseurl }}/2.0/sample-config/).
 
 * Contents
 {:toc}


### PR DESCRIPTION
Fixes #2085 

New environment variable behavior needed to be more explicitly called out in the migration doc. Specifically, workarounds re: env var interpolation were unclear.