### PR TITLE
Document CIRCLE_WORKFLOW_ID in env-vars.md

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -351,3 +351,7 @@ The directory where test timing data can be found.
 `CIRCLE_STAGE`
 
 The job being executed. The default 2.0 job is `build` without using Workflows.
+
+`CIRCLE_WORKFLOW_ID`
+
+A unique identifier for the current workflow instance that the build is running in. This identifier will be the same for every job that runs within this instance of the workflow.


### PR DESCRIPTION
I wanted a way to consistently name artifacts created by one job that could be referenced by another job (i.e. for tagging Docker images). It took me a long time to realize that the undocumented `CIRCLE_WORKFLOW_ID` env var was available to me. 

I don't know if `CIRCLE_WORKFLOW_ID` is an "official" env var, and whether the description is accurate or not.