### PR TITLE
Update yarn.md caching path

### DIFF
--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -41,7 +41,7 @@ Here's an example:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn
+            - node_modules
 #...
 ```
 {% endraw %}


### PR DESCRIPTION
`node_modules` looks a more convenient place for storing packages than `~/.cache/yarn`