### PR TITLE
only display footer on non-1.0 pages

### DIFF
--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -19,7 +19,7 @@
 			<article>
 				{% if page.page-type != "index" and page.page-type != "homepage" %}<h1>{{ page.title }}</h1>{% endif %}
 				{{ content }}
-				{% if page.page-type != "index" and page.layout == "classic-docs" or page.layout == "enterprise" %}
+				{% if page.collection != 'cci1' and page.page-type != "index" and page.layout == "classic-docs" or page.layout == "enterprise" %}
 					{% include doc-footer.html %}
 				{% endif %}
 			</article>


### PR DESCRIPTION
# Description
This PR removes the "Help make this document better" footer from 1.0 documentation.

# Reasons
1.0 documentation is no longer being maintained. Since the footer encourages users to suggest edits and changes, it should only be doing so for pages where changes will actually be made.