### PR TITLE
add warning to use environment variables in scripts

### DIFF
--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -16,7 +16,7 @@ CircleCI can be configured to deploy to virtually any service. This document pro
 
 To deploy your application,
 add a [job]({{ site.baseurl }}/2.0/jobs-steps/#jobs-overview) to your `.circleci/config.yml` file.
-You will also need to [add environment variables]({{ site.baseurl }}/2.0/env-vars/#adding-project-level-environment-variables) and [add SSH keys]({{ site.baseurl }}/2.0/add-ssh-key/).
+You will also need to [add environment variables]({{ site.baseurl }}/2.0/env-vars/#setting-project-level-environment-variables) and [add SSH keys]({{ site.baseurl }}/2.0/add-ssh-key/).
 
 Below is a simple example of deploying a Rails application to Heroku. The full application can be found in the [Sequential Job branch of the CircleCI Demo Workflows repository](https://github.com/CircleCI-Public/circleci-demo-workflows/tree/sequential-branch-filter).
 
@@ -259,7 +259,7 @@ and follow the [Getting Started on Heroku](https://devcenter.heroku.com/start) d
 to set up a project in your chosen language.
 
 2. Add the name of your Heroku application and your Heroku API key as environment variables.
-See [Adding Project Environment Variables]({{ site.baseurl }}/2.0/env-vars/#adding-project-level-environment-variables) for instructions.
+See [Adding Project Environment Variables]({{ site.baseurl }}/2.0/env-vars/#setting-project-level-environment-variables) for instructions.
 In this example, these variables are defined as `HEROKU_APP_NAME` and `HEROKU_API_KEY`, respectively.
 
 4. In your `.circleci/config.yml`,
@@ -365,7 +365,7 @@ to which you're deploying.
 For instructions, see the [Adding an SSH Key to CircleCI]({{ site.baseurl }}/2.0/add-ssh-key/) document.
 
 2. Add the SSH username and SSH hostname of your build VM as environment variables.
-For instructions, see the [Adding Project Environment Variables]({{ site.baseurl }}/2.0/env-vars/#adding-project-level-environment-variables) document.
+For instructions, see the [Adding Project Environment Variables]({{ site.baseurl }}/2.0/env-vars/#setting-project-level-environment-variables) document.
 In this example, these variables are defined as `SSH_USER` and `SSH_HOST`, respectively.
 
 3. In your `.circleci/config.yml`,

--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -16,7 +16,7 @@ CircleCI can be configured to deploy to virtually any service. This document pro
 
 To deploy your application,
 add a [job]({{ site.baseurl }}/2.0/jobs-steps/#jobs-overview) to your `.circleci/config.yml` file.
-You will also need to [add environment variables]({{ site.baseurl }}/2.0/env-vars/#setting-project-level-environment-variables) and [add SSH keys]({{ site.baseurl }}/2.0/add-ssh-key/).
+You will also need to [add environment variables]({{ site.baseurl }}/2.0/env-vars/#setting-an-environment-variable-in-a-project) and [add SSH keys]({{ site.baseurl }}/2.0/add-ssh-key/).
 
 Below is a simple example of deploying a Rails application to Heroku. The full application can be found in the [Sequential Job branch of the CircleCI Demo Workflows repository](https://github.com/CircleCI-Public/circleci-demo-workflows/tree/sequential-branch-filter).
 
@@ -259,7 +259,7 @@ and follow the [Getting Started on Heroku](https://devcenter.heroku.com/start) d
 to set up a project in your chosen language.
 
 2. Add the name of your Heroku application and your Heroku API key as environment variables.
-See [Adding Project Environment Variables]({{ site.baseurl }}/2.0/env-vars/#setting-project-level-environment-variables) for instructions.
+See [Adding Project Environment Variables]({{ site.baseurl }}/2.0/env-vars/#setting-an-environment-variable-in-a-project) for instructions.
 In this example, these variables are defined as `HEROKU_APP_NAME` and `HEROKU_API_KEY`, respectively.
 
 4. In your `.circleci/config.yml`,
@@ -365,7 +365,7 @@ to which you're deploying.
 For instructions, see the [Adding an SSH Key to CircleCI]({{ site.baseurl }}/2.0/add-ssh-key/) document.
 
 2. Add the SSH username and SSH hostname of your build VM as environment variables.
-For instructions, see the [Adding Project Environment Variables]({{ site.baseurl }}/2.0/env-vars/#setting-project-level-environment-variables) document.
+For instructions, see the [Adding Project Environment Variables]({{ site.baseurl }}/2.0/env-vars/#setting-an-environment-variable-in-a-project) document.
 In this example, these variables are defined as `SSH_USER` and `SSH_HOST`, respectively.
 
 3. In your `.circleci/config.yml`,

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -100,18 +100,7 @@ in the same way that `docker` does.
 
 To set global environment variables that may be shared across projects, use the Settings > Contexts page of the CircleCI application. See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
 
-## Setting Environment Variables in `.circleci/config.yml`
-
-It is also possible to set environment variables at the **job**, **container**, and **step** levels,
-in order of increasing specificity.
-
-1. Environment variables set at the **job** level
-are overwritten by...
-2. ...environment variables set at the **container** level,
-which are overwritten by...
-3. ...environment variables set at the **step** level.
-
-### Setting Job-Level Environment Variables
+## Setting Job-Level Environment Variables
 
 To set environment variables at the job level,
 use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
@@ -126,7 +115,7 @@ jobs:
       FOO: "bar"
 ```
 
-### Setting Container-Level Environment Variables
+## Setting Container-Level Environment Variables
 
 To set environment variables at the container level,
 use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#docker--machine--macosexecutor).
@@ -159,7 +148,7 @@ jobs:
       - image: circleci/postgres:9.6
 ```
 
-### Setting Step-Level Environment Variables
+## Setting Step-Level Environment Variables
 
 To set environment variables at the step level,
 use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#run)

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -94,55 +94,6 @@ Environment variables set within configuration are fully visible in build output
 If you are adding secrets or sensitive data,
 set these at the [project level](#adding-project-level-environment-variables) instead.
 
-### Setting an Environment Variable for a Step
-
-Use the environment key inside a run step to set variables for a single command shell as shown in the following example:
-
-```yaml
-version: 2
-jobs:
-  build:
-    docker:
-      - image: smaant/lein-flyway:2.7.1-4.0.3
-    steps:
-      - checkout
-      - run:
-          name: Run migrations
-          command: sql/docker-entrypoint.sh sql
-          # Environment variable for a single command shell
-          environment:
-            DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
-```
-
-### Interpolating Environment Variables 
-
-CircleCI does not support interpolation
-when defining configuration variables like `working_directory` or `images`.
-All defined values are treated literally.
-
-However, it is possible to interpolate a variable within a command
-by setting it for the current shell.
-
-```yaml
-version: 2
-jobs:
-  build:
-    steps:
-      - run:
-          name: Update PATH and Define Environment Variable at Runtime
-          command: |
-            echo 'export PATH=/path/to/foo/bin:$PATH' >> $BASH_ENV
-            echo 'export VERY_IMPORTANT=$(cat important_value)' >> $BASH_ENV
-            source $BASH_ENV
-```
-
-**Note**:
-Depending on your shell,
-you may have to append the new variable to a shell startup file
-like `~/.tcshrc` or `~/.zshrc`.
-For more information,
-refer to your shell's documentation on setting environment variables.
-
 ### Setting Environment Variables for a Job
 
 To define environment variables for a job, use the `environment` key under the job name in the `jobs` section.
@@ -191,6 +142,55 @@ jobs:
           TEST_DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
       - image: circleci/postgres:9.6
 ```
+
+### Setting an Environment Variable for a Step
+
+Use the environment key inside a run step to set variables for a single command shell as shown in the following example:
+
+```yaml
+version: 2
+jobs:
+  build:
+    docker:
+      - image: smaant/lein-flyway:2.7.1-4.0.3
+    steps:
+      - checkout
+      - run:
+          name: Run migrations
+          command: sql/docker-entrypoint.sh sql
+          # Environment variable for a single command shell
+          environment:
+            DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
+```
+
+### Interpolating Environment Variables
+
+CircleCI does not support interpolation
+when defining configuration variables like `working_directory` or `images`.
+All defined values are treated literally.
+
+However, it is possible to interpolate a variable within a command
+by setting it for the current shell.
+
+```yaml
+version: 2
+jobs:
+  build:
+    steps:
+      - run:
+          name: Update PATH and Define Environment Variable at Runtime
+          command: |
+            echo 'export PATH=/path/to/foo/bin:$PATH' >> $BASH_ENV
+            echo 'export VERY_IMPORTANT=$(cat important_value)' >> $BASH_ENV
+            source $BASH_ENV
+```
+
+**Note**:
+Depending on your shell,
+you may have to append the new variable to a shell startup file
+like `~/.tcshrc` or `~/.zshrc`.
+For more information,
+refer to your shell's documentation on setting environment variables.
 
 See the [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#docker--machine-executor) document for details of the specification for the `environment` key of the docker executor type.
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -96,9 +96,12 @@ Login Succeeded
 Not all command-line programs take credentials
 in the same way that `docker` does.
 
-## Setting Global Environment Variables
+## Setting Context-Level Environment Variables
 
-To set global environment variables that may be shared across projects, use the Settings > Contexts page of the CircleCI application. See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
+Creating a context
+allows you to share environment variables across multiple projects.
+To set environment variables at the context level,
+see the [Contexts documentation]({{ site.baseurl }}/2.0/contexts/).
 
 ## Setting Job-Level Environment Variables
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -17,26 +17,25 @@ This document describes using environment variables in CircleCI in the following
 ## Overview
 
 Environment variables can be set at several scope levels.
-From general to specific, these levels are:
+From specific to general, these levels are:
 
-1. Environment variables [built into CircleCI](#circleci-built-in-environment-variables).
-Automatically available.
-2. [Project-level](#setting-project-level-environment-variables) environment variables.
-Set within the CircleCI application.
-3. [Context-level]({{ site.baseurl }}/2.0/contexts/) environment variables.
-Set within the CircleCI application.
+1. Environment variables [set within shell commands](#setting-command-level-environment-variables).
+Set in your `.circleci/config.yml` file.
+2. [Step-level](#setting-step-level-environment-variables) environment variables.
+Set in your `.circleci/config.yml` file.
+3. [Container-level](#setting-container-level-environment-variables) environment variables.
+Set in your `.circleci/config.yml` file.
 4. [Job-level](#setting-job-level-environment-variables) environment variables.
 Set in your `.circleci/config.yml` file.
-5. [Container-level](#setting-container-level-environment-variables) environment variables.
-Set in your `.circleci/config.yml` file.
-6. [Step-level](#setting-step-level-environment-variables) environment variables.
-Set in your `.circleci/config.yml` file.
-7. Environment variables [set within shell commands](#setting-command-level-environment-variables).
-Set in your `.circleci/config.yml` file.
+5. 3. [Context-level]({{ site.baseurl }}/2.0/contexts/) environment variables.
+Set within the CircleCI application.
+6. [Project-level](#setting-project-level-environment-variables) environment variables.
+Set within the CircleCI application.
+7. Environment variables [built into CircleCI](#circleci-built-in-environment-variables).
+Automatically available.
 
-CircleCI also loads environment variables in this order.
 If an environment variable is set at multiple scope levels,
-CircleCI uses the variable set at the **lowest level**.
+CircleCI uses the variable set at the **most specific** level.
 
 **Warning**:
 Do not add secret or sensitive data anywhere inside `.circleci/config.yml`.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -143,6 +143,8 @@ jobs:
       - image: circleci/postgres:9.6
 ```
 
+See the [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#docker--machine-executor) document for details of the specification for the `environment` key of the docker executor type.
+
 ### Setting an Environment Variable for a Step
 
 Use the environment key inside a run step to set variables for a single command shell as shown in the following example:
@@ -191,9 +193,6 @@ you may have to append the new variable to a shell startup file
 like `~/.tcshrc` or `~/.zshrc`.
 For more information,
 refer to your shell's documentation on setting environment variables.
-
-See the [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#docker--machine-executor) document for details of the specification for the `environment` key of the docker executor type.
-
 
 ## Injecting Environment Variables with the API
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -43,6 +43,10 @@ Environment variables set within configuration (levels 4-7)
 are **fully visible** in build output.
 If you are adding secrets or sensitive data,
 set these within the CircleCI application (levels 2-3).
+Also note that
+running scripts within configuration
+can sometimes expose secret environment variables.
+See the [Using Shell Scripts]({{ site.baseurl }}/2.0/using-shell-scripts/#shell-script-best-practices) document for more information.
 
 ## Setting Project-Level Environment Variables
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -19,7 +19,7 @@ This document describes using environment variables in CircleCI in the following
 Environment variables are used according to a specific precedence order, as follows:
 
 1. Environment variables declared [inside a shell command](#setting-an-environment-variable-in-a-shell-command) in a `run` step, for example `FOO=bar make install`.
-2. Environment variables declared with the `environment` key [for a `run` step](#setting-an-environment-variable-in-a-run-step).
+2. Environment variables declared with the `environment` key [for a `run` step](#setting-an-environment-variable-in-a-step).
 3. Environment variables set with the `environment` key [for a container](#setting-an-environment-variable-in-a-container).
 4. Environment variables set with the `environment` key [for a job](#setting-an-environment-variable-in-a-job).
 5. Context environment variables (assuming the user has access to the Context). See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -80,7 +80,7 @@ refer to your shell's documentation on setting environment variables.
 ## Setting Step-Level Environment Variables
 
 To set environment variables at the step level,
-use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#run)
+use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#run).
 
 ```yaml
 version: 2

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -19,17 +19,17 @@ This document describes using environment variables in CircleCI in the following
 Environment variables can be set at several scope levels.
 From specific to general, these levels are:
 
-1. Environment variables [set in shell commands](#setting-command-level-environment-variables).
+1. Environment variables [set in shell commands](#setting-an-environment-variable-in-a-shell-command).
 Set in your `.circleci/config.yml` file.
-2. Environment variables [set in a step](#setting-step-level-environment-variables).
+2. Environment variables [set in a step](#setting-an-environment-variable-in-a-step).
 Set in your `.circleci/config.yml` file.
-3. Environment variables [set in a container](#setting-container-level-environment-variables).
+3. Environment variables [set in a container](#setting-an-environment-variable-in-a-container).
 Set in your `.circleci/config.yml` file.
-4. Environment variables [set in a job](#setting-job-level-environment-variables).
+4. Environment variables [set in a job](#setting-an-environment-variable-in-a-job).
 Set in your `.circleci/config.yml` file.
-5. Environment variables [set in a context](#setting-context-level-environment-variables).
+5. Environment variables [set in a context](#setting-an-environment-variable-in-a-context).
 Set within the CircleCI application.
-6. Environment variables [set in a project](#setting-project-level-environment-variables).
+6. Environment variables [set in a project](#setting-an-environment-variable-in-a-project).
 Set within the CircleCI application.
 7. Environment variables [built into CircleCI](#circleci-built-in-environment-variables).
 Automatically available.
@@ -48,7 +48,7 @@ that running scripts within configuration
 can sometimes expose secret environment variables.
 See the [Using Shell Scripts]({{ site.baseurl }}/2.0/using-shell-scripts/#shell-script-best-practices) document for more information.
 
-## Setting Command-Level Environment Variables
+## Setting an Environment Variable in a Shell Command
 
 CircleCI does not support interpolation
 when defining configuration variables like `working_directory` or `images`.
@@ -77,9 +77,9 @@ like `~/.tcshrc` or `~/.zshrc`.
 For more information,
 refer to your shell's documentation on setting environment variables.
 
-## Setting Step-Level Environment Variables
+## Setting an Environment Variable in a Step
 
-To set environment variables at the step level,
+To set environment variables in a step,
 use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#run).
 
 ```yaml
@@ -98,7 +98,7 @@ jobs:
             DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
 ```
 
-## Setting Container-Level Environment Variables
+## Setting an Environment Variable in a Container
 
 To set environment variables at the container level,
 use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#docker--machine--macosexecutor).
@@ -131,7 +131,7 @@ jobs:
       - image: circleci/postgres:9.6
 ```
 
-## Setting Job-Level Environment Variables
+## Setting an Environment Variable in a Job
 
 To set environment variables at the job level,
 use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
@@ -146,14 +146,14 @@ jobs:
       FOO: "bar"
 ```
 
-## Setting Context-Level Environment Variables
+## Setting an Environment Variable in a Context
 
 Creating a context
 allows you to share environment variables across multiple projects.
 To set environment variables at the context level,
 see the [Contexts documentation]({{ site.baseurl }}/2.0/contexts/).
 
-## Setting Project-Level Environment Variables
+## Setting an Environment Variable in a Project
 
 1. In the CircleCI application,
 go to your project's settings
@@ -268,7 +268,6 @@ export param2="500"
 ```
 
 Start a run with the POST API call, see the [new build]( {{ site.baseurl }}/api/v1-reference/#new-build) section of the API documentation for details. A POST with an empty body will start a new run of the named branch.
-
 
 ## CircleCI Built-in Environment Variables
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -40,7 +40,7 @@ CircleCI uses the variable set at the **lowest level**.
 
 **Warning**:
 Environment variables set within configuration (levels 4-7)
-are **fully visible** in build output.
+are **fully visible** in build output and on the build page.
 If you are adding secrets or sensitive data,
 set these within the CircleCI application (levels 2-3).
 Also note that

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -19,17 +19,17 @@ This document describes using environment variables in CircleCI in the following
 Environment variables can be set at several scope levels.
 From specific to general, these levels are:
 
-1. Environment variables [set within shell commands](#setting-command-level-environment-variables).
+1. Environment variables [set in shell commands](#setting-command-level-environment-variables).
 Set in your `.circleci/config.yml` file.
-2. [Step-level](#setting-step-level-environment-variables) environment variables.
+2. Environment variables [set in a step](#setting-step-level-environment-variables).
 Set in your `.circleci/config.yml` file.
-3. [Container-level](#setting-container-level-environment-variables) environment variables.
+3. Environment variables [set in a container](#setting-container-level-environment-variables).
 Set in your `.circleci/config.yml` file.
-4. [Job-level](#setting-job-level-environment-variables) environment variables.
+4. Environment variables [set in a job](#setting-job-level-environment-variables).
 Set in your `.circleci/config.yml` file.
-5. 3. [Context-level]({{ site.baseurl }}/2.0/contexts/) environment variables.
+5. Environment variables [set in a context](#setting-context-level-environment-variables).
 Set within the CircleCI application.
-6. [Project-level](#setting-project-level-environment-variables) environment variables.
+6. Environment variables [set in a project](#setting-project-level-environment-variables).
 Set within the CircleCI application.
 7. Environment variables [built into CircleCI](#circleci-built-in-environment-variables).
 Automatically available.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -84,10 +84,15 @@ in the same way that `docker` does.
 
 To add global environment variables that may be shared across projects, use the Settings > Contexts page of the CircleCI application. See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
 
-## Setting Environment Variables
+## Setting Environment Variables in `.circleci/config.yml`
 
-**Warning**: Do **not** add keys or secrets to a public CircleCI project. 
-Be careful that the output doesn't appear in build logs and that the variables are set using the CircleCI application and not in the `config.yml` file.
+It is also possible to set environment variables at the **job**, **container**, and **step** levels,
+in order of increasing specificity.
+
+**Warning**:
+Environment variables set within configuration are fully visible in build output.
+If you are adding secrets or sensitive data,
+set these at the [project level](#adding-project-level-environment-variables) instead.
 
 ### Setting an Environment Variable for a Step
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -96,8 +96,8 @@ set these at the [project level](#adding-project-level-environment-variables) in
 
 ### Setting Job-Level Environment Variables
 
-To define environment variables for a job, use the `environment` key under the job name in the `jobs` section.
-See [here](https://circleci.com/docs/2.0/configuration-reference/#job_name) for more details.
+To set environment variables at the job level,
+use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
 
 ```yaml
 version: 2

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -39,12 +39,13 @@ If an environment variable is set at multiple scope levels,
 CircleCI uses the variable set at the **lowest level**.
 
 **Warning**:
-Environment variables set within configuration (levels 4-7)
-are **fully visible** in build output and on the build page.
-If you are adding secrets or sensitive data,
-set these within the CircleCI application (levels 2-3).
-Also note that
-running scripts within configuration
+Do not add secret or sensitive data anywhere inside `.circleci/config.yml`.
+The full text of `config.yml` is **fully visible**
+to anyone who has access to your project on CircleCI.
+Instead, put these data into [project](#setting-project-level-environment-variables) or [context]({{ site.baseurl }}/2.0/contexts/) settings.
+
+Also note
+that running scripts within configuration
 can sometimes expose secret environment variables.
 See the [Using Shell Scripts]({{ site.baseurl }}/2.0/using-shell-scripts/#shell-script-best-practices) document for more information.
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -98,7 +98,7 @@ which are overwritten by...
 **Warning**:
 Environment variables set within configuration are fully visible in build output.
 If you are adding secrets or sensitive data,
-set these at the [project level](#adding-project-level-environment-variables) instead.
+set these at the [project level](#setting-project-level-environment-variables) instead.
 
 ### Setting Job-Level Environment Variables
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -88,10 +88,10 @@ To add global environment variables that may be shared across projects, use the 
 
 It is also possible to set environment variables at the **job**, **container**, and **step** levels,
 in order of increasing specificity.
-Environment variables set at the container level
-take precedence over job-level environment variables,
-and environment variables set at the step level
-take precedence over container-level environment variables.
+Environment variables set at the **container** level
+take precedence over environment variables set at the **job** level,
+and environment variables set at the **step** level
+take precedence over environment variables set at the **container** level.
 
 **Warning**:
 Environment variables set within configuration are fully visible in build output.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -98,11 +98,9 @@ set these at the [project level](#adding-project-level-environment-variables) in
 
 To define environment variables for a job, use the `environment` key under the job name in the `jobs` section.
 See [here](https://circleci.com/docs/2.0/configuration-reference/#job_name) for more details.
-Ex:
 
 ```yaml
 version: 2
-
 jobs:
   build:
     docker:

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -28,7 +28,7 @@ Environment variables are used according to a specific precedence order, as foll
 
 Environment variables declared inside a shell command `run step`, for example `FOO=bar make install`, will override environment variables declared with the `environment` and `contexts` keys. Environment variables added on the Contexts page will take precedence over variables added on the Project Settings page. Finally, special CircleCI environment variables are loaded.
 
-## Adding Project-Level Environment Variables
+## Setting Project-Level Environment Variables
 
 1. In the CircleCI application,
 go to your project's settings
@@ -80,9 +80,9 @@ Login Succeeded
 Not all command-line programs take credentials
 in the same way that `docker` does.
 
-## Adding Global Environment Variables
+## Setting Global Environment Variables
 
-To add global environment variables that may be shared across projects, use the Settings > Contexts page of the CircleCI application. See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
+To set global environment variables that may be shared across projects, use the Settings > Contexts page of the CircleCI application. See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
 
 ## Setting Environment Variables in `.circleci/config.yml`
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -84,12 +84,12 @@ in the same way that `docker` does.
 
 To add global environment variables that may be shared across projects, use the Settings > Contexts page of the CircleCI application. See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
 
-## Declaring Environment Variables
+## Setting Environment Variables
 
 **Warning**: Do **not** add keys or secrets to a public CircleCI project. 
 Be careful that the output doesn't appear in build logs and that the variables are set using the CircleCI application and not in the `config.yml` file.
 
-### Declaring an Environment Variable for a Step
+### Setting an Environment Variable for a Step
 
 Use the environment key inside a run step to set variables for a single command shell as shown in the following example:
 
@@ -138,7 +138,7 @@ like `~/.tcshrc` or `~/.zshrc`.
 For more information,
 refer to your shell's documentation on setting environment variables.
 
-### Declaring Environment Variables for a Job
+### Setting Environment Variables for a Job
 
 To define environment variables for a job, use the `environment` key under the job name in the `jobs` section.
 See [here](https://circleci.com/docs/2.0/configuration-reference/#job_name) for more details.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -38,6 +38,11 @@ CircleCI also loads environment variables in this order.
 If an environment variable is set at multiple scope levels,
 CircleCI uses the variable set at the **lowest level**.
 
+**Warning**:
+Environment variables set within configuration are fully visible in build output.
+If you are adding secrets or sensitive data,
+set these at the [project level](#setting-project-level-environment-variables) instead.
+
 ## Setting Project-Level Environment Variables
 
 1. In the CircleCI application,
@@ -104,11 +109,6 @@ are overwritten by...
 2. ...environment variables set at the **container** level,
 which are overwritten by...
 3. ...environment variables set at the **step** level.
-
-**Warning**:
-Environment variables set within configuration are fully visible in build output.
-If you are adding secrets or sensitive data,
-set these at the [project level](#setting-project-level-environment-variables) instead.
 
 ### Setting Job-Level Environment Variables
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -165,7 +165,7 @@ jobs:
             DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
 ```
 
-### Interpolating Environment Variables
+## Interpolating Environment Variables
 
 CircleCI does not support interpolation
 when defining configuration variables like `working_directory` or `images`.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -25,13 +25,13 @@ Automatically available.
 Set within the CircleCI application.
 3. [Context-level]({{ site.baseurl }}/2.0/contexts/) environment variables.
 Set within the CircleCI application.
-3. [Job-level](#setting-job-level-environment-variables) environment variables.
+4. [Job-level](#setting-job-level-environment-variables) environment variables.
 Set in your `.circleci/config.yml` file.
-4. [Container-level](#setting-container-level-environment-variables) environment variables.
+5. [Container-level](#setting-container-level-environment-variables) environment variables.
 Set in your `.circleci/config.yml` file.
-5. [Step-level](#setting-step-level-environment-variables) environment variables.
+6. [Step-level](#setting-step-level-environment-variables) environment variables.
 Set in your `.circleci/config.yml` file.
-6. Environment variables [set within shell commands](#interpolating-environment-variables).
+7. Environment variables [set within shell commands](#interpolating-environment-variables).
 Set in your `.circleci/config.yml` file.
 
 CircleCI also loads environment variables in this order.
@@ -39,9 +39,10 @@ If an environment variable is set at multiple scope levels,
 CircleCI uses the variable set at the **lowest level**.
 
 **Warning**:
-Environment variables set within configuration are fully visible in build output.
+Environment variables set within configuration (levels 4-7)
+are **fully visible** in build output.
 If you are adding secrets or sensitive data,
-set these at the [project level](#setting-project-level-environment-variables) instead.
+set these within the CircleCI application (levels 2-3).
 
 ## Setting Project-Level Environment Variables
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -93,8 +93,8 @@ Be careful that the output doesn't appear in build logs and that the variables a
 
 Use the environment key inside a run step to set variables for a single command shell as shown in the following example:
 
-```
-version: 2.0
+```yaml
+version: 2
 jobs:
   build:
     docker:

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -18,13 +18,13 @@ This document describes using environment variables in CircleCI in the following
 
 Environment variables are used according to a specific precedence order, as follows:
 
-1. Environment variables declared inside a shell command in a `run` step, for example `FOO=bar make install`.
-2. Environment variables declared with the `environment` key for a `run` step.
-3. Environment variables set with the `environment` key for a job.
-4. Environment variables set with the `environment` key for a container.
+1. Environment variables declared [inside a shell command](#setting-an-environment-variable-in-a-shell-command) in a `run` step, for example `FOO=bar make install`.
+2. Environment variables declared with the `environment` key [for a `run` step](#setting-an-environment-variable-in-a-run-step).
+3. Environment variables set with the `environment` key [for a container](#setting-an-environment-variable-in-a-container).
+4. Environment variables set with the `environment` key [for a job](#setting-an-environment-variable-in-a-job).
 5. Context environment variables (assuming the user has access to the Context). See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
-6. Project-level environment variables set on the Project Settings page.
-7. Special CircleCI environment variables defined in the [CircleCI Environment Variable Descriptions]({{ site.baseurl }}/2.0/env-vars/#circleci-built-in-environment-variables) section of this document.
+6. [Project-level environment variables](#setting-an-environment-variable-in-a-project) set on the Project Settings page.
+7. Special CircleCI environment variables defined in the [CircleCI Environment Variable Descriptions](#circleci-built-in-environment-variables) section of this document.
 
 Environment variables declared inside a shell command `run step`, for example `FOO=bar make install`, will override environment variables declared with the `environment` and `contexts` keys. Environment variables added on the Contexts page will take precedence over variables added on the Project Settings page. Finally, special CircleCI environment variables are loaded.
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -21,7 +21,7 @@ From general to specific, these levels are:
 
 1. Environment variables [built into CircleCI](#circleci-built-in-environment-variables).
 Automatically available.
-2. [Project-specific](#setting-project-level-environment-variables) environment variables.
+2. [Project-level](#setting-project-level-environment-variables) environment variables.
 Set within the CircleCI application.
 3. [Context-level]({{ site.baseurl }}/2.0/contexts/) environment variables.
 Set within the CircleCI application.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -24,7 +24,7 @@ Environment variables are used according to a specific precedence order, as foll
 4. Environment variables set with the `environment` key [for a job](#setting-an-environment-variable-in-a-job).
 5. Context environment variables (assuming the user has access to the Context). See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
 6. [Project-level environment variables](#setting-an-environment-variable-in-a-project) set on the Project Settings page.
-7. Special CircleCI environment variables defined in the [CircleCI Environment Variable Descriptions](#circleci-built-in-environment-variables) section of this document.
+7. Special CircleCI environment variables defined in the [CircleCI Built-in Environment Variables](#circleci-built-in-environment-variables) section of this document.
 
 Environment variables declared inside a shell command `run step`, for example `FOO=bar make install`, will override environment variables declared with the `environment` and `contexts` keys. Environment variables added on the Contexts page will take precedence over variables added on the Project Settings page. Finally, special CircleCI environment variables are loaded.
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -111,7 +111,8 @@ jobs:
 
 ### Setting Container-Level Environment Variables
 
-Use the `environment` key in your `image` section to set variables for all commands run in the container.
+To set environment variables at the container level,
+use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#docker--machine--macosexecutor).
 
 ```yaml
 version: 2
@@ -120,7 +121,7 @@ jobs:
     docker:
       - image: smaant/lein-flyway:2.7.1-4.0.3
       - image: circleci/postgres:9.6
-      # Environment variable for all commands executed in the primary container
+      # environment variables for all commands executed in the primary container
         environment:
           POSTGRES_USER: conductor
           POSTGRES_DB: conductor_test
@@ -134,14 +135,12 @@ jobs:
   build:
     docker:
       - image: circleci/python:3.6.2
-       # Environment variable for all commands executed in the primary container
+       # environment variables for all commands executed in the primary container
         environment:
           FLASK_CONFIG: testing
           TEST_DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
       - image: circleci/postgres:9.6
 ```
-
-See the [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#docker--machine-executor) document for details of the specification for the `environment` key of the docker executor type.
 
 ### Setting Step-Level Environment Variables
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -88,10 +88,12 @@ To add global environment variables that may be shared across projects, use the 
 
 It is also possible to set environment variables at the **job**, **container**, and **step** levels,
 in order of increasing specificity.
-Environment variables set at the **container** level
-take precedence over environment variables set at the **job** level,
-and environment variables set at the **step** level
-take precedence over environment variables set at the **container** level.
+
+1. Environment variables set at the **job** level
+are overwritten by...
+2. ...environment variables set at the **container** level,
+which are overwritten by...
+3. ...environment variables set at the **step** level.
 
 **Warning**:
 Environment variables set within configuration are fully visible in build output.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -48,6 +48,111 @@ that running scripts within configuration
 can sometimes expose secret environment variables.
 See the [Using Shell Scripts]({{ site.baseurl }}/2.0/using-shell-scripts/#shell-script-best-practices) document for more information.
 
+## Setting Command-Level Environment Variables
+
+CircleCI does not support interpolation
+when defining configuration variables like `working_directory` or `images`.
+All defined values are treated literally.
+
+However, it is possible to interpolate a variable within a command
+by setting it for the current shell.
+
+```yaml
+version: 2
+jobs:
+  build:
+    steps:
+      - run:
+          name: Update PATH and Define Environment Variable at Runtime
+          command: |
+            echo 'export PATH=/path/to/foo/bin:$PATH' >> $BASH_ENV
+            echo 'export VERY_IMPORTANT=$(cat important_value)' >> $BASH_ENV
+            source $BASH_ENV
+```
+
+**Note**:
+Depending on your shell,
+you may have to append the new variable to a shell startup file
+like `~/.tcshrc` or `~/.zshrc`.
+For more information,
+refer to your shell's documentation on setting environment variables.
+
+## Setting Step-Level Environment Variables
+
+To set environment variables at the step level,
+use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#run)
+
+```yaml
+version: 2
+jobs:
+  build:
+    docker:
+      - image: smaant/lein-flyway:2.7.1-4.0.3
+    steps:
+      - checkout
+      - run:
+          name: Run migrations
+          command: sql/docker-entrypoint.sh sql
+          # Environment variable for a single command shell
+          environment:
+            DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
+```
+
+## Setting Container-Level Environment Variables
+
+To set environment variables at the container level,
+use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#docker--machine--macosexecutor).
+
+```yaml
+version: 2
+jobs:
+  build:
+    docker:
+      - image: smaant/lein-flyway:2.7.1-4.0.3
+      - image: circleci/postgres:9.6
+      # environment variables for all commands executed in the primary container
+        environment:
+          POSTGRES_USER: conductor
+          POSTGRES_DB: conductor_test
+```
+
+The following example shows separate environment variable settings for the primary container image (listed first) and the secondary or service container image.
+
+```yaml
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.2
+       # environment variables for all commands executed in the primary container
+        environment:
+          FLASK_CONFIG: testing
+          TEST_DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
+      - image: circleci/postgres:9.6
+```
+
+## Setting Job-Level Environment Variables
+
+To set environment variables at the job level,
+use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
+
+```yaml
+version: 2
+jobs:
+  build:
+    docker:
+      - image: buildpack-deps:trusty
+    environment:
+      FOO: "bar"
+```
+
+## Setting Context-Level Environment Variables
+
+Creating a context
+allows you to share environment variables across multiple projects.
+To set environment variables at the context level,
+see the [Contexts documentation]({{ site.baseurl }}/2.0/contexts/).
+
 ## Setting Project-Level Environment Variables
 
 1. In the CircleCI application,
@@ -99,111 +204,6 @@ Login Succeeded
 **Note:**
 Not all command-line programs take credentials
 in the same way that `docker` does.
-
-## Setting Context-Level Environment Variables
-
-Creating a context
-allows you to share environment variables across multiple projects.
-To set environment variables at the context level,
-see the [Contexts documentation]({{ site.baseurl }}/2.0/contexts/).
-
-## Setting Job-Level Environment Variables
-
-To set environment variables at the job level,
-use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
-
-```yaml
-version: 2
-jobs:
-  build:
-    docker:
-      - image: buildpack-deps:trusty
-    environment:
-      FOO: "bar"
-```
-
-## Setting Container-Level Environment Variables
-
-To set environment variables at the container level,
-use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#docker--machine--macosexecutor).
-
-```yaml
-version: 2
-jobs:
-  build:
-    docker:
-      - image: smaant/lein-flyway:2.7.1-4.0.3
-      - image: circleci/postgres:9.6
-      # environment variables for all commands executed in the primary container
-        environment:
-          POSTGRES_USER: conductor
-          POSTGRES_DB: conductor_test
-```
-
-The following example shows separate environment variable settings for the primary container image (listed first) and the secondary or service container image.
-
-```yaml
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/python:3.6.2
-       # environment variables for all commands executed in the primary container
-        environment:
-          FLASK_CONFIG: testing
-          TEST_DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
-      - image: circleci/postgres:9.6
-```
-
-## Setting Step-Level Environment Variables
-
-To set environment variables at the step level,
-use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#run)
-
-```yaml
-version: 2
-jobs:
-  build:
-    docker:
-      - image: smaant/lein-flyway:2.7.1-4.0.3
-    steps:
-      - checkout
-      - run:
-          name: Run migrations
-          command: sql/docker-entrypoint.sh sql
-          # Environment variable for a single command shell
-          environment:
-            DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
-```
-
-## Setting Command-Level Environment Variables
-
-CircleCI does not support interpolation
-when defining configuration variables like `working_directory` or `images`.
-All defined values are treated literally.
-
-However, it is possible to interpolate a variable within a command
-by setting it for the current shell.
-
-```yaml
-version: 2
-jobs:
-  build:
-    steps:
-      - run:
-          name: Update PATH and Define Environment Variable at Runtime
-          command: |
-            echo 'export PATH=/path/to/foo/bin:$PATH' >> $BASH_ENV
-            echo 'export VERY_IMPORTANT=$(cat important_value)' >> $BASH_ENV
-            source $BASH_ENV
-```
-
-**Note**:
-Depending on your shell,
-you may have to append the new variable to a shell startup file
-like `~/.tcshrc` or `~/.zshrc`.
-For more information,
-refer to your shell's documentation on setting environment variables.
 
 ## Injecting Environment Variables with the API
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -94,7 +94,7 @@ Environment variables set within configuration are fully visible in build output
 If you are adding secrets or sensitive data,
 set these at the [project level](#adding-project-level-environment-variables) instead.
 
-### Setting Environment Variables for a Job
+### Setting Job-Level Environment Variables
 
 To define environment variables for a job, use the `environment` key under the job name in the `jobs` section.
 See [here](https://circleci.com/docs/2.0/configuration-reference/#job_name) for more details.
@@ -111,7 +111,7 @@ jobs:
       FOO: "bar"
 ```
 
-### Adding Environment Variables for a Container
+### Setting Container-Level Environment Variables
 
 Use the `environment` key in your `image` section to set variables for all commands run in the container.
 
@@ -145,7 +145,7 @@ jobs:
 
 See the [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#docker--machine-executor) document for details of the specification for the `environment` key of the docker executor type.
 
-### Setting an Environment Variable for a Step
+### Setting Step-Level Environment Variables
 
 Use the environment key inside a run step to set variables for a single command shell as shown in the following example:
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -16,26 +16,17 @@ This document describes using environment variables in CircleCI in the following
 
 ## Overview
 
-Environment variables can be set at several scope levels.
-From specific to general, these levels are:
+Environment variables are used according to a specific precedence order, as follows:
 
-1. Environment variables [set in shell commands](#setting-an-environment-variable-in-a-shell-command).
-Set in your `.circleci/config.yml` file.
-2. Environment variables [set in a step](#setting-an-environment-variable-in-a-step).
-Set in your `.circleci/config.yml` file.
-3. Environment variables [set in a container](#setting-an-environment-variable-in-a-container).
-Set in your `.circleci/config.yml` file.
-4. Environment variables [set in a job](#setting-an-environment-variable-in-a-job).
-Set in your `.circleci/config.yml` file.
-5. Environment variables [set in a context](#setting-an-environment-variable-in-a-context).
-Set within the CircleCI application.
-6. Environment variables [set in a project](#setting-an-environment-variable-in-a-project).
-Set within the CircleCI application.
-7. Environment variables [built into CircleCI](#circleci-built-in-environment-variables).
-Automatically available.
+1. Environment variables declared inside a shell command in a `run` step, for example `FOO=bar make install`.
+2. Environment variables declared with the `environment` key for a `run` step.
+3. Environment variables set with the `environment` key for a job.
+4. Environment variables set with the `environment` key for a container.
+5. Context environment variables (assuming the user has access to the Context). See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
+6. Project-level environment variables set on the Project Settings page.
+7. Special CircleCI environment variables defined in the [CircleCI Environment Variable Descriptions]({{ site.baseurl }}/2.0/env-vars/#circleci-built-in-environment-variables) section of this document.
 
-If an environment variable is set at multiple scope levels,
-CircleCI uses the variable set at the **most specific** level.
+Environment variables declared inside a shell command `run step`, for example `FOO=bar make install`, will override environment variables declared with the `environment` and `contexts` keys. Environment variables added on the Contexts page will take precedence over variables added on the Project Settings page. Finally, special CircleCI environment variables are loaded.
 
 **Warning**:
 Do not add secret or sensitive data anywhere inside `.circleci/config.yml`.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -41,7 +41,7 @@ CircleCI uses the variable set at the **most specific** level.
 Do not add secret or sensitive data anywhere inside `.circleci/config.yml`.
 The full text of `config.yml` is **fully visible**
 to anyone who has access to your project on CircleCI.
-Instead, put these data into [project](#setting-project-level-environment-variables) or [context]({{ site.baseurl }}/2.0/contexts/) settings.
+Instead, put these data into [project](#setting-an-environment-variable-in-a-project) or [context]({{ site.baseurl }}/2.0/contexts/) settings.
 
 Also note
 that running scripts within configuration

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -148,7 +148,8 @@ jobs:
 
 ### Setting Step-Level Environment Variables
 
-Use the environment key inside a run step to set variables for a single command shell as shown in the following example:
+To set environment variables at the step level,
+use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#run)
 
 ```yaml
 version: 2

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -16,17 +16,27 @@ This document describes using environment variables in CircleCI in the following
 
 ## Overview
 
-Environment variables are used according to a specific precedence order, as follows:
+Environment variables can be set at several scope levels.
+From general to specific, these levels are:
 
-1. Environment variables declared inside a shell command in a `run` step, for example `FOO=bar make install`.
-2. Environment variables declared with the `environment` key for a `run` step.
-3. Environment variables set with the `environment` key for a job.
-4. Environment variables set with the `environment` key for a container.
-5. Context environment variables (assuming the user has access to the Context). See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
-6. Project-level environment variables set on the Project Settings page.
-7. Special CircleCI environment variables defined in the [CircleCI Environment Variable Descriptions]({{ site.baseurl }}/2.0/env-vars/#circleci-built-in-environment-variables) section of this document.
+1. Environment variables [built into CircleCI](#circleci-built-in-environment-variables).
+Automatically available.
+2. [Project-specific](#setting-project-level-environment-variables) environment variables.
+Set within the CircleCI application.
+3. [Context-level]({{ site.baseurl }}/2.0/contexts/) environment variables.
+Set within the CircleCI application.
+3. [Job-level](#setting-job-level-environment-variables) environment variables.
+Set in your `.circleci/config.yml` file.
+4. [Container-level](#setting-container-level-environment-variables) environment variables.
+Set in your `.circleci/config.yml` file.
+5. [Step-level](#setting-step-level-environment-variables) environment variables.
+Set in your `.circleci/config.yml` file.
+6. Environment variables [set within shell commands](#interpolating-environment-variables).
+Set in your `.circleci/config.yml` file.
 
-Environment variables declared inside a shell command `run step`, for example `FOO=bar make install`, will override environment variables declared with the `environment` and `contexts` keys. Environment variables added on the Contexts page will take precedence over variables added on the Project Settings page. Finally, special CircleCI environment variables are loaded.
+CircleCI also loads environment variables in this order.
+If an environment variable is set at multiple scope levels,
+CircleCI uses the variable set at the **lowest level**.
 
 ## Setting Project-Level Environment Variables
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -79,7 +79,7 @@ refer to your shell's documentation on setting environment variables.
 
 ## Setting an Environment Variable in a Step
 
-To set environment variables in a step,
+To set an environment variable in a step,
 use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#run).
 
 ```yaml
@@ -100,7 +100,7 @@ jobs:
 
 ## Setting an Environment Variable in a Container
 
-To set environment variables at the container level,
+To set an environment variable in a container,
 use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#docker--machine--macosexecutor).
 
 ```yaml
@@ -133,7 +133,7 @@ jobs:
 
 ## Setting an Environment Variable in a Job
 
-To set environment variables at the job level,
+To set an environment variable in a job,
 use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
 
 ```yaml
@@ -150,7 +150,7 @@ jobs:
 
 Creating a context
 allows you to share environment variables across multiple projects.
-To set environment variables at the context level,
+To set an environment variables in a context,
 see the [Contexts documentation]({{ site.baseurl }}/2.0/contexts/).
 
 ## Setting an Environment Variable in a Project

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -144,8 +144,8 @@ To define environment variables for a job, use the `environment` key under the j
 See [here](https://circleci.com/docs/2.0/configuration-reference/#job_name) for more details.
 Ex:
 
-```
-version: 2.0
+```yaml
+version: 2
 
 jobs:
   build:
@@ -159,8 +159,8 @@ jobs:
 
 Use the `environment` key in your `image` section to set variables for all commands run in the container.
 
-```
-version: 2.0
+```yaml
+version: 2
 jobs:
   build:
     docker:
@@ -174,7 +174,7 @@ jobs:
 
 The following example shows separate environment variable settings for the primary container image (listed first) and the secondary or service container image.
 
-```
+```yaml
 version: 2
 jobs:
   build:

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -88,6 +88,10 @@ To add global environment variables that may be shared across projects, use the 
 
 It is also possible to set environment variables at the **job**, **container**, and **step** levels,
 in order of increasing specificity.
+Environment variables set at the container level
+take precedence over job-level environment variables,
+and environment variables set at the step level
+take precedence over container-level environment variables.
 
 **Warning**:
 Environment variables set within configuration are fully visible in build output.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -31,7 +31,7 @@ Set in your `.circleci/config.yml` file.
 Set in your `.circleci/config.yml` file.
 6. [Step-level](#setting-step-level-environment-variables) environment variables.
 Set in your `.circleci/config.yml` file.
-7. Environment variables [set within shell commands](#interpolating-environment-variables).
+7. Environment variables [set within shell commands](#setting-command-level-environment-variables).
 Set in your `.circleci/config.yml` file.
 
 CircleCI also loads environment variables in this order.
@@ -180,7 +180,7 @@ jobs:
             DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
 ```
 
-## Interpolating Environment Variables
+## Setting Command-Level Environment Variables
 
 CircleCI does not support interpolation
 when defining configuration variables like `working_directory` or `images`.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -20,8 +20,8 @@ Environment variables are used according to a specific precedence order, as foll
 
 1. Environment variables declared [inside a shell command](#setting-an-environment-variable-in-a-shell-command) in a `run` step, for example `FOO=bar make install`.
 2. Environment variables declared with the `environment` key [for a `run` step](#setting-an-environment-variable-in-a-step).
-3. Environment variables set with the `environment` key [for a container](#setting-an-environment-variable-in-a-container).
-4. Environment variables set with the `environment` key [for a job](#setting-an-environment-variable-in-a-job).
+3. Environment variables set with the `environment` key [for a job](#setting-an-environment-variable-in-a-job).
+4. Environment variables set with the `environment` key [for a container](#setting-an-environment-variable-in-a-container).
 5. Context environment variables (assuming the user has access to the Context). See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
 6. [Project-level environment variables](#setting-an-environment-variable-in-a-project) set on the Project Settings page.
 7. Special CircleCI environment variables defined in the [CircleCI Built-in Environment Variables](#circleci-built-in-environment-variables) section of this document.
@@ -89,6 +89,21 @@ jobs:
             DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
 ```
 
+## Setting an Environment Variable in a Job
+
+To set an environment variable in a job,
+use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
+
+```yaml
+version: 2
+jobs:
+  build:
+    docker:
+      - image: buildpack-deps:trusty
+    environment:
+      FOO: "bar"
+```
+
 ## Setting an Environment Variable in a Container
 
 To set an environment variable in a container,
@@ -120,21 +135,6 @@ jobs:
           FLASK_CONFIG: testing
           TEST_DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
       - image: circleci/postgres:9.6
-```
-
-## Setting an Environment Variable in a Job
-
-To set an environment variable in a job,
-use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
-
-```yaml
-version: 2
-jobs:
-  build:
-    docker:
-      - image: buildpack-deps:trusty
-    environment:
-      FOO: "bar"
 ```
 
 ## Setting an Environment Variable in a Context


### PR DESCRIPTION
Fixes #2314 and improves document flow and consistency.

Highlights include:
- Reordered sections. Sections listed in the same order as Overview
- "Setting" > "Declaring" / "Using" / "Adding". Corrected inconsistent usage.
- Created a follow-up to [reformat this section](https://circleci.atlassian.net/browse/CIRCLE-11426) with tables.

@ndintenfass and @marcomorain for technical accuracy
@michelle-luna for language edits