### PR TITLE
prevent redundant builds on non-deploy branches

### DIFF
--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -391,7 +391,7 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - build
+      - build:
         filters:
           branches:
             only: master

--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -392,6 +392,9 @@ workflows:
   build-and-deploy:
     jobs:
       - build
+        filters:
+          branches:
+            only: master
       - deploy:
           requires:
             - build


### PR DESCRIPTION
Follow-up to [this comment](https://github.com/circleci/circleci-docs/pull/2341#discussion_r189397775) on the SSH Deploy guide.