### PR TITLE
Use AWS Docker image for deployment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,17 +62,13 @@ jobs:
             - docs
   deploy:
     docker:
-      - image: circleci/python:2.7
-    working_directory: ~/circleci-docs  
+      - image: cibuilds/aws:1.15.44
     steps:
       - attach_workspace:
-          at: ~/circleci-docs/jekyll/_site 
-      - run:
-          name: Install awscli
-          command: sudo pip install awscli
+          at: ./generated-site 
       - run:
           name: Deploy to S3 if tests pass and branch is Master
-          command: aws s3 sync jekyll/_site/docs s3://circle-production-static-site/docs/ --delete
+          command: aws s3 sync generated-site/docs s3://circle-production-static-site/docs/ --delete
 
 workflows:
   version: 2


### PR DESCRIPTION
Proposing a switch to a lighter, more deterministic Docker image for the CircleCI Docs deployment.

I maintain several "CI Builds" Docker images geared specifically towards CI. This AWS image now has 10K+ pulls on Docker Hub and stable enough for Docs.

Also, it's hard to tell but this should reduce deployment time but only by a couple of seconds. We're already doing this fairly fast.

Also I did a `--dryrun` for the `sync` command to make sure it still does what we think: https://circleci.com/gh/circleci/workflows/circleci-docs/tree/try-aws-image