### PR TITLE
Migrate VCS permissions blurb to 2.0

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -107,7 +107,9 @@ CircleCI will use the machine user's SSH key for any git commands run during you
 
 ## Permissions Overview
 
-CircleCI requires the following permissions from your VCS provider.
+CircleCI requests the following permissions from your VCS provider,
+as defined by the [GitHub permissions model](http://developer.github.com/v3/oauth/#scopes)
+and the [Bitbucket permissions model](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes).
 
 **Read Permission**
 - get a user's email address
@@ -118,10 +120,13 @@ CircleCI requires the following permissions from your VCS provider.
 - get a list of a user's repos
 - add an SSH to a user's account
 
-CircleCI requests these permissions
-as defined by the [GitHub permissions model](http://developer.github.com/v3/oauth/#scopes)
-and the [Bitbucket permissions model](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes).
-
+**Note:**
+CircleCI feels strongly about only asking for
+permissions that are absolutely necessary.
+However, CircleCI is constrained
+by the specific permissions each VCS provider supplies.
+For example, getting a list of a user's repos from GitHub requires write access
+because GitHub does not provide a read-only permission.
 
 ## Permissions for Team Accounts
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -109,7 +109,7 @@ CircleCI will use the machine user's SSH key for any git commands run during you
 
 CircleCI requires the following permissions from your VCS provider.
 
-**Read Permissions**
+**Read Permission**
 - get a user's email address
 
 **Write Permissions**
@@ -118,8 +118,10 @@ CircleCI requires the following permissions from your VCS provider.
 - get a list of a user's repos
 - add an SSH to a user's account
 
-CircleCI requests permissions as required by the
-[GitHub permissions model](http://developer.github.com/v3/oauth/#scopes) and [Bitbucket permission model](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes) as follows:
+CircleCI requests these permissions
+as defined by the [GitHub permissions model](http://developer.github.com/v3/oauth/#scopes)
+and the [Bitbucket permissions model](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes).
+
 
 ## Permissions for Team Accounts
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -107,16 +107,19 @@ CircleCI will use the machine user's SSH key for any git commands run during you
 
 ## Permissions Overview
 
-CircleCI requests permissions as required by the 
+CircleCI requires the following permissions from your VCS provider.
+
+**Read Permissions**
+- get a user's email address
+
+**Write Permissions**
+- add deploy keys to a repo
+- add service hooks to a repo
+- get a list of a user's repos
+- add an SSH to a user's account
+
+CircleCI requests permissions as required by the
 [GitHub permissions model](http://developer.github.com/v3/oauth/#scopes) and [Bitbucket permission model](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes) as follows:
-
-*   add deploy keys to a repo
-*   add service hooks to a repo
-*   get a list of a user's repos
-*   get a user's email address
-*   (in some cases) add an SSH key to a user's account
-
-The first two permissions require write-permission to a repo.
 
 ## Permissions for Team Accounts
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -121,12 +121,15 @@ and the [Bitbucket permissions model](https://confluence.atlassian.com/bitbucket
 - add an SSH to a user's account
 
 **Note:**
-CircleCI feels strongly about only asking for
+CircleCI only asks for
 permissions that are absolutely necessary.
 However, CircleCI is constrained
-by the specific permissions each VCS provider supplies.
+by the specific permissions each VCS provider chooses to supply.
 For example, getting a list of a user's repos from GitHub requires write access
 because GitHub does not provide a read-only permission.
+
+If you feel strongly about reducing the number of permissions CircleCI uses,
+consider contacting your VCS provider to communicate your concerns.
 
 ## Permissions for Team Accounts
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -112,13 +112,13 @@ as defined by the [GitHub permissions model](http://developer.github.com/v3/oaut
 and the [Bitbucket permissions model](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html#OAuthonBitbucketCloud-Scopes).
 
 **Read Permission**
-- get a user's email address
+- Get a user's email address
 
 **Write Permissions**
-- add deploy keys to a repo
-- add service hooks to a repo
-- get a list of a user's repos
-- add an SSH to a user's account
+- Add deploy keys to a repo
+- Add service hooks to a repo
+- Get a list of a user's repos
+- Add an SSH key to a user's account
 
 **Note:**
 CircleCI only asks for


### PR DESCRIPTION
Request made by @sararead to move a 1.0 explanation about VCS permissions to 2.0. I have some open questions about:

- how this relates to Bitbucket
- how strongly we want to be encouraging our users to send their complaints to GitHub/Bitbucket

JIRA issue here: https://circleci.atlassian.net/browse/CIRCLE-11903