### PR TITLE
Updates YAML syntax in Postgres config examples.

### DIFF
--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -110,16 +110,16 @@ jobs:
     docker:
       - image: ruby:2.3.1
         environment:
-          PG_HOST=localhost
-          PG_USER=ubuntu
-          RAILS_ENV=test
-          RACK_ENV=test
+          PG_HOST: localhost
+          PG_USER: ubuntu
+          RAILS_ENV: test
+          RACK_ENV: test
       # The following example uses the official postgres 9.6 image, you may also use circleci/postgres:9.6 
       # which includes a few enhancements and modifications. It is possible to use either image.
       - image: postgres:9.6
         environment:
-          POSTGRES_USER=ubuntu
-          POSTGRES_DB=db_name
+          POSTGRES_USER: ubuntu
+          POSTGRES_DB: db_name
     steps:
       - checkout
       - run:


### PR DESCRIPTION
It's possible that something else was going on, but I believe my config was not working due to the `=` syntax in the example. It appears to work now that I switched to `:`.