### PR TITLE
Explain BASH_ENV use cases and functionality

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -47,6 +47,49 @@ Running scripts within configuration
 may expose secret environment variables.
 See the [Using Shell Scripts]({{ site.baseurl }}/2.0/using-shell-scripts/#shell-script-best-practices) document for best practices for secure scripts.
 
+## Using `BASH_ENV` to Set Environment Variables
+
+CircleCI does not support interpolation
+when setting environment variables.
+This can cause issues
+when defining `working_directory`,
+modifying `PATH`,
+and sharing variables across multiple `run` steps.
+
+In the example below,
+`$ORGNAME` and `$REPONAME` will not be interpolated.
+
+```yaml
+working_directory: /go/src/github.com/$ORGNAME/$REPONAME
+```
+
+As a workaround,
+export environment variables to `BASH_ENV`,
+as shown below.
+
+```yaml
+name: Setup Environment Variables
+command: |
+  echo 'export IMPORT_PATH="github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
+  echo 'export SERVER_FOLDER="/home/circleci/.go_workspace/src/$IMPORT_PATH"' >> $BASH_ENV
+  echo 'export CIRCLE_ARTIFACTS="$SERVER_FOLDER/artifacts"' >> $BASH_ENV
+  echo 'export PATH="$GOPATH/bin:$PATH"' >> $BASH_ENV
+  echo 'export GIT_SHA1="$CIRCLE_SHA1"' >> $BASH_ENV
+```
+
+In every step,
+CircleCI automatically loads and runs `BASH_ENV`,
+allowing you to use interpolation
+and share environment variables across `run` steps.
+
+**Note:**
+The `BASH_ENV` workaround only works with `bash`.
+Other implementations like `sh` will not work.
+This limitation affects your image options.
+For example,
+[Alpine images](https://alpinelinux.org/), do not support `bash`,
+and thus do not support the `BASH_ENV` workaround.
+
 ## Setting an Environment Variable in a Shell Command
 
 CircleCI does not support interpolation

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -47,7 +47,7 @@ Running scripts within configuration
 may expose secret environment variables.
 See the [Using Shell Scripts]({{ site.baseurl }}/2.0/using-shell-scripts/#shell-script-best-practices) document for best practices for secure scripts.
 
-## Using `BASH_ENV` to Set Environment Variables
+### Using `BASH_ENV` to Set Environment Variables
 
 CircleCI does not support interpolation
 when setting environment variables.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -96,8 +96,14 @@ they do not support the `BASH_ENV` workaround.
 CircleCI does not support interpolation
 when setting environment variables.
 
-However, it is possible to interpolate a variable within a command
-by setting it for the current shell.
+However,
+it is possible
+to set variables for the current shell
+by [using `BASH_ENV`](#using-bash_env-to-set-environment-variables).
+This is useful
+for both modifying your `PATH`
+and setting environment variables
+that reference other variables.
 
 ```yaml
 version: 2

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -51,6 +51,7 @@ See the [Using Shell Scripts]({{ site.baseurl }}/2.0/using-shell-scripts/#shell-
 
 CircleCI does not support interpolation
 when setting environment variables.
+All defined values are treated literally.
 This can cause issues
 when defining `working_directory`,
 modifying `PATH`,
@@ -93,8 +94,7 @@ they do not support the `BASH_ENV` workaround.
 ## Setting an Environment Variable in a Shell Command
 
 CircleCI does not support interpolation
-when defining configuration variables like `working_directory` or `images`.
-All defined values are treated literally.
+when setting environment variables.
 
 However, it is possible to interpolate a variable within a command
 by setting it for the current shell.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -152,8 +152,7 @@ jobs:
 Environment variables are not shared across steps.
 If you need an environment variable
 to be accessible in more than one step,
-export the value using `$BASH_ENV`,
-as shown above.
+export the value [using `BASH_ENV`](#using-bash_env-to-set-environment-variables).
 
 ## Setting an Environment Variable in a Job
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -99,6 +99,13 @@ jobs:
             DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
 ```
 
+**Note:**
+Environment variables are not shared across steps.
+If you need an environment variable
+to be accessible in more than one step,
+export the value using `$BASH_ENV`,
+as shown above.
+
 ## Setting an Environment Variable in a Job
 
 To set an environment variable in a job,

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -70,13 +70,12 @@ to export environment variables to `BASH_ENV`,
 as shown below.
 
 ```yaml
-name: Setup Environment Variables
-command: |
-  echo 'export IMPORT_PATH="github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
-  echo 'export SERVER_FOLDER="/home/circleci/.go_workspace/src/$IMPORT_PATH"' >> $BASH_ENV
-  echo 'export CIRCLE_ARTIFACTS="$SERVER_FOLDER/artifacts"' >> $BASH_ENV
-  echo 'export PATH="$GOPATH/bin:$PATH"' >> $BASH_ENV
-  echo 'export GIT_SHA1="$CIRCLE_SHA1"' >> $BASH_ENV
+steps:
+  - run:
+      name: Setup Environment Variables
+      command: |
+        echo 'export PATH="$GOPATH/bin:$PATH"' >> $BASH_ENV
+        echo 'export GIT_SHA1="$CIRCLE_SHA1"' >> $BASH_ENV
 ```
 
 In every step,

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -65,7 +65,8 @@ working_directory: /go/src/github.com/$ORGNAME/$REPONAME
 ```
 
 As a workaround,
-export environment variables to `BASH_ENV`,
+use a `run` step
+to export environment variables to `BASH_ENV`,
 as shown below.
 
 ```yaml

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -87,8 +87,8 @@ The `BASH_ENV` workaround only works with `bash`.
 Other implementations like `sh` will not work.
 This limitation affects your image options.
 For example,
-[Alpine images](https://alpinelinux.org/), do not support `bash`,
-and thus do not support the `BASH_ENV` workaround.
+because [Alpine images](https://alpinelinux.org/) do not support `bash`,
+they do not support the `BASH_ENV` workaround.
 
 ## Setting an Environment Variable in a Shell Command
 


### PR DESCRIPTION
# Description
Adds a new section to the environment variables document specifically about `BASH_ENV`. There's an argument to be made to sprinkle links to this new section around the documentation — in places that match users' actions. Perhaps in a future PR!

# Reasons
@levlaz reported some lackluster documentation on how we rely on `BASH_ENV` for path updates and environment variable definitions.

# Context
Fixes #2439 and resolves [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-12064).

@levlaz for technical accuracy.
@michelle-luna for language edits.