### PR TITLE
Document differences between GitHub and Bitbucket user key creation

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -168,11 +168,16 @@ In the "Hostname" field,
 enter "github.com",
 and press the submit button.
 
-4. In you config.yml, you can refer to the key with the following:
-```
-steps:
-  - add_ssh_keys:
-      fingerprints:
-        - "SO:ME:FIN:G:ER:PR:IN:T"
+4. In your config.yml,
+add the key using the `add_ssh_keys` key:
+
+```yaml
+version: 2
+jobs:
+  deploy-job:
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SO:ME:FIN:G:ER:PR:IN:T"
 ```
 That's it! Now, when you push to your GitHub repository from a job run, the read/write key that you added will be used.

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -132,7 +132,7 @@ If you enable these restrictions on an organization for which CircleCI has been 
 
 The account and permissions system we use is not as clear as we would like and as mentioned we have a much improved system in development with users as first class citizens in CircleCI.
 
-## Deployment Keys
+## Deployment Keys and User Keys
 
 When you add a new project,
 CircleCI creates a deployment key on the web-based VCS (GitHub or Bitbucket) for your project.
@@ -140,8 +140,8 @@ To prevent CircleCI from pushing to your repository,
 this deployment key is read-only.
 
 If you want to push to the repository from your builds,
-you will need a deployment key with write access.
-The steps to create a user deployment key depend on your VCS.
+you will need a deployment key with write access (user key).
+The steps to create a user key depend on your VCS.
 
 ### Creating a GitHub User Key
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -149,11 +149,19 @@ In this example,
 the GitHub repository is `https://github.com/you/test-repo`,
 and the CircleCI project is `https://circleci.com/gh/you/test-repo`.
 
+#### Steps
 
+1. Create an SSH key pair by following the [GitHub instructions](https://help.github.com/articles/generating-ssh-keys/).
+When prompted to enter a passphrase,
+do **not** enter one.
 
-1. Create an ssh key pair by following the [GitHub instructions](https://help.github.com/articles/generating-ssh-keys/)
-  Note: when asked "Enter passphrase (empty for no passphrase)", do ***not*** enter a passphrase.
-2. Go to `https://github.com/you/test-repo/settings/keys` on GitHub and click **Add deploy key**. Enter any title in the **Title** field, then copy and paste the public key you just created. Make sure to check **Allow write access**, then click **Add key**.
+2. Go to `https://github.com/you/test-repo/settings/keys`,
+and click "Add deploy key".
+Enter a title in the "Title" field,
+then copy and paste the public key you created in step 1.
+Check "Allow write access",
+then click "Add key".
+
 3. Go to `https://circleci.com/gh/you/test-repo/edit#ssh` on CircleCI and add the private key that you just created. Enter `github.com` in the **Hostname** field and press the submit button.
 4. In you config.yml, you can refer to the key with the following:
 ```
@@ -163,6 +171,3 @@ steps:
         - "SO:ME:FIN:G:ER:PR:IN:T"
 ```
 That's it! Now, when you push to your GitHub repository from a job run, the read/write key that you added will be used.
-
-
-

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -169,7 +169,7 @@ enter "github.com",
 and press the submit button.
 
 4. In your config.yml,
-add the key using the `add_ssh_keys` key:
+add the fingerprint using the `add_ssh_keys` key:
 
 ```yaml
 version: 2

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -132,14 +132,18 @@ If you enable these restrictions on an organization for which CircleCI has been 
 
 The account and permissions system we use is not as clear as we would like and as mentioned we have a much improved system in development with users as first class citizens in CircleCI.
 
-## Adding Deployment Keys to GitHub or Bitbucket
+## Deployment Keys
 
 When you add a new project,
 CircleCI creates a deployment key on the web-based VCS (GitHub or Bitbucket) for your project.
 To prevent CircleCI from pushing to your repository,
 this deployment key is read-only.
 
-The deployment key is read-only, to prevent CircleCI from pushing to your repository. However, sometimes you may want push to the repository from your builds and you cannot do this with a read-only deployment key. It is possible to manually add a read/write deployment key with the following steps.
+If you want to push to the repository from your builds,
+you will need a deployment key with write access.
+The steps to create a read-write deployment key depend on your VCS.
+
+### Creating a GitHub Read-Write Key
 
 In this example, the GitHub repository is `https://github.com/you/test-repo` and the project on CircleCI is `https://circleci.com/gh/you/test-repo`.
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -158,11 +158,16 @@ do **not** enter one.
 2. Go to `https://github.com/you/test-repo/settings/keys`,
 and click "Add deploy key".
 Enter a title in the "Title" field,
-then copy and paste the public key you created in step 1.
+then copy and paste the key you created in step 1.
 Check "Allow write access",
 then click "Add key".
 
-3. Go to `https://circleci.com/gh/you/test-repo/edit#ssh` on CircleCI and add the private key that you just created. Enter `github.com` in the **Hostname** field and press the submit button.
+3. Go to `https://circleci.com/gh/you/test-repo/edit#ssh`,
+and add the key you created in step 1.
+In the "Hostname" field,
+enter "github.com",
+and press the submit button.
+
 4. In you config.yml, you can refer to the key with the following:
 ```
 steps:

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -180,4 +180,6 @@ jobs:
           fingerprints:
             - "SO:ME:FIN:G:ER:PR:IN:T"
 ```
-That's it! Now, when you push to your GitHub repository from a job run, the read/write key that you added will be used.
+
+When you push to your GitHub repository from a job,
+CircleCI will use the SSH key you added.

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -132,7 +132,7 @@ If you enable these restrictions on an organization for which CircleCI has been 
 
 The account and permissions system we use is not as clear as we would like and as mentioned we have a much improved system in development with users as first class citizens in CircleCI.
 
-## Adding Read/Write Deployment Keys to GitHub or Bitbucket
+## Adding Deployment Keys to GitHub or Bitbucket
 
 When you add a new project,
 CircleCI creates a deployment key on the web-based VCS (GitHub or Bitbucket) for your project.

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -141,9 +141,9 @@ this deployment key is read-only.
 
 If you want to push to the repository from your builds,
 you will need a deployment key with write access.
-The steps to create a read-write deployment key depend on your VCS.
+The steps to create a user deployment key depend on your VCS.
 
-### Creating a GitHub Read-Write Key
+### Creating a GitHub User Key
 
 In this example,
 the GitHub repository is `https://github.com/you/test-repo`,

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -149,8 +149,6 @@ In this example,
 the GitHub repository is `https://github.com/you/test-repo`,
 and the CircleCI project is `https://circleci.com/gh/you/test-repo`.
 
-#### Steps
-
 1. Create an SSH key pair by following the [GitHub instructions](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/).
 When prompted to enter a passphrase,
 do **not** enter one.
@@ -190,8 +188,6 @@ Bitbucket does not currently provide CircleCI with an API
 to create user keys.
 It is still possible to create a user key
 by following this workaround:
-
-#### Steps
 
 1. In your project's settings
 on the "Checkout SSH Keys" page,

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -151,7 +151,7 @@ and the CircleCI project is `https://circleci.com/gh/you/test-repo`.
 
 #### Steps
 
-1. Create an SSH key pair by following the [GitHub instructions](https://help.github.com/articles/generating-ssh-keys/).
+1. Create an SSH key pair by following the [GitHub instructions](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/).
 When prompted to enter a passphrase,
 do **not** enter one.
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -145,7 +145,11 @@ The steps to create a read-write deployment key depend on your VCS.
 
 ### Creating a GitHub Read-Write Key
 
-In this example, the GitHub repository is `https://github.com/you/test-repo` and the project on CircleCI is `https://circleci.com/gh/you/test-repo`.
+In this example,
+the GitHub repository is `https://github.com/you/test-repo`,
+and the CircleCI project is `https://circleci.com/gh/you/test-repo`.
+
+
 
 1. Create an ssh key pair by following the [GitHub instructions](https://help.github.com/articles/generating-ssh-keys/)
   Note: when asked "Enter passphrase (empty for no passphrase)", do ***not*** enter a passphrase.

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -183,3 +183,45 @@ jobs:
 
 When you push to your GitHub repository from a job,
 CircleCI will use the SSH key you added.
+
+### Creating a Bitbucket User Key
+
+Bitbucket does not currently provide CircleCI with an API
+to create user keys.
+It is still possible to create a user key
+by following this workaround:
+
+#### Steps
+
+1. In your project's settings
+on the "Checkout SSH Keys" page,
+open the "Inspect Element" feature
+in your browser's developer tools.
+
+2. Click "Create User Key".
+
+3. In the "Network" tab
+of your developer tools,
+find the generated public key
+and copy it to your clipboard.
+
+4. In your project's "Bitbucket settings",
+click "SSH Keys",
+then click "Add Key".
+Paste the key you generated in step 3.
+
+5. In your config.yml,
+add the fingerprint using the `add_ssh_keys` key:
+
+```yaml
+version: 2
+jobs:
+  deploy-job:
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SO:ME:FIN:G:ER:PR:IN:T"
+```
+
+When you push to your Bitbucket project from a job,
+CircleCI will use the SSH key you added.

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -134,7 +134,12 @@ The account and permissions system we use is not as clear as we would like and a
 
 ## Adding Read/Write Deployment Keys to GitHub or Bitbucket
 
-When you add a new project, CircleCI creates a deployment key on the web-based VCS (GitHub or Bitbucket) for your project. The deployment key is read-only, to prevent CircleCI from pushing to your repository. However, sometimes you may want push to the repository from your builds and you cannot do this with a read-only deployment key. It is possible to manually add a read/write deployment key with the following steps.
+When you add a new project,
+CircleCI creates a deployment key on the web-based VCS (GitHub or Bitbucket) for your project.
+To prevent CircleCI from pushing to your repository,
+this deployment key is read-only.
+
+The deployment key is read-only, to prevent CircleCI from pushing to your repository. However, sometimes you may want push to the repository from your builds and you cannot do this with a read-only deployment key. It is possible to manually add a read/write deployment key with the following steps.
 
 In this example, the GitHub repository is `https://github.com/you/test-repo` and the project on CircleCI is `https://circleci.com/gh/you/test-repo`.
 


### PR DESCRIPTION
Fixes #2133. Fixes #1667.

These changes highlight the differences between user key generation for both GitHub and Bitbucket. The entire document could benefit from more clearly calling out these differences. It's a bit misleading to overgeneralize processes between the version control systems.

Will create a follow-up JIRA ticket to capture potential improvement.