### PR TITLE
Clarify that the add_ssh_keys step is more necessary than you think

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -20,7 +20,9 @@ to add SSH keys to CircleCI:
 2. To enable running processes to access other services.
 
 If you are adding an SSH key for the first reason,
-refer to the [GitHub and Bitbucket Integration](https://circleci.com/docs/2.0/gh-bb-integration/#enable-your-project-to-check-out-additional-private-repositories) document. Otherwise, follow the steps below to add an SSH key to your project.
+refer to the [GitHub and Bitbucket Integration](https://circleci.com/docs/2.0/gh-bb-integration/#enable-your-project-to-check-out-additional-private-repositories) document.
+Otherwise,
+follow the steps below to add an SSH key to your project.
 
 ## Steps
 
@@ -50,14 +52,10 @@ every new key must have an empty passphrase.
 
 ## Advanced Usage
 
-By default,
-all CircleCI jobs are configured with `ssh-agent`
-and automatically load _all_ keys.
-While this is usually sufficient,
-you may need finer control
-over which keys authenticate.
-This is particularly useful
-for handling a "Too many authentication failures" error.
+Even though all CircleCI jobs use `ssh-agent`
+to automatically sign all added SSH keys,
+you **must** use the `add_ssh_keys` key
+to actually add keys to a container.
 
 To add a set of SSH keys to a container,
 use the `add_ssh_keys` [special step]({{ site.baseurl }}/2.0/configuration-reference/#add_ssh_keys)

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -844,9 +844,10 @@ fingerprints | N | List | List of fingerprints corresponding to the keys to be a
 {: class="table table-striped"}
 
 ```yaml
-- add_ssh_keys:
-    fingerprints:
-      - "b7:35:a6:4e:9b:0d:6d:d4:78:1e:9a:97:2a:66:6b:be"
+steps:
+  - add_ssh_keys:
+      fingerprints:
+        - "b7:35:a6:4e:9b:0d:6d:d4:78:1e:9a:97:2a:66:6b:be"
 ```
 
 **Note:**

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -842,7 +842,7 @@ Key | Required | Type | Description
 fingerprints | N | List | List of fingerprints corresponding to the keys to be added (default: all keys added)
 {: class="table table-striped"}
 
-``` YAML
+```yaml
 - add_ssh_keys:
     fingerprints:
       - "b7:35:a6:4e:9b:0d:6d:d4:78:1e:9a:97:2a:66:6b:be"

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -835,7 +835,8 @@ Refer to the [Persisting Data in Workflows: When to Use Caching, Artifacts, and 
 
 ##### **`add_ssh_keys`**
 
-Special step that adds SSH keys configured in the project's UI to the container, and configure ssh to use them.
+Special step that adds SSH keys from a project's settings to a container.
+Also configures SSH to use these keys.
 
 Key | Required | Type | Description
 ----|-----------|------|------------
@@ -848,7 +849,11 @@ fingerprints | N | List | List of fingerprints corresponding to the keys to be a
       - "b7:35:a6:4e:9b:0d:6d:d4:78:1e:9a:97:2a:66:6b:be"
 ```
 
-Note that CircleCI 2.0 jobs are auto configured with `ssh-agent` with all keys auto-loaded, and is sufficient for most cases. `add_ssh_keys` may be needed to have greater control over which SSH keys to authenticate (e.g. avoid "Too many authentication failures" problem when having too many SSH keys).
+**Note:**
+Even though CircleCI uses `ssh-agent`
+to sign all added SSH keys,
+you **must** use the `add_ssh_keys` key
+to actually add keys to a container.
 
 ## **`workflows`**
 Used for orchestrating all jobs. Each workflow consists of the workflow name as a key and a map as a value. A name should be unique within the current `config.yml`. The top-level keys for the Workflows configuration are `version` and `jobs`.


### PR DESCRIPTION
Resolves [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-12038).

Users have been under the impression that all SSH keys are automatically added to containers by the `ssh-agent`. This PR should make it more clear that they have to explicitly use the `add_ssh_keys` special step to do that.