### PR TITLE
Fix md proofer errors

### DIFF
--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -13,7 +13,7 @@ This document describes how to initiate jobs using the CircleCI API. **Note:** I
 
 The following example initiates a `deploy_production` job by using `curl`.
 
-```YAML
+```yaml
 curl -u ${CIRCLE_API_TOKEN}: \
      -d build_parameters[CIRCLE_JOB]=deploy_production \
      https://circleci.com/api/v1.1/project/<vcs-type>/<org>/<repo>/tree/master
@@ -29,7 +29,7 @@ A few notes about this example:
 
 The next example demonstrates a configuration for building docker images with `setup_remote_docker` only for builds that should be deployed. 
 
-```YAML
+```yaml
 version: 2
 jobs:
   build:

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -103,7 +103,7 @@ This section describes how to get [core dumps](http://man7.org/linux/man-pages/m
 Following is a full `config.yml` that compiles the example C abort program, and collects the core dumps as artifacts.
 
 ```yaml
-version: 2.0
+version: 2
 jobs:
   build:
     docker:
@@ -113,7 +113,7 @@ jobs:
       - checkout
       - run: make
       - run: |
-    # tell the operating system to remove the file size limit on core dump files 
+          # tell the operating system to remove the file size limit on core dump files 
           ulimit -c unlimited
           ./dump
       - run:

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -46,7 +46,7 @@ to find artifacts at a given path within the application.
 
 To upload artifacts created during builds, use the following example:
 
-```YAML
+```yaml
 version: 2
 jobs:
   build:
@@ -102,7 +102,7 @@ This section describes how to get [core dumps](http://man7.org/linux/man-pages/m
 
 Following is a full `config.yml` that compiles the example C abort program, and collects the core dumps as artifacts.
 
-```YAML
+```yaml
 version: 2.0
 jobs:
   build:

--- a/jekyll/_cci2/build-publish-snap-packages.md
+++ b/jekyll/_cci2/build-publish-snap-packages.md
@@ -21,7 +21,7 @@ To build a snap in any environment (local, company servers CI, etc) there needs 
 
 ## Build Environment
 
-```YAML
+```yaml
 ...
 version: 2
 jobs:
@@ -35,7 +35,7 @@ The `docker` executor is used here with the [`cibuilds/snapcraft`](https://githu
 
 ## Running Snapcraft
 
-```YAML
+```yaml
 ...
     steps:
       - checkout
@@ -66,7 +66,7 @@ base64 snapcraft.login | xsel --clipboard
 
 1. Create a Snapcraft "login file" on your local machine that we upload to CircleCI. Assuming your local machine already has these tools installed and you are logged in to the Snapcraft Store (`snapcraft login`), we use the command `snapcraft export-login snapcraft.login` to generate a login file called `snapcraft.login`. As we don't want this file visible to the public or stored in the Git repository, we will base64 encode this file and store it in a [private environment variable](https://circleci.com/docs/2.0/env-vars/#adding-environment-variables-in-the-app) called `$SNAPCRAFT_LOGIN_FILE`.
 
-```YAML
+```yaml
 ...
       - run:
           name: "Publish to Store"
@@ -99,7 +99,7 @@ We can utilize multiple jobs to better organize our snap build. A job to build/c
 
 Utilize CircleCI `workspaces` to move a generated snap file between jobs when necessary. Here's an example showing a snippet from the "from" job and a snippet of the "to" job:
 
-```YAML
+```yaml
 ... # from a job that already has the snap
       - persist_to_workspace:
           root: .
@@ -116,7 +116,7 @@ Below is a complete example of how a snap package could be built on CircleCI. Th
 
 ## Full Example Config
 
-```YAML
+```yaml
 version: 2
 jobs:
   build:

--- a/jekyll/_cci2/build-publish-snap-packages.md
+++ b/jekyll/_cci2/build-publish-snap-packages.md
@@ -22,13 +22,13 @@ To build a snap in any environment (local, company servers CI, etc) there needs 
 ## Build Environment
 
 ```yaml
-...
+#...
 version: 2
 jobs:
   build:
     docker:
       - image: cibuilds/snapcraft:stable
-...
+#...
 ```
 
 The `docker` executor is used here with the [`cibuilds/snapcraft`](https://github.com/cibuilds/snapcraft) Docker image. This image is based on the official [`snapcore/snapcraft`](https://github.com/snapcore/snapcraft/tree/master/docker) Docker image by Canonical with all of the command-line tools you'd want to be installed in a CI environment. This image includes the `snapcraft` command which will be used to build the actual snap.

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -136,18 +136,23 @@ The job and [remote docker]({{ site.baseurl }}/2.0/glossary/#remote-docker) run 
 It’s impossible to start a service in remote docker and ping it directly from a primary container (and vice versa). To solve that, you’ll need to interact with a service from remote docker, as well as through the same container:
 
 ```yaml
-# start service and check that it’s running
-- run: |
-    docker run -d --name my-app my-app
-    docker exec my-app curl --retry 10 --retry-connrefused http://localhost:8080
+#...
+      - run:
+          name: "Start Service and Check That it’s Running"
+          command: |
+            docker run -d --name my-app my-app
+            docker exec my-app curl --retry 10 --retry-connrefused http://localhost:8080
+#...
 ```
 
 A different way to do this is to use another container running in the same network as the target container:
 
 ```yaml
-- run: |
-    docker run -d --name my-app my-app
-    docker run --network container:my-app appropriate/curl --retry 10 --retry-connrefused http://localhost:8080
+#...
+      - run: |
+          docker run -d --name my-app my-app
+          docker run --network container:my-app appropriate/curl --retry 10 --retry-connrefused http://localhost:8080
+#...
 ```
 
 ### Mounting Folders

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -18,7 +18,7 @@ This document explains how to build Docker images for deploying elsewhere or for
 
 To build Docker images for deployment, you must use a special `setup_remote_docker` key which creates a separate environment for each build for security. This environment is remote, fully-isolated and has been configured to execute Docker commands. If your {% comment %} TODO: Job {% endcomment %}build requires `docker` or `docker-compose` commands, add the `setup_remote_docker` step into your `.circleci/config.yml`:
 
-```YAML
+```yaml
 jobs:
   build:
     steps:
@@ -44,7 +44,7 @@ CPUs | Processor                 | RAM | HD
 
 Following is an example of building a Docker image using `machine` with the default image:
 
-```YAML
+```yaml
 version: 2
 jobs:
  build:
@@ -67,7 +67,7 @@ jobs:
 
 Following is an example where we build and push a Docker image for our [demo docker project](https://github.com/CircleCI-Public/circleci-demo-docker):
 
-```YAML
+```yaml
 version: 2
 jobs:
   build:
@@ -111,7 +111,7 @@ Let’s break down what’s happening during this build’s execution:
 
 If your {% comment %} TODO: Job {% endcomment %}build requires a specific docker image, you can set it as an `image` attribute:
 
-```YAML
+```yaml
       - setup_remote_docker:
           version: 17.05.0-ce
 ```
@@ -135,7 +135,7 @@ The job and [remote docker]({{ site.baseurl }}/2.0/glossary/#remote-docker) run 
 ### Accessing Services
 It’s impossible to start a service in remote docker and ping it directly from a primary container (and vice versa). To solve that, you’ll need to interact with a service from remote docker, as well as through the same container:
 
-```YAML
+```yaml
 # start service and check that it’s running
 - run: |
     docker run -d --name my-app my-app
@@ -144,7 +144,7 @@ It’s impossible to start a service in remote docker and ping it directly from 
 
 A different way to do this is to use another container running in the same network as the target container:
 
-```YAML
+```yaml
 - run: |
     docker run -d --name my-app my-app
     docker run --network container:my-app appropriate/curl --retry 10 --retry-connrefused http://localhost:8080

--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -20,7 +20,7 @@ A good example is package dependency managers such as Yarn, Bundler, or Pip. Wit
 Caching keys are simple to configure. The following example updates a cache if it changes by using checksum of `pom.xml` with a cascading fallback:
 
 {% raw %}
-```YAML
+```yaml
     steps:
       - restore_cache:
          keys:
@@ -102,7 +102,7 @@ CircleCI restores caches in the order of keys listed in the `restore_cache` step
 In the example below, two keys are provided:
 
 {% raw %}
-```YAML
+```yaml
     steps:
       - restore_cache:
           keys:
@@ -136,7 +136,7 @@ The extra control and power in CircleCI 2.0 manual dependency caching requires t
 
 To save a cache of a file or directory, add the `save_cache` step to a job in your `.circleci/config.yml` file:
 
-```YAML
+```yaml
     steps:
       - save_cache:
           key: my-cache
@@ -179,7 +179,7 @@ Template | Description
 The following example demonstrates how to use `restore_cache` and `save_cache` together with templates and keys in your `.circleci/config.yml` file.
 
 {% raw %}
-```YAML
+```yaml
     docker:
       - image: customimage/ruby:2.3-node-phantomjs-0.0.1
         environment:

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -298,7 +298,7 @@ A working `.circleci/config.yml` section might look like this:
       - run: npm install
       - run: mkdir ~/junit
       - run:
-          command: karma start ./karma.conf.js:
+          command: karma start ./karma.conf.js
           environment:
             JUNIT_REPORT_PATH: ./junit/
             JUNIT_REPORT_NAME: test-results.xml

--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -20,7 +20,7 @@ Steps are actions that need to be taken to perform your job. ![step illustration
 
 
 ```yaml
-...
+#...
     steps:
       - checkout # Special step to checkout your source code
       - run: # Run step to execute commands, see
@@ -29,7 +29,7 @@ Steps are actions that need to be taken to perform your job. ![step illustration
           command: make test # executable command run in
           # non-login shell with /bin/bash -eo pipefail option
           # by default.
-...          
+#...          
 ```          
 
 ## Image
@@ -83,7 +83,7 @@ Each job may contain special steps for caching dependencies from previous jobs t
 {% raw %}
 
 ```yaml
-version 2
+version: 2
 jobs:
   build1:
     docker: # Each job requires specifying an executor
@@ -120,7 +120,7 @@ Workflows define a list of jobs and their run order. It is possible to run jobs 
 
 {% raw %}
 ```yaml
-version 2
+version: 2
 jobs:
   build1:
     docker:

--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -19,7 +19,7 @@ This document provides an overview of the concepts used in CircleCI 2.0 in the f
 Steps are actions that need to be taken to perform your job. ![step illustration]( {{ site.baseurl }}/assets/img/docs/concepts_step.png) Steps are usually a collection of executable commands. For example, the `checkout` step checks out the source code for a job over SSH. Then, the `run` step executes the `make test` command using a non-login shell by default.
 
 
-```YAML
+```yaml
 ...
     steps:
       - checkout # Special step to checkout your source code
@@ -37,7 +37,7 @@ Steps are actions that need to be taken to perform your job. ![step illustration
 An image is a packaged system that has the instructions for creating a running container. ![image illustration]( {{ site.baseurl }}/assets/img/docs/concepts_image.png)
  The Primary Container is defined by the first image listed in `.circleci/config.yml` file. This is where commands are executed for jobs using the Docker executor.
 
- ```YAML
+ ```yaml
  version 2
  jobs:
    build1: # job name
@@ -82,7 +82,7 @@ Each job may contain special steps for caching dependencies from previous jobs t
 
 {% raw %}
 
-```YAML
+```yaml
 version 2
 jobs:
   build1:
@@ -119,7 +119,7 @@ Workflows define a list of jobs and their run order. It is possible to run jobs 
 ![workflows illustration]( {{ site.baseurl }}/assets/img/docs/workflow_detail.png)
 
 {% raw %}
-```YAML
+```yaml
 version 2
 jobs:
   build1:
@@ -179,7 +179,7 @@ Each workflow has a temporary workspace associated with it. The workspace can be
 ![workflow illustration]( {{ site.baseurl }}/assets/img/docs/concepts_workflow.png)
 
   {% raw %}
-  ```YAML
+  ```yaml
 version: 2
 jobs:
   build1:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -221,6 +221,7 @@ You can use one of the `year-month` versioned images to pin the version used by 
 **Example:** use an Ubuntu version `14.04` image with Docker `17.06.1-ce` and docker-compose `1.14.0`:
 
 ```yaml
+version: 2
 jobs:
   build:
     machine:
@@ -232,9 +233,10 @@ The machine executor supports [Docker Layer Caching]({{ site.baseurl }}/2.0/dock
 **Example**
 
 ```yaml
+version: 2
 jobs:
   build:
-    machine: true
+    machine:
       docker_layer_caching: true    # default - false
 ```
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -152,7 +152,7 @@ jobs:
 
 If you are using a private image, you can specify the username and password in the `auth` field.  To protect the password, you can set it as a project setting which you reference here:
 
-```YAML
+```yaml
 jobs:
   build:
     docker:
@@ -220,7 +220,7 @@ You can use one of the `year-month` versioned images to pin the version used by 
 
 **Example:** use an Ubuntu version `14.04` image with Docker `17.06.1-ce` and docker-compose `1.14.0`:
 
-```YAML
+```yaml
 jobs:
   build:
     machine:
@@ -231,7 +231,7 @@ The machine executor supports [Docker Layer Caching]({{ site.baseurl }}/2.0/dock
 
 **Example**
 
-```YAML
+```yaml
 jobs:
   build:
     machine: true
@@ -251,7 +251,7 @@ xcode | Y | String | The version of Xcode that is installed on the virtual machi
 
 **Example:** Use a macOS virtual machine with Xcode version `9.0`:
 
-```YAML
+```yaml
 jobs:
   build:
     macos:

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -96,9 +96,10 @@ The images have common language tools preinstalled. Refer to the [specification 
 The following example uses the default machine image and enables [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or Workflow. **Note:** You must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.
 
 ```yaml
+version: 2
 jobs:
   build:
-    machine: true
+    machine:
       docker_layer_caching: true    # default - false
 ```
 

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -66,7 +66,7 @@ CPUs | Processor                 | RAM | HD
 
 To use the machine executor with the default `machine` image, set the `machine` key to `true` in `.circleci/config.yml`:
 
-```YAML
+```yaml
 jobs:
   build:
     machine: true
@@ -76,7 +76,7 @@ Using the `machine` executor enables your application with full access to OS res
 
 This example specifies a particular image for the `machine` executor:
 
-```YAML
+```yaml
 jobs:
   build:
     machine:
@@ -95,7 +95,7 @@ The images have common language tools preinstalled. Refer to the [specification 
 
 The following example uses the default machine image and enables [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or Workflow. **Note:** You must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.
 
-```YAML
+```yaml
 jobs:
   build:
     machine: true

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -106,14 +106,14 @@ Yes, CircleCI 2.0 is now available to enterprise clients, see [Administrator's O
 
 CircleCI 2.0 currently supports pulling (and pushing with Docker Engine) Docker images from [Docker Hub][docker-hub]. For [official images][docker-library], you can pull by simply specifying the name of the image and a tag:
 
-```YAML
+```yaml
 golang:1.7.1
 redis:3.0.7
 ```
 
 For public images on Docker Hub, you can pull the image by prefixing the account or team username:
 
-```YAML
+```yaml
 myUsername/couchdb:1.6.1
 ```
 

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -106,14 +106,14 @@ Yes, CircleCI 2.0 is now available to enterprise clients, see [Administrator's O
 
 CircleCI 2.0 currently supports pulling (and pushing with Docker Engine) Docker images from [Docker Hub][docker-hub]. For [official images][docker-library], you can pull by simply specifying the name of the image and a tag:
 
-```yaml
+```
 golang:1.7.1
 redis:3.0.7
 ```
 
 For public images on Docker Hub, you can pull the image by prefixing the account or team username:
 
-```yaml
+```
 myUsername/couchdb:1.6.1
 ```
 

--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -27,7 +27,7 @@ Running the Android emulator is not currently supported by the type of virtualiz
 ## Sample Configuration
 
 {% raw %}
-```YAML
+```yaml
 version: 2
 jobs:
   build:
@@ -67,7 +67,7 @@ jobs:
 
 We always start with the version.
 
-```YAML
+```yaml
 version: 2
 ```
 
@@ -75,7 +75,7 @@ Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deplo
 
 In each job, we have the option of specifying a `working_directory`. This is the directory into which our code will be checked out, and this path will be used as the default working directory for the rest of the `job` unless otherwise specified.
 
-```YAML
+```yaml
 jobs:
   build:
     working_directory: ~/code
@@ -83,7 +83,7 @@ jobs:
 
 Directly beneath `working_directory`, we can specify container images under a `docker` key.
 
-```YAML
+```yaml
     docker:
       - image: circleci/android:api-25-alpha
 ```

--- a/jekyll/_cci2/language-clojure.md
+++ b/jekyll/_cci2/language-clojure.md
@@ -28,7 +28,7 @@ If you use another testing tool, you can just adjust that step to run a differen
 ## Sample Configuration
 
 {% raw %}
-```YAML
+```yaml
 version: 2 # use CircleCI 2.0
 jobs: # basic units of work in a run
   build: # runs not using Workflows must have a `build` job as entry point
@@ -67,7 +67,7 @@ Now we’re ready to build a `config.yml` from scratch.
 
 We always start with the version.
 
-```YAML
+```yaml
 version: 2
 ```
 
@@ -75,7 +75,7 @@ Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deplo
 
 In each job, we have the option of specifying a `working_directory`. In this sample config, we’ll name it after the project in our home directory.
 
-```YAML
+```yaml
 version: 2
 jobs:
   build:
@@ -86,7 +86,7 @@ This path will be used as the default working directory for the rest of the `job
 
 Directly beneath `working_directory`, we can specify container images under a `docker` key.
 
-```YAML
+```yaml
 version: 2
 ...
     docker:
@@ -99,7 +99,7 @@ We set `JVM_OPTS` here in order to limit the maximum heap size; otherwise we'll 
 
 Normally Leiningen expects to be run as a non-root user and will assume you're running as root by accident. We set the `LEIN_ROOT` environment variable to indicate that it's intentional in this case. 
 
-```YAML
+```yaml
     environment:
       JVM_OPTS: -Xmx3200m
       LEIN_ROOT: nbd
@@ -116,7 +116,7 @@ Then `lein do test, uberjar` runs the actual tests, and if they succeed, it crea
 Finally we store the uberjar as an [artifact](https://circleci.com/docs/1.0/build-artifacts/) using the `store_artifacts` step. From there this can be tied into a continuous deployment scheme of your choice.
 
 {% raw %}
-```YAML
+```yaml
 ...
     steps:
       - checkout

--- a/jekyll/_cci2/language-elixir.md
+++ b/jekyll/_cci2/language-elixir.md
@@ -15,8 +15,8 @@ If you're in a rush, just copy the configuration below into `.circleci/config.ym
 
 ## Sample Configuration
 
-```yaml
 {% raw %}
+```yaml
 version: 2  # use CircleCI 2.0 instead of CircleCI Classic
 jobs:  # basic units of work in a run
   build:  # runs not using Workflows must have a `build` job as entry point
@@ -73,5 +73,5 @@ jobs:  # basic units of work in a run
 
       - store_test_results:  # upload test results for display in Test Summary
           path: _build/test/junit
-{% endraw %}
 ```
+{% endraw %}

--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -50,7 +50,7 @@ This section explains the commands in `.circleci/config.yml`
 
 We always start with the version.
 
-```YAML
+```yaml
 version: 2
 ```
 
@@ -58,7 +58,7 @@ Next, we have a `jobs` key. Every config file must have a ‘build’ job. This 
 
 In the job, we specify a `working_directory`. Go is very strict about the structure of the [Go Workspace](https://golang.org/doc/code.html#Workspaces), so we’ll need to specify a path that satisfies those requirements.
 
-```YAML
+```yaml
 version: 2
 jobs:
   build:
@@ -69,7 +69,7 @@ This path will be used as the default working directory for the rest of the `job
 
 Directly beneath `working_directory`, we’ll specify [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) images for this job under `docker`.
 
-```YAML
+```yaml
     docker:
       - image: circleci/golang:1.8
 ```
@@ -78,7 +78,7 @@ We'll use a custom image which is based on `golang:1.8.0` and includes also `net
 
 We're also using an image for PostgreSQL, along with 2 environment variables for initializing the database.
 
-```YAML
+```yaml
       - image: circleci/postgres:9.4.12-alpine
         environment:
           POSTGRES_USER: root
@@ -89,20 +89,20 @@ Now we need to add several `steps` within the `build` job.
 
 The `checkout` step will default to the `working_directory` we have already defined.
 
-```YAML
+```yaml
     steps:
       - checkout
 ```
 
 Next we create a directory for collecting test results
 
-```YAML
+```yaml
       - run: mkdir -p $TEST_RESULTS
 ```
 
 Then we pull down the cache (if present). If this is your first run, this won't do anything.
 
-```YAML
+```yaml
       - restore_cache:
           keys:
             - v1-pkg-cache
@@ -110,7 +110,7 @@ Then we pull down the cache (if present). If this is your first run, this won't 
 
 And install the Go implementation of the JUnit reporting tool and other dependencies for our application. These are good candidates to be pre-installed in primary container.
 
-```YAML
+```yaml
       - run: go get github.com/lib/pq
       - run: go get github.com/mattes/migrate
       - run: go get github.com/jstemmer/go-junit-report
@@ -135,7 +135,7 @@ This is why `netcat` installed on the CircleCI Go image. We use it to validate t
 
 Now we run our tests. To do that, we need to set an environment variable for our database's URL and path to the DB migrations files. This step has some additional commands, we'll explain them below.
 
-```YAML
+```yaml
       - run:
           name: Run unit tests
           environment:
@@ -188,7 +188,7 @@ To start the service we need to build it first. After that we use the same envir
 
 Finally, let's specify a path to store the results of the tests.
 
-```YAML
+```yaml
       - store_test_results:
           path: /tmp/test-results
 ```

--- a/jekyll/_cci2/language-java.md
+++ b/jekyll/_cci2/language-java.md
@@ -29,7 +29,7 @@ We're going to make a few assumptions here:
 ## Sample Configuration
 
 {% raw %}
-```YAML
+```yaml
 version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
@@ -76,7 +76,7 @@ Now we’re ready to build a `config.yml` from scratch.
 
 We always start with the version.
 
-```YAML
+```yaml
 version: 2
 ```
 
@@ -84,7 +84,7 @@ Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deplo
 
 In each job, we must specify a `working_directory`. In this sample config, we’ll name it after the project in our home directory.
 
-```YAML
+```yaml
 version: 2
 jobs:
   build:
@@ -95,7 +95,7 @@ This path will be used as the default working directory for the rest of the `job
 
 Directly beneath `working_directory`, we can specify container images under a `docker` key.
 
-```YAML
+```yaml
 version: 2
 ...
     docker:
@@ -117,7 +117,7 @@ Next `store_test_results` uploads the test metadata from the `target/surefire-re
 Finally we store the uberjar as an [artifact](https://circleci.com/docs/2.0/artifacts/) using the `store_artifacts` step. From there this can be tied into a continuous deployment scheme of your choice.
 
 {% raw %}
-```YAML
+```yaml
 ...
     steps:
 

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -43,7 +43,7 @@ A good way to start using CircleCI is to build a project yourself. Here's how to
 
 Start with the version:
 
-```YAML
+```yaml
 version: 2 # use CircleCI 2.0
 ```
 
@@ -51,7 +51,7 @@ First, specify a `jobs` key. Each job represents a phase in your Build-Test-Depl
 
 Specify a working directory and container images for this build in `docker` section:
 
-```YAML
+```yaml
 ...
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
@@ -67,7 +67,7 @@ jobs: # a collection of steps
 Finally, add several `steps` within the `build` job:
 
 {% raw %}
-```YAML
+```yaml
     steps: # a collection of executable commands
       - checkout # special step to check out source code to the working directory
       - restore_cache: # restores saved dependency cache if the Branch key template or requirements.txt files have not changed since the previous run

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -40,7 +40,7 @@ Database images for use as a secondary 'service' container are also available on
 ## Sample Configuration
 
 {% raw %}
-```YAML
+```yaml
 version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
@@ -140,7 +140,7 @@ A good way to start using CircleCI is to build a project yourself. Here's how to
 
 Start with the version.
 
-```YAML
+```yaml
 version: 2
 ```
 
@@ -148,7 +148,7 @@ Next, add a `jobs` key. Each job represents a phase in your Build-Test-Deploy pr
 
 In each job, you have the option of specifying a `working_directory`. In this sample config, it is named after the project in the home directory.
 
-```YAML
+```yaml
 version: 2
 jobs:
   build:
@@ -160,7 +160,7 @@ This path will be used as the default working directory for the rest of the `job
 
 Directly beneath `working_directory`, you can specify container images under a `docker` key.
 
-```YAML
+```yaml
 version: 2
 # ...
     docker:
@@ -189,7 +189,7 @@ Finally, add several `steps` within the `build` job.
 
 Start with `checkout` so CircleCI can operate on the codebase.
 
-```YAML
+```yaml
 steps:
   - checkout
 ```
@@ -199,7 +199,7 @@ This step tells CircleCI to checkout the project code into the working directory
 Next CircleCI pulls down the cache, if present. If this is your first run, or if you've changed `Gemfile.lock`, this won't do anything. The `bundle install` command runs next to pull down the project's dependencies. Normally, you never call this task directly since it's done automatically when it's needed, but calling it directly allows a `save_cache` step that will store the dependencies to speed things up for next time.
 
 {% raw %}
-```YAML
+```yaml
 steps:
   # ...
 
@@ -224,7 +224,7 @@ steps:
 If your application is using Webpack or Yarn for JavaScript dependencies, you should also add the following to your config.
 
 {% raw %}
-```YAML
+```yaml
 steps:
   # ...
 
@@ -248,7 +248,7 @@ steps:
 
 The next section sets up the test database. It uses the `dockerize` [utility](https://github.com/jwilder/dockerize) to delay starting the main process of the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) until after the database service is available.
 
-```YAML
+```yaml
 steps:
   # ...
 
@@ -269,7 +269,7 @@ If they succeed, it stores the test results using `store_test_results` so Circle
 From there this can be tied into a continuous deployment scheme of your choice.
 
 {% raw %}
-```YAML
+```yaml
 steps:
   # ...
 

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -161,8 +161,6 @@ This path will be used as the default working directory for the rest of the `job
 Directly beneath `working_directory`, you can specify container images under a `docker` key.
 
 ```yaml
-version: 2
-# ...
     docker:
       - image: circleci/ruby:2.4-node
         environment:

--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -11,7 +11,7 @@ order: 50
 
 To use private images, specify the username and password in the `auth` field.  To protect the password, create an Environment Variable in the CircleCI Project Settings page, and then reference it:
 
-```YAML
+```yaml
 jobs:
   build:
     docker:


### PR DESCRIPTION
Fixed the YAML code fence errors I found using `md-proofer`. Also standardize the use of the lowercase string `yaml` for code fences.

Not counting the superficial changes, was able to fix 11 separate code fences to be copy & pastable YAML.