### PR TITLE
Update high-availability.md

### DIFF
--- a/jekyll/_cci2/high-availability.md
+++ b/jekyll/_cci2/high-availability.md
@@ -17,7 +17,7 @@ This document describes how to to set up a highly available CircleCI 2.0 install
 
 Before you configure an existing CircleCI installation for high availability, you must update your license by contacting our account team or by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new). Configuring an existing CircleCI installation for HA without updating the license through the CircleCI customer success team is **not** supported.
 
-The steps in this document also assume you have an existing CircleCI 2.0 Services machine and Builders in use. To configure your existing CircleCI 2.0 installation for high availability, you must export the databases currently in use on the Services machine to new AWS instances. This procedure uses three instances for the MongoDB replica set and a new AWS Auto Scaling group for PostgreSQL.
+The steps in this document also assume that you have an existing clustered Terraform installation of CircleCI 2.0 on AWS—see [Installing CircleCI 2.0 on Amazon Web Services with Terraform]({{ site.baseurl }}/2.0/aws) for more information. To configure your existing CircleCI 2.0 installation for high availability, you must export the databases currently in use on the Services machine to new AWS instances. This procedure uses three instances for the MongoDB replica set and a new AWS Auto Scaling group for PostgreSQL.
 
 ## MongoDB Instance Requirements
 


### PR DESCRIPTION
folks were getting tripped up because our HA docs are not a complete guide to setting up CircleCI 2.0*—we assume some knowledge of our general 2.0 installation process. adding an explicit link to that page up top should clarify things.

_* for example, we don't mention anywhere here (nor should we, given how this page is currently structured) that you need to configure VM service in Replicated in order to use the `machine` executor or `setup_remote_docker`_