### PR TITLE
Fix inconsistent config ref naming

### DIFF
--- a/jekyll/_cci2/browser-testing.md
+++ b/jekyll/_cci2/browser-testing.md
@@ -108,7 +108,7 @@ This section provides some examples of how to debug browser tests on CircleCI.
 
 CircleCI may be configured to collect [build artifacts]( {{ site.baseurl }}/2.0/artifacts/)
 and make them available from your build. For example, artifacts enable you to save screenshots as part of your {% comment %} TODO: Job {% endcomment %}build,
-and view them when the {% comment %} TODO: Job {% endcomment %}build finishes. You must explicitly collect those files with the `store_artifacts` step and specify the `path` and `destination`. See the [store_artifacts]( {{ site.baseurl }}/2.0/configuration-reference/#store_artifacts) section of the Configuration Reference for an example.
+and view them when the {% comment %} TODO: Job {% endcomment %}build finishes. You must explicitly collect those files with the `store_artifacts` step and specify the `path` and `destination`. See the [store_artifacts]( {{ site.baseurl }}/2.0/configuration-reference/#store_artifacts) section of the Configuring CircleCI document for an example.
 
 Saving screenshots is straightforward: it's a built-in feature in WebKit and Selenium, and is supported by most test suites:
 

--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -132,7 +132,7 @@ For example, you may want to clear the cache in the following scenarios by incre
 
 ## <a name="dependency-caching"></a>Basic Example of Dependency Caching
 
-The extra control and power in CircleCI 2.0 manual dependency caching requires that you be explicit about what you cache and how you cache it. See the [save cache section](https://circleci.com/docs/2.0/configuration-reference/#save_cache) of the Writing Jobs and Steps document for additional examples.
+The extra control and power in CircleCI 2.0 manual dependency caching requires that you be explicit about what you cache and how you cache it. See the [save cache section](https://circleci.com/docs/2.0/configuration-reference/#save_cache) of the Configuring CircleCI document for additional examples.
 
 To save a cache of a file or directory, add the `save_cache` step to a job in your `.circleci/config.yml` file:
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -707,7 +707,7 @@ There can be multiple `store_artifacts` steps in a job. Using a unique prefix fo
 
 ##### **`store_test_results`**
 
-Special step used to upload test results so they display in builds' Test Summary section and can be used for timing analysis. To also see test result as build artifacts, please use [the **store_artifacts** step]({{ site.baseurl }}/2.0/configuration-reference/#store_artifacts).
+Special step used to upload test results so they display in builds' Test Summary section and can be used for timing analysis. To also see test result as build artifacts, please use [the **store_artifacts** step](#store_artifacts).
 
 Key | Required | Type | Description
 ----|-----------|------|------------

--- a/jekyll/_cci2/containers.md
+++ b/jekyll/_cci2/containers.md
@@ -19,7 +19,7 @@ Every change committed to your VCS system triggers CircleCI to checkout your cod
 - **Concurrency** - Utilizing multiple containers to run multiple builds at the same time. To take advantage of concurrency, configure your development workflow using the [Orchestrating Workflows document]({{ site.baseurl }}/2.0/workflows/)
 and run your jobs in parallel as shown in the [Sample 2.0 Config Files document]({{ site.baseurl }}/2.0/sample-config/#sample-configuration-with-parallel-jobs).
 
-- **Parallelism** - Splitting tests across multiple containers, allowing you to dramatically speed up your test suite. Update your `.circleci/config.yml` file to run your tests in parallel as documented in the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism). Learn how to update your config file to parallelize and split tests to decrease your build time by reading the [Running Tests in Parallel]({{ site.baseurl }}/2.0/parallelism-faster-jobs/) documentation.
+- **Parallelism** - Splitting tests across multiple containers, allowing you to dramatically speed up your test suite. Update your `.circleci/config.yml` file to run your tests in parallel as documented in the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/#parallelism) document. Learn how to update your config file to parallelize and split tests to decrease your build time by reading the [Running Tests in Parallel]({{ site.baseurl }}/2.0/parallelism-faster-jobs/) documentation.
 
 ## Getting Started
 

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -95,7 +95,7 @@ Following are the available machine images:
 
 * `circleci/classic:latest` is the default image. Changes to this will be announced at least one week before they go live.
 * `circleci/classic:edge` receives the latest updates and will be upgraded at short notice.
-* `circleci/classic:[year-month]` This lets you pin the image version to prevent breaking changes. Refer to the [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#machine) for versions.
+* `circleci/classic:[year-month]` This lets you pin the image version to prevent breaking changes. Refer to the [Configuring CircleCI](https://circleci.com/docs/2.0/configuration-reference/#machine) document for versions.
 
 **Note:** These images are **not** available on your private installation of CircleCI. For information about customizing `machine` executor service images on the installable CircleCI, see our [VM Service documentation]({{ site.baseurl }}/2.0/vm-service).
 

--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -51,6 +51,6 @@ See the [Concepts]({{ site.baseurl }}/2.0/concepts/) document for a summary of 2
 
 Refer to the [Workflows]({{ site.baseurl }}/2.0/workflows) document for examples of orchestrating job runs with parallel, sequential, scheduled, and manual approval workflows.
 
-Find complete reference information for all keys and pre-built images in the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/) and [CircleCI Images]({{ site.baseurl }}/2.0/circleci-images/) documentation.
+Find complete reference information for all keys and pre-built images in the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/) and [CircleCI Images]({{ site.baseurl }}/2.0/circleci-images/) documentation.
 
 

--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -69,7 +69,7 @@ You should see your build start to run automatically—and pass! So, what just h
 
 3. **echo:** This was the only other instruction in your `config.yml` file: CircleCI ran the echo command with the input "A first hello" ([echo](https://linux.die.net/man/1/echo), does exactly what you'd think it would do).
 
-Even though there was no actual source code in your repo, and no actual tests configured in your `config.yml`, CircleCI considers your build to have "succeeded" because all steps completed successfully (returned an [exit code](https://en.wikipedia.org/wiki/Exit_status) of 0). Most projects are far more complicated, oftentimes with multiple Docker images and multiple steps, including a large number of tests. You can learn more about all the possible steps one may put in a `config.yml` file in the [Configuration Reference](https://circleci.com/docs/2.0/configuration-reference).
+Even though there was no actual source code in your repo, and no actual tests configured in your `config.yml`, CircleCI considers your build to have "succeeded" because all steps completed successfully (returned an [exit code](https://en.wikipedia.org/wiki/Exit_status) of 0). Most projects are far more complicated, oftentimes with multiple Docker images and multiple steps, including a large number of tests. You can learn more about all the possible steps one may put in a `config.yml` file in the [Configuring CircleCI](https://circleci.com/docs/2.0/configuration-reference) document.
 
 ## Breaking Your Build!
 

--- a/jekyll/_cci2/ios-migrating-from-1-2.md
+++ b/jekyll/_cci2/ios-migrating-from-1-2.md
@@ -188,7 +188,7 @@ jobs:
       - ...
 ```
 
-You can see all the available step types in [this doc]({{ site.baseurl }}/2.0/configuration-reference/).
+You can see all the available step types in the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/) document.
 **Note:** Docker support is not available in the macOS builds.
 
 ### Checking out the Project Code

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -92,7 +92,8 @@ Finally, add several `steps` within the `build` job:
 ```
 {% endraw %}
 
-Refer to the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/) for the complete list of available CircleCI configuration keys.
+For the complete list of CircleCI configuration keys,
+refer to the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/) document.
 
 ## Deploy
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -88,7 +88,7 @@ See the [Migrating Your iOS Project From 1.0 to 2.0](https://circleci.com/docs/2
      ```
      If you do not have a `checkout` step, you must add this step to your `config.yml` file.
      
-7. (Optional) Add  the `add_ssh_keys` step with fingeprint to enable SSH into builds, see the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#add_ssh_keys) for details.
+7. (Optional) Add  the `add_ssh_keys` step with fingeprint to enable SSH into builds, see the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/#add_ssh_keys) document for details.
 
 8. Validate your YAML at <http://codebeautify.org/yaml-validator> to check the changes.
 
@@ -225,7 +225,7 @@ With the following, nested under `steps:` and customizing for your application a
 
 **Notes on Deployment:**
 
-- See the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#deploy) document for valid `deploy` options to configure deployments on CircleCI 2.0
+- See the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/#deploy) document for valid `deploy` options to configure deployments on CircleCI 2.0
 - Please read the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for examples of deployment for CircleCI 2.0.
 
 ## Validate YAML
@@ -235,5 +235,5 @@ When you have all the sections in `.circleci/config.yml` we recommend that you c
 ## Next Steps
 
 - Refer to the [Specifying Container Images]({{ site.baseurl }}/2.0/executor-types/) document for more information about Docker and Machine images in CircleCI 2.0.
-- Refer to the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/) document for details on the exact syntax of CircleCI 2.0 `jobs` and `steps` and all available options.
+- Refer to the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/) document for details on the exact syntax of CircleCI 2.0 `jobs` and `steps` and all available options.
 

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -40,7 +40,7 @@ jobs:
 ```
 
 For more information,
-see the [configuration reference]({{ site.baseurl }}/2.0/configuration-reference/#parallelism).
+see the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/#parallelism) document.
 
 ## Using the CircleCI CLI to Split Tests
 

--- a/jekyll/_cci2/reference.md
+++ b/jekyll/_cci2/reference.md
@@ -8,7 +8,7 @@ Refer to the reference materials for YAML syntax, specifications, FAQs, help, an
 
 Document | Description
 ----|----------
-[Configuration]({{ site.baseurl }}/2.0/configuration-reference/) | Complete specification for `config.yml` syntax.
+[Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/) | Complete specification for `config.yml` syntax.
 [Prebuilt Images]({{ site.baseurl }}/2.0/circleci-images/) | Complete list of prebuilt CircleCI Docker images.
 [API]({{ site.baseurl }}/api/v1-reference/) | CircleCI v1.1 API reference documentation.
 [Glossary]({{ site.baseurl }}/2.0/glossary/) | CircleCI terms and definitions.

--- a/jekyll/_cci2/test.md
+++ b/jekyll/_cci2/test.md
@@ -17,7 +17,7 @@ Watch the following video for a detailed tutorial of Docker, iOS, and Android bu
 
 Document | Description
 ----|----------
-<a href="{{ site.baseurl }}/2.0/configuration-reference/#run">Configuration Reference `run` Step section</a> | Write a job to run your tests.
+<a href="{{ site.baseurl }}/2.0/configuration-reference/#run">Configuring CircleCI: `run` Step section</a> | Write a job to run your tests.
 [Browser Testing]({{ site.baseurl }}/2.0/browser-testing/) | Common methods for running and debugging browser tests in CircleCI.
 <a href="{{ site.baseurl }}/2.0/collect-test-data/">Collecting Test Metadata</a> | How to set up various common test runners in your CircleCI configuration.
 <a href="{{ site.baseurl }}/2.0/testing-ios/">Testing iOS Applications on macOS</a> | How to set up and customize testing for an iOS application with CircleCI.

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -322,7 +322,7 @@ image:
 ### Creating a `config.yml` File
 The most flexible means to customize your build is to add a `.circleci/config.yml` file to your project,
 which allows you to run arbitrary bash commands
-at various points in the build process. See the [Configuration Reference]( {{ site.baseurl }}/2.0/configuration-reference/) document for
+at various points in the build process. See the [Configuring CircleCI]( {{ site.baseurl }}/2.0/configuration-reference/) document for
 a detailed discussion of the structure of the `config.yml` file. **Note:** A number of options in the document will not work for macOS builds.
 
 ### Installing Custom Packages

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -39,7 +39,7 @@ Refer to the [Workflows]({{ site.baseurl }}/2.0/faq) section of the Migration FA
 
 ## Workflows Configuration Examples
 
-_For a full specification of the_ `workflows` _key, see the [Workflows]({{ site.baseurl }}/2.0/configuration-reference/#workflows) section of the Configuration Reference document._
+_For a full specification of the_ `workflows` _key, see the [Workflows]({{ site.baseurl }}/2.0/configuration-reference/#workflows) section of the Configuring CircleCI document._
 
 **Note:** Projects configured with Workflows often include multiple jobs that share syntax for Docker images, environment variables, or `run` steps. Refer the [YAML Anchors/Aliases](http://yaml.org/spec/1.2/spec.html#id2765878) documentation for information about how to alias and reuse syntax to keep your `.circleci/config.yml` file small. See the [Reuse YAML in the CircleCI Config](https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/) blog post for a summary.
 
@@ -234,7 +234,7 @@ The value of the `filters` key must be a map
 that defines rules for execution on specific branches.
 
 For more details,
-see the [configuration reference page]({{ site.baseurl }}/2.0/configuration-reference/#branches-1) for the `branches` key.
+see the `branches` section of the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/#branches-1) document.
 
 For a full configuration example,
 see the [Sample Scheduled Workflows configuration](https://github.com/CircleCI-Public/circleci-demo-workflows/blob/try-schedule-workflow/.circleci/config.yml).


### PR DESCRIPTION
Updates "Configuration Reference" to "Configuring CircleCI" after file renaming completed #2355.

[JIRA ticket](https://circleci.atlassian.net/browse/CIRCLE-11486).