### PR TITLE
fix typo in CF example app name

### DIFF
--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -192,7 +192,7 @@ This is the first step in a Blue-Green deployment, pushing the application to no
       cf set-env app-name-dark circle_user ${CIRCLE_PROJECT_USERNAME}
       cf set-env app-name-dark circle_repo ${CIRCLE_PROJECT_REPONAME}
       # Start the application
-      cf start blueskygreenbuilds-dark
+      cf start app-name-dark
       # Ensure dark route is exclusive to dark app
       cf unmap-route app-name example.com -n dark || echo "Dark Route Already exclusive"
 ```


### PR DESCRIPTION
Brief description of changes:

There was a typo in the commands used in example manifest left over from my personal project.  This aligns it to the example "app-name"