### PR TITLE
Edited Step #2 on Adding SSH key to CircleCI page

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -28,7 +28,7 @@ refer to the [GitHub and Bitbucket Integration](https://circleci.com/docs/2.0/gh
 go to your project's settings
 by clicking the gear icon next to your project.
 
-2. In the **Build Settings** section,
+2. In the **Permissions** section,
 click on **SSH Permissions**.
 
 3. Click the **Add SSH Key** button.


### PR DESCRIPTION
Edited **Step 2** of this page to reflect the new navigation.
https://circleci.com/docs/2.0/add-ssh-key/

Changed it to:
> In the **Permissions** section, click on **SSH Permissions**

from 

> In the **Build Settings** section, click on **SSH Permissions**.