### PR TITLE
Add quotes around globbing example for consistency

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -134,7 +134,7 @@ Provide a path to the test files.
 
 Or pipe a glob of test files.
 
-    circleci tests glob test/**/*.java | circleci tests split
+    circleci tests glob "test/**/*.java" | circleci tests split
 
 #### Splitting by Filesize
 


### PR DESCRIPTION
Adds consistent quoting around examples of globbing for test splitting in the CLI.

Follow-up resolution for #2444 and [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-12137).
