### PR TITLE
Google Container Engine clarifications

### DIFF
--- a/jekyll/_cci2/google-auth.md
+++ b/jekyll/_cci2/google-auth.md
@@ -10,6 +10,7 @@ Before you can use the `gcloud` command line tool with CircleCI, you must authen
 
 ## Prerequisites
 
+- A CircleCI 2.0 project.
 - A Google account.
 - A Google Cloud Platform project.
 

--- a/jekyll/_cci2/google-auth.md
+++ b/jekyll/_cci2/google-auth.md
@@ -26,7 +26,7 @@ Go to Google's [Getting Started with Authentication][] article and follow the in
 2. In the CircleCI application, go to your project's settings by clicking the gear icon in the top right.
 3. In the **Build Settings** section, click **Environment Variables**, then click the **Add Variable** button.
 4. Name the variable. In this example, the variable is named `$GCLOUD_SERVICE_KEY`.
-5. Paste the contents from Step 2 into the **Value** field.
+5. Paste the contents from Step 1 into the **Value** field.
 6. Click the **Add Variable** button.
 
 ### Decode and Store Service Account

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -28,14 +28,14 @@ consider using Google's base image.
 You can find this image on DockerHub as [`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/).
 Otherwise, follow the [SDK installation instructions](https://cloud.google.com/sdk/) for your base image's operating system.
 
-### Authenticate Google Cloud Platform
+### Authenticate `gcloud`
 
 Before you can use the `gcloud` command line tool with CircleCI,
 you must authenticate it.
 To do this,
 follow the instructions in the [Authenticating Google Cloud Platform]({{ site.baseurl }}/2.0/google-auth/) document.
 After completing these steps,
-you should have an environment variable called `GCLOUD_SERVICE_KEY`.
+you should have created an environment variable called `GCLOUD_SERVICE_KEY`.
 Using this particular name is not required,
 but it will be used throughout the examples in this document.
 
@@ -47,25 +47,42 @@ For convenience, add three more environment variables to your project:
 - `GOOGLE_CLUSTER_NAME`: the target cluster for all deployments
 - `GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/)
 
-### Setting Up a Job Step to Decode Credentials
+### Authenticate to Google's Container Registry
 
-Once the `GCLOUD_SERVICE_KEY` environment variable has been saved to your project, it will be readily available for use in the steps of your job's primary container.
-
-**config.yml**
+Since you are [using a JSON key file](https://cloud.google.com/container-registry/docs/advanced-authentication#using_a_json_key_file)
+to authenticate to Google's Container Registry (GCR),
+use the `auth` key in `config.yml`
+to specify credentials:
 
 ```yaml
-docker: 
-  - image: gcr.io/project/image-name
-    auth:
-    #Put the contents of keyfile.json into an environment variable for the build called GCR_CREDS, which is then passed in.
-      username: _json_key
-      password: $GCLOUD_SERVICE_KEY
-  - steps:
-     # ...
-     - run:
-       name: Decode and Store Service Account
-       command: echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
-     # ...  
+version: 2
+jobs:
+  deploy-job:
+    docker:
+      - image: gcr.io/project/image-name
+        auth:
+          username: _json_key  # default username when using a JSON key file to authenticate
+          password: $GCLOUD_SERVICE_KEY  # encoded service account you created
+```
+
+### Add a Job Step to Decode Credentials
+
+To authenticate the `gcloud` tool,
+add a job step to decode the `GCLOUD_SERVICE_KEY` environment variable:
+
+```yaml
+version: 2
+jobs:
+  deploy-job:
+    docker:
+      - image: gcr.io/project/image-name
+        auth:
+          username: _json_key  # default username when using a JSON key file to authenticate
+          password: $GCLOUD_SERVICE_KEY  # encoded service account you created
+    steps:
+      - run:
+        name: Decode and Store Service Account
+        command: echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
 ```
 
 ## Configuring `gcloud`

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -49,8 +49,20 @@ For convenience, add three more environment variables to your project:
 
 ### Authenticate to Google's Container Registry
 
-Since you are [using a JSON key file](https://cloud.google.com/container-registry/docs/advanced-authentication#using_a_json_key_file)
-to authenticate to Google's Container Registry (GCR),
+If you chose the `google/cloud-sdk` image,
+no authentication is needed since this is a public image.
+
+```yaml
+version: 2
+jobs:
+  deploy-job:
+    docker:
+      - image: google/cloud-sdk
+```
+
+If you are using a custom image,
+authenticate to Google's Container Registry (GCR).
+Since you are [using a JSON key file](https://cloud.google.com/container-registry/docs/advanced-authentication#using_a_json_key_file),
 use the `auth` key in `config.yml`
 to specify credentials:
 
@@ -75,10 +87,7 @@ version: 2
 jobs:
   deploy-job:
     docker:
-      - image: gcr.io/project/image-name
-        auth:
-          username: _json_key  # default username when using a JSON key file to authenticate
-          password: $GCLOUD_SERVICE_KEY  # encoded service account you created
+      - image: google/cloud-sdk
     steps:
       - run:
         name: Decode and Store Service Account

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -44,8 +44,8 @@ but it will be used throughout the examples in this document.
 For convenience, add three more environment variables to your project:
 
 - `GOOGLE_PROJECT_ID`: the ID of your GCP project
-- `GOOGLE_CLUSTER_NAME`: the target cluster for all deployments
 - `GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/)
+- `GOOGLE_CLUSTER_NAME`: the target cluster for all deployments
 
 ### Authenticate to Google's Container Registry
 
@@ -85,13 +85,17 @@ jobs:
         command: echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
 ```
 
-## Configuring `gcloud`
+### Configure `gcloud`
 
-As part of your deployment commands, configure `gcloud` to use the newly-configured service account and set up the appropriate defaults:
+Finally, as part of your deployment commands,
+update `gcloud`, authenticate, and set appropriate defaults for your project:
 
 ```bash
-gcloud auth activate-service-account --key-file ${HOME}/gcp-key.json
+gcloud --quiet components update
+gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
 gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
 gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 gcloud --quiet container clusters get-credentials ${GOOGLE_CLUSTER_NAME}
 ```
+
+Refer to the [Google Cloud](https://circleci.com/docs/2.0/deployment-integrations/#google-cloud) deploy example for further steps.

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -9,10 +9,8 @@ order: 60
 
 *[Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) > Using Google Container Engine*
 
-In order to use Google Cloud, you will need to ensure that the [Google Cloud SDK](https://cloud.google.com/sdk/) is installed on your primary container as described in the following sections:
-
-* TOC
-{:toc}
+In order to deploy to Google Kubernetes Engine,
+you must install the [Google Cloud SDK](https://cloud.google.com/sdk/) in your primary container.
 
 ## Prerequisites
 
@@ -71,5 +69,3 @@ gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
 gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 gcloud --quiet container clusters get-credentials ${GOOGLE_CLUSTER_NAME}
 ```
-
-

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -9,17 +9,15 @@ order: 60
 
 *[Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) > Using Google Container Engine*
 
-In order to deploy to Google Kubernetes Engine,
+In order to deploy to Google Kubernetes Engine (GKE),
 you must install the [Google Cloud SDK](https://cloud.google.com/sdk/) in your primary container.
 
 ## Prerequisites
 
-This document makes the following assumptions:
-
-1. You have a working knowledge of Docker and building Docker images.
-1. You already have a GCP project registered. Keep the project name handy.
-1. A Container Engine cluster has already been created in your GCP project. Keep the cluster name handy.
-1. Your repository has already been configured as a CircleCI 2.0 project.
+1. A CircleCI 2.0 project.
+2. A working knowledge of Docker and building Docker images.
+3. A registered Google Cloud Platform (GCP) project. Keep the project name handy.
+4. A GKE cluster connected to your GCP project. Keep the cluster name handy.
 
 ## Selecting a Base Image
 If Debian is acceptable as a base for your custom primary container, Google's [`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/) image can be a good base image to use.

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -34,7 +34,7 @@ Before you can use the `gcloud` command line tool with CircleCI,
 you must authenticate it.
 Follow the instructions in the [Authenticating Google Cloud Platform]({{ site.baseurl }}/2.0/google-auth/) document.
 After completing those steps,
-you should have an environment variable called `GCLOUD_SERVICE_KEY`.
+you should have an environment variable called `$GCLOUD_SERVICE_KEY`.
 Using this particular  name is not required,
 but will be used throughout the examples in this document.
 
@@ -43,9 +43,9 @@ but will be used throughout the examples in this document.
 For convenicnce,
 add three more environment variables to your project:
 
-- `GOOGLE_PROJECT_ID`: the ID of your GCP project
-- `GOOGLE_CLUSTER_NAME`: the target cluster for all deployments
-- `GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/)
+- `$GOOGLE_PROJECT_ID`: the ID of your GCP project
+- `$GOOGLE_CLUSTER_NAME`: the target cluster for all deployments
+- `$GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/)
 
 ### Setting Up a Job Step to Decode Credentials
 Once the `GCLOUD_SERVICE_KEY` environment variable has been saved to your project, it will be readily available for use in the steps of your job's primary container.

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -32,11 +32,12 @@ Otherwise, follow the [SDK installation instructions](https://cloud.google.com/s
 
 Before you can use the `gcloud` command line tool with CircleCI,
 you must authenticate it.
-Follow the instructions in the [Authenticating Google Cloud Platform]({{ site.baseurl }}/2.0/google-auth/) document.
-After completing those steps,
+To do this,
+follow the instructions in the [Authenticating Google Cloud Platform]({{ site.baseurl }}/2.0/google-auth/) document.
+After completing these steps,
 you should have an environment variable called `GCLOUD_SERVICE_KEY`.
 Using this particular name is not required,
-but will be used throughout the examples in this document.
+but it will be used throughout the examples in this document.
 
 ### Add More Environment Variables
 

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -28,9 +28,15 @@ consider using Google's [`google/cloud-sdk`](https://hub.docker.com/r/google/clo
 Otherwise,
 follow the [SDK installation instructions](https://cloud.google.com/sdk/) for your base image's operating system.
 
-### Authenticate
+### Authenticate Google Cloud Platform
 
-Setting Up Authentication
+Before you can use the `gcloud` command line tool with CircleCI,
+you must authenticate it.
+Follow the instructions in the [Authenticating Google Cloud Platform]({{ site.baseurl }}/2.0/google-auth/) document.
+After completing those steps,
+you should have an environment variable called `GCLOUD_SERVICE_KEY`.
+Using this particular  name is not required,
+but will be used throughout the examples in this document.
 
 ### Generating a Service Account Key
 After the Google Cloud SDK has been integrated into your primary container (see above), authentication can be achieved with the use of a [service account](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow). Ensure that you follow the Google Cloud documentation for generating a service account, or create a new key for an existing service account, saving the credentials as a JSON key.

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -14,10 +14,10 @@ you must install the [Google Cloud SDK](https://cloud.google.com/sdk/) in your p
 
 ## Prerequisites
 
-1. A CircleCI 2.0 project.
-2. A working knowledge of Docker and building Docker images.
-3. A registered Google Cloud Platform (GCP) project. Keep the project name handy.
-4. A GKE cluster connected to your GCP project. Keep the cluster name handy.
+- A CircleCI 2.0 project.
+- A working knowledge of Docker and building Docker images.
+- A registered Google Cloud Platform (GCP) project. Keep the project name handy.
+- A GKE cluster connected to your GCP project. Keep the cluster name handy.
 
 ## Selecting a Base Image
 If Debian is acceptable as a base for your custom primary container, Google's [`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/) image can be a good base image to use.

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -24,9 +24,9 @@ you must install the [Google Cloud SDK](https://cloud.google.com/sdk/) in your p
 ### Select a Base Image
 
 If Debian is an acceptable operating system for your primary container,
-consider using Google's [`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/) as a base image.
-Otherwise,
-follow the [SDK installation instructions](https://cloud.google.com/sdk/) for your base image's operating system.
+consider using Google's base image.
+You can find this image on DockerHub as [`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/).
+Otherwise, follow the [SDK installation instructions](https://cloud.google.com/sdk/) for your base image's operating system.
 
 ### Authenticate Google Cloud Platform
 
@@ -35,19 +35,19 @@ you must authenticate it.
 Follow the instructions in the [Authenticating Google Cloud Platform]({{ site.baseurl }}/2.0/google-auth/) document.
 After completing those steps,
 you should have an environment variable called `$GCLOUD_SERVICE_KEY`.
-Using this particular  name is not required,
+Using this particular name is not required,
 but will be used throughout the examples in this document.
 
 ### Add More Environment Variables
 
-For convenicnce,
-add three more environment variables to your project:
+For convenience, add three more environment variables to your project:
 
 - `$GOOGLE_PROJECT_ID`: the ID of your GCP project
 - `$GOOGLE_CLUSTER_NAME`: the target cluster for all deployments
 - `$GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/)
 
 ### Setting Up a Job Step to Decode Credentials
+
 Once the `GCLOUD_SERVICE_KEY` environment variable has been saved to your project, it will be readily available for use in the steps of your job's primary container.
 
 **config.yml**

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -48,7 +48,7 @@ add three more environment variables:
 - `GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/)
 
 ### Setting Up a Job Step to Decode Credentials
-Once the `GOOGLE_AUTH` environment variable has been saved to your project, it will be readily available for use in the steps of your job's primary container. 
+Once the `GCLOUD_SERVICE_KEY` environment variable has been saved to your project, it will be readily available for use in the steps of your job's primary container.
 
 **config.yml**
 
@@ -58,12 +58,12 @@ docker:
     auth:
     #Put the contents of keyfile.json into an environment variable for the build called GCR_CREDS, which is then passed in.
       username: _json_key
-      password: $GOOGLE_AUTH 
+      password: $GCLOUD_SERVICE_KEY
   - steps:
      # ...
      - run:
        name: Dump Google Cloud Credentials to file
-       command: echo ${GOOGLE_AUTH} > ${HOME}/gcp-key.json
+       command: echo ${GCLOUD_SERVICE_KEY} > ${HOME}/gcp-key.json
      # ...  
 ```
 

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -34,7 +34,7 @@ Before you can use the `gcloud` command line tool with CircleCI,
 you must authenticate it.
 Follow the instructions in the [Authenticating Google Cloud Platform]({{ site.baseurl }}/2.0/google-auth/) document.
 After completing those steps,
-you should have an environment variable called `$GCLOUD_SERVICE_KEY`.
+you should have an environment variable called `GCLOUD_SERVICE_KEY`.
 Using this particular name is not required,
 but will be used throughout the examples in this document.
 
@@ -42,9 +42,9 @@ but will be used throughout the examples in this document.
 
 For convenience, add three more environment variables to your project:
 
-- `$GOOGLE_PROJECT_ID`: the ID of your GCP project
-- `$GOOGLE_CLUSTER_NAME`: the target cluster for all deployments
-- `$GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/)
+- `GOOGLE_PROJECT_ID`: the ID of your GCP project
+- `GOOGLE_CLUSTER_NAME`: the target cluster for all deployments
+- `GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/)
 
 ### Setting Up a Job Step to Decode Credentials
 

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -38,16 +38,14 @@ you should have an environment variable called `GCLOUD_SERVICE_KEY`.
 Using this particular  name is not required,
 but will be used throughout the examples in this document.
 
-### Generating a Service Account Key
-After the Google Cloud SDK has been integrated into your primary container (see above), authentication can be achieved with the use of a [service account](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow). Ensure that you follow the Google Cloud documentation for generating a service account, or create a new key for an existing service account, saving the credentials as a JSON key.
+### Add More Environment Variables
 
-Paste this into a new environment variable's "Value" field, using the name `GOOGLE_AUTH`. Using this particular name is not required, but will be used throughout the examples in this document.
+For convenicnce,
+add three more environment variables:
 
-Next, simply set up three more environment variables for convenience:
-
-* `GOOGLE_PROJECT_ID`: the ID of your GCP project
-* `GOOGLE_CLUSTER_NAME`: the cluster to which deployments will occur
-* `GOOGLE_COMPUTE_ZONE`: which compute zone to use by default, e.g. `us-central1-a`
+- `GOOGLE_PROJECT_ID`: the ID of your GCP project
+- `GOOGLE_CLUSTER_NAME`: the target cluster for all deployments
+- `GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/)
 
 ### Setting Up a Job Step to Decode Credentials
 Once the `GOOGLE_AUTH` environment variable has been saved to your project, it will be readily available for use in the steps of your job's primary container. 

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -19,12 +19,18 @@ you must install the [Google Cloud SDK](https://cloud.google.com/sdk/) in your p
 - A registered Google Cloud Platform (GCP) project. Keep the project name handy.
 - A GKE cluster connected to your GCP project. Keep the cluster name handy.
 
-## Selecting a Base Image
-If Debian is acceptable as a base for your custom primary container, Google's [`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/) image can be a good base image to use.
+## Steps
 
-For those with more complicated custom primary containers, follow the [installation instructions](https://cloud.google.com/sdk/) for the operating system of your base image.
+### Select a Base Image
 
-## Setting Up Authentication
+If Debian is an acceptable operating system for your primary container,
+consider using Google's [`google/cloud-sdk`](https://hub.docker.com/r/google/cloud-sdk/) as a base image.
+Otherwise,
+follow the [SDK installation instructions](https://cloud.google.com/sdk/) for your base image's operating system.
+
+### Authenticate
+
+Setting Up Authentication
 
 ### Generating a Service Account Key
 After the Google Cloud SDK has been integrated into your primary container (see above), authentication can be achieved with the use of a [service account](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow). Ensure that you follow the Google Cloud documentation for generating a service account, or create a new key for an existing service account, saving the credentials as a JSON key.

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -41,7 +41,7 @@ but will be used throughout the examples in this document.
 ### Add More Environment Variables
 
 For convenicnce,
-add three more environment variables:
+add three more environment variables to your project:
 
 - `GOOGLE_PROJECT_ID`: the ID of your GCP project
 - `GOOGLE_CLUSTER_NAME`: the target cluster for all deployments

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -1,13 +1,13 @@
 ---
 layout: classic-docs
-title: "Deploying to Google Container Engine"
-short-title: "Deploying to Google Container Engine"
+title: "Deploying to Google Kubernetes Engine"
+short-title: "Deploying to Google Kubernetes Engine"
 categories: [containerization]
-description: "Deploying to Google Container Engine with CircleCI 2.0."
+description: "Deploying to Google Kubernetes Engine with CircleCI 2.0."
 order: 60
 ---
 
-*[Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) > Using Google Container Engine*
+*[Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) > Deploying to Google Kubernetes Engine*
 
 In order to deploy to Google Kubernetes Engine (GKE),
 you must install the [Google Cloud SDK](https://cloud.google.com/sdk/) in your primary container.

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -46,7 +46,7 @@ Once the `GOOGLE_AUTH` environment variable has been saved to your project, it w
 
 **config.yml**
 
-```yml
+```yaml
 docker: 
   - image: gcr.io/project/image-name
     auth:
@@ -65,7 +65,7 @@ docker:
 
 As part of your deployment commands, configure `gcloud` to use the newly-configured service account and set up the appropriate defaults:
 
-```sh
+```bash
 gcloud auth activate-service-account --key-file ${HOME}/gcp-key.json
 gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
 gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -62,8 +62,8 @@ docker:
   - steps:
      # ...
      - run:
-       name: Dump Google Cloud Credentials to file
-       command: echo ${GCLOUD_SERVICE_KEY} > ${HOME}/gcp-key.json
+       name: Decode and Store Service Account
+       command: echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
      # ...  
 ```
 


### PR DESCRIPTION
Fixes #2134 and fixes #1670.

While working on this document, I realized a couple of things:

1. There is a lot of overlapping information between [this document](https://circleci.com/docs/2.0/google-container-engine/) and the [Authenticating Google Cloud](https://circleci.com/docs/2.0/google-auth/) document.

2. Both documents are mostly focused on steps preceding the *actual deploy* (authentication, environment variables, etc.).

3. The actual deploy instructions seem to be on the [deploy landing page](https://circleci.com/docs/2.0/deployment-integrations/#google-cloud), but these seem to be a bit lean.

---

At the very least, we should consolidate [Authenticating Google Cloud Platform](https://circleci.com/docs/2.0/google-auth/) and [Deploying to Google Container Engine](https://circleci.com/docs/2.0/google-container-engine/).

If we're feeling ambitious, I would pull all relevant Google Cloud setup documentation into a single document that is linked to from the Deploy landing page. The other deploy platforms could benefit from their own spaces as well.