### PR TITLE
Clarify how split tests are run

### DIFF
--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -168,7 +168,7 @@ Not yet, but we are working on that functionality.
 Not yet, but we are working on that functionality.
 
 ### Can I use `store_test_results` with Workflows?
-You can use `store_test_results` in order to populate your builds' Test Summary section with your test results information and for [timing-based test-splitting]({{ site.baseurl }}/2.0/parallelism-faster-jobs/#splitting-patterns). Test timings data is available for 2.0 with Workflows, using data from a job with the same name going back 50 builds.
+You can use `store_test_results` in order to populate your builds' Test Summary section with your test results information and for [timing-based test-splitting]({{ site.baseurl }}/2.0/parallelism-faster-jobs/#splitting-by-timings). Test timings data is available for 2.0 with Workflows, using data from a job with the same name going back 50 builds.
  
 ### Can I use Workflows with CircleCI 1.0?
  

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -13,7 +13,7 @@ CircleCI can run your tests in parallel,
 allowing you to save time and resources.
 This document describes
 how to split tests into groups
-before running them.
+before running the tests in parallel.
 
 ## Overview
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -61,13 +61,13 @@ This set of files is run across the number of machines you specified with the `p
 
 #### Supported Globbing Patterns
 
-The following patterns are used to glob files.
+The following patterns are used to glob files:
 
-- `*`: matches any sequence of characters (excluding path separators)
-- `**`: matches any sequence of characters (including path separators)
-- `?`: matches any single character (excluding path separators)
-- `[abc]`: matches any character (excluding path separators) against characters in braces
-- `{foo,bar,...}`: matches a sequence of characters if any of the alternatives in braces matches
+- `*` matches any sequence of characters (excluding path separators)
+- `**` matches any sequence of characters (including path separators)
+- `?` matches any single character (excluding path separators)
+- `[abc]` matches any character (excluding path separators) against characters in brackets
+- `{foo,bar,...}` matches a sequence of characters, if any of the alternatives in braces matches
 
 #### Checking Glob Results
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -33,6 +33,8 @@ Test suites are conventionally defined at the [job]({{ site.baseurl }}/2.0/jobs-
 To run a job's steps in parallel,
 set the `parallelism` key in your `.circleci/config.yml`
 to a value greater than 1.
+This value specifies how many independent executors will be set up
+to run the steps of a job.
 For more information,
 see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -29,6 +29,12 @@ using the CircleCI Local CLI.
 
 ### Specifying a Job's Parallelism Level
 
+Test suites are conventionally defined at the [job]({{ site.baseurl }}/2.0/jobs-steps/#sample-configuration-with-parallel-jobs) level.
+To run a job's steps in parallel,
+set the `parallelism` key to a value greater than 1.
+
+See the [configuration reference](https://circleci.com/docs/2.0/configuration-reference/#parallelism) for more info.
+
 ### Splitting Tests Into Groups
 
 Use the circle tests glob command to specify multiple globs to merge using a pattern, for example: 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -29,7 +29,7 @@ using the CircleCI Local CLI.
 
 ### Specifying a Job's Parallelism Level
 
-Test suites are conventionally defined at the [job]({{ site.baseurl }}/2.0/jobs-steps/#sample-configuration-with-parallel-jobs) level.
+Test suites are conventionally defined at the [job]({{ site.baseurl }}/2.0/jobs-steps/#sample-configuration-with-parallel-jobs) level in your `.circleci/config.yml` file.
 The `parallelism` key specifies
 how many independent executors will be set up
 to run the steps of a job.

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -9,12 +9,14 @@ order: 60
 
 *[Test]({{ site.baseurl }}/2.0/test/) > Running Tests in Parallel*
 
-This document describes how to run tests in parallel in the following sections:
-
-* TOC
-{:toc}
+CircleCI can run your tests in parallel,
+allowing you to save time and resources.
+This document describes
+how to split tests into groups
+before running them.
 
 ## Overview
+
 One of the most powerful features of CircleCI is the ability to run your tests in parallel. This section describes how to use `circleci` commands in your `config.yml` file to merge and split tests with the hosted CircleCI CLI for faster builds. See [Writing Jobs with Steps]({{ site.baseurl }}/2.0/configuration-reference/#jobs) for information about setting the `parallelism` key in your configuration file. 
 
 Use the circle tests glob command to specify multiple globs to merge using a pattern, for example: 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -27,7 +27,7 @@ specifying a parallelism level
 and globbing or splitting test files
 using the CircleCI Local CLI.
 
-### Specifying a Job's Parallelism Level
+## Specifying a Job's Parallelism Level
 
 Test suites are conventionally defined at the [job]({{ site.baseurl }}/2.0/jobs-steps/#sample-configuration-with-parallel-jobs) level in your `.circleci/config.yml` file.
 The `parallelism` key specifies
@@ -39,17 +39,20 @@ set the `parallelism` key to a value greater than 1.
 For more information,
 see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
 
-### Installing the CircleCI Local CLI
+## Installing the CircleCI Local CLI
 
 Running tests in parallel requires the CircleCI Local CLI.
 For installation instructions,
 refer to the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document
 
-### Globbing and Splitting
+## Using Pattern-Matching to Create Groups of Tests
 
 Test allocation across containers is file-based.
 You can make groups of files by
-specifying patterns for globbing or splitting.
+specifying patterns for globbing or splitting files.
+
+### Globbing
+
 To specify patterns for globbing,
 use the `circleci tests glob` command,
 as shown below:
@@ -81,8 +84,8 @@ jobs:
     steps:
       - run:
           command: |
-            echo $(circleci tests glob "foo/**/*" "bar/**/*")  # Print all files on one line
-            circleci tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo  # Print one file per line
+            echo $(circleci tests glob "foo/**/*" "bar/**/*")
+            circleci tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo
 ```
 
 ### Splitting Patterns

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -59,16 +59,6 @@ In this example, the `glob` command takes the Java files in the `tests/unit/` an
 This set of files is run acrossthe number of machines
 you specified with the `parallelism` key.
 
-#### Supported Globbing Patterns
-
-- `*` matches any sequence of characters (excluding path separators)
-- `**` matches any sequence of characters (including path separators)
-- `?` matches any single character (excluding path separators)
-- `[abc]` matches any character (excluding path separators) against characters in brackets
-- `{foo,bar,...}` matches a sequence of characters, if any of the alternatives in braces matches
-
-#### Checking Globbing Results
-
 You can check the results of pattern-matching
 by using the `echo` command in your `.circleci/config.yml` file:
 
@@ -83,7 +73,18 @@ jobs:
             circleci tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo
 ```
 
-### Splitting Patterns
+#### Supported Globbing Patterns
+
+- `*` matches any sequence of characters (excluding path separators)
+- `**` matches any sequence of characters (including path separators)
+- `?` matches any single character (excluding path separators)
+- `[abc]` matches any character (excluding path separators) against characters in brackets
+- `{foo,bar,...}` matches a sequence of characters, if any of the alternatives in braces matches
+
+### Splitting
+
+When running parallel builds,
+the CircleCI Local CLI can split a list of test files across machines.o
 
 The `circleci` CLI can be used to split a list of test files or classnames when running parallel builds on 2.0. The CLI uses the environment to look up the total number of containers, along with the current container index. Then, it uses deterministic splitting algorithms to return a distinct subset of the input filenames or classnames on each container.
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -24,7 +24,7 @@ To reduce this time,
 you can spread your tests across multiple machines.
 This requires
 specifying a parallelism level
-and globbing or splitting tests
+and globbing or splitting test files
 using the CircleCI Local CLI.
 
 ### Specifying a Job's Parallelism Level

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -39,11 +39,11 @@ set the `parallelism` key to a value greater than 1.
 For more information,
 see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
 
-### Installing the Local CLI Tool
+### Installing the CircleCI Local CLI
 
 Running tests in parallel requires the CircleCI Local CLI.
-For more information,
-see the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli) document.
+For installation instructions,
+refer to the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document
 
 ### Globbing and Splitting
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -49,12 +49,27 @@ refer to the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#in
 
 Test allocation across containers is file-based.
 You can make groups of files by
-specifying rules for globbing or splitting.
+specifying patterns for globbing or splitting.
+To specify patterns for globbing,
+use the `circleci tests glob` command,
+as shown below:
 
-The number of containers available for running tests is defined by the `parallelism` key.
+    circleci tests glob "tests/unit/*.java" "tests/functional/*.java"
 
-Use the circle tests glob command to specify multiple globs to merge using a pattern, for example: 
-	`circleci tests glob "tests/unit/*.java" "tests/functional/*.java"`
+In this example, the `glob` command takes the Java files in the `tests/unit/` and `tests/functional` directories as arguments.
+This set of files is run across the number of machines you specified with the `parallelism` key.
+
+#### Supported Globbing Patterns
+
+The following patterns are used to glob files.
+
+- `*`: matches any sequence of characters (excluding path separators)
+- `**`: matches any sequence of characters (including path separators)
+- `?`: matches any single character (excluding path separators)
+- `[abc]`: matches any character (excluding path separators) against characters in braces
+- `{foo,bar,...}`: matches a sequence of characters if any of the alternatives in braces matches
+
+#### Checking Glob Results
 
 In your `config.yml` file, check your glob results by using the `circleci tests glob` command, for example:
 
@@ -67,20 +82,6 @@ run:
   # Print one file per line
   circleci tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo
 ```
-
-### Supported Globbing Patterns
-
-The following patterns are used to glob files.
-
-- `*`: matches any sequence of characters (excluding path separators)
-- `**`: matches any sequence of characters (including path separators)
-- `?`: matches any single character (excluding path separators)
-- `[abc]`: matches any character (excluding path separators) against characters in braces
-- `{foo,bar,...}`: matches a sequence of characters if any of the alternatives in braces matches
-
-For example:
-
-`circleci tests glob "**/*.java"`
 
 ### Splitting Patterns
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -31,9 +31,10 @@ using the CircleCI Local CLI.
 
 Test suites are conventionally defined at the [job]({{ site.baseurl }}/2.0/jobs-steps/#sample-configuration-with-parallel-jobs) level.
 To run a job's steps in parallel,
-set the `parallelism` key to a value greater than 1.
-
-See the [configuration reference](https://circleci.com/docs/2.0/configuration-reference/#parallelism) for more info.
+set the `parallelism` key in your `.circleci/config.yml`
+to a value greater than 1.
+For more information about the `parallelism` key,
+see the [configuration reference](https://circleci.com/docs/2.0/configuration-reference/#parallelism).
 
 ### Splitting Tests Into Groups
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -13,7 +13,7 @@ CircleCI can run your tests in parallel,
 allowing you to validate your code more quickly.
 This document describes
 how to organize tests
-before running them.
+before running them in parallel.
 
 ## Overview
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -71,16 +71,18 @@ The following patterns are used to glob files:
 
 #### Checking Glob Results
 
-In your `config.yml` file, check your glob results by using the `circleci tests glob` command, for example:
+You can check the results of pattern-matching
+by using the `echo` command in your `.circleci/config.yml` file:
 
-```
-run:
-- type: shell
-  command: |
-  # Print all files in one line
-  echo $(circleci tests glob "foo/**/*" "bar/**/*")
-  # Print one file per line
-  circleci tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo
+```yaml
+version: 2
+jobs:
+  test-job:
+    steps:
+      - run:
+          command: |
+            echo $(circleci tests glob "foo/**/*" "bar/**/*")  # Print all files on one line
+            circleci tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo  # Print one file per line
 ```
 
 ### Splitting Patterns

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -38,7 +38,7 @@ jobs:
 For more information,
 see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
 
-## Using Pattern-Matching to Create Groups of Tests
+## Using the CircleCI Local CLI to Group Test Files
 
 Test allocation across containers is file-based.
 You can make groups of files by
@@ -46,18 +46,18 @@ using the CircleCI Local CLI
 to specifying patterns for globbing or splitting files
 
 To install the Local CLI,
-refer to the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document.
+see the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document.
 
 ### Globbing
 
 To specify patterns for globbing,
-use the `circleci tests glob` command,
-as shown below:
+use the `circleci tests glob` command:
 
     circleci tests glob "tests/unit/*.java" "tests/functional/*.java"
 
-In this example, the `glob` command takes the Java files in the `tests/unit/` and `tests/functional` directories as arguments.
-This set of files is run across the number of machines you specified with the `parallelism` key.
+In this example, the `glob` command takes the Java files in the `tests/unit/` and `tests/functional/` directories as arguments.
+This set of files is run acrossthe number of machines
+you specified with the `parallelism` key.
 
 #### Supported Globbing Patterns
 
@@ -67,7 +67,7 @@ This set of files is run across the number of machines you specified with the `p
 - `[abc]` matches any character (excluding path separators) against characters in brackets
 - `{foo,bar,...}` matches a sequence of characters, if any of the alternatives in braces matches
 
-#### Checking Glob Results
+#### Checking Globbing Results
 
 You can check the results of pattern-matching
 by using the `echo` command in your `.circleci/config.yml` file:

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -16,7 +16,7 @@ you can run tests in parallel
 by spreading them across multiple machines.
 This requires specifying a parallelism level
 and using the CircleCI Local CLI
-to glob or split test files.
+to glob and split test files.
 
 ## Specifying a Job's Parallelism Level
 
@@ -40,24 +40,31 @@ see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference
 
 ## Using the CircleCI Local CLI to Group Test Files
 
-Test allocation across containers is file-based.
-You can make groups of files by
-using the CircleCI Local CLI
-to specifying patterns for globbing or splitting files
-
-To install the Local CLI,
+Test allocation across containers is file-based
+and requires the CircleCI Local CLI.
+To install the CLI,
 see the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document.
 
 ### Globbing
 
-To specify patterns for globbing,
+The CLI supports globbing test files
+using the following patterns:
+
+- `*` matches any sequence of characters (excluding path separators)
+- `**` matches any sequence of characters (including path separators)
+- `?` matches any single character (excluding path separators)
+- `[abc]` matches any character (excluding path separators) against characters in brackets
+- `{foo,bar,...}` matches a sequence of characters, if any of the alternatives in braces matches
+
+To use these patterns to group test files,
 use the `circleci tests glob` command:
 
     circleci tests glob "tests/unit/*.java" "tests/functional/*.java"
 
-In this example, the `glob` command takes the Java files in the `tests/unit/` and `tests/functional/` directories as arguments.
-This set of files is run acrossthe number of machines
-you specified with the `parallelism` key.
+In this example,
+the `glob` command takes the Java files in the `tests/unit/` and `tests/functional/` directories as arguments.
+This set of files is run across the number of machines
+specified by the `parallelism` key.
 
 You can check the results of pattern-matching
 by using the `echo` command in your `.circleci/config.yml` file:
@@ -73,15 +80,7 @@ jobs:
             circleci tests glob "foo/**/*" "bar/**/*" | xargs -n 1 echo
 ```
 
-#### Supported Globbing Patterns
-
-- `*` matches any sequence of characters (excluding path separators)
-- `**` matches any sequence of characters (including path separators)
-- `?` matches any single character (excluding path separators)
-- `[abc]` matches any character (excluding path separators) against characters in brackets
-- `{foo,bar,...}` matches a sequence of characters, if any of the alternatives in braces matches
-
-### Splitting
+### Splitting Test Files
 
 When running parallel builds,
 the CircleCI Local CLI can split a list of test files across machines.o

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -10,7 +10,7 @@ order: 60
 *[Test]({{ site.baseurl }}/2.0/test/) > Running Tests in Parallel*
 
 CircleCI can run your tests in parallel,
-allowing you to save time and resources.
+allowing you to validate your code more quickly.
 This document describes
 how to split tests into groups
 before running the tests.

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -18,23 +18,31 @@ This requires specifying a parallelism level
 and using the CircleCI Local CLI
 to glob or split test files.
 
+## Requirement
+
+Running tests in parallel requires the CircleCI Local CLI.
+For installation instructions,
+refer to the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document.
+
 ## Specifying a Job's Parallelism Level
 
 Test suites are conventionally defined at the [job]({{ site.baseurl }}/2.0/jobs-steps/#sample-configuration-with-parallel-jobs) level in your `.circleci/config.yml` file.
 The `parallelism` key specifies
 how many independent executors will be set up
 to run the steps of a job.
+
 To run a job's steps in parallel,
-set the `parallelism` key to a value greater than 1.
+set the `parallelism` key to a value greater than 1:
+
+```yaml
+version: 2
+jobs:
+  test:
+    parallelism: 5
+```
 
 For more information,
 see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
-
-## Installing the CircleCI Local CLI
-
-Running tests in parallel requires the CircleCI Local CLI.
-For installation instructions,
-refer to the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document
 
 ## Using Pattern-Matching to Create Groups of Tests
 
@@ -69,7 +77,7 @@ by using the `echo` command in your `.circleci/config.yml` file:
 ```yaml
 version: 2
 jobs:
-  test-job:
+  test:
     steps:
       - run:
           command: |

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -154,27 +154,3 @@ You can also split classnames
 by using the `--timings-type` flag.
 
     cat my_java_test_classnames | circleci tests split --split-by=timings --timings-type=classname
-
-## Test Balancing Libraries
-
-The following libraries have built-in support for the CircleCI environment variables:
-
-* [Knapsack](https://github.com/ArturT/knapsack) - Deterministic test suite split. A ruby gem for Knapsack will automatically divide your tests between parallel CI nodes, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber, Minitest, Spinach and Turnip.
-
-```yaml
-- run: bundle exec rake knapsack:rspec
-```
-
-* [Knapsack Pro](https://github.com/KnapsackPro/knapsack_pro-ruby) - Dynamic optimal test suite split. Knapsack Pro is a more advanced version of knapsack gem. It has automated recording of tests time execution across branches, commits and it can distribute tests across parallel CI nodes with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split.
-
-```yaml
-# some tests that are not balanced and executed only on first CI node
-- run: case $CIRCLE_NODE_INDEX in 0) npm test ;; esac
-
-# auto-balancing CI build time execution to be flat and optimal (as fast as possible).
-# Queue Mode does dynamic tests allocation so the previous not balanced run command won't
-# create a bottleneck on the CI node
-- run: bundle exec rake knapsack_pro:queue:rspec
-```
-
-{% include third-party-info.html app='Knapsack'%}

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -64,8 +64,6 @@ This set of files is run across the number of machines you specified with the `p
 
 #### Supported Globbing Patterns
 
-The following patterns are used to glob files:
-
 - `*` matches any sequence of characters (excluding path separators)
 - `**` matches any sequence of characters (including path separators)
 - `?` matches any single character (excluding path separators)

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -38,7 +38,19 @@ to run the steps of a job.
 For more information,
 see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
 
-### Splitting Tests Into Groups
+### Installing the Local CLI Tool
+
+Running tests in parallel requires the CircleCI Local CLI.
+For more information,
+see the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli) document.
+
+### Globbing and Splitting
+
+Test allocation across containers is file-based.
+You can make groups of files by
+specifying rules for globbing or splitting.
+
+The number of containers available for running tests is defined by the `parallelism` key.
 
 Use the circle tests glob command to specify multiple globs to merge using a pattern, for example: 
 	`circleci tests glob "tests/unit/*.java" "tests/functional/*.java"`

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -17,7 +17,15 @@ before running the tests.
 
 ## Overview
 
-One of the most powerful features of CircleCI is the ability to run your tests in parallel. This section describes how to use `circleci` commands in your `config.yml` file to merge and split tests with the hosted CircleCI CLI for faster builds. See [Writing Jobs with Steps]({{ site.baseurl }}/2.0/configuration-reference/#jobs) for information about setting the `parallelism` key in your configuration file. 
+If your project has a large suite of tests,
+it will take more time
+to run those tests on one machine.
+To reduce this time,
+you can spread your tests across multiple machines.
+This requires
+specifying a parallelism level for your tests
+and using the CircleCI Local CLI
+to split the tests into groups.
 
 Use the circle tests glob command to specify multiple globs to merge using a pattern, for example: 
 	`circleci tests glob "tests/unit/*.java" "tests/functional/*.java"`

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -9,7 +9,7 @@ order: 60
 
 *[Test]({{ site.baseurl }}/2.0/test/) > Running Tests in Parallel*
 
-If your project has a lot of tests,
+If your project has a large number of tests,
 it will need more time to run them on one machine.
 To reduce this time,
 you can run tests in parallel
@@ -17,12 +17,6 @@ by spreading them across multiple machines.
 This requires specifying a parallelism level
 and using the CircleCI Local CLI
 to glob or split test files.
-
-## Requirement
-
-Running tests in parallel requires the CircleCI Local CLI.
-For installation instructions,
-refer to the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document.
 
 ## Specifying a Job's Parallelism Level
 
@@ -48,7 +42,11 @@ see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference
 
 Test allocation across containers is file-based.
 You can make groups of files by
-specifying patterns for globbing or splitting files.
+using the CircleCI Local CLI
+to specifying patterns for globbing or splitting files
+
+To install the Local CLI,
+refer to the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document.
 
 ### Globbing
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -24,8 +24,8 @@ To reduce this time,
 you can spread your tests across multiple machines.
 This requires
 specifying a parallelism level for your tests
-and using the CircleCI Local CLI
-to split the tests into groups.
+and splitting the tests into groups
+using the CircleCI Local CLI.
 
 Use the circle tests glob command to specify multiple globs to merge using a pattern, for example: 
 	`circleci tests glob "tests/unit/*.java" "tests/functional/*.java"`

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -30,11 +30,12 @@ using the CircleCI Local CLI.
 ### Specifying a Job's Parallelism Level
 
 Test suites are conventionally defined at the [job]({{ site.baseurl }}/2.0/jobs-steps/#sample-configuration-with-parallel-jobs) level.
-To run a job's steps in parallel,
-set the `parallelism` key in your `.circleci/config.yml`
-to a value greater than 1.
-This value specifies how many independent executors will be set up
+The `parallelism` key specifies
+how many independent executors will be set up
 to run the steps of a job.
+To run a job's steps in parallel,
+set the `parallelism` key to a value greater than 1.
+
 For more information,
 see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -9,23 +9,14 @@ order: 60
 
 *[Test]({{ site.baseurl }}/2.0/test/) > Running Tests in Parallel*
 
-CircleCI can run your tests in parallel,
-allowing you to validate your code more quickly.
-This document describes
-how to organize tests
-before running them in parallel.
-
-## Overview
-
-If your project has a large suite of tests,
-it will take more time
-to run those tests on one machine.
+If your project has a lot of tests,
+it will need more time to run them on one machine.
 To reduce this time,
-you can spread your tests across multiple machines.
-This requires
-specifying a parallelism level
-and globbing or splitting test files
-using the CircleCI Local CLI.
+you can run tests in parallel
+by spreading them across multiple machines.
+This requires specifying a parallelism level
+and using the CircleCI Local CLI
+to glob or split test files.
 
 ## Specifying a Job's Parallelism Level
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -13,7 +13,7 @@ CircleCI can run your tests in parallel,
 allowing you to save time and resources.
 This document describes
 how to split tests into groups
-before running the tests in parallel.
+before running the tests.
 
 ## Overview
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -26,9 +26,10 @@ how many independent executors will be set up
 to run the steps of a job.
 
 To run a job's steps in parallel,
-set the `parallelism` key to a value greater than 1:
+set the `parallelism` key to a value greater than 1.
 
 ```yaml
+# ~/.circleci/config.yml
 version: 2
 jobs:
   test:
@@ -38,14 +39,14 @@ jobs:
 For more information,
 see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
 
-## Using the CircleCI Local CLI to Group Test Files
+## Using the CircleCI Local CLI to Split Tests
 
 Test allocation across containers is file-based
 and requires the CircleCI Local CLI.
 To install the CLI,
 see the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/#installing-the-circleci-local-cli-on-macos-and-linux-distros) document.
 
-### Globbing
+### Globbing Test Files
 
 The CLI supports globbing test files
 using the following patterns:
@@ -56,20 +57,16 @@ using the following patterns:
 - `[abc]` matches any character (excluding path separators) against characters in brackets
 - `{foo,bar,...}` matches a sequence of characters, if any of the alternatives in braces matches
 
-To use these patterns to group test files,
-use the `circleci tests glob` command:
+To glob test files,
+pass one or more patterns to the `circleci tests glob` command.
 
     circleci tests glob "tests/unit/*.java" "tests/functional/*.java"
 
-In this example,
-the `glob` command takes the Java files in the `tests/unit/` and `tests/functional/` directories as arguments.
-This set of files is run across the number of machines
-specified by the `parallelism` key.
-
-You can check the results of pattern-matching
-by using the `echo` command in your `.circleci/config.yml` file:
+To check the results of pattern-matching,
+use the `echo` command.
 
 ```yaml
+# ~/.circleci/config.yml
 version: 2
 jobs:
   test:
@@ -82,21 +79,45 @@ jobs:
 
 ### Splitting Test Files
 
-When running parallel builds,
-the CircleCI Local CLI can split a list of test files across machines.o
+The CLI supports splitting tests across machines
+when running parallel builds.
+To do this,
+pass a list of filenames to the `circleci tests split` command.
 
-The `circleci` CLI can be used to split a list of test files or classnames when running parallel builds on 2.0. The CLI uses the environment to look up the total number of containers, along with the current container index. Then, it uses deterministic splitting algorithms to return a distinct subset of the input filenames or classnames on each container.
+    circleci tests split test_filenames.txt
 
-The list of items to split can be provided via standard input or as a file argument, as follows:
+The CLI looks up the number of containers
+specified by the `parallelism` key,
+along with the current container index.
+Then, it uses deterministic splitting algorithms
+to spread the test files across all available containers.
 
-- Piping: `circleci tests glob test/**/*.java | circleci tests split`
-- `stdin` redirection: `circleci tests split < /path/to/items/to/split`
-- Process substitution: `circleci tests split <(circleci tests glob test/**/*.java)`
-- From file: `circleci tests split test_filenames.txt`
+#### Splitting by Name
 
-By default, it is assumed that the items being split are filenames and should be split by name. However, the tool can also split by file size or may use historical data to split by test runtimes.
+By default,
+`circleci tests split` expects a list of filenames
+and splits tests alphabetically by test name.
+There are a few ways to provide this list:
 
-Items can be split by `name`, `filesize` (for filepaths), or `timings` (when run on CircleCI). Splitting by name is the default and splits items alphabetically, for example:
+Create a text file with test filenames.
+
+    circleci tests split test_filenames.txt
+
+Provide a path to the test files.
+
+    circleci tests split < /path/to/items/to/split
+
+Or pipe a glob of test files.
+
+    circleci tests glob test/**/*.java | circleci tests split
+
+However, the tool can also split by file size or may use historical data to split by test runtimes.
+
+#### Splitting by Filesize
+
+The CLI can also split by filesize.
+
+`filesize` (for filepaths), or `timings` (when run on CircleCI).
 
 `circleci tests glob "**/*.go" | circleci tests split`
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -12,8 +12,8 @@ order: 60
 CircleCI can run your tests in parallel,
 allowing you to validate your code more quickly.
 This document describes
-how to split tests into groups
-before running the tests.
+how to organize tests
+before running them.
 
 ## Overview
 
@@ -23,8 +23,8 @@ to run those tests on one machine.
 To reduce this time,
 you can spread your tests across multiple machines.
 This requires
-specifying a parallelism level for your tests
-and splitting the tests into groups
+specifying a parallelism level
+and globbing or splitting tests
 using the CircleCI Local CLI.
 
 ### Specifying a Job's Parallelism Level
@@ -33,8 +33,8 @@ Test suites are conventionally defined at the [job]({{ site.baseurl }}/2.0/jobs-
 To run a job's steps in parallel,
 set the `parallelism` key in your `.circleci/config.yml`
 to a value greater than 1.
-For more information about the `parallelism` key,
-see the [configuration reference](https://circleci.com/docs/2.0/configuration-reference/#parallelism).
+For more information,
+see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
 
 ### Splitting Tests Into Groups
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -27,6 +27,10 @@ specifying a parallelism level for your tests
 and splitting the tests into groups
 using the CircleCI Local CLI.
 
+### Specifying a Job's Parallelism Level
+
+### Splitting Tests Into Groups
+
 Use the circle tests glob command to specify multiple globs to merge using a pattern, for example: 
 	`circleci tests glob "tests/unit/*.java" "tests/functional/*.java"`
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -132,39 +132,42 @@ Or pipe a glob of test files.
 When provided with filepaths,
 the CLI can also split by filesize.
 To do this,
-use the `--split-by` flag.
+use the `--split-by` flag with the `filesize` split type.
 
     circleci tests glob "**/*.go" | circleci tests split --split-by=filesize
 
-#### Splitting by Runtime
+#### Splitting by Timings
 
-may use historical data to split by test runtimes.
+CircleCI automatically saves timing data from previous successful runs to a default location (`$CIRCLE_INTERNAL_TASK_DATA/circle-test-results`).
+Ensure you are using the [`store_test_results` key]({{ site.baseurl }}/2.0/configuration-reference/#store_test_results)
+to save your timing data,
+or there will be no historical data available.
 
-The `timings` split type uses historical timing data to weight the split. CircleCI automatically makes timing data from previous successful runs available inside your container in a default location so the CLI tool can discover them (`$CIRCLE_INTERNAL_TASK_DATA/circle-test-results`). Make sure you are using the [`store_test_results` key]({{ site.baseurl }}/2.0/configuration-reference/#store_test_results) to save your test timing data, otherwise there will not be any historical timing data available.
+To split by timings,
+use the `--split-by` flag with the `timings` split type.
 
-`timings` (when run on CircleCI).
+    circleci tests glob "**/*.go" | circleci tests split --split-by=timings
 
-When splitting by `timings`, the tool will assume it’s splitting filenames. If you’re splitting classnames, you’ll need to specify that with the `--timings-type` flag, as in the following examples:
+By default,
+the CLI assumes that it is splitting filenames.
+You can also split classnames
+by using the `--timings-type` flag.
 
-`circleci tests glob "**/*.go" | circleci tests split --split-by=timings --timings-type=filename`
+    cat my_java_test_classnames | circleci tests split --split-by=timings --timings-type=classname
 
-`cat my_java_test_classnames | circleci tests split --split-by=timings --timings-type=classname`
-
-### Balancing Libraries
+## Test Balancing Libraries
 
 The following libraries have built-in support for the CircleCI environment variables:
 
-{% include third-party-info.html app='Knapsack'%}
-
 * [Knapsack](https://github.com/ArturT/knapsack) - Deterministic test suite split. A ruby gem for Knapsack will automatically divide your tests between parallel CI nodes, as well as making sure each job runs in comparable time. Supports RSpec, Cucumber, Minitest, Spinach and Turnip.
 
-```
+```yaml
 - run: bundle exec rake knapsack:rspec
 ```
 
 * [Knapsack Pro](https://github.com/KnapsackPro/knapsack_pro-ruby) - Dynamic optimal test suite split. Knapsack Pro is a more advanced version of knapsack gem. It has automated recording of tests time execution across branches, commits and it can distribute tests across parallel CI nodes with predetermine split (regular mode) or in a dynamic way (queue mode) to get most optimal test suite split.
 
-```
+```yaml
 # some tests that are not balanced and executed only on first CI node
 - run: case $CIRCLE_NODE_INDEX in 0) npm test ;; esac
 
@@ -173,3 +176,5 @@ The following libraries have built-in support for the CircleCI environment varia
 # create a bottleneck on the CI node
 - run: bundle exec rake knapsack_pro:queue:rspec
 ```
+
+{% include third-party-info.html app='Knapsack'%}


### PR DESCRIPTION
Monster PR that fixes #1471. This is a full revision of the test splitting document with the following goals:

- clarify how split tests are actually run
- reorganize and reorder for better flow
- a slew of language improvements