### PR TITLE
Update Jekyll to v3.8.3 and HTML Proofer to latest release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 ruby '2.5.1'
 
-gem 'jekyll', "3.8.1"
-gem 'html-proofer', "3.8.0"
+gem 'jekyll', "3.8.3"
+gem 'html-proofer', "3.9.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,10 +16,10 @@ GEM
       http_parser.rb (~> 0.6.0)
     ethon (0.11.0)
       ffi (>= 1.3.0)
-    eventmachine (1.2.6)
-    ffi (1.9.23)
+    eventmachine (1.2.7)
+    ffi (1.9.25)
     forwardable-extended (2.6.0)
-    html-proofer (3.8.0)
+    html-proofer (3.9.1)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       colorize (~> 0.8)
@@ -31,7 +31,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.1)
+    jekyll (3.8.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -48,7 +48,7 @@ GEM
       sass (~> 3.4)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
-    kramdown (1.16.2)
+    kramdown (1.17.0)
     liquid (4.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -85,11 +85,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer (= 3.8.0)
-  jekyll (= 3.8.1)
+  html-proofer (= 3.9.1)
+  jekyll (= 3.8.3)
 
 RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 jekyll:
-    image: jekyll/jekyll:3.8.0
+    image: jekyll/jekyll:3.8.3
     command: jekyll serve --watch --incremental
     ports:
         - 4000:4000


### PR DESCRIPTION
Update Jekyll and HTML Proofer to their latest, stable releases.