### PR TITLE
divide supported releases into stable/edge categories

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -118,14 +118,18 @@ If your {% comment %} TODO: Job {% endcomment %}build requires a specific docker
 
 The currently supported versions are:
 
-* `17.03.0-ce` (default)
-* `17.05.0-ce`
-* `17.06.0-ce`
-* `17.06.1-ce`
-* `17.07.0-ce`
-* `17.09.0-ce`
-* `17.10.0-ce`
-* `17.11.0-ce`
+[Stable releases](https://download.docker.com/linux/static/stable/x86_64/)
+- `17.03.0-ce` (default)
+- `17.06.0-ce`
+- `17.06.1-ce`
+- `17.09.0-ce`
+
+[Edge releases](https://download.docker.com/linux/static/edge/x86_64/)
+- `17.05.0-ce`
+- `17.07.0-ce`
+- `17.09.0-ce`
+- `17.10.0-ce`
+- `17.11.0-ce`
 
 If you need a Docker image that installs Docker and has Git, use `17.05.0-ce-git`. **Note:** The `version` key is not currently supported on CircleCI installed in your private cloud or datacenter. Contact your system administrator for information about the Docker version installed in your remote Docker environment.
 

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -127,7 +127,6 @@ The currently supported versions are:
 [Edge releases](https://download.docker.com/linux/static/edge/x86_64/)
 - `17.05.0-ce`
 - `17.07.0-ce`
-- `17.09.0-ce`
 - `17.10.0-ce`
 - `17.11.0-ce`
 


### PR DESCRIPTION
Fixes #2387 by dividing supported releases into stable and edge versions.