### PR TITLE
Migrate forked PR build security info

### DIFF
--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -52,23 +52,40 @@ see the [Environment Variables]({{ site.baseurl }}/2.0/env-vars/#setting-an-envi
 
 By default, CircleCI builds every commit from every branch.
 This behavior may be too aggressive for open source projects,
-which often have considerably more commits than private projects.
-
+which often have significantly more commits than private projects.
 To change this setting,
 go to the **Advanced Settings** of your project
 and set the **Only build pull requests** option to _On_.
 
 **Note:**
 Even if this option is enabled,
-CircleCI will build all commits from your project's default branch.
+CircleCI will still build all commits from your project's default branch.
 
-### Building Pull Requests From Forked Repositories
+### Build Pull Requests From Forked Repositories
 
 Many open source projects accept pull requests from forked repositories.
 Building these pull requests is an effective way
 to catch bugs before manually reviewing changes.
 
-**Advanced Settings -> Only build pull request** - This setting determines that only pull requests (PRs) and the project’s default branch (typically master) will be built. This setting is useful for projects with a lot of commit activity which helps reduce the number of builds that will be run.
+By default, CircleCI does not build pull requests from forked repositories.
+To change this setting,
+go to the **Advanced Settings** of your project
+and set the **Build forked pull requests** option to _Off_.
+
+### Pass Secrets to Builds From Forked Pull Requests
+
+Running an unrestricted build in a parent repository can be dangerous.
+Projects often contain sensitive information,
+and this information is freely available to anyone
+who can push code that triggers a build.
+
+By default, CircleCI does not pass secrets to builds from forked pull requests.
+Builds that require these secrets
+will not run successfully on CircleCI.
+If you are comfortable sharing secrets with anyone who forks your project and opens a pull request,
+you can enable this option.
+In the **Advanced Settings** of your project,
+set the **Pass secrets to builds from forked pull requests** option to _On_.
 
 ## Example Open Source Projects 
 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -100,7 +100,8 @@ In the **Advanced Settings** of your project,
 set the **Pass secrets to builds from forked pull requests** option to _On_.
 
 **Note:**
-Builds that require these secrets
+If this setting is disabled,
+forked builds that require secrets
 will not run successfully on CircleCI.
 
 ## Example Open Source Projects 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -22,8 +22,8 @@ projects that are public on GitHub or Bitbucket
 receive three free build containers,
 for a total of four containers.
 Multiple build containers allow you
-to build a single pull request faster with parallelism,
-or build multiple pull requests at once.
+to build a single pull request (PR) faster with parallelism,
+or build multiple PRs at once.
 
 These additional containers are automatically enabled,
 as long as the project is public and running on CircleCI's default platform (Linux).
@@ -35,18 +35,18 @@ set the **Free and Open Source** option to _Off_.
 
 **Note:**
 If you are building an open source project on macOS,
-contact billing@circleci.com to enable the additional containers.
+contact billing@circleci.com to enable these additional containers.
 
 ## Security
 
 While open source can be a liberating practice,
-be sure that you are not liberating sensitive information:
+take care not to liberate sensitive information.
 
 - If your repository is public,
-your CircleCI project and its build logs will also be public.
+your CircleCI project and its build logs is also public.
 Pay attention to the information you choose to print.
 - While environment variables set in the CircleCI application are hidden from the public,
-these variables will be shared in [forked pull requests](#pass-secrets-to-builds-from-forked-pull-requests)
+these variables will be shared in [forked PRs](#pass-secrets-to-builds-from-forked-pull-requests)
 unless explicitly blocked.
 
 ## Features and Settings for Open Source Projects
@@ -77,11 +77,11 @@ CircleCI will still build all commits from your project's default branch.
 
 ### Build Pull Requests From Forked Repositories
 
-Many open source projects accept pull requests from forked repositories.
-Building these pull requests is an effective way
+Many open source projects accept PRs from forked repositories.
+Building these PRs is an effective way
 to catch bugs before manually reviewing changes.
 
-By default, CircleCI does not build pull requests from forked repositories.
+By default, CircleCI does not build PRs from forked repositories.
 To change this setting,
 go to the **Advanced Settings** of your project
 and set the **Build forked pull requests** option to _Off_.
@@ -93,15 +93,27 @@ Projects often contain sensitive information,
 and this information is freely available to anyone
 who can push code that triggers a build.
 
-By default, CircleCI passes secrets to builds from forked pull requests
-If you are uncomfortable sharing secrets with anyone who forks your project and opens a pull request,
+By default, CircleCI passes secrets to builds from forked PRs
+If you are uncomfortable sharing secrets with anyone who forks your project and opens a PR,
 you can disable this option.
 In the **Advanced Settings** of your project,
-set the **Pass secrets to builds from forked pull requests** option to _On_.
+set the **Pass secrets to builds from forked pull requests** option to _Off_.
+
+When this setting is disabled,
+CircleCI hides four types of configuration data:
+
+- [Environment variables](#private-environment-variables) set through the application.
+
+- [Deployment keys and user keys]({{ site.baseurl }}/2.0/gh-bb-integration/#deployment-keys-and-user-keys).
+
+- Passphraseless private SSH keys you have [added to CircleCI]({{ site.baseurl }}/2.0/add-ssh-key)
+to access arbitrary hosts during a build.
+
+- [AWS permissions]({{ site.baseurl }}/2.0/deployment-integrations/#aws) and configuration files.
 
 **Note:**
 If this setting is disabled,
-forked builds that require secrets
+forked PR builds that require secrets
 will not run successfully on CircleCI.
 
 ## Example Open Source Projects 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -39,9 +39,11 @@ you can make the builds of your project public.
 In the **Advanced Settings** of your project,
 set the **Free and Open Source** option to _On_.
 
-**Advanced Settings > Build forked Pull Request** - This page of the CircleCI app determines whether or not PRs opened from forked repositories will be built. The benefit is the ability to test user contributions quickly and efficiently, indicating  whether their PR is good before you even get a chance to look at it. A possible downside could be that a high volume of forked PRs or poorly crafted PRs may keep your build containers too busy to working on building your own code.
+### Building Pull Requests From Forked Repositories
 
-**Advanced Settings > Pass secrets to builds from forked pull request** - This setting is extremely important for security. If this setting is enabled, private environment variables, AWS & Heroku credentials, and SSH keys stored on CircleCI are made available to everyone who makes a fork and opens a PR to your project. The upside to this setting is that builds that require these variables will be able to pass. The security risk is that everyone may edit your CircleCI configuration to print out your SSH key to terminal and get access to your servers.
+Many open source projects accept pull requests from forked repositories.
+Building these pull requests is an effective way
+to catch bugs before manually reviewing changes.
 
 **Advanced Settings -> Only build pull request** - This setting determines that only pull requests (PRs) and the project’s default branch (typically master) will be built. This setting is useful for projects with a lot of commit activity which helps reduce the number of builds that will be run.
 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -32,9 +32,12 @@ CircleCI offers open-source projects additional free build containers for run th
 
 The following features and settings are especially useful for open source projects.
 
-**Public build pages** - Your project build pages can be public to allow core contributors, collaborators, and the general community to have transparency into your project.
+### Public Build Pages
 
-**Private environment variables** - Many projects will end up needing an API token, SSH key, or password  to build all dependencies or perhaps to deploy. Private environment variables enable you to store secrets safely even when your project can be seen and contributed by thousands of outside users.
+To increase transparency among contributors and collaborators,
+you can make the builds of your project public.
+In the **Advanced Settings** of your project,
+set the **Free and Open Source** option to _On_.
 
 **Advanced Settings > Build forked Pull Request** - This page of the CircleCI app determines whether or not PRs opened from forked repositories will be built. The benefit is the ability to test user contributions quickly and efficiently, indicating  whether their PR is good before you even get a chance to look at it. A possible downside could be that a high volume of forked PRs or poorly crafted PRs may keep your build containers too busy to working on building your own code.
 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -26,7 +26,7 @@ to build a single pull request (PR) faster with parallelism,
 or build multiple PRs at once.
 
 These additional containers are automatically enabled,
-as long as the project is public and running on CircleCI's default platform (Linux).
+as long as the project is public and running on Linux.
 If you do not want to use the additional containers
 or do not want your CircleCI project to be public,
 you can change this setting.

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -9,35 +9,49 @@ order: 1
 
 *[Basics]({{ site.baseurl }}/2.0/basics/) > Building Open Source Projects*
 
-This document provides tips and best practices for building your open source project with CircleCI 2.0 in the following sections: 
+This document provides tips and best practices
+for building your open source project on CircleCI in the following sections:
 
 * TOC
 {:toc}
 
-In addition to a free plan for open source repos, the CircleCI app includes extra resources and settings specifically for open source projects.
+## Overview
 
-**Note:** Consider the following basics about visibility of configuration details and logs for your project: 
+To support the open source community,
+projects that are public on GitHub or Bitbucket
+receive three free build containers,
+for a total of four containers.
+Multiple build containers allow you
+to build a single pull request faster with parallelism,
+or build multiple pull requests at once.
 
-- If your repository is public, your CircleCI project will also be publicly available.
-- CircleCI app settings are accessible only by contributors, therefore, environment variables set in the app are hidden from the public. However env-vars are shared in forks unless these are turned off.
-- Build-logs are publicly visible, so don't print sensitive information in them.
+These additional containers are automatically enabled,
+as long as the project is public and running on CircleCI's default platform (Linux).
+If you do not want to use the additional containers
+or do not want your CircleCI project to be public,
+you can change this setting.
+In the **Advanced Settings** of your project,
+set the **Free and Open Source** option to _Off_.
 
-## Open Source Container Overview
+**Note:**
+If you are building an open source project on macOS,
+contact billing@circleci.com to enable the additional containers.
 
-CircleCI offers open-source projects additional free build containers for run their jobs. An open source project being built on CircleCI gets **three additional build containers**, four containers in total. Multiple build containers allow you to  either build multiple pull requests (PRs) at a time, or to build a single PR much faster with CircleCI’s parallelism. 
+## Security
 
-**Note:** Projects built on Linux (our default platform) will automatically receive the additional containers if they are public projects on GitHub or Bitbucket. If you are building an open source project on macOS and want to take advantage of our offer, contact billing@circleci.com.
+While open source can be a liberating practice,
+be sure that you are not liberating sensitive information:
+
+- If your repository is public,
+your CircleCI project and its build logs will also be public.
+Pay attention to the information you choose to print.
+- While environment variables set in the CircleCI application are hidden from the public,
+these variables will be shared in [forked pull requests](#pass-secrets-to-builds-from-forked-pull-requests)
+unless explicitly blocked.
 
 ## Features and Settings for Open Source
 
 The following features and settings are especially useful for open source projects.
-
-### Public Build Pages
-
-To increase transparency among contributors and collaborators,
-you can make the builds of your project public.
-In the **Advanced Settings** of your project,
-set the **Free and Open Source** option to _On_.
 
 ### Private Environment Variables
 
@@ -79,13 +93,15 @@ Projects often contain sensitive information,
 and this information is freely available to anyone
 who can push code that triggers a build.
 
-By default, CircleCI does not pass secrets to builds from forked pull requests.
-Builds that require these secrets
-will not run successfully on CircleCI.
-If you are comfortable sharing secrets with anyone who forks your project and opens a pull request,
-you can enable this option.
+By default, CircleCI passes secrets to builds from forked pull requests
+If you are uncomfortable sharing secrets with anyone who forks your project and opens a pull request,
+you can disable this option.
 In the **Advanced Settings** of your project,
 set the **Pass secrets to builds from forked pull requests** option to _On_.
+
+**Note:**
+Builds that require these secrets
+will not run successfully on CircleCI.
 
 ## Example Open Source Projects 
 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -43,7 +43,7 @@ While open source can be a liberating practice,
 take care not to liberate sensitive information.
 
 - If your repository is public,
-your CircleCI project and its build logs is also public.
+your CircleCI project and its build logs are also public.
 Pay attention to the information you choose to print.
 - While environment variables set in the CircleCI application are hidden from the public,
 these variables will be shared in [forked PRs](#pass-secrets-to-builds-from-forked-pull-requests)

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -30,7 +30,7 @@ CircleCI offers open-source projects additional free build containers for run th
 
 ## Features and Settings for Open Source
 
-The following features and setting are useful for contributors to your project:
+The following features and settings are especially useful for open source projects.
 
 **Public build pages** - Your project build pages can be public to allow core contributors, collaborators, and the general community to have transparency into your project.
 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -39,6 +39,20 @@ you can make the builds of your project public.
 In the **Advanced Settings** of your project,
 set the **Free and Open Source** option to _On_.
 
+### Only Build Pull Requests
+
+By default, CircleCI builds every commit from every branch.
+This behavior may be too aggressive for open source projects,
+which often have considerably more commits than private projects.
+
+To change this setting,
+go to the **Advanced Settings** of your project
+and set the **Only build pull requests** option to _On_.
+
+**Note:**
+Even if this option is enabled,
+CircleCI will build all commits from your project's default branch.
+
 ### Building Pull Requests From Forked Repositories
 
 Many open source projects accept pull requests from forked repositories.

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -39,6 +39,15 @@ you can make the builds of your project public.
 In the **Advanced Settings** of your project,
 set the **Free and Open Source** option to _On_.
 
+### Private Environment Variables
+
+Many projects require API tokens, SSH keys, or passwords.
+Private environment variables allow you
+to safely store secrets,
+even if your project is public.
+For more information,
+see the [Environment Variables]({{ site.baseurl }}/2.0/env-vars/#setting-an-environment-variable-in-a-project) document.
+
 ### Only Build Pull Requests
 
 By default, CircleCI builds every commit from every branch.

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -49,7 +49,7 @@ Pay attention to the information you choose to print.
 these variables will be shared in [forked pull requests](#pass-secrets-to-builds-from-forked-pull-requests)
 unless explicitly blocked.
 
-## Features and Settings for Open Source
+## Features and Settings for Open Source Projects
 
 The following features and settings are especially useful for open source projects.
 

--- a/jekyll/_data/categories.yml
+++ b/jekyll/_data/categories.yml
@@ -43,12 +43,6 @@
   name: "Optimization"
   icon: "parallelism.svg"
 
-#- section: cci1
-#  slug: mobile-platforms
-#  name: "Mobile Platforms"
-#  index: mobile
-#  icon: "mobile.svg"
-
 - section: cci1
   slug: how-to
   name: "Integrations"
@@ -63,22 +57,6 @@
   slug: troubleshooting
   name: "Troubleshooting"
   icon: "troubleshooting.svg"  
-
-#- section: cci1
-#  slug: privacy-and-security
-#  name: "Privacy and Security"
-#  index: privacy-security
-#  icon: "privacy-security.svg"
-
-
-# Legacy 1.0 Enterprise Docs
-#- section: ccie
-#  slug: documentation
-#  name: "Getting Started"
-
-#- section: ccie
-#  slug: installation
-#  name: "Installation"
 
 - section: ccie
   slug: advanced-config
@@ -129,25 +107,9 @@
   slug: language-guides
   name: "Language Guides"
 
-#- section: cci2
-#  slug: docker
-#  name: "Using Docker"
-
 - section: cci2
   slug: reference
   name: "Reference"
-
-# - section: cci2
-#   slug: troubleshooting-and-debugging
-#   name: "Troubleshooting and Debugging"
-
-# - section: cci2
-#   slug: api
-#   name: "API"
-
-# - section: cci2
-#   slug: help-and-support
-#   name: "Help and Support"
 
 # CircleCI API Docs
 - section: api


### PR DESCRIPTION
This PR migrates information contained in [Building Pull Requests from Forks](https://circleci.com/docs/1.0/fork-pr-builds/) to a 2.0 document.

Since we already had a document that discussed this feature, I went ahead and stuffed the information in there. And then I got carried away with revisions.

I've added @felicianotech as primary reviewer (and original author), and @KyleTryon as the primary responder of the [related JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-11487).