### PR TITLE
Add nofollow to internal app links

### DIFF
--- a/jekyll/_api/v1-reference.md
+++ b/jekyll/_api/v1-reference.md
@@ -132,9 +132,9 @@ All CircleCI API endpoints begin with `"https://circleci.com/api/v1.1/"`.
 
 ## Getting Started
 
-1.  Add an API token from your [account dashboard](https://circleci.com/account/api).
+1.  Add an API token from your [account dashboard](https://circleci.com/account/api){:rel="nofollow"}.
 2.  To test it,
-    [View it in your browser](https://circleci.com/api/v1.1/me)
+    [View it in your browser](https://circleci.com/api/v1.1/me){:rel="nofollow"}
     or call the API using `curl`:
 
     ```

--- a/jekyll/_cci1/adding-read-write-deployment-key.md
+++ b/jekyll/_cci1/adding-read-write-deployment-key.md
@@ -7,12 +7,12 @@ description: What to know when adding read/write deployment keys
 When you add a new project on CircleCI, we will create a deployment key on the web-based VCS (GitHub or Bitbucket) for your project. We'll use GitHub in the following examples. The deployment key is read-only, so CircleCI cannot push to your repository with the key. This is good from the security standpoint of view. However, sometimes you may want push to the repository from builds and you cannot do this with a read-only deployment key. You can manually add a read/write deployment key with the following steps.
 
 
-Suppose your GitHub repository is `https://github.com/you/test-repo` and the project on CircleCI is `https://circleci.com/gh/you/test-repo`.
+Suppose your GitHub repository is `https://github.com/you/test-repo` and the project on CircleCI is [https://circleci.com/gh/you/test-repo](https://circleci.com/gh/you/test-repo){:rel="nofollow"}.
 
 - Create a ssh key pair by following the [GitHub instructions](https://help.github.com/articles/generating-ssh-keys/)
   Note: when asked "Enter passphrase (empty for no passphrase)", do ***not*** enter a passphrase.
 - Go to `https://github.com/you/test-repo/settings/keys` on GitHub and click **Add deploy key**. Enter any title in the **Title** field, then copy and paste the public key you just created. Make sure to check **Allow write access**, then click **Add key**.
-- Go to `https://circleci.com/gh/you/test-repo/edit#ssh` on CircleCI and add the private key that you just created. Enter `github.com` in the **Hostname** field and press the submit button.
+- Go to [https://circleci.com/gh/you/test-repo/edit#ssh](https://circleci.com/gh/you/test-repo/edit#ssh){:rel="nofollow"} on CircleCI and add the private key that you just created. Enter `github.com` in the **Hostname** field and press the submit button.
 - If your project has an old deploy key CircleCI has generated, you'll need to remove it from `https://circleci.com/gh/you/test-repo/edit#checkout`
 
 * Note: You may need to add the hostname to your .ssh/config.

--- a/jekyll/_cci1/continuous-deployment-with-google-container-engine.md
+++ b/jekyll/_cci1/continuous-deployment-with-google-container-engine.md
@@ -142,7 +142,7 @@ starting up-to-date ones.
 We've seen how we can use CircleCI to deploy an app, in this examples, a Rails
 app, to Google Container Engine while using Google Container Registry to store
 the images. An example of a green (passing) build for the example project can
-be found [here](https://circleci.com/gh/circleci/docker-hello-google/43).
+be found [here](https://circleci.com/gh/circleci/docker-hello-google/43){:rel="nofollow"}.
 
 ### The Example Project Doesn't Run on GKE
 If you were following along with the

--- a/jekyll/_cci1/differences-between-trusty-and-precise.md
+++ b/jekyll/_cci1/differences-between-trusty-and-precise.md
@@ -57,6 +57,6 @@ On 14.04, both tools and creation process of build image are public. Namely, the
 
 [circleci/image-builder](https://github.com/circleci/image-builder) is a collection of shell scripts that installs many tools and software in a way that works the best on CircleCI.
 The shell scripts are called by a command `circleci-install` in the main [Dockerfile](https://github.com/circleci/image-builder/blob/master/Dockerfile).
-Whenever we make a new build image, we run a [image-builder build](https://circleci.com/gh/circleci/image-builder) that builds a Docker image and push to our [Docker Hub](https://hub.docker.com/r/circleci/build-image/tags/) repository.
+Whenever we make a new build image, we run a [image-builder build](https://circleci.com/gh/circleci/image-builder){:rel="nofollow"} that builds a Docker image and push to our [Docker Hub](https://hub.docker.com/r/circleci/build-image/tags/) repository.
 
-[circleci/package-builder](https://github.com/circleci/package-builder) builds different versions of Ruby, Python, Nodejs, and PHP and creates Debian packages that are easy to install on image-builder. These packages are then pushed to our [PackageCloud](https://packagecloud.io/circleci/trusty) repository by [package-builder build](https://circleci.com/gh/circleci/package-builder).
+[circleci/package-builder](https://github.com/circleci/package-builder) builds different versions of Ruby, Python, Nodejs, and PHP and creates Debian packages that are easy to install on image-builder. These packages are then pushed to our [PackageCloud](https://packagecloud.io/circleci/trusty) repository by [package-builder build](https://circleci.com/gh/circleci/package-builder){:rel="nofollow"}.

--- a/jekyll/_cci1/downgrading-mysql-to-5.6.md
+++ b/jekyll/_cci1/downgrading-mysql-to-5.6.md
@@ -72,7 +72,7 @@ sudo dpkg -i .dependency-cache/mysql5.6/libmysqlclient18_5.6.23-1ubuntu14.04_amd
 sudo dpkg -i .dependency-cache/mysql5.6/libmysqlclient-dev_5.6.23-1ubuntu14.04_amd64.deb
 ```
 
-The [following build](https://circleci.com/gh/zzak/mysql-down/8#config/containers/0) demonstrates successfully downgrading MySQL to 5.6.
+The [following build](https://circleci.com/gh/zzak/mysql-down/8#config/containers/0){:rel="nofollow"} demonstrates successfully downgrading MySQL to 5.6.
 
 ![](  {{ site.baseurl }}/assets/img/docs/downgrade-mysql-to-5.6.png)
 

--- a/jekyll/_cci1/getting-started.md
+++ b/jekyll/_cci1/getting-started.md
@@ -18,7 +18,7 @@ The reason it's so easy is that we automatically infer your settings from your c
 We expect you to have a project that roughly follows best practices for your platform.
 If you do, your tests will be up and running in a flash.
 Add
-your [first project](https://circleci.com/dashboard) now!
+your [first project](https://circleci.com/dashboard){:rel="nofollow"} now!
 
 ### When the magic doesn't work?
 

--- a/jekyll/_cci1/ios-builds-on-os-x.md
+++ b/jekyll/_cci1/ios-builds-on-os-x.md
@@ -9,7 +9,7 @@ order: 71
 
 CircleCI offers support for building and testing iOS and macOS projects.
 You can select a macOS project you would like to build on the [Add
-Projects page](https://circleci.com/add-projects).
+Projects page](https://circleci.com/add-projects){:rel="nofollow"}.
 
 If you're unable to find your project in the "OS X" tab, it may be listed as a
 "Linux" project. After adding your project as a "Linux" build, you can change
@@ -397,7 +397,7 @@ Please try using any of the versions of simulator that are present on the machin
 
 ### Can't Add Project as macOS Build
 
-If you are trying to add an macOS project from the ["add-project"](https://circleci.com/add-projects) page, but you don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page, then on the "Build Environment" page you will see the "Build OS X project" option.
+If you are trying to add an macOS project from the ["add-project"](https://circleci.com/add-projects){:rel="nofollow"} page, but you don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page, then on the "Build Environment" page you will see the "Build OS X project" option.
 
 ### Ruby Segfaults
 

--- a/jekyll/_cci1/ios-getting-started.md
+++ b/jekyll/_cci1/ios-getting-started.md
@@ -7,7 +7,7 @@ description: Setting Up iOS applications on CircleCI
 order: 70
 ---
 
-To get your build running on CircleCI, you first need to [add your project to CircleCI](https://circleci.com/projects). Once you’ve done this, GitHub/Bitbucket will start notifying us of changes to your repository so we can perform builds.
+To get your build running on CircleCI, you first need to [add your project to CircleCI](https://circleci.com/projects){:rel="nofollow"}. Once you’ve done this, GitHub/Bitbucket will start notifying us of changes to your repository so we can perform builds.
 
 By default, we build projects on Linux, so you’ll need to enable macOS for your project. You can do this by going to **Project Settings** -> **Build Environment** and enabling the **Build OS X Project** setting.
 

--- a/jekyll/_cci1/perform-maven-release.md
+++ b/jekyll/_cci1/perform-maven-release.md
@@ -80,7 +80,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
 }' "https://circleci.com/api/v1.1/project/github/ORG/PROJECT/tree/master?circle-token=TOKEN"
 ```
 
-**NOTE**: replace `TOKEN` in the URL shown with the API token from your [account dashboard](https://circleci.com/account/api). Be sure to also replace `ORG` and `PROJECT` in the URL shown.
+**NOTE**: replace `TOKEN` in the URL shown with the API token from your [account dashboard](https://circleci.com/account/api){:rel="nofollow"}. Be sure to also replace `ORG` and `PROJECT` in the URL shown.
 
 Within the JSON body, adjust these fields as needed for this particular release build:
 

--- a/jekyll/_cci1/polling-project-status.md
+++ b/jekyll/_cci1/polling-project-status.md
@@ -13,7 +13,7 @@ which is the format (originally from CruiseControl) consumed by common CI monito
 
 ### Configuration
 
-Make sure to use an account api token, which you can find or create in your [user settings page](https://circleci.com/account/api)
+Make sure to use an account api token, which you can find or create in your [user settings page](https://circleci.com/account/api){:rel="nofollow"}
 
 It should be possible to use any of these tools to poll your CircleCI builds, by
 configuring them with a URL of the form:

--- a/jekyll/_cci1/setting-up-parallelism.md
+++ b/jekyll/_cci1/setting-up-parallelism.md
@@ -8,7 +8,7 @@ order: 20
 
 This guide assumes you already have a green build without parallelism. If you haven't set up your project yet, check out [getting started guide]({{ site.baseurl }}/1.0/getting-started/).
 
-Head to [your dashboard](https://circleci.com/dashboard) and locate the project you'd like to adjust parallelism for. Click the gear icon to the right, and you'll be treated to the settings for that project.
+Head to [your dashboard](https://circleci.com/dashboard){:rel="nofollow"} and locate the project you'd like to adjust parallelism for. Click the gear icon to the right, and you'll be treated to the settings for that project.
 
 Now click **Adjust Parallelism** in the "Build Settings" section. Simply choose the number of parallel containers you want to use for each build.
 

--- a/jekyll/_cci1/shipio-to-circleci-migration.md
+++ b/jekyll/_cci1/shipio-to-circleci-migration.md
@@ -11,7 +11,7 @@ Coming from Ship.io? You've come to the right place, we'll help you get started.
 
 For iOS projects, please [contact support](https://support.circleci.com/hc/en-us) with the name of your GitHub user or organization for access to the iOS build system. Once you've been enabled,
 
-1. Add your project on the [Add Projects page](https://circleci.com/add-projects).
+1. Add your project on the [Add Projects page](https://circleci.com/add-projects){:rel="nofollow"}.
 2. Turn on the "Build iOS project" setting through the **Project Settings > Build Settings > Build Environment** page of your your project.
 3. Push a new commit to start a build on the iOS build system.
 
@@ -19,7 +19,7 @@ For iOS projects, please [contact support](https://support.circleci.com/hc/en-us
 
 You can easily migrate your Android projects from Ship.io to CircleCI in a few simple steps.
 
-1. Add your project on the [Add Projects page](https://circleci.com/add-projects).
+1. Add your project on the [Add Projects page](https://circleci.com/add-projects){:rel="nofollow"}.
 2. After adding your project, CircleCI will usually infer your build settings. Sometimes the magic doesn't always work. Please take a look at our [getting started]( {{ site.baseurl }}/1.0/getting-started/) documentation.
 3. Check out the [Testing Android on CircleCI]( {{ site.baseurl }}/1.0/android/) documentation.
 
@@ -48,7 +48,7 @@ CircleCI will detect your workspace. If you have more than one workspace, you ca
 Make sure any scripts that you want to run are included in your repository. You can run your script using a bash command (e.g. `./example_script.sh`) configured in our UI (through **Project Settings > Dependency/Test Commands**) or in a [circle.yml]( {{ site.baseurl }}/1.0/configuration/) file.
 
 ### Configure build notifications
-You can configure build notifications using the "Notifications" section of your Project Settings. Email notifications can be configured from the [Account page](https://circleci.com/account).
+You can configure build notifications using the "Notifications" section of your Project Settings. Email notifications can be configured from the [Account page](https://circleci.com/account){:rel="nofollow"}.
 
 ### Customize the build commands
 You can add to or override our inferred commands through your Project Settings or through a [circle.yml file]( {{ site.baseurl }}/1.0/configuration/).
@@ -66,7 +66,7 @@ We recommend using [fastlane](https://medium.com/mitoo-insider/how-to-set-up-con
 CircleCI is a powerful, developer friendly platform that allows for much greater flexibility in customizing your build environment. At Ship.io, "build steps" were used to specify configuration settings.
 Rather than manually adding Gradle tasks individually or spending precious time tinkering with how much RAM the Android Emulator uses, at CircleCI, nearly all of your configuration is done on the circle.yml. CircleCI has customizable notifications that keep you up to speed with the status of your build.
 You can configure build notifications using the "Notifications" section of your Project Settings.
-Email notifications can be configured from the [Account page](https://circleci.com/account).
+Email notifications can be configured from the [Account page](https://circleci.com/account){:rel="nofollow"}.
 
 
 ### Run Gradle tests

--- a/jekyll/_cci1/status-badges.md
+++ b/jekyll/_cci1/status-badges.md
@@ -9,10 +9,10 @@ We provide project and branch status images, which you can embed anywhere you wa
 README, a dashboard, or anywhere else you can imagine!
 
 Here's our current build status:
-![](https://circleci.com/gh/circleci/circle.png?circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e)
+![](https://circleci.com/gh/circleci/circle.png?circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e){:rel="nofollow"}
 
 The status images are also available in "shield" style:
-![](https://circleci.com/gh/circleci/circle.svg?style=shield&circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e)
+![](https://circleci.com/gh/circleci/circle.svg?style=shield&circle-token=3cc80b12ab3627373c76e13735b8bc00a1259b9e){:rel="nofollow"}
 
 In the project settings for each of your repositories, there's a "Status Badges" section that can generate code for Markdown, rst, etc.  Or if you want to tweak them manually, how they work is straightforward:
 
@@ -22,8 +22,8 @@ You can use a simple image URL like this to see the status of your project's def
 `https://circleci.com/gh/:owner/:repo.svg?style=shield&circle-token=:circle-token`
 
 For example:
-`circleci/mongofinil` [badge](https://circleci.com/gh/circleci/mongofinil.png?circle-token=b14acf911433d315298235b0c2fbf7b2670a92a8)
-and [shield](https://circleci.com/gh/circleci/mongofinil.svg?&style=shield&circle-token=b14acf911433d315298235b0c2fbf7b2670a92a8)
+`circleci/mongofinil` [badge](https://circleci.com/gh/circleci/mongofinil.png?circle-token=b14acf911433d315298235b0c2fbf7b2670a92a8){:rel="nofollow"}
+and [shield](https://circleci.com/gh/circleci/mongofinil.svg?&style=shield&circle-token=b14acf911433d315298235b0c2fbf7b2670a92a8){:rel="nofollow"}
 
 Or you can see the status of any specific branch: `https://circleci.com/gh/:owner/:repo/tree/:branch.png?circle-token=:circle-token`
 
@@ -31,8 +31,8 @@ Or you can see the status of any specific branch: `https://circleci.com/gh/:owne
 
 For example:
 circleci/mongofinil master branch
-[badge](https://circleci.com/gh/circleci/mongofinil/tree/master.png?circle-token=b14acf911433d315298235b0c2fbf7b2670a92a8)
-and [shield](https://circleci.com/gh/circleci/mongofinil/tree/master.svg?style=shield&circle-token=b14acf911433d315298235b0c2fbf7b2670a92a8)
+[badge](https://circleci.com/gh/circleci/mongofinil/tree/master.png?circle-token=b14acf911433d315298235b0c2fbf7b2670a92a8){:rel="nofollow"}
+and [shield](https://circleci.com/gh/circleci/mongofinil/tree/master.svg?style=shield&circle-token=b14acf911433d315298235b0c2fbf7b2670a92a8){:rel="nofollow"}
 
 One small wrinkle: if your branch name includes characters that are "special" in URLs (most commonly '/') they'll need to be
 [URL encoded](http://www.w3schools.com/tags/ref_urlencode.asp)

--- a/jekyll/_cci1/web-notifications.md
+++ b/jekyll/_cci1/web-notifications.md
@@ -9,7 +9,7 @@ order: 40
 
 ## Turning On Build Notifications
 
-Go to your [CircleCI account settings](https://circleci.com/account). If you've
+Go to your [CircleCI account settings](https://circleci.com/account){:rel="nofollow"}. If you've
 not yet granted CircleCI permission to send you web notifications, you should see
 the following message at the bottom in the "Web Notifications" section:
 

--- a/jekyll/_cci1/what-happens.md
+++ b/jekyll/_cci1/what-happens.md
@@ -27,5 +27,5 @@ This means that:
     *   Your code isn't accessible to other users
     *   We run your tests freshly each time you push
 
-*   You can watch your tests update in real-time on [your dashboard](https://circleci.com/dashboard).
+*   You can watch your tests update in real-time on [your dashboard](https://circleci.com/dashboard){:rel="nofollow"}.
 *   We'll send you a notification when you're done.

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -138,7 +138,7 @@ When CircleCI runs a build, a link to the core dump file appears under the Artif
 To download your artifacts with `curl`,
 follow these steps.
 
-1. On the [Personal API Tokens](https://circleci.com/account/api) settings page,
+1. On the [Personal API Tokens](https://circleci.com/account/api){:rel="nofollow"} settings page,
 click **Create New Token**.
 
 2. In the **Token name** field,

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -11,7 +11,7 @@ order: 34
 
 CircleCI collects test metadata from XML files and uses it to provide insights into your {% comment %} TODO: Job {% endcomment %}build. This document describes how to configure CircleCI to output test metadata as XML for some common test runners and store reports with the `store_test_results` step. To see test result as artifacts, upload them using the `store_artifacts` step.
 
-After configuring CircleCI to collect your test metadata, tests that fail most often appear in a list on the details page of   [Insights](https://circleci.com/build-insights) in the application to identify flaky tests and isolate recurring issues.  
+After configuring CircleCI to collect your test metadata, tests that fail most often appear in a list on the details page of [Insights](https://circleci.com/build-insights){:rel="nofollow"} in the application to identify flaky tests and isolate recurring issues.
 
 ![Insights for Failed Tests]( {{ site.baseurl }}/assets/img/docs/insights.png)
 

--- a/jekyll/_cci2/examples.md
+++ b/jekyll/_cci2/examples.md
@@ -15,7 +15,7 @@ Refer to the following documents and linked `.circleci/config.yml` files for com
 </div>
 
 1. Add a shell script in your `.circleci` directory, for example, `run-build-locally.sh`.
-2. Create a token on the [Personal API Tokens page](https://circleci.com/account/api).
+2. Create a token on the [Personal API Tokens page](https://circleci.com/account/api){:rel="nofollow"}.
 3. Export the token on the command line `export CIRCLE_TOKEN=<token-from-step-above>`.
 4. Gather the following information:
   - Commit hash from which to build

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -46,7 +46,7 @@ jobs:
           bundle exec cucumber
 ```
         
-CircleCI runs your tests on a clean container every time so that your code is never accessible to other users and the tests are fresh each time you push. Watch your tests update in real-time on [your dashboard](https://circleci.com/dashboard) or get status when CircleCI sends you a notification email after the job finishes. Status badges also appear on GitHub or Bitbucket as shown in the following screenshot for a commit from user keybits:
+CircleCI runs your tests on a clean container every time so that your code is never accessible to other users and the tests are fresh each time you push. Watch your tests update in real-time on [your dashboard](https://circleci.com/dashboard){:rel="nofollow"} or get status when CircleCI sends you a notification email after the job finishes. Status badges also appear on GitHub or Bitbucket as shown in the following screenshot for a commit from user keybits:
 
 ![Status Badge After Commit]({{ site.baseurl }}/assets/img/docs/status_badge.png)
 
@@ -97,7 +97,7 @@ Here are the steps to set a machine user's SSH key as a checkout key for your pr
 
 2. Go to <https://circleci.com> and log in. GitHub will ask you to authorize CircleCI to access the machine user's account, so click on the **Authorize application** button.
 
-3. Go to <https://circleci.com/add-projects> and follow the projects you want the machine user to have access to.
+3. Go to <[https://circleci.com/add-projects](https://circleci.com/add-projects){:rel="nofollow"}> and follow the projects you want the machine user to have access to.
 
 4. Go to the **Project Settings > Checkout SSH keys** page and then click on the ***Authorize w/GitHub*** button to give CircleCI permission to create and upload SSH keys to GitHub on behalf of the machine user.
 
@@ -124,7 +124,7 @@ This section provides an overview of the possible team and individual account ch
 
 1. If an individual has a personal GitHub account, they will use it to log in to CircleCI and follow the project on CircleCI. Each 'collaborator' on that repository in GitHub is also able to follow the project and build on CircleCI when they push commits. Due to how GitHub and Bitbucket store collaborators, the CircleCI Team page may not show a complete list. For an accurate list of contributors, please refer to your GitHub or Bitbucket project page.
 
-2. If an individual upgrades to a GitHub Team account they can add team members and may give admin permissions on the repo to those who run builds. The owner of the team GitHub account (org) must go to the CircleCI [Add Project](https://circleci.com/add-projects), click the link to GitHub's application permissions screen, and select Authorize CircleCI to enable members of the org to follow the project from their account. A team account with two members is $25 per month instead of $7 per month for a personal account.
+2. If an individual upgrades to a GitHub Team account they can add team members and may give admin permissions on the repo to those who run builds. The owner of the team GitHub account (org) must go to the CircleCI [Add Project](https://circleci.com/add-projects){:rel="nofollow"}, click the link to GitHub's application permissions screen, and select Authorize CircleCI to enable members of the org to follow the project from their account. A team account with two members is $25 per month instead of $7 per month for a personal account.
 
 3. An individual Bitbucket account is free for private repos for teams of up to five. An individual may create a Bitbucket team, add members and give out admin permissions on the repo as needed to those who need to build. This project would appear in CircleCI for members to follow without additional cost.
 
@@ -162,7 +162,7 @@ The steps to create a user key depend on your VCS.
 
 In this example,
 the GitHub repository is `https://github.com/you/test-repo`,
-and the CircleCI project is `https://circleci.com/gh/you/test-repo`.
+and the CircleCI project is [https://circleci.com/gh/you/test-repo](https://circleci.com/gh/you/test-repo){:rel="nofollow"}.
 
 1. Create an SSH key pair by following the [GitHub instructions](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/).
 When prompted to enter a passphrase,
@@ -175,7 +175,7 @@ then copy and paste the key you created in step 1.
 Check "Allow write access",
 then click "Add key".
 
-3. Go to `https://circleci.com/gh/you/test-repo/edit#ssh`,
+3. Go to [https://circleci.com/gh/you/test-repo/edit#ssh](https://circleci.com/gh/you/test-repo/edit#ssh){:rel="nofollow"},
 and add the key you created in step 1.
 In the "Hostname" field,
 enter "github.com",

--- a/jekyll/_cci2/help-and-support.md
+++ b/jekyll/_cci2/help-and-support.md
@@ -23,7 +23,7 @@ If you can't find your question, post it yourself and one of our support enginee
 
 ## Create a Support Request
 
-If you have a paid account, then you can ask directly for help from our support team. To create a support request, head to your [dashboard](https://circleci.com/dashboard/), click the round question mark button in the lower-right corner, then click 'Support'.
+If you have a paid account, then you can ask directly for help from our support team. To create a support request, head to your [dashboard](https://circleci.com/dashboard/){:rel="nofollow"}, click the round question mark button in the lower-right corner, then click 'Support'.
 
 In the form that appears, enter a title for your question, along with a message detailing your problem. You can also attach files if you have a helpful screenshot or cute cat picture.
 

--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -51,7 +51,7 @@ The `- image: circleci/ruby:2.4.1` text tells CircleCI what Docker image to use 
 
 ## Setting up Your Build on CircleCI
 
-1. For this step, you will need a CircleCI account.  Visit the CircleCI [signup page](https://circleci.com/signup) and click "Start with GitHub". You will need to give CircleCI access to your GitHub account to run your builds. If you already have a CircleCI account then you can navigate to your [dashboard](https://circleci.com/dashboard).
+1. For this step, you will need a CircleCI account.  Visit the CircleCI [signup page](https://circleci.com/signup) and click "Start with GitHub". You will need to give CircleCI access to your GitHub account to run your builds. If you already have a CircleCI account then you can navigate to your [dashboard](https://circleci.com/dashboard){:rel="nofollow"}.
 
 2. Next, you will be given the option of *following* any projects you have access to that are already building on CircleCI (this would typically apply to developers connected to a company or organization's GitHub account). On the next screen, you'll be able to add the repo you just created as a new project on CircleCI.
 

--- a/jekyll/_cci2/language-clojure.md
+++ b/jekyll/_cci2/language-clojure.md
@@ -59,7 +59,7 @@ jobs: # basic units of work in a run
 
 The configuration above is from a demo Clojure app, which you can access at [https://github.com/CircleCI-Public/circleci-demo-clojure-luminus](https://github.com/CircleCI-Public/circleci-demo-clojure-luminus).
 
-If you want to step through it yourself, you can fork the project on GitHub and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
+If you want to step through it yourself, you can fork the project on GitHub and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
 
 Now we’re ready to build a `config.yml` from scratch.
 

--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -24,7 +24,7 @@ If you're new to CircleCI 2.0, we recommend reading our [walkthrough](#config-wa
 We maintain a reference Go project to show how to build on CircleCI 2.0:
 
 - <a href="https://github.com/CircleCI-Public/circleci-demo-go" target="_blank">Demo Go Project on GitHub</a>
-- <a href="https://circleci.com/gh/CircleCI-Public/circleci-demo-go" target="_blank">Demo Go Project building on CircleCI</a>
+- [Demo Go Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-go){:rel="nofollow"}
 
 In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-go/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using CircleCI 2.0 with Go projects.
 
@@ -37,7 +37,7 @@ We recommend using a CircleCI pre-built image that comes pre-installed with tool
 A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
 
 1. Fork the project on GitHub to your own account
-2. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to the project you just forked
+2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to the project you just forked
 3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 If you want to test your changes locally, use [our CLI tool](https://circleci.com/docs/2.0/local-jobs/) and run `circleci build`.
@@ -193,7 +193,7 @@ Finally, let's specify a path to store the results of the tests.
           path: /tmp/test-results
 ```
 
-Success! You just set up CircleCI 2.0 for a Go app. Check out our {% comment %} TODO: Jobs {% endcomment %} [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-go) to see how this looks when building on CircleCI.
+Success! You just set up CircleCI 2.0 for a Go app. Check out our {% comment %} TODO: Jobs {% endcomment %} [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-go){:rel="nofollow"} to see how this looks when building on CircleCI.
 
 ## Deploy
 

--- a/jekyll/_cci2/language-java.md
+++ b/jekyll/_cci2/language-java.md
@@ -68,7 +68,7 @@ jobs: # a collection of steps
 
 The configuration above is from a demo Java app, which you can access at [https://github.com/CircleCI-Public/circleci-demo-java-spring](https://github.com/CircleCI-Public/circleci-demo-java-spring).
 
-If you want to step through it yourself, you can fork the project on GitHub and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
+If you want to step through it yourself, you can fork the project on GitHub and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
 
 Now we’re ready to build a `config.yml` from scratch.
 

--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -19,7 +19,7 @@ If you're new to CircleCI 2.0, we recommend reading our [Project Walkthrough]({{
 We maintain a reference JavaScript NodeJS project to show how to build an Express.js app on CircleCI 2.0:
 
 - <a href="https://github.com/CircleCI-Public/circleci-demo-javascript-express" target="_blank">Demo JavaScript Node Project on GitHub</a>
-- <a href="https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express" target="_blank">Demo JavaScript Node Project building on CircleCI</a>
+- [Demo JavaScript Node Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express){:rel="nofollow"}
 
 In the project you will find a CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-javascript-express/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using CircleCI 2.0 with Node projects.
 
@@ -34,7 +34,7 @@ Database images for use as a secondary 'service' container are also available.
 A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
 
 1. Fork the project on GitHub to your own account
-2. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to the project you just forked
+2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to the project you just forked
 3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 ## Config Walkthrough
@@ -83,7 +83,7 @@ jobs: # a collection of steps
 {% endraw %}          
 ---
 
-Success! You just set up CircleCI 2.0 for a NodeJS app. Check out our [project’s {% comment %} TODO: Job {% endcomment %}build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express) to see how this looks when building on CircleCI.
+Success! You just set up CircleCI 2.0 for a NodeJS app. Check out our [project’s {% comment %} TODO: Job {% endcomment %}build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express){:rel="nofollow"} to see how this looks when building on CircleCI.
 
 ## Deploy
 

--- a/jekyll/_cci2/language-php.md
+++ b/jekyll/_cci2/language-php.md
@@ -19,7 +19,7 @@ If you're new to CircleCI 2.0, we recommend reading our [Project Walkthrough]({{
 We maintain a reference PHP Laravel project to show how to build PHP on CircleCI 2.0:
 
 - <a href="https://github.com/CircleCI-Public/circleci-demo-php-laravel" target="_blank">Demo PHP Laravel Project on GitHub</a>
-- <a href="https://circleci.com/gh/CircleCI-Public/circleci-demo-php-laravel" target="_blank">Demo PHP Laravel Project building on CircleCI</a>
+- [Demo PHP Laravel Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-php-laravel){:rel="nofollow"}
 
 In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-php-laravel/blob/circleci-2.0/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using CircleCI 2.0 with PHP projects.
 
@@ -34,7 +34,7 @@ Database images for use as a secondary 'service' container are also available.
 A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
 
 1. Fork the project on GitHub to your own account
-2. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to the project you just forked
+2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to the project you just forked
 3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 ---
@@ -85,7 +85,7 @@ jobs: # a collection of steps
 
 ---
 
-Success! You just set up CircleCI 2.0 for a PHP app. Check out our {% comment %} TODO: Job {% endcomment %} [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-php-laravel) to see how this looks when building on CircleCI.
+Success! You just set up CircleCI 2.0 for a PHP app. Check out our {% comment %} TODO: Job {% endcomment %} [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-php-laravel){:rel="nofollow"} to see how this looks when building on CircleCI.
 
 ## Deploy
 

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -19,7 +19,7 @@ This document describes CircleCI configuration for a sample application written 
 We maintain a reference Python Django project to show how to build Django on CircleCI 2.0:
 
 - <a href="https://github.com/CircleCI-Public/circleci-demo-python-django" target="_blank">Demo Python Django Project on GitHub</a>
-- <a href="https://circleci.com/gh/CircleCI-Public/circleci-demo-python-django" target="_blank">Demo Python Django Project building on CircleCI</a>
+[Demo Python Django Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-python-django){:rel="nofollow"}
 
 In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-python-django/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using CircleCI 2.0 with Python projects.
 
@@ -36,7 +36,7 @@ Database images for use as a secondary 'service' container are also available on
 A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
 
 1. Fork the project on GitHub to your own account.
-2. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to the project you just forked.
+2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to the project you just forked.
 3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 ## Config Walkthrough

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -21,7 +21,7 @@ If you’re in a rush, just copy the sample configuration below into a `.circlec
 CircleCI maintains the sample Ruby on Rails project at the following links:
 
 - <a href="https://github.com/CircleCI-Public/circleci-demo-ruby-rails" target="_blank">Demo Ruby on Rails Project on GitHub</a>
-- <a href="https://circleci.com/gh/CircleCI-Public/circleci-demo-ruby-rails" target="_blank">Demo Ruby on Rails Project building on CircleCI</a>
+- [Demo Ruby on Rails Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-ruby-rails){:rel="nofollow"}
 
 In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-ruby-rails/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>.
 
@@ -131,7 +131,7 @@ jobs: # a collection of steps
 A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
 
 1. [Fork the project][fork-demo-project] on GitHub to your own account.
-2. Go to the [Add Projects](https://circleci.com/add-projects) page in CircleCI and click the Build Project button next to the project you just forked.
+2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to the project you just forked.
 3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 ---
@@ -296,7 +296,7 @@ For more on `circleci tests glob` and `circleci tests split` commands, please re
 
 ---
 
-Success! You just set up CircleCI 2.0 for a Ruby on Rails app. Check out our {% comment %} TODO: Job {% endcomment %} [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-ruby-rails) to see how this looks when building on CircleCI.
+Success! You just set up CircleCI 2.0 for a Ruby on Rails app. Check out our {% comment %} TODO: Job {% endcomment %} [project’s build page](https://circleci.com/gh/CircleCI-Public/circleci-demo-ruby-rails){:rel="nofollow"} to see how this looks when building on CircleCI.
 
 ## Deployment
 

--- a/jekyll/_cci2/managing-api-tokens.md
+++ b/jekyll/_cci2/managing-api-tokens.md
@@ -38,8 +38,8 @@ is to delete and recreate them.
 ### Creating a Personal API Token
 
   1. In the CircleCI application,
-  go to your [User settings](https://circleci.com/account).
-  2. Click [Personal API Tokens](https://circleci.com/account/api).
+  go to your [User settings](https://circleci.com/account){:rel="nofollow"}.
+  2. Click [Personal API Tokens](https://circleci.com/account/api){:rel="nofollow"}.
   3. Click the **Create New Token** button.
   4. In the **Token name** field,
   type a memorable name for the token.

--- a/jekyll/_cci2/nomad.md
+++ b/jekyll/_cci2/nomad.md
@@ -63,20 +63,9 @@ Complete the following steps to get logs from the allocation of the specified jo
 
 1. Get the logs from the allocation with `nomad logs -stderr <allocation-id>`
 
-<!---
-## Scaling the Nomad Cluster
-Nomad itself does not provide a scaling method for cluster, so you must implement one. This section provides basic operations regarding scaling a cluster.
---->
-
 ### Scaling Up the Client Cluster
 
 Refer to the Auto Scaling section of the [Administrative Variables, Monitoring, and Logging](https://circleci.com/docs/2.0/monitoring/#auto-scaling) document for details about adding Nomad Client instances to an AWS auto scaling group and using a scaling policy to scale up automatically according to your requirements. 
-
-<!--- 
-commenting until we have non-aws installations?
-Scaling up Nomad cluster is very straightforward. To scale up, you need to register new Nomad clients into the cluster. If a Nomad client knows the IP addresses of Nomad servers, then the client can register to the cluster automatically.
-HashiCorp recommends using Consul or other service discovery mechanisms to make this more robust in production. For more information, see the following pages in the official documentation for [Clustering](https://www.nomadproject.io/intro/getting-started/cluster.html), [Service Discovery](https://www.nomadproject.io/docs/service-discovery/index.html), and [Consul Integration](https://www.nomadproject.io/docs/agent/configuration/consul.html).
---->
 
 ### Shutting Down a Nomad Client
 

--- a/jekyll/_cci2/notifications.md
+++ b/jekyll/_cci2/notifications.md
@@ -16,11 +16,11 @@ CircleCI has integrated chat notifications, automated email notifications, and w
 CircleCI supports Slack, HipChat, Campfire, Flowdock and IRC notifications. Configure chat notifications on the Project Settings > Chat Notifications page of the CircleCI application using the in-app instructions and links for each chat app.
 
 ## Set or Change Email Notifications
-Use the [Notifications](https://circleci.com/account/notifications) page of the CircleCI application to set or change your default email address for notifications, to turn off email notifications, or get a notification email for every build.
+Use the [Notifications](https://circleci.com/account/notifications){:rel="nofollow"} page of the CircleCI application to set or change your default email address for notifications, to turn off email notifications, or get a notification email for every build.
 
 ## Enabling Web Notifications
 
-1. Go to your [CircleCI user settings](https://circleci.com/account/notifications). The link to turn on permissions is at the bottom in the Web Notifications section as shown in the screenshot:
+1. Go to your [CircleCI user settings](https://circleci.com/account/notifications){:rel="nofollow"}. The link to turn on permissions is at the bottom in the Web Notifications section as shown in the screenshot:
 ![](  {{ site.baseurl }}/assets/img/docs/notification-default-message.png)
 
 2. Click the link to turn on permissions. Your browser will ask you to confirm that you want to allow notifications from CircleCI. 

--- a/jekyll/_cci2/project-walkthrough.md
+++ b/jekyll/_cci2/project-walkthrough.md
@@ -318,7 +318,7 @@ jobs:
             git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git master
 ```
 
-Here's a passing build with deployment for the demo app: <https://circleci.com/gh/CircleCI-Public/circleci-demo-python-flask/23>
+Here's a passing build with deployment for the demo app: <[https://circleci.com/gh/CircleCI-Public/circleci-demo-python-flask/23](https://circleci.com/gh/CircleCI-Public/circleci-demo-python-flask/23){:rel="nofollow"}>
 
 ### Additional Heroku Configuration
 


### PR DESCRIPTION
Makes all internal application links nofollow.

Resolves [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-7186).