### PR TITLE
Added option to run jobs other than the default build

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -67,6 +67,11 @@ To run your build, navigate to your repo and run `circleci build`.
 
 **Note:** If your _config.yml_ uses Workflows and has a job named `build`, only that `build` job will run. If you are using Workflows and have no jobs named `build`, the CLI will not be able to run your project locally.
 
+To run jobs other than build use --job argument.
+```
+$ circleci build --job test
+```
+
 ### Troubleshooting Container Configurations Locally
 
 Test locally to quickly retry configurations such as connecting on different ports or with different users. Jobs often have several containers that need to “talk” to each other. For example, you might want to locally test that a job can connect and create the relevant database with correct permissions on the correct port for a PostgreSQL container. Or you might be using a pre-built container, but you’re unsure if it has all the services you need, or if they're running in the way you hope.


### PR DESCRIPTION
CircleCI CLI supports --job option but it is not documented. 

      --job string            job to be executed (default "build")

$ circleci version

circleci version: 0.0.5762-f6bc418
Build Agent version: 0.0.5763-f6bc418
built: 2018-05-22T19:06:47+0000