### PR TITLE
Update Jekyll to v3.8.1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 ruby '2.5.1'
 
-gem 'jekyll', "3.7.2"
+gem 'jekyll', "3.8.1"
 gem 'html-proofer', "3.8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       http_parser.rb (~> 0.6.0)
     ethon (0.11.0)
       ffi (>= 1.3.0)
-    eventmachine (1.2.5)
+    eventmachine (1.2.6)
     ffi (1.9.23)
     forwardable-extended (2.6.0)
     html-proofer (3.8.0)
@@ -31,7 +31,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.2)
+    jekyll (3.8.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -86,7 +86,7 @@ PLATFORMS
 
 DEPENDENCIES
   html-proofer (= 3.8.0)
-  jekyll (= 3.7.2)
+  jekyll (= 3.8.1)
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 jekyll:
-    image: jekyll/jekyll:3.7.2
+    image: jekyll/jekyll:3.8.0
     command: jekyll serve --watch --incremental
     ports:
         - 4000:4000


### PR DESCRIPTION
This updates Jekyll to the last major release (v3.8.x) before Jekyll 4.0 which will have breaking changes. We'll need to pay attention to the changes in the future.

The Docker image we use for local dev is updated only to v3.8.0 for now as they haven't made an image for the latest point release.