### PR TITLE
Correct macos test results

### DIFF
--- a/jekyll/_cci2/ios-migrating-from-1-2.md
+++ b/jekyll/_cci2/ios-migrating-from-1-2.md
@@ -75,8 +75,13 @@ jobs:
       # Collect XML test results data to show in the UI,
       # and save the same XML files under test-results folder
       # in the Artifacts tab.
+      - run:
+          command: mv fastlane/test_output/report.junit fastlane/test_output/report.xml
+          when: always
+
       - store_test_results:
-          path: test_output/report.xml
+          path: fastlane/test_output
+          
       - store_artifacts:
           path: /tmp/test-results
           destination: scan-test-results

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -83,9 +83,13 @@ jobs:
           environment:
             SCAN_DEVICE: iPhone 8
             SCAN_SCHEME: WebTests
+            
+      - run:
+          command: mv fastlane/test_output/report.junit fastlane/test_output/report.xml
+          when: always
 
       - store_test_results:
-          path: test_output/report.xml
+          path: fastlane/test_output
       - store_artifacts:
           path: /tmp/test-results
           destination: scan-test-results


### PR DESCRIPTION
A customer pointed out that Fastlane outputs a file named `report.junit`.

This needs to be renamed to be picked up by our test results parser. 