### PR TITLE
Update status badges source

### DIFF
--- a/jekyll/_cci2/status-badges.md
+++ b/jekyll/_cci2/status-badges.md
@@ -5,7 +5,7 @@ title: Embedding Build Status Badges
 
 [Basics]({{ site.baseurl }}/2.0/basics/) > Embedding Build Status Badges
 
-This document describes how to create a badge that displays your project's build status (passed or failed) in a README or other document.
+This document describes how to create a badge that displays your project's build status.
 You can generate code for the following formats: Image URL, Markdown, Textile, Rdoc, AsciiDoc, reStructuredText, and pod.
 
 ## Overview

--- a/jekyll/_cci2/status-badges.md
+++ b/jekyll/_cci2/status-badges.md
@@ -36,7 +36,7 @@ and create  a label for the token.
 If you created a token in the previous step,
 select the token you want to use in the _API Token_ dropdown menu.
 5. Select the appropriate language from the _Embed Code_ dropdown menu.
-6. Copy and paste the generated link to the document where you want to display the status badge.
+6. Copy and paste the generated link in the document where you want to display the status badge.
 
 ## Customization
 

--- a/jekyll/_cci2/status-badges.md
+++ b/jekyll/_cci2/status-badges.md
@@ -40,9 +40,8 @@ select the token you want to use in the _API Token_ dropdown menu.
 
 ## Customization
 
-If you find the standard status badge ugly, you can use the highly-attractive shield style. Behold the difference:
-
-- Standard ![](https://circleci.com/gh/circleci/circle.png?circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e)
-- Shield ![](https://circleci.com/gh/circleci/circle.svg?style=shield&circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e)
-
-To use the shield style, simply replace `style=svg` with `style=shield` in the link you generated above.
+If you find the default status badge too minimal,
+you can use the [shield style](https://shields.io/).
+To use the shield style,
+replace `style=svg` with `style=shield`
+in the link you generated above.

--- a/jekyll/_cci2/status-badges.md
+++ b/jekyll/_cci2/status-badges.md
@@ -5,23 +5,31 @@ title: Embedding Build Status Badges
 
 [Basics]({{ site.baseurl }}/2.0/basics/) > Embedding Build Status Badges
 
-This document describes how to create a badge that displays your project's build status.
-You can generate code for the following formats: Image URL, Markdown, Textile, Rdoc, AsciiDoc, reStructuredText, and pod.
+This document describes how to create a badge that displays your project's build status (passed or failed) in a README or other document.
 
 ## Overview
 
-CircleCI provides build status badges for projects and branches.
 Status badges are commonly embedded in project READMEs,
-although they can be placed virtually anywhere.
+although they can be placed in any web document.
+CircleCI provides a tool to generate embed code for status badges.
+By default, a badge displays the status of a project's default branch,
+though you can also select other branches.
+
+You can generate code for the following formats:
+
+- Image URL
+- Markdown
+- Textile
+- Rdoc
+- AsciiDoc
+- reStructuredText
+- pod
 
 ## Steps
 
-CircleCI provides a tool to generate embed code for status badges.
-
 1. In the _Notifications_ section of your project's settings,
 click _Status Badges_.
-2. By default,
-the badge displays the status of your project's default branch.
+2. By default, the badge displays the status of your project's default branch.
 If you want to show the status of a different branch,
 use the Branch dropdown menu to select it.
 3. (Optional)

--- a/jekyll/_cci2/status-badges.md
+++ b/jekyll/_cci2/status-badges.md
@@ -10,7 +10,9 @@ You can generate code for the following formats: Image URL, Markdown, Textile, R
 
 ## Overview
 
-CircleCI provides build status badges for projects and branches. Status badges are commonly embedded in GitHub READMEs, although they can be placed virtually anywhere.
+CircleCI provides build status badges for projects and branches.
+Status badges are commonly embedded in project READMEs,
+although they can be placed virtually anywhere.
 
 ## Steps
 

--- a/jekyll/_cci2/status-badges.md
+++ b/jekyll/_cci2/status-badges.md
@@ -5,7 +5,8 @@ title: Embedding Build Status Badges
 
 [Basics]({{ site.baseurl }}/2.0/basics/) > Embedding Build Status Badges
 
-This document describes how to embed a badge that shows the build status (passed or failed) for your project in your README or in another document. You can generate code for the following formats: Image URL, Markdown, Textile, Rdoc, AsciiDoc, reStructuredText, and pod. 
+This document describes how to create a badge that displays your project's build status (passed or failed) in a README or other document.
+You can generate code for the following formats: Image URL, Markdown, Textile, Rdoc, AsciiDoc, reStructuredText, and pod.
 
 ## Overview
 

--- a/jekyll/_cci2/status-badges.md
+++ b/jekyll/_cci2/status-badges.md
@@ -18,12 +18,25 @@ although they can be placed virtually anywhere.
 
 CircleCI provides a tool to generate embed code for status badges.
 
-1. In the _Notifications_ section of your project's settings, click _Status Badges_.
-2. By default, the badge will display the status of your project's default branch. If you want to show the status of a different branch, use the Branch dropdown menu to select it.
-3. (Optional) If your project is private, you will need an API token for viewing a project's details. If you haven't created a token yet, click on _API Permissions_ in the _Permissions_ section. Next, click _Create Token_, choose the _Status_ scope, and create a label for the token.
-4. (Optional) If you created a token in the previous step, select the token you want to use in the _API Token_ dropdown menu.
+1. In the _Notifications_ section of your project's settings,
+click _Status Badges_.
+2. By default,
+the badge displays the status of your project's default branch.
+If you want to show the status of a different branch,
+use the Branch dropdown menu to select it.
+3. (Optional)
+If your project is private,
+you will need an API token for viewing a project's details.
+If you haven't created a token yet,
+click on the _API Permissions_ in the _Permissions_ section.
+Click _Create Token_,
+choose the _Status_ scope,
+and create  a label for the token.
+4. (Optional)
+If you created a token in the previous step,
+select the token you want to use in the _API Token_ dropdown menu.
 5. Select the appropriate language from the _Embed Code_ dropdown menu.
-6. Copy and paste the generated link to the web page or document where you want to display the status badge.
+6. Copy and paste the generated link to the document where you want to display the status badge.
 
 ## Customization
 


### PR DESCRIPTION
Fixes #2097 

Rereading this makes me wonder why we don't just default to the shield style for status badges. Those seem to be the industry standard, so it's odd to force users to do extra work to get that.