### PR TITLE
Update yarn cache to be more reliable

### DIFF
--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -33,18 +33,15 @@ Here's an example:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - yarn-packages-{{ .Branch }}
-            - yarn-packages-master
-            - yarn-packages-
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install
       - save_cache:
           name: Save Yarn Package Cache
-          key: yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
-            - node_modules/
+            - ~/.cache/yarn
 #...
 ```
 {% endraw %}

--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -41,7 +41,7 @@ Here's an example:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn
+            - ~/.cache/yarn/v1
 #...
 ```
 {% endraw %}

--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -41,7 +41,7 @@ Here's an example:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn/v1
+            - ~/.cache/yarn
 #...
 ```
 {% endraw %}


### PR DESCRIPTION
Fallbacks are undesirable since they make `yarn.lock` essentially useless and caching yarn's cache also makes it so `node_modules/`is rebuilt and will also include globally installed packages.