### PR TITLE
remove link to discuss

### DIFF
--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -10,6 +10,5 @@
         see the <a href="{{ site.gh_url }}/wiki/GitHub-Issues-Workflow">GitHub Issues Workflow wiki page</a>
         and <a href="{{ site.gh_url }}/issues/new?body=This%20issue%20is%20about%20<https://circleci.com/docs{{ page.url }}>%20(source%20file%3A%20<{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}>)" target="_blank">open an issue about this page</a>.
     </li>
-	<li><a href="https://discuss.circleci.com/" target="_blank">Visit our forum 'Discuss'</a> to ask questions and search for solutions.</li>
 </ul>
 <hr />


### PR DESCRIPTION
@keybits this is an adjustment of the issues we talked about last week. We had decided to add a link to the support center in the footer after the meeting re: Discuss.

However! After discussing with @michelle-luna, we feel like the footer should be reserved for links that explicitly help improve documentation. Since both Discuss and the Support Center are contained in the "Support" dropdown, we felt like it made sense to keep things consistent and not double link.

Resolves [CIRCLE-10317](https://circleci.atlassian.net/browse/CIRCLE-10317).