### PR TITLE
specify what kind of problem is reportable

### DIFF
--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -6,7 +6,7 @@
 <ul>
 	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}" target="_blank">Suggest an edit to this page</a> (please read the <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs" target="_blank">contributing guide</a> first).</li>
 	<li>
-        To report a problem,
+        To report a problem with this documentation,
         <a href="{{ site.gh_url }}/issues/new/choose">open an issue on GitHub.</a>
     </li>
 </ul>


### PR DESCRIPTION
# Description
Makes footer language more specific around how we request issue reports.

# Reasons
We don't want folks to hit the bottom of the document, have a problem unrelated to docs, and feel like they can report it through the docs repository.
