### PR TITLE
update CIRCLE_INTERNAL_TASK_DATA value and location

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -373,10 +373,6 @@ The username or organization name of the project being tested, i.e. “foo” in
 
 The repository name of the project being tested, i.e. “bar” in circleci.com/gh/foo/bar/123.
 
-`CIRCLE_INTERNAL_TASK_DATA`
-
-The directory where test timing data can be found.
-
 `CIRCLE_STAGE`
 
 The job being executed. The default 2.0 job is `build` without using Workflows.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -373,6 +373,10 @@ The username or organization name of the project being tested, i.e. “foo” in
 
 The repository name of the project being tested, i.e. “bar” in circleci.com/gh/foo/bar/123.
 
+`CIRCLE_INTERNAL_TASK_DATA`	
+
+The directory where test timing data can be found.
+
 `CIRCLE_STAGE`
 
 The job being executed. The default 2.0 job is `build` without using Workflows.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -373,7 +373,7 @@ The username or organization name of the project being tested, i.e. “foo” in
 
 The repository name of the project being tested, i.e. “bar” in circleci.com/gh/foo/bar/123.
 
-`CIRCLE_INTERNAL_TASK_DATA`	
+`CIRCLE_INTERNAL_TASK_DATA`
 
 The directory where test timing data can be found.
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -140,7 +140,8 @@ use the `--split-by` flag with the `filesize` split type.
 
 #### Splitting by Timings
 
-CircleCI automatically saves timing data from previous successful runs to a default location (`CIRCLE_INTERNAL_TASK_DATA=/.circleci-task-data`).
+CircleCI automatically saves timing data from previous successful runs to a default directory.
+This directory is specified by the [built-in environment variable]({{ site.baseurl }}/2.0/env-vars/#circleci-built-in-environment-variables) `CIRCLE_INTERNAL_TASK_DATA`.
 Ensure you are using the [`store_test_results` key]({{ site.baseurl }}/2.0/configuration-reference/#store_test_results)
 to save your timing data,
 or there will be no historical data available.

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -140,7 +140,7 @@ use the `--split-by` flag with the `filesize` split type.
 
 #### Splitting by Timings
 
-CircleCI automatically saves timing data from previous successful runs to a default location.
+CircleCI automatically saves timing data from previous successful runs to a default location (`CIRCLE_INTERNAL_TASK_DATA=/.circleci-task-data`).
 Ensure you are using the [`store_test_results` key]({{ site.baseurl }}/2.0/configuration-reference/#store_test_results)
 to save your timing data,
 or there will be no historical data available.

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -140,7 +140,7 @@ use the `--split-by` flag with the `filesize` split type.
 
 #### Splitting by Timings
 
-CircleCI automatically saves timing data from previous successful runs to a default location (`$CIRCLE_INTERNAL_TASK_DATA/circle-test-results`).
+CircleCI automatically saves timing data from previous successful runs to a default location.
 Ensure you are using the [`store_test_results` key]({{ site.baseurl }}/2.0/configuration-reference/#store_test_results)
 to save your timing data,
 or there will be no historical data available.


### PR DESCRIPTION
Removed references to CIRCLE_INTERNAL_TASK_DATA. This env var seems to have been removed in this commit: https://github.com/circleci/picard-services/commit/14195162baca1243426ad0fb8fb0c93eda07f884