### PR TITLE
Point to new api permissions doc

### DIFF
--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -138,23 +138,14 @@ When CircleCI runs a build, a link to the core dump file appears under the Artif
 To download your artifacts with `curl`,
 follow these steps.
 
-1. On the [Personal API Tokens](https://circleci.com/account/api){:rel="nofollow"} settings page,
-click **Create New Token**.
+1. [Create a personal API token]({{ site.baseurl }}/2.0/managing-api-tokens/#creating-a-personal-api-token)
+and copy it to a clipboard.
 
-2. In the **Token name** field,
-add a name for this token
-to remind you how and where it is used.
-
-3. To create the API token,
-click the **Add API Token** button.
-
-4. Copy the token that appears in the field.
-
-5. In a Terminal window,
+2. In a Terminal window,
 `cd` to a directory
 where you want the artifact files.
 
-6. Run the commands below,
+3. Run the commands below,
 replacing all variables starting with a `:` with real values for your project.
 `:your_token` should be replaced with the token you copied earlier.
 `:vcs-type` is dependent on your version control system (either `github` or `bitbucket`).

--- a/jekyll/_cci2/config-translation.md
+++ b/jekyll/_cci2/config-translation.md
@@ -41,7 +41,7 @@ The `config-translator` endpoint does **not** currently support translation of t
 
      `https://circleci.com/api/v1.1/project/github/bar/foo/config-translation`
 
-3. To use the `config-translation` from your browser when you are **not** authenticated in circleci.com for a repository called `foo` in a GitHub org named `bar`, request the following URL and pass your `circle-token` directly in the query string. The following example calls this with `curl`, passes the `branch` to translate, and assumes your CircleCI API token is in an environment variable called `CIRCLE_TOKEN`. 
+3. To use the `config-translation` from your browser when you are **not** authenticated in circleci.com for a repository called `foo` in a GitHub org named `bar`, request the following URL and pass your `circle-token` directly in the query string. The following example calls this with `curl`, passes the `branch` to translate, and assumes your [CircleCI API token]({{ site.baseurl }}/2.0/managing-api-tokens/#creating-a-personal-api-token) is in an environment variable called `CIRCLE_TOKEN`.
 
      ``` Shell
      curl "https://circleci.com/api/v1.1/project/github/bar/foo/config-translation?circle-token=$CIRCLE_TOKEN&branch=develop"

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -254,6 +254,9 @@ curl \
   https://circleci.com/api/v1.1/project/github/circleci/mongofinil/tree/master?circle-token=$CIRCLE_TOKEN
 ```
 
+In the above example,
+`$CIRCLE_TOKEN` is a [personal API token]({{ site.baseurl }}/2.0/managing-api-tokens/#creating-a-personal-api-token).
+
 The build will see the environment variables:
 
 ```

--- a/jekyll/_cci2/examples.md
+++ b/jekyll/_cci2/examples.md
@@ -15,7 +15,7 @@ Refer to the following documents and linked `.circleci/config.yml` files for com
 </div>
 
 1. Add a shell script in your `.circleci` directory, for example, `run-build-locally.sh`.
-2. Create a token on the [Personal API Tokens page](https://circleci.com/account/api){:rel="nofollow"}.
+2. [Create a personal API token]({{ site.baseurl }}/2.0/managing-api-tokens/#creating-a-personal-api-token).
 3. Export the token on the command line `export CIRCLE_TOKEN=<token-from-step-above>`.
 4. Gather the following information:
   - Commit hash from which to build

--- a/jekyll/_cci2/status-badges.md
+++ b/jekyll/_cci2/status-badges.md
@@ -34,12 +34,7 @@ If you want to show the status of a different branch,
 use the Branch dropdown menu to select it.
 3. (Optional)
 If your project is private,
-you will need an API token for viewing a project's details.
-If you haven't created a token yet,
-click on the _API Permissions_ in the _Permissions_ section.
-Click _Create Token_,
-choose the _Status_ scope,
-and create  a label for the token.
+you will need to [create a project API token]({{ site.baseurl }}/2.0/managing-api-tokens/#creating-a-project-api-token).
 4. (Optional)
 If you created a token in the previous step,
 select the token you want to use in the _API Token_ dropdown menu.


### PR DESCRIPTION
Updates wherever we mention making API tokens to point to the new API tokens document.

[JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-11318)