### PR TITLE
Replace footer link to new issue creation page

### DIFF
--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -7,7 +7,7 @@
 	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}" target="_blank">Suggest an edit to this page</a> (please read the <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs" target="_blank">contributing guide</a> first).</li>
 	<li>
         To report a problem,
-        <a href="{{ site.gh_url }}/issues/new/choose">open an issue.</a>
+        <a href="{{ site.gh_url }}/issues/new/choose">open an issue on GitHub.</a>
     </li>
 </ul>
 <hr />

--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -7,8 +7,7 @@
 	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}" target="_blank">Suggest an edit to this page</a> (please read the <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs" target="_blank">contributing guide</a> first).</li>
 	<li>
         To report a problem,
-        see the <a href="{{ site.gh_url }}/wiki/GitHub-Issues-Workflow">GitHub Issues Workflow wiki page</a>
-        and <a href="{{ site.gh_url }}/issues/new?body=This%20issue%20is%20about%20<https://circleci.com/docs{{ page.url }}>%20(source%20file%3A%20<{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}>)" target="_blank">open an issue about this page</a>.
+        <a href="{{ site.gh_url }}/issues/new/choose">open an issue.</a>
     </li>
 </ul>
 <hr />


### PR DESCRIPTION
This PR updates the link in the docs footer to point at the new [issue selection page](https://github.com/circleci/circleci-docs/issues/new/choose).

Copy review from @michelle-luna 
Adding @felicianotech since you implemented the dynamic issue body selection.