### PR TITLE
add link to wiki page in footer

### DIFF
--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -5,7 +5,11 @@
 </p>
 <ul>
 	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}" target="_blank">Suggest an edit to this page</a> (please read the <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs" target="_blank">contributing guide</a> first).</li>
-	<li><a href="{{ site.gh_url }}/issues/new?body=This%20issue%20is%20about%20<https://circleci.com/docs{{ page.url }}>%20(source%20file%3A%20<{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}>)" target="_blank">Open an issue about this page</a> to report a problem.</li>
+	<li>
+        To report a problem,
+        see the <a href="{{ site.gh_url }}/wiki/GitHub-Issues-Workflow">GitHub Issues Workflow wiki page</a>
+        and <a href="{{ site.gh_url }}/issues/new?body=This%20issue%20is%20about%20<https://circleci.com/docs{{ page.url }}>%20(source%20file%3A%20<{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}>)" target="_blank">open an issue about this page</a>.
+    </li>
 	<li><a href="https://discuss.circleci.com/" target="_blank">Visit our forum 'Discuss'</a> to ask questions and search for solutions.</li>
 </ul>
 <hr />


### PR DESCRIPTION
Follow-up to new wiki page. This change aims to send people to the wiki page before filing an issue.