### PR TITLE
sort terms before generating list

### DIFF
--- a/jekyll/_cci2/glossary.html
+++ b/jekyll/_cci2/glossary.html
@@ -9,7 +9,8 @@ order: 2
 
 <a href="https://circleci.com/docs/2.0/reference/">Reference</a> > Glossary
 
-{% for term in site._glossary %}
+{% assign sorted_terms = site._glossary | sort: 'term' %}
+{% for term in sorted_terms %}
     <h3 id="{{ term.term | slugify }}">{{ term.term }}</h3>
     {{ term.output }}
 {% endfor %}


### PR DESCRIPTION
Glossary was being sorted by filename rather than term name.