### PR TITLE
[Xcode] Include 9.3.0 image support

### DIFF
--- a/jekyll/_cci1/build-image-macos.md
+++ b/jekyll/_cci1/build-image-macos.md
@@ -28,6 +28,7 @@ You should specify the version of Xcode that you would like to build by specifyi
 
 The currently available Xcode versions are:
 
+* `9.3.0`: Xcode 9.3.0 (Build 9E145)
 * `9.2.0`: Xcode 9.2.0 (Build 9C40b)
 * `9.1.0`: Xcode 9.1.0 (Build 9B55)
 * `9.0`: Xcode 9.0.1 (Build 9A1004)
@@ -49,6 +50,7 @@ The currently available Xcode versions are:
 
 We maintain a manifest of the software installed on our OSX and macOS build images. This includes version of the operating system, Xcode, Python, Ruby, etc.
 
+* [Xcode version 9.3.0 (macOS 10.13 High Sierra)](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-405/index.html).
 * [Xcode version 9.2.0 (macOS 10.12 Sierra)](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-298/index.html).
 * [Xcode version 9.1.0 (macOS 10.12 Sierra)](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-290/index.html).
 * [Xcode version 9.0.1 (macOS 10.12 Sierra)](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-282/index.html).


### PR DESCRIPTION
Original announcement here: https://discuss.circleci.com/t/xcode-9-3-gm-release-for-circleci-2-0/21291

And seemed to missed this in a prior change: https://github.com/circleci/circleci-docs/commit/34623f1ffb6cfeb2b18921e9e3321837a9bc2602#diff-1db399f6e524fd001cb4753bbd8970c4