### PR TITLE
Remove duplicate env var section

### DIFF
--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -221,8 +221,8 @@ With the following, nested under `steps:` and customizing for your application a
 
 ## Environment Variables
 
-In CircleCI 2.0, all defined values are treated literally.
-However, you **can** interpolate a variable within a command
+In CircleCI 2.0, all defined environment variables are treated literally.
+It is possible to interpolat variables within a command
 by setting it for the current shell.
 
 For full details,

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -225,8 +225,8 @@ In CircleCI 2.0, all defined environment variables are treated literally.
 It is possible to interpolat variables within a command
 by setting it for the current shell.
 
-For full details,
-refer to the CircleCI 2.0 document [Using Environment Variables](http://localhost:4000/docs/2.0/env-vars/).
+For more information,
+refer to the CircleCI 2.0 document [Using Environment Variables]({{ site.baseurl }}/2.0/env-vars/).
 
 ## Validate YAML
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -222,8 +222,6 @@ With the following, nested under `steps:` and customizing for your application a
 ## Environment Variables
 
 In CircleCI 2.0, all defined values are treated literally.
-When defining configuration variables like `working_directory` or `images`,
-you will not be able to interpolate other variables.
 However, you **can** interpolate a variable within a command
 by setting it for the current shell.
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -92,17 +92,6 @@ See the [Migrating Your iOS Project From 1.0 to 2.0](https://circleci.com/docs/2
 
 8. Validate your YAML at <http://codebeautify.org/yaml-validator> to check the changes.
 
-## Environment Variables
-
-In CircleCI 2.0, all defined values are treated literally.
-When defining configuration variables like `working_directory` or `images`,
-you will not be able to interpolate other variables.
-However, you **can** interpolate a variable within a command
-by setting it for the current shell.
-
-For full details,
-refer to the CircleCI 2.0 document [Using Environment Variables](http://localhost:4000/docs/2.0/env-vars/).
-
 ## Steps to Configure Workflows
 
 To increase the speed of your software development through faster feedback, shorter re-runs, and more efficient use of resources, configure workflows using the following instructions:
@@ -229,6 +218,17 @@ With the following, nested under `steps:` and customizing for your application a
 
 - See the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#deploy) document for valid `deploy` options to configure deployments on CircleCI 2.0
 - Please read the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for examples of deployment for CircleCI 2.0.
+
+## Environment Variables
+
+In CircleCI 2.0, all defined values are treated literally.
+When defining configuration variables like `working_directory` or `images`,
+you will not be able to interpolate other variables.
+However, you **can** interpolate a variable within a command
+by setting it for the current shell.
+
+For full details,
+refer to the CircleCI 2.0 document [Using Environment Variables](http://localhost:4000/docs/2.0/env-vars/).
 
 ## Validate YAML
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -94,85 +94,14 @@ See the [Migrating Your iOS Project From 1.0 to 2.0](https://circleci.com/docs/2
 
 ## Environment Variables
 
-CircleCI 2.0 allows you to set environment variables at several scope levels.
-
-To set environment variables **for all commands in a build**,
-set environment variables for a [job]({{ site.baseurl }}/2.0/glossary/#job)
-by using the `environment` key in the associated job.
-
-```yaml
-version: 2.0
-jobs:
-  build:
-    docker:
-      - image: buildpack-deps:trusty
-    environment:
-      - FOO: "bar"
-```
-
-To set environment variables **for all commands in a container**,
-use the `environment` key in the associated `image`.
-
-```yaml
-version: 2.0
-jobs:
-  build:
-    docker:
-      - image: smaant/lein-flyway:2.7.1-4.0.3
-      - image: circleci/postgres:9.6
-        environment:
-          POSTGRES_USER: conductor
-          POSTGRES_DB: conductor_test
-```
-
-To set environment variables **for a single command**,
-use the `environment` key in the associated `run` [step]({{ site.baseurl }}/2.0/glossary/#step).
-
-```yaml
-version: 2.0
-jobs:
-  build:
-    docker:
-      - image: smaant/lein-flyway:2.7.1-4.0.3
-    steps:
-      - checkout
-      - run:
-          name: Run migrations
-          command: sql/docker-entrypoint.sh sql
-          environment:
-            DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
-```
-
-### Interpolating Environment Variables
-
-CircleCI does not support interpolation
-when defining configuration variables like `working_directory` or `images`.
-All defined values are treated literally.
-
-However, it is possible to interpolate a variable within a command
+In CircleCI 2.0, all defined values are treated literally.
+When defining configuration variables like `working_directory` or `images`,
+you will not be able to interpolate other variables.
+However, you **can** interpolate a variable within a command
 by setting it for the current shell.
 
-```yaml
-version: 2
-jobs:
-  build:
-    steps:
-      - run:
-          name: Update PATH and Define Environment Variable at Runtime
-          command: |
-            echo 'export PATH=/path/to/foo/bin:$PATH' >> $BASH_ENV
-            echo 'export VERY_IMPORTANT=$(cat important_value)' >> $BASH_ENV
-            source $BASH_ENV
-```
-
-Depending on your shell,
-you may have to append the new variable to a shell startup file
-like `~/.tcshrc` or `~/.zshrc`.
-For more information,
-refer to your shell's documentation on setting environment variables.
-
-For more information,
-see the CircleCI 2.0 document [Using Environment Variables]({{ site.baseurl }}/2.0/env-vars/).
+For full details,
+refer to the CircleCI 2.0 document [Using Environment Variables](http://localhost:4000/docs/2.0/env-vars/).
 
 ## Steps to Configure Workflows
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -92,6 +92,15 @@ See the [Migrating Your iOS Project From 1.0 to 2.0](https://circleci.com/docs/2
 
 8. Validate your YAML at <http://codebeautify.org/yaml-validator> to check the changes.
 
+## Environment Variables
+
+In CircleCI 2.0, all defined environment variables are treated literally.
+It is possible to interpolat variables within a command
+by setting it for the current shell.
+
+For more information,
+refer to the CircleCI 2.0 document [Using Environment Variables]({{ site.baseurl }}/2.0/env-vars/).
+
 ## Steps to Configure Workflows
 
 To increase the speed of your software development through faster feedback, shorter re-runs, and more efficient use of resources, configure workflows using the following instructions:
@@ -218,15 +227,6 @@ With the following, nested under `steps:` and customizing for your application a
 
 - See the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#deploy) document for valid `deploy` options to configure deployments on CircleCI 2.0
 - Please read the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for examples of deployment for CircleCI 2.0.
-
-## Environment Variables
-
-In CircleCI 2.0, all defined environment variables are treated literally.
-It is possible to interpolat variables within a command
-by setting it for the current shell.
-
-For more information,
-refer to the CircleCI 2.0 document [Using Environment Variables]({{ site.baseurl }}/2.0/env-vars/).
 
 ## Validate YAML
 


### PR DESCRIPTION
Rather than repeat information, this change focuses users' attention on the major difference between 1.0 and 2.0 (lack of interpolation when defining certain variables), then links them to the current Env Vars document.

Resolves [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-10062).