### PR TITLE
Revise document for better structure and explanation of image tags

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -13,7 +13,15 @@ This document provides information about pre-built CircleCI images and a listing
 * TOC
 {:toc}
 
-For convenience, CircleCI maintains several Docker images. These images are extensions of official Docker images and include tools that are especially useful for CI/CD. All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/). The source code for these images is available at [github.com/circleci/circleci-images](https://github.com/circleci/circleci-images). Dockerfiles for each CircleCI image variant are archived at [github.com/circleci-public/circleci-dockerfiles](https://github.com/circleci-public/circleci-dockerfiles).
+## Overview
+
+For convenience,
+CircleCI maintains several Docker images.
+These images are extensions of official Docker images
+and include tools that are especially useful for CI/CD.
+All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/).
+The source code for these images is [available on GitHub](https://github.com/circleci/circleci-images).
+Dockerfiles for these images are also [archived on GitHub](https://github.com/circleci-public/circleci-dockerfiles).
 
 ## Best Practices
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -142,7 +142,7 @@ That is, to prevent unintended changes that come from upstream, instead of using
 For example, add `-jessie` or `-stretch` to the end of each of those containers to ensure you're only using that base OS. You can pin down those images to a specific point version, like `circleci/ruby:2.3.7-jessie`, or you can just specify the OS version, with `circleci/ruby:2.3-jessie`. This is possible for any of the CircleCI images.
 
 It is also possible to specify all the way down to the specific SHA of the image you want to use. Doing so allows you to test specific images for as long as you like before making any changes. To find the value, navigate to on older Build page in the CircleCI app that utilized the image you wish to use and select the drop-down for `Spin up Environment`. Inside you will find the SHA256, for example, 
-`circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e`. 
+`circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e`.
 
 
 {% assign images = site.data.docker-image-tags | sort %}

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -62,7 +62,7 @@ by adding an [image tag](https://docs.docker.com/engine/reference/commandline/ta
 
 For example,
 instead of `circleci/golang`,
-you can specify the version and OS
+specify the version and OS
 by using `circleci/golang:1.8.6-jessie`.
 Because the second image specifies a version and OS,
 it is less likely

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -125,13 +125,13 @@ If you choose to use the `latest` tag,
 the image may change unexpectedly
 and create surprising results.
 
-### Language Image Variants
+For language images:
 
 - `-node`: includes Node.js for polyglot applications
 - `-browsers`: includes Java 8, PhantomJS, Firefox, and Chrome
 - `-node-browsers`: a combination of the `-node` and `-browsers` variants
 
-### Service Image Variants
+For service images:
 
 - `-ram`: variants that use the RAM volume to speed up builds
 
@@ -172,5 +172,3 @@ It is also possible to specify all the way down to the specific SHA of the image
 ## See Also
 
 See [Using Private Images]({{ site.baseurl }}/2.0/private-images/) for information about how to authorize your build to use an image in a private repository or in Amazon ECR.
-
-

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -187,7 +187,7 @@ For service images:
 Below is a list of the latest image tags, sorted by language.
 
 For specific details about the contents of each image,
-refer to the Dockerfiles in the [circleci-dockerfiles repo](https://github.com/circleci-public/circleci-dockerfiles).
+refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circleci-dockerfiles).
 
 {% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -24,7 +24,7 @@ The source code for these images is [available on GitHub](https://github.com/cir
 Dockerfiles for these images are also [archived on GitHub](https://github.com/circleci-public/circleci-dockerfiles).
 
 For a brief overview,
-watch this video.
+watch the video below.
 
 <div class="video-wrapper">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -115,18 +115,22 @@ The following packages are installed via `curl` or other means:
 
 ## Image Tags
 
+You can make convenience images more specific by adding tags.
+There are two good reasons to do this:
 
+- You want to pin an image to a certain version, operating system, or SHA.
+- You want to modify an image by adding tools or changing behavior.
 
-CircleCI maintains several variants for convenience images.
-These can be created by adding optional suffixes to the end of image tags.
+Since convenience images are based on the **latest** versions of upstream images,
+it is best practice to use the most specific image possible.
+This prevents the upstream image from introducing unintended changes to your image.
 
-For language images:
+Instead of using `circleci/golang:1.8`,
+for example,
+you could specify both the version and operating system
+by using `circleci/golang:1.8.6-jessie`.
 
-- `-node`: includes Node.js for polyglot applications
-- `-browsers`: includes Java 8, PhantomJS, Firefox, and Chrome
-- `-node-browsers`: a combination of the `-node` and `-browsers` variants
-
-For service images:
+You can also use a SHA to specify an image.
 
 - `-ram`: variants that use the RAM volume to speed up builds
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -45,7 +45,7 @@ to use a more specific tag.
 ### Language Images
 
 Language images are convenience images for common programming languages.
-These images include both the relevant language and [commonly-used tools.](#pre-installed-tools).
+These images include both the relevant language and [commonly-used tools](#pre-installed-tools).
 A language image should be listed first under the `docker` key in your configuration,
 making it the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -18,7 +18,7 @@ This document provides information about pre-built CircleCI images and a listing
 For convenience,
 CircleCI maintains several Docker images.
 These images are extensions of official Docker images
-and include tools that are especially useful for CI/CD.
+and include tools especially useful for CI/CD.
 All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/).
 The source code for these images is [available on GitHub](https://github.com/circleci/circleci-images).
 Dockerfiles for these images are also [available on GitHub](https://github.com/circleci-public/circleci-dockerfiles).
@@ -32,20 +32,19 @@ watch the video below.
 
 ## Image Types
 
-CircleCI's pre-built Docker images fall into two categories:
+CircleCI's convenience images fall into two categories:
 **language** images and **service** images.
 All images add a `circleci` user as a system user.
 
 **Note:**
 The images below are based on the **most current** upstream images for their respective languages.
 Because the latest images are more likely to change,
-it is best practice to use a more specific tag.
-For more details,
-see the [Best Practices](#best-practices) section.
+it is [best practice](#best-practices)
+to use a more specific tag.
 
 ### Language Images
 
-Language images are images for common programming languages.
+Language images are convenience images for common programming languages.
 These images include both the relevant language and [commonly-used tools.](#pre-installed-tools).
 A language image should be listed first under the `docker` key in your configuration,
 making it the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -139,14 +139,30 @@ If you choose to use the `latest` tag,
 the image may change unexpectedly
 and create surprising results.
 
+### Image Variants
+
+CircleCI maintains variants for convenience images.
+You can use these variants by adding the following suffixes to the end of image tags.
+
+For language images:
+
+- `-node` includes Node.js for polyglot applications
+- `-browsers` includes Java 8, PhantomJS, Firefox, and Chrome
+- `-node-browsers` combines the `-node` and `-browsers` variants
+
+For service images:
+
+- `-ram` uses the RAM volume to speed up builds
+
+**Note:**
+Besides the variants above,
+image tags are chosen by upstream projects.
+CircleCI does not control which tags are used.
+Do not assume that a specific tag always means the same thing!
+
 ### Latest Image Tags by Language
 
-That is, to prevent unintended changes that come from upstream, instead of using `circleci/ruby:2.4-node` use a more specific version of these containers to ensure the image does not change with upstream changes until you change the tag.
-
-For example, add `-jessie` or `-stretch` to the end of each of those containers to ensure you're only using that base OS. You can pin down those images to a specific point version, like `circleci/ruby:2.3.7-jessie`, or you can just specify the OS version, with `circleci/ruby:2.3-jessie`. This is possible for any of the CircleCI images.
-
-It is also possible to specify all the way down to the specific SHA of the image you want to use. Doing so allows you to test specific images for as long as you like before making any changes. To find the value, navigate to on older Build page in the CircleCI app that utilized the image you wish to use and select the drop-down for `Spin up Environment`. Inside you will find the SHA256, for example, 
-`circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e`.
+[link to Dockerfiles for all of these](https://github.com/circleci-public/circleci-dockerfiles)
 
 {% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -181,10 +181,11 @@ For service images:
 - `-ram` uses the RAM volume to speed up builds
 
 **Note:**
-Besides the variants above,
-image tags are chosen by upstream projects.
+Excluding the above variants,
 CircleCI does not control which tags are used.
-Do not assume that a specific tag always means the same thing!
+These tags are chosen and maintained by upstream projects.
+Do not assume
+that a given tag has the same meaning across images!
 
 ### Latest Image Tags by Language
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -61,7 +61,7 @@ CircleCI also maintains a wizard you can use to create a custom image.
 See the [Dockerfile Wizard]({{ site.baseurl }}/2.0/custom-images/#circleci-dockerfile-wizard) section of the Using Custom-Built Docker Images document for instructions.
 
 **Note:**
-The above images are based on the **most current** versions of their respective languages.
+The above images are based on the **most current** upstream images for their respective languages.
 Because the latest images are more likely to change,
 it is best practice to use a more specific tag.
 For more details,

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -165,13 +165,6 @@ it is less likely to change unexpectedly.
 
 See below for a list of the [Latest Image Tags by Language](#latest-image-tags-by-language).
 
-**Note:**
-Excluding the [variants below](#changing-the-tools-and-behavior-of-an-image),
-CircleCI does not control which tags are used.
-These tags are chosen and maintained by upstream projects.
-Do not assume
-that a given tag has the same meaning across images!
-
 ### Specifying a Fixed Image Version With a Digest
 
 You can also use a SHA
@@ -203,6 +196,12 @@ For service images:
 ## Latest Image Tags by Language
 
 Below is a list of the latest image tags, sorted by language.
+
+Excluding the [variants below](#changing-the-tools-and-behavior-of-an-image),
+CircleCI does not control which tags are used.
+These tags are chosen and maintained by upstream projects.
+Do not assume
+that a given tag has the same meaning across images!
 
 For details about the contents of each image,
 refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circleci-dockerfiles).

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -157,8 +157,12 @@ On the **Test Summary** tab,
 click the **Spin up environment** step.
 In the log output,
 locate the sha256 for the appropriate image.
-The full string looks like:
-`circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e`.
+
+Look for something like the example below.
+
+```
+circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e
+```
 
 ### Changing the Tools and Behavior of an Image
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -148,7 +148,7 @@ This makes your builds more deterministic
 by preventing an upstream image
 from introducing unintended changes to your image.
 
-There are a couple ways
+There are two ways
 to make an image more specific:
 
 - You can use a tag
@@ -159,7 +159,7 @@ to pin an image to a fixed version.
 ### Using an Image Tag to Pin an Image Version or OS
 
 You can specify a variant of a Docker image
-by adding an image tag.
+by adding an [image tag](https://docs.docker.com/engine/reference/commandline/tag/#extended-description).
 
 For example,
 instead of `circleci/golang`,
@@ -171,21 +171,39 @@ to change unexpectedly.
 
 See below for a list of the [Latest Image Tags by Language](#latest-image-tags-by-language).
 
-### Using a Digest to Pin a Fixed Image Version
+**Note:**
+If you do not specify a tag,
+Docker applies the `latest` tag.
+The `latest` tag refers to the most recent stable release of an image.
+However,
+since this tag may change unexpectedly,
+it is best practice
+to add an explicit image tag.
 
-You can also use a SHA
-to specify a particular instance of an image.
+### Using a Docker Image ID to Pin an Image to a Fixed Version
 
-To find a SHA,
-go to the CircleCI application
-and choose a past build
-that used the same image.
-On the **Test Summary** tab,
+Every Docker image has a [unique ID](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier).
+You can use this image ID
+to pin an image to a fixed version.
+
+Each image ID is an immutable SHA256 digest
+and looks like this:
+
+```
+sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e
+```
+
+#### Finding an Image ID
+
+1. In the CircleCI application,
+go to a past build
+that used the image.
+2. On the **Test Summary** tab,
 click the **Spin up environment** step.
-In the log output,
-locate the sha256 for the appropriate image.
-
-Look for something like the example below.
+3. In the log output,
+locate the digest for the image.
+4. Add the image ID to the image name in your `config.yml` file,
+as shown below.
 
 ```
 circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -38,10 +38,10 @@ All images add a `circleci` user as a system user.
 
 ### Language Images
 
-Language images are images for common programming languages,
-along with some common [pre-installed tools](#pre-installed-tools).
+Language images are images for common programming languages.
+These images include both the relevant language and [commonly-used tools.](#pre-installed-tools).
 A language image should be listed first under the `docker` key in your configuration,
-thus becoming the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.
+making it the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.
 
 CircleCI maintains images for the languages below.
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -21,7 +21,7 @@ These images are extensions of official Docker images
 and include tools that are especially useful for CI/CD.
 All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/).
 The source code for these images is [available on GitHub](https://github.com/circleci/circleci-images).
-Dockerfiles for these images are also [archived on GitHub](https://github.com/circleci-public/circleci-dockerfiles).
+Dockerfiles for these images are also [available on GitHub](https://github.com/circleci-public/circleci-dockerfiles).
 
 For a brief overview,
 watch the video below.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -118,7 +118,7 @@ The following packages are installed via `curl` or other means:
 
 ## Image Variants
 
-CircleCI maintains variants of convenience images.
+CircleCI maintains several variants for convenience images.
 These can be created by adding optional suffixes to the end of image tags.
 
 **Note:**

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -168,7 +168,7 @@ it is less likely to change unexpectedly.
 
 See below for a list of the [Latest Image Tags by Language](#latest-image-tags-by-language).
 
-### Specifying a Fixed Image Version With a Digest
+### Using a Digest to Pin a Fixed Image Version
 
 You can also use a SHA
 to specify a particular instance of an image.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -193,7 +193,6 @@ refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circ
 {% for image in images %}
 
 ### {{ image[1].name }}
-{:no_toc}
 
 **Usage:** Add the following under `docker:` in your config.yml:  
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -43,7 +43,8 @@ It is also possible to specify all the way down to the specific SHA of the image
 
 ## Image Types
 
-CircleCI's pre-built Docker images fall into two categories: **language** images and **service** images.
+CircleCI's pre-built Docker images fall into two categories:
+**language** images and **service** images.
 All images add a `circleci` user as a system user.
 
 ### Language Images

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -135,9 +135,7 @@ For service images:
 
 - `-ram`: variants that use the RAM volume to speed up builds
 
-## Latest Image Tags by Language
-
-
+### Latest Image Tags by Language
 
 That is, to prevent unintended changes that come from upstream, instead of using `circleci/ruby:2.4-node` use a more specific version of these containers to ensure the image does not change with upstream changes until you change the tag.
 
@@ -146,11 +144,10 @@ For example, add `-jessie` or `-stretch` to the end of each of those containers 
 It is also possible to specify all the way down to the specific SHA of the image you want to use. Doing so allows you to test specific images for as long as you like before making any changes. To find the value, navigate to on older Build page in the CircleCI app that utilized the image you wish to use and select the drop-down for `Spin up Environment`. Inside you will find the SHA256, for example, 
 `circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e`.
 
-
 {% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}
 
-### {{ image[1].name }} 
+#### {{ image[1].name }}
 
 **Usage:** Add the following under `docker:` in your config.yml:  
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -43,11 +43,15 @@ It is also possible to specify all the way down to the specific SHA of the image
 
 ## Image Types
 
-CircleCI's pre-built Docker images fall into two categories: **language** images and **service** images. All images add a `circleci` user as a system user.
+CircleCI's pre-built Docker images fall into two categories: **language** images and **service** images.
+All images add a `circleci` user as a system user.
 
 ### Language Images
 
-Language images are images for common programming languages, along with some common [pre-installed tools](#pre-installed-tools). A language image should be listed first under the `docker` key in your configuration, thus becoming the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.
+Language images are images for common programming languages,
+along with some common [pre-installed tools](#pre-installed-tools).
+A language image should be listed first under the `docker` key in your configuration,
+thus becoming the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.
 
 CircleCI maintains language images for the following languages:
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -39,11 +39,11 @@ This makes your builds more deterministic
 by preventing an upstream image
 from introducing unintended changes to your image.
 
-CircleCI bases pre-built images off of upstream, for example, circleci/ruby:2.4-node is based off the most up to date version of the Ruby 2.4-node container. Using circleci/ruby:2.4-node is similar to using :latest. It is best practice to lock down aspects of your build container by specifying an additional tag to pin down the image in your configuration.
+CircleCI bases pre-built images off of upstream, for example, `circleci/ruby:2.4-node` is based off the most up to date version of the Ruby 2.4-node container. Using `circleci/ruby:2.4-node` is similar to using `:latest`. It is best practice to lock down aspects of your build container by specifying an additional tag to pin down the image in your configuration.
 
-That is, to prevent unintended changes that come from upstream, instead of using circleci/ruby:2.4-node use a more specific version of these containers to ensure the image does not change with upstream changes until you change the tag.
+That is, to prevent unintended changes that come from upstream, instead of using `circleci/ruby:2.4-node` use a more specific version of these containers to ensure the image does not change with upstream changes until you change the tag.
 
-For example, add -jessie or -stretch to the end of each of those containers to ensure you’re only using that version of the Debian base OS. Pin down those images to a specific point version, like circleci/ruby:2.3.7-jessie, or specify the OS version with circleci/ruby:2.3-jessie. Specifying the version is possible for any of the CircleCI images.
+For example, add `-jessie` or `-stretch` to the end of each of those containers to ensure you’re only using that version of the Debian base OS. Pin down those images to a specific point version, like `circleci/ruby:2.3.7-jessie`, or specify the OS version with `circleci/ruby:2.3-jessie`. Specifying the version is possible for any of the CircleCI images.
 
 It is also possible to specify all the way down to the specific SHA of the image you want to use. Doing so allows you to test specific images for as long as you like before making any changes.
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -30,6 +30,75 @@ watch the video below.
     <iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>
 </div>
 
+## Best Practices
+
+Since convenience images are based on the most recently built versions of upstream images,
+**it is best practice
+to use the most specific image possible**.
+This makes your builds more deterministic
+by preventing an upstream image
+from introducing unintended changes to your image.
+
+There are two ways
+to make an image more specific:
+
+- You can use a tag
+to pin an image to a version or operating system (OS).
+- You can use a Docker image ID
+to pin an image to a fixed version.
+
+### Using an Image Tag to Pin an Image Version or OS
+
+You can pin aspects of a Docker image
+by adding an [image tag](https://docs.docker.com/engine/reference/commandline/tag/#extended-description).
+
+For example,
+instead of `circleci/golang`,
+you can specify the version and OS
+by using `circleci/golang:1.8.6-jessie`.
+Because the second image specifies a version and OS,
+it is less likely
+to change unexpectedly.
+
+See below for a list of the [Latest Image Tags by Language](#latest-image-tags-by-language).
+
+**Note:**
+If you do not specify a tag,
+Docker applies the `latest` tag.
+The `latest` tag refers to the most recent stable release of an image.
+However,
+since this tag may change unexpectedly,
+it is best practice
+to add an explicit image tag.
+
+### Using a Docker Image ID to Pin an Image to a Fixed Version
+
+Every Docker image has a [unique ID](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier).
+You can use this image ID
+to pin an image to a fixed version.
+
+Each image ID is an immutable SHA256 digest
+and looks like this:
+
+```
+sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e
+```
+
+#### Finding an Image ID
+
+1. In the CircleCI application,
+go to a past build
+that used the image.
+2. On the **Test Summary** tab,
+click the **Spin up environment** step.
+3. In the log output,
+locate the digest for the image.
+4. Add the image ID to the image name as shown below.
+
+```
+circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e
+```
+
 ## Image Types
 
 CircleCI's convenience images fall into two categories:
@@ -138,75 +207,6 @@ The following packages are installed via `curl` or other means.
 - [Docker Compose](https://docs.docker.com/compose/overview/)
 - [dockerize](https://github.com/jwilder/dockerize)
 - [jq](https://stedolan.github.io/jq/)
-
-## Best Practices
-
-Since convenience images are based on the most recently built versions of upstream images,
-**it is best practice
-to use the most specific image possible**.
-This makes your builds more deterministic
-by preventing an upstream image
-from introducing unintended changes to your image.
-
-There are two ways
-to make an image more specific:
-
-- You can use a tag
-to pin an image to a version or operating system (OS).
-- You can use a Docker image ID
-to pin an image to a fixed version.
-
-### Using an Image Tag to Pin an Image Version or OS
-
-You can pin aspects of a Docker image
-by adding an [image tag](https://docs.docker.com/engine/reference/commandline/tag/#extended-description).
-
-For example,
-instead of `circleci/golang`,
-you can specify the version and OS
-by using `circleci/golang:1.8.6-jessie`.
-Because the second image specifies a version and OS,
-it is less likely
-to change unexpectedly.
-
-See below for a list of the [Latest Image Tags by Language](#latest-image-tags-by-language).
-
-**Note:**
-If you do not specify a tag,
-Docker applies the `latest` tag.
-The `latest` tag refers to the most recent stable release of an image.
-However,
-since this tag may change unexpectedly,
-it is best practice
-to add an explicit image tag.
-
-### Using a Docker Image ID to Pin an Image to a Fixed Version
-
-Every Docker image has a [unique ID](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier).
-You can use this image ID
-to pin an image to a fixed version.
-
-Each image ID is an immutable SHA256 digest
-and looks like this:
-
-```
-sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e
-```
-
-#### Finding an Image ID
-
-1. In the CircleCI application,
-go to a past build
-that used the image.
-2. On the **Test Summary** tab,
-click the **Spin up environment** step.
-3. In the log output,
-locate the digest for the image.
-4. Add the image ID to the image name as shown below.
-
-```
-circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e
-```
 
 ## Latest Image Tags by Language
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -151,20 +151,23 @@ from introducing unintended changes to your image.
 There are a couple ways
 to make an image more specific:
 
-- You can use a more specific tag
+- You can use a tag
 to pin an image to a version or operating system (OS).
-- You can use a digest
+- You can use a Docker image ID
 to pin an image to a fixed version.
 
 ### Using an Image Tag to Pin an Image Version or OS
 
-To pin the version or OS of an image,
+You can specify a variant of a Docker image
+by adding an image tag.
 
 For example,
-instead of `circleci/golang:latest`,
-consider using `circleci/golang:1.8.6-jessie`.
-Since the second image specifies both the version and OS,
-it is less likely to change unexpectedly.
+instead of `circleci/golang`,
+you can specify the version and OS
+by using `circleci/golang:1.8.6-jessie`.
+Because the second image specifies a version and OS,
+it is less likely
+to change unexpectedly.
 
 See below for a list of the [Latest Image Tags by Language](#latest-image-tags-by-language).
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -132,17 +132,19 @@ This prevents the upstream image
 from introducing unintended changes to your image.
 
 For example,
-instead of `circleci/golang:1.8`,
+instead of `circleci/golang:latest`,
 consider using `circleci/golang:1.8.6-jessie`.
-Since the second image specifies both the patch version and OS,
+Since the second image specifies both the version and OS,
 it is less likely to change unexpectedly.
 
 See below for a list of the [Latest Image Tags by Language](#latest-image-tags-by-language).
 
 **Note:**
-If you choose to use the `latest` tag,
-the image may change unexpectedly
-and create surprising results.
+Excluding the [variants below](#changing-the-tools-and-behavior-of-an-image),
+CircleCI does not control which tags are used.
+These tags are chosen and maintained by upstream projects.
+Do not assume
+that a given tag has the same meaning across images!
 
 ### Specifying a Past Image Build With a SHA
 
@@ -179,13 +181,6 @@ For language images:
 For service images:
 
 - `-ram` uses the RAM volume to speed up builds
-
-**Note:**
-Excluding the above variants,
-CircleCI does not control which tags are used.
-These tags are chosen and maintained by upstream projects.
-Do not assume
-that a given tag has the same meaning across images!
 
 ### Latest Image Tags by Language
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -66,11 +66,15 @@ CircleCI maintains images for the languages below.
 - [Python](#python)
 - [Ruby](#ruby)
 
-If your language is not listed, CircleCI also maintains a wizard you can use to create a custom image. See the [Dockerfile Wizard]({{ site.baseurl }}/2.0/custom-images/#circleci-dockerfile-wizard) section of the Using Custom-Built Docker Images document for instructions. 
+If your language is not listed,
+CircleCI also maintains a wizard you can use to create a custom image.
+See the [Dockerfile Wizard]({{ site.baseurl }}/2.0/custom-images/#circleci-dockerfile-wizard) section of the Using Custom-Built Docker Images document for instructions.
 
 ### Service Images
 
-Service images are images for services like databases. These images should be listed _after_ language images so they become secondary service containers.
+Service images are images for services like databases.
+These images should be listed **after** language images
+so they become secondary service containers.
 
 CircleCI maintains images for the services below.
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -186,7 +186,7 @@ For service images:
 
 Below is a list of the latest image tags, sorted by language.
 
-For specific details about the contents of each image,
+For details about the contents of each image,
 refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circleci-dockerfiles).
 
 {% assign images = site.data.docker-image-tags | sort %}

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -70,6 +70,13 @@ If your language is not listed,
 CircleCI also maintains a wizard you can use to create a custom image.
 See the [Dockerfile Wizard]({{ site.baseurl }}/2.0/custom-images/#circleci-dockerfile-wizard) section of the Using Custom-Built Docker Images document for instructions.
 
+**Note:**
+The above images use the **most current** version of the upstream image.
+Because the latest images are often less stable,
+it is best practice to use a more specific tag.
+For more details,
+see the [Latest Image Tags by Language](#latest-image-tags-by-language).
+
 ### Service Images
 
 Service images are images for services like databases.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -39,6 +39,14 @@ This makes your builds more deterministic
 by preventing an upstream image
 from introducing unintended changes to your image.
 
+CircleCI bases pre-built images off of upstream, for example, circleci/ruby:2.4-node is based off the most up to date version of the Ruby 2.4-node container. Using circleci/ruby:2.4-node is similar to using :latest. It is best practice to lock down aspects of your build container by specifying an additional tag to pin down the image in your configuration.
+
+That is, to prevent unintended changes that come from upstream, instead of using circleci/ruby:2.4-node use a more specific version of these containers to ensure the image does not change with upstream changes until you change the tag.
+
+For example, add -jessie or -stretch to the end of each of those containers to ensure you’re only using that version of the Debian base OS. Pin down those images to a specific point version, like circleci/ruby:2.3.7-jessie, or specify the OS version with circleci/ruby:2.3-jessie. Specifying the version is possible for any of the CircleCI images.
+
+It is also possible to specify all the way down to the specific SHA of the image you want to use. Doing so allows you to test specific images for as long as you like before making any changes.
+
 There are two ways
 to make an image more specific:
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -116,33 +116,55 @@ The following packages are installed via `curl` or other means:
 ## Image Tags
 
 You can make convenience images more specific by adding tags.
-There are two good reasons to do this:
+There are three good reasons to do this:
 
-- You want to pin an image to a certain version, operating system, or SHA.
-- You want to modify an image by adding tools or changing behavior.
+- You want to pin an image to a certain version or operating system (OS).
+- You want to specify a particular instance of an image with a SHA.
+- You want to modify an image by installing additional tools
+or changing the behavior of the image.
+
+### Pinning an Image Version or OS
 
 Since convenience images are based on the **latest** versions of upstream images,
-it is best practice to use the most specific image possible.
-This prevents the upstream image from introducing unintended changes to your image.
+it is best practice
+to use the most specific image possible.
+This prevents the upstream image
+from introducing unintended changes to your image.
 
-Instead of using `circleci/golang:1.8`,
-for example,
-you could specify both the version and operating system
-by using `circleci/golang:1.8.6-jessie`.
+For example,
+instead of `circleci/golang:1.8`,
+consider using `circleci/golang:1.8.6-jessie`.
+Since the second image specifies both the patch version and OS,
+it is less likely to change unexpectedly.
 
-You can also use a SHA to specify an image.
-
-- `-ram`: variants that use the RAM volume to speed up builds
+See below for a list of the [Latest Image Tags by Language](#latest-image-tags-by-language).
 
 **Note:**
 If you choose to use the `latest` tag,
 the image may change unexpectedly
 and create surprising results.
 
-### Image Variants
+### Specifying a Past Image Build With a SHA
 
-CircleCI maintains variants for convenience images.
-You can use these variants by adding the following suffixes to the end of image tags.
+You can also use a SHA
+to specify a particular instance of an image.
+
+To find a SHA,
+go to the CircleCI application
+and choose a past build
+that used the same image.
+On the **Test Summary** tab,
+click the **Spin up environment** step.
+In the log output,
+locate the sha256 for the appropriate image.
+The full string looks like:
+`circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e`.
+
+### Changing the Tools and Behavior of an Image
+
+CircleCI maintains several variants for convenience images.
+You can use these variants
+by adding the following suffixes to the end of image tags.
 
 For language images:
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -38,7 +38,7 @@ All images add a `circleci` user as a system user.
 
 **Note:**
 The images below are based on the most recently built upstream images for their respective languages.
-Because the latest images are more likely to change,
+Because the most recent images are more likely to change,
 it is [best practice](#best-practices)
 to use a more specific tag.
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -20,8 +20,8 @@ CircleCI maintains several Docker images.
 These images are extensions of official Docker images
 and include tools especially useful for CI/CD.
 All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/).
-The source code for these images is [available on GitHub](https://github.com/circleci/circleci-images).
-Dockerfiles for these images are also [available on GitHub](https://github.com/circleci-public/circleci-dockerfiles).
+Visit the `circleci-images` GitHub repo for the [source code for the CircleCI Docker images](https://github.com/circleci/circleci-images).
+Visit the `circleci-dockerfiles` GitHub repo for the [Dockerfiles for the CircleCI Docker images](https://github.com/circleci-public/circleci-dockerfiles).
 
 For a brief overview,
 watch the video below.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -184,7 +184,10 @@ For service images:
 
 ## Latest Image Tags by Language
 
-[link to Dockerfiles for all of these](https://github.com/circleci-public/circleci-dockerfiles)
+Below is a list of the latest image tags, sorted by language.
+
+For specific details about the contents of each image,
+refer to the Dockerfiles in the [circleci-dockerfiles repo](https://github.com/circleci-public/circleci-dockerfiles).
 
 {% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -36,6 +36,13 @@ CircleCI's pre-built Docker images fall into two categories:
 **language** images and **service** images.
 All images add a `circleci` user as a system user.
 
+**Note:**
+The images below are based on the **most current** upstream images for their respective languages.
+Because the latest images are more likely to change,
+it is best practice to use a more specific tag.
+For more details,
+see the [Best Practices](#best-practices) section.
+
 ### Language Images
 
 Language images are images for common programming languages.
@@ -60,12 +67,20 @@ If your language is not listed,
 CircleCI also maintains a wizard you can use to create a custom image.
 See the [Dockerfile Wizard]({{ site.baseurl }}/2.0/custom-images/#circleci-dockerfile-wizard) section of the Using Custom-Built Docker Images document for instructions.
 
-**Note:**
-The above images are based on the **most current** upstream images for their respective languages.
-Because the latest images are more likely to change,
-it is best practice to use a more specific tag.
-For more details,
-see the [Customizing a Convenience Image](#customizing-a-convenience-image) section.
+#### Language Image Variants
+
+CircleCI maintains several variants for language images.
+To use these variants,
+add one of the following suffixes to the end of an image tag.
+
+- `-node` includes Node.js for polyglot applications
+- `-browsers` includes Chrome, Firefox, Java 8, and PhantomJS
+- `-node-browsers` combines the `-node` and `-browsers` variants
+
+For example,
+if you want
+to add browsers to the `circleci/golang:1.9` image,
+use the `circleci/golang:1.9-browsers` image.
 
 ### Service Images
 
@@ -80,6 +95,17 @@ CircleCI maintains images for the services below.
 - [MongoDB](#mongodb)
 - [MySQL](#mysql)
 - [PostgreSQL](#postgresql)
+
+#### Service Image Variant
+
+CircleCI maintains one variant for service images.
+To use RAM volume on a service image to speed up builds,
+add the `-ram` suffix to the end of a service image tag.
+
+For example,
+if you want the `circleci/postgres:9.5-postgis` image
+to use RAM volume,
+use the `circleci/postgres:9.5-postgis-ram` image.
 
 ## Pre-installed Tools
 
@@ -113,23 +139,24 @@ The following packages are installed via `curl` or other means:
 - [dockerize](https://github.com/jwilder/dockerize)
 - [jq](https://stedolan.github.io/jq/)
 
-## Customizing a Convenience Image
-
-You can customize convenience images by adding image tags.
-There are three good reasons to do this:
-
-- You want to pin an image to a certain version or operating system (OS).
-- You want to specify a particular instance of an image with a SHA.
-- You want to modify an image by installing additional tools
-or changing the behavior of the image.
-
-### Pinning an Image Version or OS
+## Best Practices
 
 Since convenience images are based on the **latest** versions of upstream images,
 it is best practice
 to use the most specific image possible.
-This prevents the upstream image
+This makes your builds more deterministic
+by preventing an upstream image
 from introducing unintended changes to your image.
+
+There are a couple ways
+to make an image more specific:
+
+- You can pin an image to a certain version or operating system (OS).
+- You can specify a fixed image version with a digest.
+
+### Pinning an Image Version or OS
+
+To pin the version or OS of an image,
 
 For example,
 instead of `circleci/golang:latest`,
@@ -146,7 +173,7 @@ These tags are chosen and maintained by upstream projects.
 Do not assume
 that a given tag has the same meaning across images!
 
-### Specifying a Past Image Build With a SHA
+### Specifying a Fixed Image Version With a Digest
 
 You can also use a SHA
 to specify a particular instance of an image.
@@ -166,17 +193,9 @@ Look for something like the example below.
 circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e
 ```
 
-### Changing the Tools and Behavior of an Image
-
 CircleCI maintains several variants for convenience images.
 You can use these variants
 by adding the following suffixes to the end of image tags.
-
-For language images:
-
-- `-node` includes Node.js for polyglot applications
-- `-browsers` includes Java 8, PhantomJS, Firefox, and Chrome
-- `-node-browsers` combines the `-node` and `-browsers` variants
 
 For service images:
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -32,8 +32,6 @@ watch the video below.
 
 ## Best Practices
 
-CircleCI bases pre-built images off of upstream, for example, `circleci/ruby:2.4-node` is based off the most up to date version of the Ruby 2.4-node container, similar to using `:latest`. It is best practice to lock down aspects of your build container, by specifying an additional tag to pin down the image in your configuration.
-
 That is, to prevent unintended changes that come from upstream, instead of using `circleci/ruby:2.4-node` use a more specific version of these containers to ensure the image does not change with upstream changes until you change the tag.
 
 For example, add `-jessie` or `-stretch` to the end of each of those containers to ensure you're only using that base OS. You can pin down those images to a specific point version, like `circleci/ruby:2.3.7-jessie`, or you can just specify the OS version, with `circleci/ruby:2.3-jessie`. This is possible for any of the CircleCI images. 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -23,6 +23,13 @@ All of these pre-built images are available in the [CircleCI org on Docker Hub](
 The source code for these images is [available on GitHub](https://github.com/circleci/circleci-images).
 Dockerfiles for these images are also [archived on GitHub](https://github.com/circleci-public/circleci-dockerfiles).
 
+For a brief overview,
+watch this video.
+
+<div class="video-wrapper">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>
+</div>
+
 ## Best Practices
 
 CircleCI bases pre-built images off of upstream, for example, `circleci/ruby:2.4-node` is based off the most up to date version of the Ruby 2.4-node container, similar to using `:latest`. It is best practice to lock down aspects of your build container, by specifying an additional tag to pin down the image in your configuration.
@@ -68,11 +75,6 @@ CircleCI maintains service images for the following services:
 - [MongoDB](#mongodb)
 - [MySQL](#mysql)
 - [PostgreSQL](#postgresql)
-
-## How to Get Started with Pre-Built Docker Images Video Tutorial
-<div class="video-wrapper">
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>
-</div>
 
 ## Pre-installed Tools
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -65,7 +65,7 @@ The above images use the **most current** version of the upstream image.
 Because the latest images are more likely to change,
 it is best practice to use a more specific tag.
 For more details,
-see the [Latest Image Tags by Language](#latest-image-tags-by-language) section.
+see the [Image Tags](#image-tags) section.
 
 ### Service Images
 
@@ -113,7 +113,9 @@ The following packages are installed via `curl` or other means:
 - [dockerize](https://github.com/jwilder/dockerize)
 - [jq](https://stedolan.github.io/jq/)
 
-## Image Variants
+## Image Tags
+
+
 
 CircleCI maintains several variants for convenience images.
 These can be created by adding optional suffixes to the end of image tags.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -120,11 +120,6 @@ The following packages are installed via `curl` or other means:
 CircleCI maintains several variants for convenience images.
 These can be created by adding optional suffixes to the end of image tags.
 
-**Note:**
-If you choose to use the `latest` tag,
-the image may change unexpectedly
-and create surprising results.
-
 For language images:
 
 - `-node`: includes Node.js for polyglot applications
@@ -134,6 +129,11 @@ For language images:
 For service images:
 
 - `-ram`: variants that use the RAM volume to speed up builds
+
+**Note:**
+If you choose to use the `latest` tag,
+the image may change unexpectedly
+and create surprising results.
 
 ### Latest Image Tags by Language
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -62,7 +62,7 @@ See the [Dockerfile Wizard]({{ site.baseurl }}/2.0/custom-images/#circleci-docke
 
 **Note:**
 The above images use the **most current** version of the upstream image.
-Because the latest images are often less stable,
+Because the latest images are more likely to change,
 it is best practice to use a more specific tag.
 For more details,
 see the [Latest Image Tags by Language](#latest-image-tags-by-language) section.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -202,8 +202,7 @@ that used the image.
 click the **Spin up environment** step.
 3. In the log output,
 locate the digest for the image.
-4. Add the image ID to the image name in your `config.yml` file,
-as shown below.
+4. Add the image ID to the image name as shown below.
 
 ```
 circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -33,8 +33,8 @@ watch the video below.
 ## Best Practices
 
 Convenience images are based on the most recently built versions of upstream images,
-so **it is best practice
-to use the most specific image possible**.
+so it is best practice
+to use the most specific image possible.
 This makes your builds more deterministic
 by preventing an upstream image
 from introducing unintended changes to your image.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -85,7 +85,7 @@ CircleCI maintains images for the services below.
 
 All convenience images have been extended with additional tools.
 
-The following packages are installed with `apt-get` on every image:
+The following packages are installed via `apt-get` on every image:
 
 - [bzip2](https://packages.debian.org/stretch/bzip2)
 - [ca-certificates](https://packages.debian.org/stretch/ca-certificates)

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -61,7 +61,7 @@ CircleCI also maintains a wizard you can use to create a custom image.
 See the [Dockerfile Wizard]({{ site.baseurl }}/2.0/custom-images/#circleci-dockerfile-wizard) section of the Using Custom-Built Docker Images document for instructions.
 
 **Note:**
-The above images use the **most current** version of the upstream image.
+The above images are based on the **most current** versions of their respective languages.
 Because the latest images are more likely to change,
 it is best practice to use a more specific tag.
 For more details,

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -53,7 +53,7 @@ along with some common [pre-installed tools](#pre-installed-tools).
 A language image should be listed first under the `docker` key in your configuration,
 thus becoming the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.
 
-CircleCI maintains language images for the following languages:
+CircleCI maintains images for the languages below.
 
 - [Android](#android)
 - [Clojure](#clojure)
@@ -72,7 +72,7 @@ If your language is not listed, CircleCI also maintains a wizard you can use to 
 
 Service images are images for services like databases. These images should be listed _after_ language images so they become secondary service containers.
 
-CircleCI maintains service images for the following services:
+CircleCI maintains images for the services below.
 
 - [buildpack-deps](#buildpack-deps)
 - [MariaDB](#mariadb)

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -111,7 +111,7 @@ use the `circleci/postgres:9.5-postgis-ram` image.
 
 All convenience images have been extended with additional tools.
 
-The following packages are installed via `apt-get` on every image:
+The following packages are installed via `apt-get` on every image.
 
 - [bzip2](https://packages.debian.org/stretch/bzip2)
 - [ca-certificates](https://packages.debian.org/stretch/ca-certificates)
@@ -132,7 +132,7 @@ The following packages are installed via `apt-get` on every image:
 - [xvfb](https://packages.debian.org/stretch/xvfb)
 - [zip](https://packages.debian.org/stretch/zip)
 
-The following packages are installed via `curl` or other means:
+The following packages are installed via `curl` or other means.
 
 - [Docker client](https://docs.docker.com/install/)
 - [Docker Compose](https://docs.docker.com/compose/overview/)

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -114,9 +114,13 @@ The following packages are installed via `curl` or other means:
 
 ## Image Variants
 
-CircleCI maintains variants of convenience images. These can be created by adding optional suffixes to the end of image tags.
+CircleCI maintains variants of convenience images.
+These can be created by adding optional suffixes to the end of image tags.
 
-**Note:** If you choose to use the `latest` tag, the image may change unexpectedly and create surprising results.
+**Note:**
+If you choose to use the `latest` tag,
+the image may change unexpectedly
+and create surprising results.
 
 ### Language Image Variants
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -32,8 +32,8 @@ watch the video below.
 
 ## Best Practices
 
-Since convenience images are based on the most recently built versions of upstream images,
-**it is best practice
+Convenience images are based on the most recently built versions of upstream images,
+so **it is best practice
 to use the most specific image possible**.
 This makes your builds more deterministic
 by preventing an upstream image
@@ -42,9 +42,9 @@ from introducing unintended changes to your image.
 There are two ways
 to make an image more specific:
 
-- You can use a tag
+- Use a tag
 to pin an image to a version or operating system (OS).
-- You can use a Docker image ID
+- Use a Docker image ID
 to pin an image to a fixed version.
 
 ### Using an Image Tag to Pin an Image Version or OS

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -37,7 +37,7 @@ CircleCI's convenience images fall into two categories:
 All images add a `circleci` user as a system user.
 
 **Note:**
-The images below are based on the **most current** upstream images for their respective languages.
+The images below are based on the most recently built upstream images for their respective languages.
 Because the latest images are more likely to change,
 it is [best practice](#best-practices)
 to use a more specific tag.
@@ -63,8 +63,8 @@ CircleCI maintains images for the languages below.
 - [Ruby](#ruby)
 
 If your language is not listed,
-CircleCI also maintains a wizard you can use to create a custom image.
-See the [Dockerfile Wizard]({{ site.baseurl }}/2.0/custom-images/#circleci-dockerfile-wizard) section of the Using Custom-Built Docker Images document for instructions.
+CircleCI also maintains a [Dockerfile Wizard](https://github.com/circleci-public/dockerfile-wizard)
+you can use to create a custom image.
 
 #### Language Image Variants
 
@@ -83,7 +83,7 @@ use the `circleci/golang:1.9-browsers` image.
 
 ### Service Images
 
-Service images are images for services like databases.
+Service images are convenience images for services like databases.
 These images should be listed **after** language images
 so they become secondary service containers.
 
@@ -97,8 +97,9 @@ CircleCI maintains images for the services below.
 
 #### Service Image Variant
 
-CircleCI maintains one variant for service images.
-To use RAM volume on a service image to speed up builds,
+CircleCI maintains only one variant for service images.
+To speed up builds
+using RAM volume,
 add the `-ram` suffix to the end of a service image tag.
 
 For example,
@@ -140,9 +141,9 @@ The following packages are installed via `curl` or other means:
 
 ## Best Practices
 
-Since convenience images are based on the **latest** versions of upstream images,
-it is best practice
-to use the most specific image possible.
+Since convenience images are based on the most recently built versions of upstream images,
+**it is best practice
+to use the most specific image possible**.
 This makes your builds more deterministic
 by preventing an upstream image
 from introducing unintended changes to your image.
@@ -150,10 +151,12 @@ from introducing unintended changes to your image.
 There are a couple ways
 to make an image more specific:
 
-- You can pin an image to a certain version or operating system (OS).
-- You can specify a fixed image version with a digest.
+- You can use a more specific tag
+to pin an image to a version or operating system (OS).
+- You can use a digest
+to pin an image to a fixed version.
 
-### Pinning an Image Version or OS
+### Using an Image Tag to Pin an Image Version or OS
 
 To pin the version or OS of an image,
 
@@ -185,31 +188,24 @@ Look for something like the example below.
 circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e
 ```
 
-CircleCI maintains several variants for convenience images.
-You can use these variants
-by adding the following suffixes to the end of image tags.
-
-For service images:
-
-- `-ram` uses the RAM volume to speed up builds
-
 ## Latest Image Tags by Language
 
-Below is a list of the latest image tags, sorted by language.
+Below is a list of the latest convenience images, sorted by language.
+For details about the contents of each image,
+refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circleci-dockerfiles).
 
-Excluding the [variants below](#changing-the-tools-and-behavior-of-an-image),
-CircleCI does not control which tags are used.
+**Note:**
+Excluding [language image variants](#language-image-variants) and [the service image variant](#service-image-variant),
+CircleCI does **not** control which tags are used.
 These tags are chosen and maintained by upstream projects.
 Do not assume
 that a given tag has the same meaning across images!
-
-For details about the contents of each image,
-refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circleci-dockerfiles).
 
 {% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}
 
 ### {{ image[1].name }}
+{:.no_toc}
 
 **Usage:** Add the following under `docker:` in your config.yml:  
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -158,7 +158,7 @@ to pin an image to a fixed version.
 
 ### Using an Image Tag to Pin an Image Version or OS
 
-You can specify a variant of a Docker image
+You can pin aspects of a Docker image
 by adding an [image tag](https://docs.docker.com/engine/reference/commandline/tag/#extended-description).
 
 For example,

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -65,7 +65,7 @@ The above images are based on the **most current** upstream images for their res
 Because the latest images are more likely to change,
 it is best practice to use a more specific tag.
 For more details,
-see the [Image Tags](#image-tags) section.
+see the [Customizing a Convenience Image](#customizing-a-convenience-image) section.
 
 ### Service Images
 
@@ -193,6 +193,7 @@ refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circ
 {% for image in images %}
 
 ### {{ image[1].name }}
+{:no_toc}
 
 **Usage:** Add the following under `docker:` in your config.yml:  
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -30,15 +30,6 @@ watch the video below.
     <iframe width="560" height="315" src="https://www.youtube.com/embed/PgIwBzXBn7M" frameborder="0" allowfullscreen></iframe>
 </div>
 
-## Best Practices
-
-That is, to prevent unintended changes that come from upstream, instead of using `circleci/ruby:2.4-node` use a more specific version of these containers to ensure the image does not change with upstream changes until you change the tag.
-
-For example, add `-jessie` or `-stretch` to the end of each of those containers to ensure you're only using that base OS. You can pin down those images to a specific point version, like `circleci/ruby:2.3.7-jessie`, or you can just specify the OS version, with `circleci/ruby:2.3-jessie`. This is possible for any of the CircleCI images. 
-
-It is also possible to specify all the way down to the specific SHA of the image you want to use. Doing so allows you to test specific images for as long as you like before making any changes. To find the value, navigate to on older Build page in the CircleCI app that utilized the image you wish to use and select the drop-down for `Spin up Environment`. Inside you will find the SHA256, for example, 
-`circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e`. 
-
 ## Image Types
 
 CircleCI's pre-built Docker images fall into two categories:
@@ -143,6 +134,16 @@ and create surprising results.
 - `-ram`: variants that use the RAM volume to speed up builds
 
 ## Latest Image Tags by Language
+
+
+
+That is, to prevent unintended changes that come from upstream, instead of using `circleci/ruby:2.4-node` use a more specific version of these containers to ensure the image does not change with upstream changes until you change the tag.
+
+For example, add `-jessie` or `-stretch` to the end of each of those containers to ensure you're only using that base OS. You can pin down those images to a specific point version, like `circleci/ruby:2.3.7-jessie`, or you can just specify the OS version, with `circleci/ruby:2.3-jessie`. This is possible for any of the CircleCI images.
+
+It is also possible to specify all the way down to the specific SHA of the image you want to use. Doing so allows you to test specific images for as long as you like before making any changes. To find the value, navigate to on older Build page in the CircleCI app that utilized the image you wish to use and select the drop-down for `Spin up Environment`. Inside you will find the SHA256, for example, 
+`circleci/ruby@sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e`. 
+
 
 {% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -136,7 +136,7 @@ and create surprising results.
 
 - `-ram`: variants that use the RAM volume to speed up builds
 
-<hr>
+## Latest Image Tags by Language
 
 {% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -113,9 +113,9 @@ The following packages are installed via `curl` or other means:
 - [dockerize](https://github.com/jwilder/dockerize)
 - [jq](https://stedolan.github.io/jq/)
 
-## Image Tags
+## Customizing a Convenience Image
 
-You can make convenience images more specific by adding tags.
+You can customize convenience images by adding image tags.
 There are three good reasons to do this:
 
 - You want to pin an image to a certain version or operating system (OS).
@@ -182,14 +182,14 @@ For service images:
 
 - `-ram` uses the RAM volume to speed up builds
 
-### Latest Image Tags by Language
+## Latest Image Tags by Language
 
 [link to Dockerfiles for all of these](https://github.com/circleci-public/circleci-dockerfiles)
 
 {% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}
 
-#### {{ image[1].name }}
+### {{ image[1].name }}
 
 **Usage:** Add the following under `docker:` in your config.yml:  
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -78,8 +78,6 @@ CircleCI maintains service images for the following services:
 
 All convenience images have been extended with additional tools.
 
-### APT Packages
-
 The following packages are installed with `apt-get` on every image:
 
 - [bzip2](https://packages.debian.org/stretch/bzip2)
@@ -100,8 +98,6 @@ The following packages are installed with `apt-get` on every image:
 - [wget](https://packages.debian.org/stretch/wget)
 - [xvfb](https://packages.debian.org/stretch/xvfb)
 - [zip](https://packages.debian.org/stretch/zip)
-
-### Other Packages
 
 The following packages are installed via `curl` or other means:
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -76,7 +76,7 @@ The above images use the **most current** version of the upstream image.
 Because the latest images are often less stable,
 it is best practice to use a more specific tag.
 For more details,
-see the [Latest Image Tags by Language](#latest-image-tags-by-language).
+see the [Latest Image Tags by Language](#latest-image-tags-by-language) section.
 
 ### Service Images
 

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -123,7 +123,7 @@ myUsername/couchdb:1.6.1
 
 ### What is the best practice for specifying image versions?
 
-It is best practice **not** to use the `latest` tag for specifying image versions. It is also best practice to use a specific version and tag, for example `circleci/ruby:2.4-jessie-node`, to pin down the image and prevent upstream changes to your containers when the underlying base distro changes. Specifying only `circleci/ruby:2.4` could result in unexpected changes from `jessie` to `stretch` for example. For more context, refer to the [Docker Image Best Practices]({{ site.baseurl }}/2.0/executor-types/#docker-image-best-practices) section of the Choosing an Executor Type document and the Customizing a Convenience Image section of the [CircleCI Images]({{ site.baseurl }}/2.0/circleci-images/#customizing-a-convenience-image) document for more details.
+It is best practice **not** to use the `latest` tag for specifying image versions. It is also best practice to use a specific version and tag, for example `circleci/ruby:2.4-jessie-node`, to pin down the image and prevent upstream changes to your containers when the underlying base distro changes. Specifying only `circleci/ruby:2.4` could result in unexpected changes from `jessie` to `stretch` for example. For more context, refer to the [Docker Image Best Practices]({{ site.baseurl }}/2.0/executor-types/#docker-image-best-practices) section of the Choosing an Executor Type document and the Best Practices section of the [CircleCI Images]({{ site.baseurl }}/2.0/circleci-images/#best-practices) document.
 
 ### How can I set the timezone in Docker images?
 

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -123,7 +123,7 @@ myUsername/couchdb:1.6.1
 
 ### What is the best practice for specifying image versions?
 
-It is best practice **not** to use the `latest` tag for specifying image versions. It is also best practice to use a specific version and tag, for example `circleci/ruby:2.4-jessie-node`, to pin down the image and prevent upstream changes to your containers when the underlying base distro changes. Specifying only `circleci/ruby:2.4` could result in unexpected changes from `jessie` to `stretch` for example. For more context, refer to the [Docker Image Best Practices]({{ site.baseurl }}/2.0/executor-types/#docker-image-best-practices) section of the Choosing an Executor Type document and the Best Practices section of the [CircleCI Images]({{ site.baseurl }}/2.0/circleci-images/#best-practices) document for more details.
+It is best practice **not** to use the `latest` tag for specifying image versions. It is also best practice to use a specific version and tag, for example `circleci/ruby:2.4-jessie-node`, to pin down the image and prevent upstream changes to your containers when the underlying base distro changes. Specifying only `circleci/ruby:2.4` could result in unexpected changes from `jessie` to `stretch` for example. For more context, refer to the [Docker Image Best Practices]({{ site.baseurl }}/2.0/executor-types/#docker-image-best-practices) section of the Choosing an Executor Type document and the Customizing a Convenience Image section of the [CircleCI Images]({{ site.baseurl }}/2.0/circleci-images/#customizing-a-convenience-image) document for more details.
 
 ### How can I set the timezone in Docker images?
 


### PR DESCRIPTION
After #2009 was re-opened, I spent some time thinking about why users were still having trouble understanding how our image tags worked. This PR is the result.

Highlights include:
- incorrect: the instructions for copying a SHA referenced old menu options
- inconsistent: document was missing "Overview" section
- unclear: a caveat about image tags being maintained by upstream sources (**not** CircleCI)
- unclear: "Best Practices" section has been split into more appropriate sections (in the previous version, Best Practices were introduced before the kinds of images and tags were discussed).

@felicianotech for technical review.
@michelle-luna for copy feedback.

Resolves #2009 and [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-12356).
