### PR TITLE
Fix extra backslash in Dockerfile in Docker Layer Caching example

### DIFF
--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -97,7 +97,7 @@ RUN set -ex \
   && ls -lha /tmp/docker.tgz \
   && tar -xz -C /tmp -f /tmp/docker.tgz \
   && mv /tmp/docker/* /usr/bin \
-  && rm -rf /tmp/docker /tmp/docker.tgz \
+  && rm -rf /tmp/docker /tmp/docker.tgz
 
 # install docker-compose
 RUN curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose \


### PR DESCRIPTION
This is to remove a backslash in the Dockerfile to prevent the curl command for installing docker-compose from being concatenated with the rm command.