### PR TITLE
Document required dockerfile label

### DIFF
--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -72,7 +72,7 @@ extend the base image
 by using the [`FROM` instruction](https://docs.docker.com/engine/reference/builder/#from).
 
 ```Dockerfile
-FROM golang:1.8.0
+FROM ubuntu:18.04
 ```
 
 ### Add an Entrypoint

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -67,26 +67,17 @@ For example,
 if you want to use version 3.6 of the [official Alpine image](https://hub.docker.com/_/alpine/),
 the full image name is `alpine:3.6`.
 
-### Creating a Dockerfile
-
-Docker has a special format
-for describing images and conventionally this file is named `Dockerfile`.
-Consider keeping this file together with your project source code in the `.circleci/images` folder.
-For example,
-in [our Docker demo project](https://github.com/circleci/cci-demo-docker) the `Dockerfile` for the primary container is in the [`.circleci/images/primary` folder](https://github.com/circleci/cci-demo-docker/tree/master/.circleci/images/primary).
-
-After choosing a base image,
-start writing a `Dockerfile`
-to extend the base image using `FROM`,
-as in the following example:
+In your `Dockerfile`,
+extend the base image
+by using the [`FROM` instruction](https://docs.docker.com/engine/reference/builder/#from).
 
 ```Dockerfile
 FROM golang:1.8.0
 ```
 
-Refer to the [CircleCI Docker demo project](https://github.com/circleci/cci-demo-docker) for a custom image build from `golang:1.8.0`
-because the project is using Go.
-See the [`FROM` command](https://docs.docker.com/engine/reference/builder/#from) Docker documentation for more information.
+### Add an Entrypoint
+
+### Adding Required Tools
 
 Add the tools
 required for your job

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -119,13 +119,13 @@ ADD ./db/migrations /migrations
 
 After all of the required tools are specified in the `Dockerfile` it is possible to build the image.
 
-``` Shell
+```bash
 $ docker build <path-to-dockerfile>
 ```
 
 You'll see how all commands specified in `Dockerfile` are executed. If there are any errors they'll be displayed and you'll need to fix them before continuing. If the build is successful you'll have something like this at the very end:
 
-``` Text
+```
 ...
 Successfully built e32703162dd4
 ```

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -43,28 +43,52 @@ As a prerequisite you'll need to have Docker installed. Please follow the [offic
 
 ## Choosing a Base Image and Creating a Dockerfile
 
-Use an image with your main language/framework as a base image. [Docker Hub](https://hub.docker.com/) has pre-built images for most popular languages and frameworks. We recommend starting with an [officially supported image](https://hub.docker.com/explore/). Docker has a special format for describing images and conventionally this file is named `Dockerfile`. We recommend keeping this file together with your project source code in the `.circleci/images` folder. For example, in [our Docker demo project](https://github.com/circleci/cci-demo-docker) the `Dockerfile` for the primary container is in the [`.circleci/images/primary` folder](https://github.com/circleci/cci-demo-docker/tree/master/.circleci/images/primary).
+Use an image with your main language/framework as a base image.
+[Docker Hub](https://hub.docker.com/) has pre-built images for most popular languages and frameworks.
+We recommend starting with an [officially supported image](https://hub.docker.com/explore/).
+Docker has a special format
+for describing images and conventionally this files is named `Dockerfile`.
+We recommend keeping this file together with your project source code in the `.circleci/images` folder.
+For example,
+in [our Docker demo project](https://github.com/circleci/cci-demo-docker) the `Dockerfile` for the primary container is in the [`.circleci/images/primary` folder](https://github.com/circleci/cci-demo-docker/tree/master/.circleci/images/primary).
 
-After choosing a base image, start writing a `Dockerfile` to extend the base image using `FROM` as in the following example:
+After choosing a base image,
+start writing a `Dockerfile`
+to extend the base image using `FROM`,
+as in the following example:
 
-``` Dockerfile
+```Dockerfile
 FROM golang:1.8.0
 ```
 
-Refer to the [CircleCI Docker demo project](https://github.com/circleci/cci-demo-docker) for a custom image build from  `golang:1.8.0` because the project is using Go. See the [`FROM` command](https://docs.docker.com/engine/reference/builder/#from) Docker documentation for more information.
+Refer to the [CircleCI Docker demo project](https://github.com/circleci/cci-demo-docker) for a custom image build from `golang:1.8.0`
+because the project is using Go.
+See the [`FROM` command](https://docs.docker.com/engine/reference/builder/#from) Docker documentation for more information.
 
-Add the tools required for your job by using the `RUN` command:
+Add the tools
+required for your job
+by using the `RUN` command:
 
-``` Dockerfile
+```Dockerfile
 RUN apt-get update && apt-get install -y netcat
 RUN go get github.com/jstemmer/go-junit-report
 ```
 
-In the example project, `netcat` is used to validate that the database is up and running. The `golang:1.8.0` base image does not have it preinstalled, so we specify `netcat` in the `Dockerfile`. The next line installs a special Go library for generating test reports `go-junit-report`.
+In the example project,
+`netcat` is used
+to validate that the database is up and running.
+The `golang:1.8.0` base image does not have it preinstalled,
+so we specify `netcat` in the `Dockerfile`.
+The next line installs a special Go library
+for generating test reports `go-junit-report`.
 
-**Note:** For images **not** based on [`Debian`-like](https://en.wikipedia.org/wiki/Debian) distributions, the command for installing additional applications might be different. For instance, for [`Alpine`](https://en.wikipedia.org/wiki/Alpine_Linux) based images the same tools might be installed using:
+**Note:**
+For images **not** based on [`Debian`-like](https://en.wikipedia.org/wiki/Debian) distributions,
+the command for installing additional applications might be different.
+For instance,
+for [`Alpine`](https://en.wikipedia.org/wiki/Alpine_Linux) based images the same tools might be installed using:
 
-``` Dockerfile
+```Dockerfile
 RUN apk update && apk add netcat-openbsd git
 RUN go get github.com/jstemmer/go-junit-report
 ```

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -128,7 +128,7 @@ ENTRYPOINT contacts
 
 **Note:**
 By default,
-CircleCI does not preserve the entrypoint.
+CircleCI does not preserve entrypoints.
 To change this behavior,
 use the [`LABEL` instruction](https://docs.docker.com/engine/reference/builder/#label)
 as shown in the above example.

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -115,7 +115,7 @@ ADD ./workdir/contacts /usr/bin/contacts
 ADD ./db/migrations /migrations
 ```
 
-### Building the image
+### Building the Image
 
 After all of the required tools are specified in the `Dockerfile` it is possible to build the image.
 

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -51,7 +51,7 @@ This is a text document containing commands
 that Docker uses
 to assemble an image.
 Consider keeping your `Dockerfile` in your `.circleci/images` folder,
-as shown in this [Docker demo project](https://github.com/circleci/cci-demo-docker).
+as shown in [this Docker demo project](https://github.com/circleci/cci-demo-docker).
 
 ### Choosing and Setting a Base Image
 

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -87,15 +87,26 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 ```
 
-### Adding Required and Custom Tools or Files
+#### Required Tools for Primary Containers
 
-There are a few tools a custom image needs to have in order to be used as a primary image in CircleCI:
+In order to be used as a primary container on CircleCI,
+a custom Docker image must have the following tools installed:
 
- * git
- * ssh
- * tar
- * gzip
- * ca-certificates
+- [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [ssh](https://help.ubuntu.com/lts/serverguide/openssh-server.html.en#openssh-installation)
+- [tar](https://www.howtoforge.com/tutorial/linux-tar-command/#installing-tar)
+- [gzip](http://www.gzip.org/)
+- [ca-certificates](https://packages.debian.org/sid/ca-certificates)
+
+**Note:**
+If you choose not to install these tools with a package manager,
+you must use the `ADD` instruction instead of `RUN` (see below).
+
+### Adding Other Files and Directories
+
+To add files and directories
+that are **not** present in package managers,
+use the [`ADD` instruction](https://docs.docker.com/engine/reference/builder/#add).
 
 Ensure that these tools are present in your custom image. You might not need to install all of them, if the base image you choose has some of them pre-installed. Without these tools, some CircleCI services (Artifacts, storing test results, etc.) may not work.
 

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -81,19 +81,6 @@ Add the tools
 required for your job
 by using the `RUN` command:
 
-```Dockerfile
-RUN apt-get update && apt-get install -y netcat
-RUN go get github.com/jstemmer/go-junit-report
-```
-
-In the example project,
-`netcat` is used
-to validate that the database is up and running.
-The `golang:1.8.0` base image does not have it preinstalled,
-so we specify `netcat` in the `Dockerfile`.
-The next line installs a special Go library
-for generating test reports `go-junit-report`.
-
 **Note:**
 For images **not** based on [`Debian`-like](https://en.wikipedia.org/wiki/Debian) distributions,
 the command for installing additional applications might be different.

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -119,7 +119,7 @@ ADD ./db/migrations /migrations
 ### Adding an Entrypoint
 
 To run the container as an executable,
-use the [ENTRYPOINT instruction](https://docs.docker.com/engine/reference/builder/#entrypoint),
+use the [`ENTRYPOINT` instruction](https://docs.docker.com/engine/reference/builder/#entrypoint).
 
 ```Dockerfile
 LABEL com.circleci.preserve-entrypoint=true
@@ -131,7 +131,7 @@ ENTRYPOINT contacts
 By default,
 CircleCI does not preserve the entrypoint.
 To change this behavior,
-use the [LABEL instruction](https://docs.docker.com/engine/reference/builder/#label)
+use the [`LABEL` instruction](https://docs.docker.com/engine/reference/builder/#label)
 as shown in the above example.
 
 ### Building the image

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -79,7 +79,7 @@ FROM ubuntu:18.04
 
 To install any additional tools
 or execute other commands,
-use the [`RUN` instruction](https://docs.docker.com/engine/reference/builder/#run):
+use the [`RUN` instruction](https://docs.docker.com/engine/reference/builder/#run).
 
 ```Dockerfile
 RUN apt-get update \
@@ -98,6 +98,9 @@ a custom Docker image must have the following tools installed:
 - [gzip](http://www.gzip.org/)
 - [ca-certificates](https://packages.debian.org/sid/ca-certificates)
 
+Without these tools,
+some CircleCI services may not work.
+
 **Note:**
 If you do not install these tools with a package manager,
 you must use the `ADD` instruction instead of `RUN` (see below).
@@ -105,18 +108,13 @@ you must use the `ADD` instruction instead of `RUN` (see below).
 ### Adding Other Files and Directories
 
 To add files and directories
-that are **not** present in package managers,
+that are not present in package managers,
 use the [`ADD` instruction](https://docs.docker.com/engine/reference/builder/#add).
 
-Ensure that these tools are present in your custom image. You might not need to install all of them, if the base image you choose has some of them pre-installed. Without these tools, some CircleCI services (Artifacts, storing test results, etc.) may not work.
-
-To add custom files or tools not present in package managers, use the `ADD` command:
-
 ``` Dockerfile
-ADD custom_tool /usr/bin/
+ADD ./workdir/contacts /usr/bin/contacts
+ADD ./db/migrations /migrations
 ```
-
-In this case we copy `custom_tool` into the `/usr/bin/` directory of an image. **Note:** `custom_tool` must be in the same directory as `Dockerfile`. Read more about the [`ADD` command](https://docs.docker.com/engine/reference/builder/#add).
 
 ### Adding an Entrypoint
 

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -51,7 +51,7 @@ This is a text document containing commands
 that Docker uses
 to assemble an image.
 Consider keeping your `Dockerfile` in your `.circleci/images` folder,
-as shown in [this Docker demo project](https://github.com/circleci/cci-demo-docker).
+as shown in [this Docker demo project](https://github.com/CircleCI-Public/circleci-demo-docker/tree/master/.circleci/images/primary).
 
 ### Choosing and Setting a Base Image
 

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -72,7 +72,7 @@ extend the base image
 by using the [`FROM` instruction](https://docs.docker.com/engine/reference/builder/#from).
 
 ```Dockerfile
-FROM ubuntu:18.04
+FROM golang:1.8.0
 ```
 
 ### Installing Additional Tools
@@ -82,9 +82,8 @@ or execute other commands,
 use the [`RUN` instruction](https://docs.docker.com/engine/reference/builder/#run).
 
 ```Dockerfile
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends mysql-client \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y netcat
+RUN go get github.com/jstemmer/go-junit-report
 ```
 
 #### Required Tools for Primary Containers

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -37,9 +37,11 @@ Watch the following video for a detailed tutorial of customizing Docker images.
 
 The following sections provide a walkthrough of how to create a custom image manually. In most cases you'll want to have a custom image for your [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) so that is the focus of this document. But, you can easily apply this knowledge to create images for supporting containers as well.
 
-### Prerequisites
+### Prerequisite
 
-As a prerequisite you'll need to have Docker installed. Please follow the [official Docker guide](https://docs.docker.com/engine/installation/). If you are unfamiliar with Docker, we recommend reading Docker's [getting started guide](https://docs.docker.com/engine/getstarted/).
+- A working [Docker installation](https://docs.docker.com/install/).
+For more details,
+see Docker's [Getting Started documentation](https://docs.docker.com/get-started/)
 
 ### Choosing a Base Image
 

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -75,26 +75,17 @@ by using the [`FROM` instruction](https://docs.docker.com/engine/reference/build
 FROM ubuntu:18.04
 ```
 
-### Adding Required Tools
+### Installing Additional Tools
 
-Add the tools
-required for your job
-by using the `RUN` command:
-
-**Note:**
-For images **not** based on [`Debian`-like](https://en.wikipedia.org/wiki/Debian) distributions,
-the command for installing additional applications might be different.
-For instance,
-for [`Alpine`](https://en.wikipedia.org/wiki/Alpine_Linux) based images the same tools might be installed using:
+To install any additional tools
+or execute other commands,
+use the [`RUN` instruction](https://docs.docker.com/engine/reference/builder/#run):
 
 ```Dockerfile
-RUN apk update && apk add netcat-openbsd git
-RUN go get github.com/jstemmer/go-junit-report
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends mysql-client \
+    && rm -rf /var/lib/apt/lists/*
 ```
-
-Read more about [`RUN` command](https://docs.docker.com/engine/reference/builder/#run).
-
-### Adding an Entrypoint
 
 ### Adding Required and Custom Tools or Files
 
@@ -115,6 +106,8 @@ ADD custom_tool /usr/bin/
 ```
 
 In this case we copy `custom_tool` into the `/usr/bin/` directory of an image. **Note:** `custom_tool` must be in the same directory as `Dockerfile`. Read more about the [`ADD` command](https://docs.docker.com/engine/reference/builder/#add).
+
+### Adding an Entrypoint
 
 ### Building the image
 

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -75,8 +75,6 @@ by using the [`FROM` instruction](https://docs.docker.com/engine/reference/build
 FROM ubuntu:18.04
 ```
 
-### Add an Entrypoint
-
 ### Adding Required Tools
 
 Add the tools
@@ -108,6 +106,8 @@ RUN go get github.com/jstemmer/go-junit-report
 ```
 
 Read more about [`RUN` command](https://docs.docker.com/engine/reference/builder/#run).
+
+### Adding an Entrypoint
 
 ### Adding Required and Custom Tools or Files
 

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -99,7 +99,7 @@ a custom Docker image must have the following tools installed:
 - [ca-certificates](https://packages.debian.org/sid/ca-certificates)
 
 **Note:**
-If you choose not to install these tools with a package manager,
+If you do not install these tools with a package manager,
 you must use the `ADD` instruction instead of `RUN` (see below).
 
 ### Adding Other Files and Directories

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -43,10 +43,20 @@ The following sections provide a walkthrough of how to create a custom image man
 For more details,
 see Docker's [Getting Started documentation](https://docs.docker.com/get-started/)
 
-### Choosing a Base Image
+### Creating a `Dockerfile`
+
+To create a custom image,
+you must [create a `Dockerfile`](https://docs.docker.com/get-started/part2/#define-a-container-with-dockerfile).
+This is a text document containing commands
+that Docker uses
+to assemble an image.
+Consider keeping your `Dockerfile` in your `.circleci/images` folder,
+as shown in this [Docker demo project](https://github.com/circleci/cci-demo-docker).
+
+### Choosing and Setting a Base Image
 
 Before you create a custom image,
-you must choose another image on which to base the custom image.
+you must choose another image from which to extend the custom image.
 [Docker Hub](https://hub.docker.com/explore/) has official, pre-built images for most popular languages and frameworks.
 Given a particular language or framework,
 there are many image variants

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -118,6 +118,22 @@ ADD ./db/migrations /migrations
 
 ### Adding an Entrypoint
 
+To run the container as an executable,
+use the [ENTRYPOINT instruction](https://docs.docker.com/engine/reference/builder/#entrypoint),
+
+```Dockerfile
+LABEL com.circleci.preserve-entrypoint=true
+
+ENTRYPOINT contacts
+```
+
+**Note:**
+By default,
+CircleCI does not preserve the entrypoint.
+To change this behavior,
+use the [LABEL instruction](https://docs.docker.com/engine/reference/builder/#label)
+as shown in the above example.
+
 ### Building the image
 
 After all of the required tools are specified in the `Dockerfile` it is possible to build the image.

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -115,24 +115,6 @@ ADD ./workdir/contacts /usr/bin/contacts
 ADD ./db/migrations /migrations
 ```
 
-### Adding an Entrypoint
-
-To run the container as an executable,
-use the [`ENTRYPOINT` instruction](https://docs.docker.com/engine/reference/builder/#entrypoint).
-
-```Dockerfile
-LABEL com.circleci.preserve-entrypoint=true
-
-ENTRYPOINT contacts
-```
-
-**Note:**
-By default,
-CircleCI does not preserve entrypoints.
-To change this behavior,
-use the [`LABEL` instruction](https://docs.docker.com/engine/reference/builder/#label)
-as shown in the above example.
-
 ### Building the image
 
 After all of the required tools are specified in the `Dockerfile` it is possible to build the image.

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -43,16 +43,25 @@ As a prerequisite you'll need to have Docker installed. Please follow the [offic
 
 ### Choosing a Base Image
 
-Use an image with your main language/framework as a base image.
-[Docker Hub](https://hub.docker.com/) has pre-built images for most popular languages and frameworks.
-We recommend starting with an [officially supported image](https://hub.docker.com/explore/).
-Docker has a special format
-for describing images and conventionally this files is named `Dockerfile`.
-We recommend keeping this file together with your project source code in the `.circleci/images` folder.
+Before you create a custom image,
+you must choose another image on which to base the custom image.
+[Docker Hub](https://hub.docker.com/explore/) has official, pre-built images for most popular languages and frameworks.
+Given a particular language or framework,
+there are many image variants
+from which to choose.
+These variants are specified by [Docker tags](https://docs.docker.com/engine/reference/commandline/tag/).
+
 For example,
-in [our Docker demo project](https://github.com/circleci/cci-demo-docker) the `Dockerfile` for the primary container is in the [`.circleci/images/primary` folder](https://github.com/circleci/cci-demo-docker/tree/master/.circleci/images/primary).
+if you want to use version 3.6 of the [official Alpine image](https://hub.docker.com/_/alpine/),
+the full image name is `alpine:3.6`.
 
 ### Creating a Dockerfile
+
+Docker has a special format
+for describing images and conventionally this file is named `Dockerfile`.
+Consider keeping this file together with your project source code in the `.circleci/images` folder.
+For example,
+in [our Docker demo project](https://github.com/circleci/cci-demo-docker) the `Dockerfile` for the primary container is in the [`.circleci/images/primary` folder](https://github.com/circleci/cci-demo-docker/tree/master/.circleci/images/primary).
 
 After choosing a base image,
 start writing a `Dockerfile`

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -23,11 +23,7 @@ CircleCI 2.0 gives you access to the power and flexibility of Docker. One of the
 
 ## CircleCI Dockerfile Wizard 
 
-Refer to the [`dockerfile-wizard` GitHub repository of CircleCI Public](https://github.com/circleci-public/dockerfile-wizard) for instructions to clone and use the wizard to create a Dockerfile to generate your custom image without installing Docker. 
-
-## Creating a Custom Image Manually
-
-The following sections provide a walkthrough of how to create a custom image manually. In most cases you'll want to have a custom image for your [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) so that is the focus of this document. But, you can easily apply this knowledge to create images for supporting containers as well.
+Refer to the [`dockerfile-wizard` GitHub repository of CircleCI Public](https://github.com/circleci-public/dockerfile-wizard) for instructions to clone and use the wizard to create a Dockerfile to generate your custom image without installing Docker.
 
 ### How to Customize Docker Images for CircleCI 2.0 Video Tutorial
 
@@ -37,11 +33,15 @@ Watch the following video for a detailed tutorial of customizing Docker images.
   <iframe width="560" height="315" src="https://www.youtube.com/embed/JYVLeguIbe0" frameborder="0" allowfullscreen></iframe>
 </div>
 
-## Prerequisites
+## Creating a Custom Image Manually
+
+The following sections provide a walkthrough of how to create a custom image manually. In most cases you'll want to have a custom image for your [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) so that is the focus of this document. But, you can easily apply this knowledge to create images for supporting containers as well.
+
+### Prerequisites
 
 As a prerequisite you'll need to have Docker installed. Please follow the [official Docker guide](https://docs.docker.com/engine/installation/). If you are unfamiliar with Docker, we recommend reading Docker's [getting started guide](https://docs.docker.com/engine/getstarted/).
 
-## Choosing a Base Image and Creating a Dockerfile
+### Choosing a Base Image
 
 Use an image with your main language/framework as a base image.
 [Docker Hub](https://hub.docker.com/) has pre-built images for most popular languages and frameworks.
@@ -51,6 +51,8 @@ for describing images and conventionally this files is named `Dockerfile`.
 We recommend keeping this file together with your project source code in the `.circleci/images` folder.
 For example,
 in [our Docker demo project](https://github.com/circleci/cci-demo-docker) the `Dockerfile` for the primary container is in the [`.circleci/images/primary` folder](https://github.com/circleci/cci-demo-docker/tree/master/.circleci/images/primary).
+
+### Creating a Dockerfile
 
 After choosing a base image,
 start writing a `Dockerfile`
@@ -95,7 +97,7 @@ RUN go get github.com/jstemmer/go-junit-report
 
 Read more about [`RUN` command](https://docs.docker.com/engine/reference/builder/#run).
 
-## Adding Required and Custom Tools or Files
+### Adding Required and Custom Tools or Files
 
 There are a few tools a custom image needs to have in order to be used as a primary image in CircleCI:
 
@@ -115,7 +117,7 @@ ADD custom_tool /usr/bin/
 
 In this case we copy `custom_tool` into the `/usr/bin/` directory of an image. **Note:** `custom_tool` must be in the same directory as `Dockerfile`. Read more about the [`ADD` command](https://docs.docker.com/engine/reference/builder/#add).
 
-## Building the image
+### Building the image
 
 After all of the required tools are specified in the `Dockerfile` it is possible to build the image.
 
@@ -134,7 +136,7 @@ Read more about [`docker build` command](https://docs.docker.com/engine/referenc
 
 Congratulations, you've just built your first image! Now we need to store it somewhere to make it available for CircleCI.
 
-## Storing Images in a Docker Registry
+### Storing Images in a Docker Registry
 
 In order to allow CircleCI to use your custom image, store it in a public [Docker Registry](https://docs.docker.com/registry/introduction/). The easiest mechanism is to create an account on [Docker Hub](https://hub.docker.com/) because Docker Hub allows you to store unlimited public images for free. If your organization is already using Docker Hub you can use your existing account.
 
@@ -171,7 +173,7 @@ $ docker push circleci/cci-demo-docker-primary:0.0.1
 
 **Note:** First, we use `docker login` to authenticate in Docker Hub. If you use a registry other than Docker Hub, refer to the related documentation about how to push images to that registry.
 
-## Using Your Image on CircleCI
+### Using Your Image on CircleCI
 
 After the image is successfully pushed it is available for use it in your `.circleci/config.yml`:
 

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -64,8 +64,8 @@ from which to choose.
 These variants are specified by [Docker tags](https://docs.docker.com/engine/reference/commandline/tag/).
 
 For example,
-if you want to use version 3.6 of the [official Alpine image](https://hub.docker.com/_/alpine/),
-the full image name is `alpine:3.6`.
+if you want to use version 3.5 of the [official Alpine image](https://hub.docker.com/_/alpine/),
+the full image name is `alpine:3.5`.
 
 In your `Dockerfile`,
 extend the base image


### PR DESCRIPTION
This PR adds context on how to enable the Docker `ENTRYPOINT` instruction in a custom Dockerfile. It also addresses a number of other issues with this document, including:

- undocumented: adding a `LABEL` to enable the `ENTRYPOINT` instruction.
- incorrect: most of the required tools can be installed with the `RUN` instruction, **not** the `ADD` instruction.
- unclear: you must create a `Dockerfile` **before** choosing a base image; section headers now represent steps in manually creating a Docker image.
- grammatical errors: some article omissions and assorted language fixes.

Resolves [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-11953).

Original request from @ndintenfass 
Tech review from @ryanwohara 
Writing review from @michelle-luna 