### PR TITLE
Update browser-testing.md

### DIFF
--- a/jekyll/_cci2/browser-testing.md
+++ b/jekyll/_cci2/browser-testing.md
@@ -166,7 +166,7 @@ sudo apt install vnc4server metacity
 ```
 4. After connecting to the CircleCI container, start the VNC server.
 ```bash
-ubuntu@box159:~$ vnc4server -geometry 1280x1024 -depth 24
+ubuntu@box159:~$ vncserver -geometry 1280x1024 -depth 24
 ```
 5. Since your connection is secured with SSH,
 there is no need for a strong password.


### PR DESCRIPTION
When I try running `vnc4server` after installing those things it doesn't work, just `vncserver` does, though.

Brief description of changes: I noticed this command seems to be wrong, this one works when I try it though.
