### PR TITLE
Link to CircleCI Docs configuration file in workspaces section

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -479,7 +479,9 @@ workflows:
 
 For a live example of using workspaces
 to pass data between build and deploy jobs,
-see the [`config.yml`](https://github.com/circleci/circleci-docs/blob/master/.circleci/config.yml) of this documentation.
+see the [`config.yml`](https://github.com/circleci/circleci-docs/blob/master/.circleci/config.yml)
+that is configured
+to build the CircleCI documentation.
 For additional conceptual information on using workspaces,
 caching,
 and artifacts,

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -480,8 +480,10 @@ workflows:
 For a live example of using workspaces
 to pass data between build and deploy jobs,
 see the [`config.yml`](https://github.com/circleci/circleci-docs/blob/master/.circleci/config.yml) of this documentation.
-
-Refer to the [Persisting Data in Workflows: When to Use Caching, Artifacts, and Workspaces](https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/) for additional conceptual information about using workspaces, caching, and artifacts.
+For additional conceptual information on using workspaces,
+caching,
+and artifacts,
+refer to the [Persisting Data in Workflows: When to Use Caching, Artifacts, and Workspaces](https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/).
 
 ## Rerunning a Workflow's Failed Jobs
 

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -483,7 +483,7 @@ see the [`config.yml`](https://github.com/circleci/circleci-docs/blob/master/.ci
 For additional conceptual information on using workspaces,
 caching,
 and artifacts,
-refer to the [Persisting Data in Workflows: When to Use Caching, Artifacts, and Workspaces](https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/).
+refer to the [Persisting Data in Workflows: When to Use Caching, Artifacts, and Workspaces](https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/) blog post.
 
 ## Rerunning a Workflow's Failed Jobs
 

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -477,6 +477,10 @@ workflows:
 
 **Note:** The `defaults:` key in this example is arbitrary. It is possible to name a new key and define it with an arbitrary `&name` to create a reusable set of configuration keys.
 
+For a live example of using workspaces
+to pass data between build and deploy jobs,
+see the [`config.yml`](https://github.com/circleci/circleci-docs/blob/master/.circleci/config.yml) of this documentation.
+
 Refer to the [Persisting Data in Workflows: When to Use Caching, Artifacts, and Workspaces](https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/) for additional conceptual information about using workspaces, caching, and artifacts.
 
 ## Rerunning a Workflow's Failed Jobs


### PR DESCRIPTION
A user brought up the lack of thorough, non-trivial examples involving workspaces in [this issue](https://github.com/circleci/circleci-docs/issues/1879). Rather than build a complete sample app from scratch, we realized that `circleci-docs` itself is actually a great example of several Workflows features.

JIRA issue: https://circleci.atlassian.net/browse/CIRCLE-8375