### PR TITLE
JSON key should not be encoded

### DIFF
--- a/jekyll/_cci2/google-auth.md
+++ b/jekyll/_cci2/google-auth.md
@@ -29,13 +29,14 @@ Go to Google's [Getting Started with Authentication][] article and follow the in
 5. Paste the JSON file from Step 1 into the **Value** field.
 6. Click the **Add Variable** button.
 
-### Decode and Store Service Account
+### Store Service Account
 
-To authenticate the `gcloud` tool, you will first need to decode the environment variable you created above. You could do that by adding the following command to `config.yml`:
+To authenticate the `gcloud` tool,
+store the contents of the environment variable in another file.
+To do this,
+add the following command to `.circleci/config.yml`.
 
-    echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
-
-This will decode the secret into a file named `gcloud-service-key.json`.
+    echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
 
 ### Authenticate the `gcloud` Tool
 

--- a/jekyll/_cci2/google-auth.md
+++ b/jekyll/_cci2/google-auth.md
@@ -22,11 +22,11 @@ Go to Google's [Getting Started with Authentication][] article and follow the in
 
 ### Add Service Account to CircleCI Environment
 
-1. Encode the JSON file you downloaded in base64 format and copy the result to the clipboard.
+1. Copy the JSON file you downloaded to the clipboard.
 2. In the CircleCI application, go to your project's settings by clicking the gear icon in the top right.
 3. In the **Build Settings** section, click **Environment Variables**, then click the **Add Variable** button.
 4. Name the variable. In this example, the variable is named `$GCLOUD_SERVICE_KEY`.
-5. Paste the contents from Step 1 into the **Value** field.
+5. Paste the JSON file from Step 1 into the **Value** field.
 6. Click the **Add Variable** button.
 
 ### Decode and Store Service Account

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -91,7 +91,7 @@ jobs:
       - image: google/cloud-sdk
     steps:
       - run:
-        name: Decode and Store Service Account
+        name: Store Service Account
         command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
 ```
 

--- a/jekyll/_cci2/google-container-engine.md
+++ b/jekyll/_cci2/google-container-engine.md
@@ -74,13 +74,14 @@ jobs:
       - image: gcr.io/project/image-name
         auth:
           username: _json_key  # default username when using a JSON key file to authenticate
-          password: $GCLOUD_SERVICE_KEY  # encoded service account you created
+          password: $GCLOUD_SERVICE_KEY  # JSON service account you created
 ```
 
 ### Add a Job Step to Decode Credentials
 
 To authenticate the `gcloud` tool,
-add a job step to decode the `GCLOUD_SERVICE_KEY` environment variable:
+add a job step
+to transfer the contents of `GCLOUD_SERVICE_KEY` into a local file.
 
 ```yaml
 version: 2
@@ -91,13 +92,13 @@ jobs:
     steps:
       - run:
         name: Decode and Store Service Account
-        command: echo $GCLOUD_SERVICE_KEY | base64 --decode --ignore-garbage > ${HOME}/gcloud-service-key.json
+        command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
 ```
 
 ### Configure `gcloud`
 
 Finally, as part of your deployment commands,
-update `gcloud`, authenticate, and set appropriate defaults for your project:
+update `gcloud`, authenticate, and set appropriate defaults for your project.
 
 ```bash
 gcloud --quiet components update


### PR DESCRIPTION
Fixes #2193.

Some cleanup around base64 encoding of the JSON service account for GCP authentication.