### PR TITLE
Add context to Bitbucket user key workaround

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -189,10 +189,8 @@ to create user keys.
 It is still possible to create a user key
 by following this workaround:
 
-1. In your project's settings
-on the "Checkout SSH Keys" page,
-open the "Inspect Element" feature
-in your browser's developer tools.
+1. In the CircleCI application,
+go to your project's settings.
 
 2. Click "Create User Key".
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -186,7 +186,7 @@ CircleCI will use the SSH key you added.
 
 Bitbucket does not currently provide CircleCI with an API
 to create user keys.
-It is still possible to create a user key
+However, it is still possible to create a user key
 by following this workaround:
 
 1. In the CircleCI application,
@@ -199,12 +199,17 @@ and click "Inspect".
 3. In the developer console,
 select the "Network" tab.
 
-4. In your project's "Bitbucket settings",
-click "SSH Keys",
-then click "Add Key".
-Paste the key you generated in step 3.
+4. Click "Create [username] user key",
+where [username] is your CircleCI username.
 
-5. In your config.yml,
+5. In the developer console,
+click the `checkout-key` with a 201 status
+and copy the `public_key` to your clipboard.
+
+6. Add the key to Bitbucket
+by following Bitbucket's guide on [setting up SSH keys](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html).
+
+7. In your config.yml,
 add the fingerprint using the `add_ssh_keys` key:
 
 ```yaml

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -196,10 +196,8 @@ go to your project's settings.
 right-click the "Create <username> user key"
 and click "Inspect".
 
-3. In the "Network" tab
-of your developer tools,
-find the generated public key
-and copy it to your clipboard.
+3. In the developer console,
+select the "Network" tab.
 
 4. In your project's "Bitbucket settings",
 click "SSH Keys",

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -192,15 +192,14 @@ by following this workaround:
 1. In the CircleCI application,
 go to your project's settings.
 
-2. On the "Checkout SSH Keys" page,
-right-click the "Create <username> user key"
-and click "Inspect".
+2. On the **Checkout SSH Keys** page,
+right-click the **Create <username> user key** button
+and select the **Inspect** option.
 
 3. In the developer console,
-select the "Network" tab.
+select the **Network** tab.
 
-4. Click "Create [username] user key",
-where [username] is your CircleCI username.
+4. Click the **Create [username] user key** button.
 
 5. In the developer console,
 click the `checkout-key` with a 201 status
@@ -209,7 +208,7 @@ and copy the `public_key` to your clipboard.
 6. Add the key to Bitbucket
 by following Bitbucket's guide on [setting up SSH keys](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html).
 
-7. In your config.yml,
+7. In your `.circleci/config.yml`,
 add the fingerprint using the `add_ssh_keys` key:
 
 ```yaml

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -192,7 +192,9 @@ by following this workaround:
 1. In the CircleCI application,
 go to your project's settings.
 
-2. Click "Create User Key".
+2. On the "Checkout SSH Keys" page,
+right-click the "Create <username> user key"
+and click "Inspect".
 
 3. In the "Network" tab
 of your developer tools,


### PR DESCRIPTION
This is a follow-up to #2164 and adds some necessary details around where to locate the generated Bitbucket user key.