### PR TITLE
Make the name of the triggered job consistent

### DIFF
--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -11,11 +11,11 @@ order: 80
  
 This document describes how to initiate jobs using the CircleCI API. **Note:** It is not yet possible to run Workflows with the API. Refer to the [CircleCI API Documentation]({{ site.baseurl }}/api/) for the complete reference. 
 
-The following example initiates a `deploy_production` job by using `curl`.
+The following example initiates a `deploy_docker` job by using `curl`.
 
 ```yaml
 curl -u ${CIRCLE_API_TOKEN}: \
-     -d build_parameters[CIRCLE_JOB]=deploy_production \
+     -d build_parameters[CIRCLE_JOB]=deploy_docker \
      https://circleci.com/api/v1.1/project/<vcs-type>/<org>/<repo>/tree/master
 ```
 


### PR DESCRIPTION
__WHY this PR was created__ There is an inconsistency within the `api-job-trigger.md` documentation page. The top part of the page talks about calling the `deploy_production` job while `config.yml` example at the bottom part of the page defines the `deploy_docker` job. 

__WHAT this PR changes__ This PR sets the name of the job at the top of the page to `deploy_docker` to match the `config.yml` definition