### PR TITLE
Remove reference to builder fleet wrt nomad

### DIFF
--- a/jekyll/_cci2/gpu.md
+++ b/jekyll/_cci2/gpu.md
@@ -1,12 +1,12 @@
 ---
 layout: classic-docs
-title: "Running GPU Builders"
+title: "Running GPU Executors"
 category: [administration]
 order: 11
-description: "How to enable GPU builders in CircleCI Server"
+description: "How to enable GPU Executors in CircleCI Server"
 ---
 
-This document outlines how to run GPU (graphics processing unit) Builders using CircleCI Server.
+This document outlines how to run GPU (graphics processing unit) machine executors using CircleCI Server.
 
 * TOC 
 {:toc}

--- a/jekyll/_cci2/non-aws.md
+++ b/jekyll/_cci2/non-aws.md
@@ -32,7 +32,7 @@ By default, CircleCI 2.0 Nomad Client instances automatically provision containe
 
 ## Architecture
 
-CircleCI Static consists of two primary components: Services and Nomad Clients. Services run on a single instance that is comprised of the core application, storage, and networking functionality. Any number of Nomad Clients (a.k.a Builder Fleet) execute your jobs and communicate back to the Services. Both components must access your instance of GitHub or GitHub Enterprise on the network as illustrated in the following architecture diagram.
+CircleCI Static consists of two primary components: Services and Nomad Clients. Services run on a single instance that is comprised of the core application, storage, and networking functionality. Any number of Nomad Clients execute your jobs and communicate back to the Services. Both components must access your instance of GitHub or GitHub Enterprise on the network as illustrated in the following architecture diagram.
 
 ![A Diagram of the CircleCI Architecture]({{site.baseurl}}/assets/img/docs/architecture-v1.png)
 


### PR DESCRIPTION
The diagram has been updated to reflect that it is a nomad client fleet.

Nomad Clients should not be referred to as builders because it confuses
1.0 and 2.0 terminology, and gets confusing when referring to things
like machine executors.