### PR TITLE
Add note about `setup_circle_ci`

### DIFF
--- a/jekyll/_cci2/ios-codesigning.md
+++ b/jekyll/_cci2/ios-codesigning.md
@@ -68,6 +68,8 @@ On CircleCI, Fastlane Match will need to be run every time you are
 going to generate an Ad-hoc build of your app. The easiest way to
 achieve that is to create a custom Fastlane lane just for that. It is best practice to create a Fastfile similar to the following:
 
+**Note:** For `fastlane match` to work correctly, you _must_ add `setup_circle_ci` to `before_all` in your `Fastfile`. This ensures that a temporary Fastlane keychain is used.
+
 ```
 # fastlane/Fastfile
 default_platform :ios


### PR DESCRIPTION
I spent some time debugging my builds on CircleCI after migrating to 2.0 until I discovered that it was necessary to add this command to `before_all`. I think that this can be more explicit in the documentation.

Or at least I think the documentation should explain that `setup_circle_ci` is an actual Fastlane command and not just an example of a command one might add to their `Fastfile`.

Thanks 🙂 