### PR TITLE
make `environment` key type consistent across docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,9 @@ jobs:
       - image: circleci/ruby:2.5.1
     working_directory: ~/circleci-docs
     environment:
-      - JEKYLL_ENV=production
-      - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-      - JOB_RESULTS_PATH=run-results
+      JEKYLL_ENV: production
+      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+      JOB_RESULTS_PATH: run-results
     steps:
       - checkout
       - run:

--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -69,7 +69,7 @@ jobs:
     docker:
       - image: ruby:2.4.0
         environment:
-          - LANG: C.UTF-8
+          LANG: C.UTF-8
     working_directory: /my-project
     parallelism: 2
     steps:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -59,7 +59,7 @@ shell | N | String | Shell to use for execution command in all steps. Can be ove
 steps | Y | List | A list of [steps](#steps) to be performed
 working_directory | N | String | In which directory to run the steps. Default: `~/project` (where `project` is a literal string, not the name of your specific project). Processes run during the job can use the `$CIRCLE_WORKING_DIRECTORY` environment variable to refer to this directory. NOTE: Paths written in your YAML configuration file will _not_ be expanded; if your `store_test_results.path` is `$CIRCLE_WORKING_DIRECTORY/tests`, then CircleCI will attempt to store the `test` subdirectory of the directory literally named `$CIRCLE_WORKING_DIRECTORY`, dollar sign `$` and all.
 parallelism | N | Integer | Number of parallel instances of this job to run (default: 1)
-environment | N | Map | A map of environment variable names and variables. (NOTE: These will override any environment variables you set in the CircleCI web interface.)
+environment | N | Map / List | A map or list of environment variable names and values.
 branches | N | Map | A map defining rules for whitelisting/blacklisting execution of specific branches for a single job that is **not** in a workflow (default: all whitelisted). See [Workflows](#workflows) for configuring branch execution for jobs in a workflow.
 resource_class | N | String | Amount of CPU and RAM allocated to each container in a job. (Only available with the `docker` executor) **Note:** A paid account is required to access this feature. Customers on paid plans can request access by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
 {: class="table table-striped"}

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -494,7 +494,7 @@ alerts in chatrooms.
 
 ##### _Example_
 
-``` YAML
+```yaml
 - run:
     name: Testing application
     command: make test

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -515,7 +515,6 @@ steps:
       name: Upload Failed Tests
       command: curl --data fail_tests.log http://example.com/error_logs
       when: on_fail
-
 ```
 
 ##### **`checkout`**

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -82,7 +82,8 @@ If `parallelism` is set to N > 1, then N independent executors will be set up an
 `working_directory` will be created automatically if it doesn't exist.
 
 Example:
-``` YAML
+
+```yaml
 jobs:
   build:
     docker:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -71,10 +71,6 @@ A map of environment variable names and values.
 These will override any environment variables
 you set in the CircleCI application.
 
-**Note**:
-While the `environment` key expects a map,
-a list will be accepted without failing or producing an error.
-
 #### `parallelism`
 
 If `parallelism` is set to N > 1, then N independent executors will be set up and each will run the steps of that job in parallel. Certain parallelism-aware steps can opt out of the parallelism and only run on a single executor (for example [`deploy` step](#deploy)). Learn more about [parallel jobs]({{ site.baseurl }}/2.0/parallelism-faster-jobs/).

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -495,25 +495,26 @@ alerts in chatrooms.
 ##### _Example_
 
 ```yaml
-- run:
-    name: Testing application
-    command: make test
-    shell: /bin/bash
-    working_directory: ~/my-app
-    no_output_timeout: 30m
-    environment:
-      FOO: bar
+steps:
+  - run:
+      name: Testing application
+      command: make test
+      shell: /bin/bash
+      working_directory: ~/my-app
+      no_output_timeout: 30m
+      environment:
+        FOO: bar
 
-- run: echo 127.0.0.1 devhost | sudo tee -a /etc/hosts
+  - run: echo 127.0.0.1 devhost | sudo tee -a /etc/hosts
 
-- run: |
-    sudo -u root createuser -h localhost --superuser ubuntu &&
-    sudo createdb -h localhost test_db
+  - run: |
+      sudo -u root createuser -h localhost --superuser ubuntu &&
+      sudo createdb -h localhost test_db
 
-- run:
-    name: Upload Failed Tests
-    command: curl --data fail_tests.log http://example.com/error_logs
-    when: on_fail
+  - run:
+      name: Upload Failed Tests
+      command: curl --data fail_tests.log http://example.com/error_logs
+      when: on_fail
 
 ```
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1048,7 +1048,8 @@ Refer to the [Orchestrating Workflows]({{ site.baseurl }}/2.0/workflows) documen
 {:.no_toc}
 
 {% raw %}
-``` YAML
+
+```yaml
 version: 2
 jobs:
   build:
@@ -1160,4 +1161,5 @@ workflows:
             branches:
               only: master          
 ```
+
 {% endraw %}

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -139,7 +139,7 @@ You can specify image versions using tags or digest. You can use any public imag
 
 Example:
 
-``` YAML
+```yaml
 jobs:
   build:
     docker:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -331,7 +331,7 @@ jobs:
   build:
     working_directory: ~/canary-python
     environment:
-      - FOO: "bar"
+      FOO: bar
     steps:
       - run:
           name: Running tests

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -67,7 +67,11 @@ resource_class | N | String | Amount of CPU and RAM allocated to each container 
 <sup>(1)</sup> exactly one of them should be specified. It is an error to set more than one.
 
 #### `environment`
-A map of environment variable names and variables (**Note**: These will override any environment variables you set in the CircleCI web interface).
+A map or list of environment variable names and values.
+
+**Note**:
+These will override any environment variables
+you set in the CircleCI web interface.
 
 #### `parallelism`
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -326,7 +326,7 @@ Java, Erlang and any other languages that introspect the `/proc` directory for i
 
 The `steps` setting in a job should be a list of single key/value pairs, the key of which indicates the step type. The value may be either a configuration map or a string (depending on what that type of step requires). For example, using a map:
 
-```
+```yaml
 jobs:
   build:
     working_directory: ~/canary-python

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -88,7 +88,7 @@ jobs:
     docker:
       - image: buildpack-deps:trusty
     environment:
-      - FOO: "bar"
+      FOO: bar
     parallelism: 3
     resource_class: large
     working_directory: ~/my-app

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -502,7 +502,7 @@ alerts in chatrooms.
     working_directory: ~/my-app
     no_output_timeout: 30m
     environment:
-      FOO: "bar"
+      FOO: bar
 
 - run: echo 127.0.0.1 devhost | sudo tee -a /etc/hosts
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -59,7 +59,7 @@ shell | N | String | Shell to use for execution command in all steps. Can be ove
 steps | Y | List | A list of [steps](#steps) to be performed
 working_directory | N | String | In which directory to run the steps. Default: `~/project` (where `project` is a literal string, not the name of your specific project). Processes run during the job can use the `$CIRCLE_WORKING_DIRECTORY` environment variable to refer to this directory. NOTE: Paths written in your YAML configuration file will _not_ be expanded; if your `store_test_results.path` is `$CIRCLE_WORKING_DIRECTORY/tests`, then CircleCI will attempt to store the `test` subdirectory of the directory literally named `$CIRCLE_WORKING_DIRECTORY`, dollar sign `$` and all.
 parallelism | N | Integer | Number of parallel instances of this job to run (default: 1)
-environment | N | Map / List | A map or list of environment variable names and values.
+environment | N | Map | A map of environment variable names and values.
 branches | N | Map | A map defining rules for whitelisting/blacklisting execution of specific branches for a single job that is **not** in a workflow (default: all whitelisted). See [Workflows](#workflows) for configuring branch execution for jobs in a workflow.
 resource_class | N | String | Amount of CPU and RAM allocated to each container in a job. (Only available with the `docker` executor) **Note:** A paid account is required to access this feature. Customers on paid plans can request access by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
 {: class="table table-striped"}
@@ -67,11 +67,13 @@ resource_class | N | String | Amount of CPU and RAM allocated to each container 
 <sup>(1)</sup> exactly one of them should be specified. It is an error to set more than one.
 
 #### `environment`
-A map or list of environment variable names and values.
+A map of environment variable names and values.
+These will override any environment variables
+you set in the CircleCI application.
 
 **Note**:
-These will override any environment variables
-you set in the CircleCI web interface.
+While the `environment` key expects a map,
+a list will be accepted without failing or producing an error.
 
 #### `parallelism`
 

--- a/jekyll/_cci2/databases.md
+++ b/jekyll/_cci2/databases.md
@@ -27,7 +27,8 @@ In the primary image the config defines an environment variable with the `enviro
 This Postgres image in the example is slightly modified already with `-ram` at the end. It runs in-memory so it does not  hit the disk and that will significantly improve the testing performance on this PostgreSQL database by using this image.
 
 {% raw %}
-```
+
+```yaml
 version: 2
 jobs:
   build:
@@ -48,19 +49,20 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install postgresql-client-9.6
       - run: whoami
-      - run: | 
+      - run: |
           psql \
           -d $TEST_DATABASE_URL \
           -c "CREATE TABLE test (name char(25));"
-      - run: | 
+      - run: |
           psql \
           -d $TEST_DATABASE_URL \
           -c "INSERT INTO test VALUES ('John'), ('Joanna'), ('Jennifer');"
-      - run: | 
+      - run: |
           psql \
           -d $TEST_DATABASE_URL \
           -c "SELECT * from test"
 ```
+
 {% endraw %}
 
 The `steps` run `checkout` first, then install the Postgres client tools. The `postgres:9.6.5-alpine-ram` image doesn't install any client-specific database adapters. For example, for Python, you might install `psychopg2` so that you can interface with the PostgreSQL database. See [Pre-Built CircleCI Services Images]({{ site.baseurl }}/2.0/circleci-images/#service-images) for the list of images and for a video of this build configuration.
@@ -100,7 +102,7 @@ To use `pg_dump`, `pg_restore` and similar utilities requires some extra configu
 Using multiple Docker containers for your jobs may cause race conditions if the service in a container does not start  before the job tries to use it. For example, your PostgreSQL container might be running, but might not be ready to accept connections. Work around this problem by using `dockerize` to wait for dependencies.
 Following is an example of how to do this in your CircleCI `config.yml` file:
 
-```
+```yaml
 version: 2.0
 jobs:
   build:

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -109,7 +109,7 @@ jobs:
     docker:
       - image: buildpack-deps:trusty
     environment:
-      FOO: "bar"
+      FOO: bar
 ```
 
 ## Setting an Environment Variable in a Container

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -127,7 +127,7 @@ You can set the timezone in Docker images with the `TZ` environment variable. In
 
 A sample `.circleci/config.yml` with a defined `TZ` variable would look like this:
 
-```
+```yaml
 version: 2
 jobs:
   build:

--- a/jekyll/_cci2/ios-codesigning.md
+++ b/jekyll/_cci2/ios-codesigning.md
@@ -189,7 +189,7 @@ platform :ios do
 end
 ```
 
-```
+```yaml
 # .circleci/config.yml
 version: 2
 jobs:

--- a/jekyll/_cci2/ios-migrating-from-1-2.md
+++ b/jekyll/_cci2/ios-migrating-from-1-2.md
@@ -36,7 +36,7 @@ benefit from the improvements in the CircleCI 2.0 platform, including:
 This sample configuration file should work for most iOS projects on
 CircleCI 2.0:
 
-```
+```yaml
 # .circleci/config.yml
 
 # Specify the config version - version 2 is latest.
@@ -209,7 +209,8 @@ key_. Here is how you can cache the Ruby gems based on the content of
 `Gemfile.lock`:
 
 {% raw %}
-```
+
+```yaml
 jobs:
   build-and-deploy:
     environment:
@@ -233,6 +234,7 @@ jobs:
           paths:
             - vendor/bundle
 ```
+
 {% endraw %}
 
 Every time your Gemfile.lock changes, a new cache will be created.
@@ -281,7 +283,7 @@ It is possible to use [Fastlane
 Scan](https://github.com/fastlane/fastlane/tree/master/scan) to run your
 tests as follows:
 
-```
+```yaml
 jobs:
   build-and-deploy:
     steps:
@@ -345,7 +347,7 @@ With the availability of Workflows in 2.0, it is best practice to
 extract all the commands related to the deployment of the app into
 its own job:
 
-```
+```yaml
 jobs:
   ...
   deploy:

--- a/jekyll/_cci2/ios-migrating-from-1-2.md
+++ b/jekyll/_cci2/ios-migrating-from-1-2.md
@@ -216,7 +216,7 @@ jobs:
     environment:
       BUNDLE_PATH: vendor/bundle  # path to install gems and use for caching
     steps:
-      ...
+      # add other steps here
       - restore_cache:
           keys:
           - v1-gems-{{ checksum "Gemfile.lock" }}
@@ -287,7 +287,7 @@ tests as follows:
 jobs:
   build-and-deploy:
     steps:
-      ...
+      # add other steps here
       - run:
           name: Run tests
           command: bundle exec fastlane scan
@@ -349,7 +349,7 @@ its own job:
 
 ```yaml
 jobs:
-  ...
+  # add other jobs here
   deploy:
     macos:
       xcode: 8.3.3

--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -27,6 +27,7 @@ Running the Android emulator is not currently supported by the type of virtualiz
 ## Sample Configuration
 
 {% raw %}
+
 ```yaml
 version: 2
 jobs:
@@ -61,6 +62,7 @@ jobs:
       # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples    
 
 ```
+
 {% endraw %}
 
 ## Config Walkthrough

--- a/jekyll/_cci2/language-clojure.md
+++ b/jekyll/_cci2/language-clojure.md
@@ -28,6 +28,7 @@ If you use another testing tool, you can just adjust that step to run a differen
 ## Sample Configuration
 
 {% raw %}
+
 ```yaml
 version: 2 # use CircleCI 2.0
 jobs: # basic units of work in a run
@@ -53,6 +54,7 @@ jobs: # basic units of work in a run
           destination: uberjar
       # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples     
 ```
+
 {% endraw %}
 
 ## Get the Code

--- a/jekyll/_cci2/language-elixir.md
+++ b/jekyll/_cci2/language-elixir.md
@@ -16,6 +16,7 @@ If you're in a rush, just copy the configuration below into `.circleci/config.ym
 ## Sample Configuration
 
 {% raw %}
+
 ```yaml
 version: 2  # use CircleCI 2.0 instead of CircleCI Classic
 jobs:  # basic units of work in a run
@@ -77,4 +78,5 @@ jobs:  # basic units of work in a run
       - store_test_results:  # upload test results for display in Test Summary
           path: _build/test/junit
 ```
+
 {% endraw %}

--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -118,7 +118,7 @@ And install the Go implementation of the JUnit reporting tool and other dependen
 
 Both containers (primary and postgres) start simultaneously, however Postgres may require some time to get ready and if our tests start before that the job will fail. So it's good practice to wait until dependent services are ready. Here we have only Postgres, so we add this step:
 
-``` YAML
+```yaml
       - run:
           name: Waiting for Postgres to be ready
           command: |
@@ -148,20 +148,20 @@ Now we run our tests. To do that, we need to set an environment variable for our
 
 Our project uses `make` for building and testing (you can see `Makefile` [here](https://github.com/CircleCI-Public/circleci-demo-go/blob/master/Makefile)), so we can just run `make test`. In order to collect test results and upload them later (read more about test results in the [Project Tutorial]({{ site.baseurl }}/2.0/project-walkthrough/)) we're using `go-junit-report`:
 
-``` YAML
+```bash
 make test | go-junit-report > ${TEST_RESULTS}/go-test-report.xml
 ```
 
 In this case all output from `make test` will go straight into `go-junit-report` without appearing in `stdout`. We can solve this by using two standard Unix commands `tee` and `trap`. The first one allows us to duplicate output into `stdout` and somewhere else ([read more](http://man7.org/linux/man-pages/man1/tee.1.html)). The second one allows us to specify some command to be executed on script exit ([read more](http://man7.org/linux/man-pages/man1/trap.1p.html)). So we can do:
 
-``` YAML
+```bash
 trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
 make test | tee ${TEST_RESULTS}/go-test.out
 ```
 
 Now we know that our unit tests succeeded we can start our service and validate it's running.
 
-``` YAML
+```yaml
       - run: make
 
       - save_cache:

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -67,6 +67,7 @@ jobs: # a collection of steps
 Finally, add several `steps` within the `build` job:
 
 {% raw %}
+
 ```yaml
     steps: # a collection of executable commands
       - checkout # special step to check out source code to the working directory
@@ -90,6 +91,7 @@ Finally, add several `steps` within the `build` job:
           destination: tr1
       # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples    
 ```
+
 {% endraw %}
 
 For the complete list of CircleCI configuration keys,

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -40,6 +40,7 @@ Database images for use as a secondary 'service' container are also available on
 ## Sample Configuration
 
 {% raw %}
+
 ```yaml
 version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
@@ -122,6 +123,7 @@ jobs: # a collection of steps
           path: test_results
       # See https://circleci.com/docs/2.0/deployment-integrations/ for example deploy configs    
 ```
+
 {% endraw %}
 
 ---

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -130,14 +130,18 @@ jobs:
                     pip install awscli
                     apt-get clean && apt-get autoclean
 ```
+
 The steps/run keys specify the types of actions to perform. The run keys represent the actions to be executed.
-```
+
+```yaml
       - run: echo 'export ARTIFACT_BUILD=$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.zip' >> $BASH_ENV
 ```
+
 This echo command defines the $ARTIFACT_BUILD environment variable and sets it to a build filename. 
 
 The next run command executes multiple commands within the openjdk container. Since we're executing multiple commands we'll be defining a multi-line run command which is designated by the pipe `|` character, as shown below. When using the multi-line option, one line represents one command.
-```
+
+```yaml
           command: |
                     apt update && apt install -y curl
                     curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb
@@ -148,6 +152,7 @@ The next run command executes multiple commands within the openjdk container. Si
                     pip install awscli
                     apt-get clean && apt-get autoclean
 ```
+
 The 2.0 version of our samplescala schema requires us to download required dependencies and install them into the container.  Below is an explanation of the example multi-line command:
 - Updates the container OS and installs curl.
 - Downloads the [Simple Build Tool (sbt)](https://www.scala-sbt.org/) compiler version specified in the $SBT_VERSION variable.
@@ -159,7 +164,8 @@ The 2.0 version of our samplescala schema requires us to download required depen
 - Removes all the unnecessary install packages to minimize container size.
 
 The following keys represent actions performed after the multi-line command is executed:
-```
+
+```yaml
       - checkout
       - restore_cache:
           key: sbt-cache
@@ -176,6 +182,7 @@ The following keys represent actions performed after the multi-line command is e
             - "~/.sbt"
             - "~/.m2"
 ```
+
 Below is an explanation of the preceding example:
 - `checkout`: basically git clones the project repo from github into the container 
 - `restore_cache` key: specifies the name of the cache files to restore. The key name is specified in the save_cache key that is found later in the schema. If the key specified is not found then nothing is restored and continues to process.
@@ -185,7 +192,7 @@ Below is an explanation of the preceding example:
 
 The final portion of the 2.0 schema are the deploy command keys which move and rename the compiled samplescala.zip to the $CIRCLE_ARTIFACTS/ directory.  The file is then uploaded to the AWS S3 bucket specified.
 
-```
+```yaml
   - deploy:
       command: |
         mv target/universal/samplescala.zip $CIRCLE_ARTIFACTS/$ARTIFACT_BUILD

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -47,7 +47,7 @@ jobs:
     docker:
       - image: openjdk:8
     environment:
-      - SBT_VERSION: 1.0.4
+      SBT_VERSION: 1.0.4
     steps:
       - run: echo 'export ARTIFACT_BUILD=$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.zip' >> $BASH_ENV
       - run:
@@ -104,11 +104,13 @@ jobs:
     docker:
       - image: openjdk:8
     environment:
-      - SBT_VERSION: 1.0.4
+      SBT_VERSION: 1.0.4
 ```
+
 The docker/image key represents the Docker image you want to use for the build. In this case, we want to use the official `openjdk:8` image from [Docker Hub](https://hub.docker.com/_/openjdk/) because it has the native Java compiler we need for our Scala project.
 
 The environment/SBT_VERSION is an environment variable that specifies the version of sbt to download in later commands which is required to compile the Scala app.
+
 ```yaml
 version: 2
 jobs:
@@ -117,7 +119,7 @@ jobs:
     docker:
       - image: openjdk:8
     environment:
-      - SBT_VERSION: 1.0.4
+      SBT_VERSION: 1.0.4
     steps:
       - run: echo 'export ARTIFACT_BUILD=$CIRCLE_PROJECT_REPONAME-$CIRCLE_BUILD_NUM.zip' >> $BASH_ENV
       - run:

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -204,5 +204,3 @@ The deploy command is another multi-line execution.
 ## See Also 
 
 See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for more example deploy target configurations.
-
-

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -121,14 +121,14 @@ jobs:
       - run:
           name: Get sbt binary
           command: |
-                    apt update && apt install -y curl
-                    curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb
-                    dpkg -i sbt-$SBT_VERSION.deb
-                    rm sbt-$SBT_VERSION.deb
-                    apt-get update
-                    apt-get install -y sbt python-pip git
-                    pip install awscli
-                    apt-get clean && apt-get autoclean
+            apt update && apt install -y curl
+            curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb
+            dpkg -i sbt-$SBT_VERSION.deb
+            rm sbt-$SBT_VERSION.deb
+            apt-get update
+            apt-get install -y sbt python-pip git
+            pip install awscli
+            apt-get clean && apt-get autoclean
 ```
 
 The steps/run keys specify the types of actions to perform. The run keys represent the actions to be executed.
@@ -142,15 +142,16 @@ This echo command defines the $ARTIFACT_BUILD environment variable and sets it t
 The next run command executes multiple commands within the openjdk container. Since we're executing multiple commands we'll be defining a multi-line run command which is designated by the pipe `|` character, as shown below. When using the multi-line option, one line represents one command.
 
 ```yaml
+      - run:
           command: |
-                    apt update && apt install -y curl
-                    curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb
-                    dpkg -i sbt-$SBT_VERSION.deb
-                    rm sbt-$SBT_VERSION.deb
-                    apt-get update
-                    apt-get install -y sbt python-pip git
-                    pip install awscli
-                    apt-get clean && apt-get autoclean
+            apt update && apt install -y curl
+            curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb
+            dpkg -i sbt-$SBT_VERSION.deb
+            rm sbt-$SBT_VERSION.deb
+            apt-get update
+            apt-get install -y sbt python-pip git
+            pip install awscli
+            apt-get clean && apt-get autoclean
 ```
 
 The 2.0 version of our samplescala schema requires us to download required dependencies and install them into the container.  Below is an explanation of the example multi-line command:
@@ -166,6 +167,7 @@ The 2.0 version of our samplescala schema requires us to download required depen
 The following keys represent actions performed after the multi-line command is executed:
 
 ```yaml
+    steps:
       - checkout
       - restore_cache:
           key: sbt-cache
@@ -193,6 +195,7 @@ Below is an explanation of the preceding example:
 The final portion of the 2.0 schema are the deploy command keys which move and rename the compiled samplescala.zip to the $CIRCLE_ARTIFACTS/ directory.  The file is then uploaded to the AWS S3 bucket specified.
 
 ```yaml
+steps:
   - deploy:
       command: |
         mv target/universal/samplescala.zip $CIRCLE_ARTIFACTS/$ARTIFACT_BUILD

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -85,17 +85,13 @@ jobs:
 ## Schema Walkthrough
 
 All version 2.0 config.yml files must start with his line:
-```yaml
-version: 2
-```
-The next key in the schema is the jobs & build keys.  These keys are required and represent the default entry point for a run.
-```yaml
-version: 2
 
-jobs:
-    build:
+```yaml
+version: 2
 ```
-The build section hosts the remainder of the schema which executes our commands. This will be explained below.
+
+The next key in the schema is the jobs & build keys.  These keys are required and represent the default entry point for a run. The build section hosts the remainder of the schema which executes our commands. This will be explained below.
+
 ```yaml
 version: 2
 jobs:

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -148,21 +148,21 @@ To increase the speed of your software development through faster feedback, shor
 
 - If your configuration sets a timezone, search and replace `timezone: America/Los_Angeles` with the following two lines:
 
-```
+```yaml
     environment:
       TZ: "/usr/share/zoneinfo/America/Los_Angeles"
 ```
 
 - If your configuration modifies $PATH, add the path to your `.bashrc` file and replace 
 
-```
+```yaml
     environment:
       PATH: "/path/to/foo/bin:$PATH"
 ```
 
 With the following to load it into your shell (the file $BASH_ENV already exists and has a random name in /tmp):
 
-```
+```yaml
     steps:
       - run: echo 'export PATH=/path/to/foo/bin:$PATH' >> $BASH_ENV 
       - run: some_program_inside_bin
@@ -170,14 +170,14 @@ With the following to load it into your shell (the file $BASH_ENV already exists
 
 - Search and replace the `hosts:` key, for example:
 
-```  
+```yaml
 hosts:
     circlehost: 127.0.0.1
 ```
 
 With an appropriate `run` Step, for example:
 
-```
+```yaml
     steps:
       - run: echo 127.0.0.1 circlehost | sudo tee -a /etc/hosts
 ```
@@ -185,7 +185,7 @@ With an appropriate `run` Step, for example:
 
 - Search and replace the `dependencies:`, `database`, or `test` and `override:` lines, for example:
 
-```
+```yaml
 dependencies:
   override:
     - <installed-dependency>
@@ -193,7 +193,7 @@ dependencies:
 
 Is replaced with:
 
-```
+```yaml
       - run:
           name: <name>
           command: <installed-dependency>
@@ -201,14 +201,14 @@ Is replaced with:
 
 - Search and replace the `cache_directories:` key:
 
-```
+```yaml
   cache_directories:
     - "vendor/bundle"
 ```
 
 With the following, nested under `steps:` and customizing for your application as appropriate:
 
-```
+```yaml
      - save_cache:
         key: dependency-cache
         paths:
@@ -219,7 +219,7 @@ With the following, nested under `steps:` and customizing for your application a
 
 - Search and replace `deployment:` with the following, nested under `steps`:
 
-```
+```yaml
      - deploy:
 ```
 

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -236,4 +236,3 @@ When you have all the sections in `.circleci/config.yml` we recommend that you c
 
 - Refer to the [Specifying Container Images]({{ site.baseurl }}/2.0/executor-types/) document for more information about Docker and Machine images in CircleCI 2.0.
 - Refer to the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/) document for details on the exact syntax of CircleCI 2.0 `jobs` and `steps` and all available options.
-

--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -24,7 +24,8 @@ follows, because the circleci/ruby:2.4.1-node image does not have psql installed
 by default and uses `pg` gem for database access.
 
 {% raw %}
-```
+
+```yaml
 version: 2
 jobs:
   build:
@@ -82,6 +83,7 @@ jobs:
       - store_test_results:
           path: /tmp/test-results
 ```
+
 {% endraw %}
 
 **Note:** An alternative is to build your own image by extending the current image,
@@ -97,7 +99,7 @@ In CircleCI 2.0 you must declare your database configuration explicitly because 
 
 The following example demonstrates this order by combining the `environment` setting with the image and by also including the `environment` configuration in the shell command to enable the database connection:
 
-```
+```yaml
 version: 2
 jobs:
   build:
@@ -135,7 +137,7 @@ This example specifies the `$DATABASE_URL` as the default user and port for Post
 
 Refer to the [Go Language Guide]({{ site.baseurl }}/2.0/language-go/) for a walkthrough of this example configuration and a link to the public code repository for the app.
 
-```
+```yaml
 version: 2
 jobs:
   build:
@@ -217,7 +219,7 @@ jobs:
 
 The following example uses MySQL and dockerize, see the [sample project on Github](https://github.com/tkuchiki/wait-for-mysql-circleci-2.0) for additional links.
 
-```
+```yaml
 version: 2
 jobs:
   build:
@@ -242,4 +244,3 @@ jobs:
           name: MySQL version
           command: bundle exec ruby mysql_version.rb
 ```
-

--- a/jekyll/_cci2/project-walkthrough.md
+++ b/jekyll/_cci2/project-walkthrough.md
@@ -48,7 +48,7 @@ If the job requires services such as databases they can be run as additional con
 
 Docker images are typically configured using environment variables, if these are necessary a set of environment variables to be passed to the container can be supplied:
 
-```
+```yaml
 version: 2
 jobs:
   build:
@@ -72,7 +72,7 @@ The `circleci/postgres:9.6.5-alpine-ram` service container is configured with a 
 
 Next the job installs Python dependencies into the *primary container* by running `pip install`. Dependencies are installed into the *primary container* by running regular Steps executing shell commands:
 
-```
+```yaml
 version: 2
 jobs:
   build:
@@ -98,7 +98,7 @@ jobs:
 
 An environment variable defined in a `run:` key will override image-level variables, e.g.:
 
-```
+```yaml
       - run:
           command: echo ${FLASK_CONFIG}
           environment:
@@ -109,7 +109,7 @@ An environment variable defined in a `run:` key will override image-level variab
 
 To speed up the jobs, the demo configuration places the Python virtualenv into the CircleCI cache and restores that cache before running `pip install`. If the virtualenv was cached the `pip install` command will not need to download any dependencies into the virtualenv because they are already present. Saving the virtualenv into the cache is done using the `save_cache` step which runs after the `pip install` command.
 
-```
+```yaml
 version: 2
 jobs:
   build:
@@ -151,7 +151,7 @@ The following describes the detail of the added key values:
 
 The demo application contains a file `tests/test_selenium.py` that uses Chrome, Selenium and webdriver to automate testing the application in a web browser. The primary image has the current stable version of Chrome pre-installed (this is designated by the `-browsers` suffix). Selenium needs to be installed and run since this is not included in the primary image:
 
-```
+```yaml
 version: 2
 jobs:
   build:

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -21,7 +21,8 @@ The CircleCI 2.0 configuration introduces a new key for `version: 2`. This new k
 Following is a sample 2.0 `.circleci/config.yml` file.
 
 {% raw %}
-```
+
+```yaml
 version: 2
 jobs:
   build:
@@ -43,7 +44,9 @@ workflows:
       - build
       - test
 ```
+
 {% endraw %}
+
 This example shows a parallel job workflow where the `build` and `test` jobs run in parallel to save time. Refer to the [Workflows]({{ site.baseurl }}/2.0/workflows) document for complete details about orchestrating job runs with parallel, sequential, and manual approval workflows.
 
 ## Sample Configuration with Sequential Workflow
@@ -51,7 +54,8 @@ This example shows a parallel job workflow where the `build` and `test` jobs run
 Following is a sample 2.0 `.circleci/config.yml` file.
 
 {% raw %}
-```
+
+```yaml
 version: 2
 jobs:
   build:
@@ -106,7 +110,9 @@ workflows:
             branches:
               only: master
 ```
+
 {% endraw %}
+
 This example shows a sequential workflow with the `test` job configured to run only on the master branch. Refer to the [Workflows]({{ site.baseurl }}/2.0/workflows) document for complete details about orchestrating job runs with parallel, sequential, and manual approval workflows.
 
 ## Sample Configuration with Fan-in/Fan-out Workflow
@@ -115,7 +121,8 @@ Following is a sample configuration for a Fan-in/Fan-out workflow. Refer to [the
 Note that since a job can only run when its dependencies are satisfied it transitively requires the dependencies of all upstream jobs, this means only the immediate upstream dependencies need to be specified in the `requires:` blocks.
 
 {% raw %}
-```
+
+```yaml
 version: 2.0
 
 jobs:
@@ -187,7 +194,7 @@ jobs:
         enabled: true
     working_directory: ~/circleci-demo-workflows
     environment:
-      - HEROKU_APP: still-shelf-38337
+      HEROKU_APP: still-shelf-38337
     steps:
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
@@ -219,6 +226,7 @@ workflows:
             - rake_test
             - precompile_assets
 ```
+
 {% endraw %}
 
 ## Sample Configuration with Multiple Executor Types (macOS + Docker)
@@ -231,7 +239,8 @@ project will be built on macOS, and additional iOS tools
 will be run in Docker.
 
 {% raw %}
-```
+
+```yaml
 version: 2
 jobs:
   build-and-test:
@@ -290,4 +299,5 @@ workflows:
       - danger
       - build-and-test
 ```
+
 {% endraw %}

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -62,7 +62,7 @@ In addition to the basic setup steps, it is best practice to include
 downloading CocoaPods specs from the CircleCI mirror (up to 70% faster)
 and linting the Swift code together with the `build-and-test` job:
 
-```
+```yaml
 # .circleci/config.yml
 version: 2
 jobs:
@@ -111,11 +111,10 @@ The recommended configuration can be extended to add a lint job and a Danger
 job as follows:
 
 
-```
+```yaml
 version: 2
 jobs:
   build-and-test:
-  ...
   swiftlint:
     docker:
       - image: dantoml/swiftlint:latest
@@ -219,7 +218,7 @@ end
 
 This configuration can be used with the following CircleCI config file:
 
-```
+```yaml
 # .circleci/config.yml
 version: 2
 jobs:
@@ -562,7 +561,8 @@ project will be built on macOS, and additional iOS tools
 will be run in Docker.
 
 {% raw %}
-```
+
+```yaml
 version: 2
 jobs:
   build-and-test:
@@ -620,6 +620,7 @@ workflows:
       - danger
       - build-and-test
 ```
+
 {% endraw %}
 
 ## React Native projects


### PR DESCRIPTION
This PR does two things:

- makes all examples of the `environment` key use a map (rather than a list)
- makes a note of the fact that we **accept** but **discourage** using the `environment` key as a list
- adds several missing yaml tags and removes whitespaces

Resolves #2445 and [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-12110).

@marcomorain for technical review of the Configuration Reference, especially.
@michelle-luna for copy review.