### PR TITLE
Clarify how to download all artifacts for a build

### DIFF
--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -193,5 +193,4 @@ All artifacts are downloaded to the current directory.
 In the above example,
 `xargs` runs four processes
 to download artifacts in parallel.
-Adjust the number following `-P`
-to fit your needs.
+Adjust the number given to the `-P` flag as needed.

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -153,8 +153,10 @@ and copy it to a clipboard.
 where you want
 to store the artifacts.
 
-3. Run the commands below,
-replacing all variables starting with a `:` with real values for your project.
+3. Run the commands below.
+You must substitute actual values
+for all variables beginning with `:`.
+
 `:your_token` should be replaced with the token you copied earlier.
 `:vcs-type` is dependent on your version control system (either `github` or `bitbucket`).
 

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -154,12 +154,16 @@ where you want
 to store the artifacts.
 
 3. Run the commands below.
-You must substitute actual values
-for all variables beginning with `:`.
+Use the table below
+to substitute actual values
+for all variables that start with `:`.
 
-Placeholder | Meaning                                                                       |
-------------|-------------------------------------------------------------------------------|
-`:vcs-type` | The version control system (VCS) you are using. Either `github` or `bitbucket`.
+Placeholder  | Meaning                                                                       |
+-------------|-------------------------------------------------------------------------------|
+`:vcs-type`  | The version control system (VCS) you are using. Either `github` or `bitbucket`.
+`:username`  | The VCS project account username for the target project. Located at the top left of the screen in the CircleCI application.
+`:project`   | The name of the target project.
+`:build_num` | The number for the build for which you want to download artifacts.
 {: class="table table-striped"}
 
 `:your_token` should be replaced with the token you copied earlier.

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -154,9 +154,17 @@ where you want
 to store the artifacts.
 
 3. Run the commands below.
-Use the table below
+Use the table beneath the commands
 to substitute actual values
 for all variables that start with `:`.
+
+```bash
+export CIRCLE_TOKEN=':your_token'
+
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts?circle-token=$CIRCLE_TOKEN | grep -o 'https://[^"]*' > artifacts.txt
+
+<artifacts.txt xargs -P4 -I % wget %?circle-token=$CIRCLE_TOKEN
+```
 
 Placeholder   | Meaning                                                                       |
 --------------|-------------------------------------------------------------------------------|
@@ -167,13 +175,7 @@ Placeholder   | Meaning                                                         
 `:build_num`  | The number for the build for which you want to download artifacts.
 {: class="table table-striped"}
 
-```bash
-export CIRCLE_TOKEN=':your_token'
-
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts?circle-token=$CIRCLE_TOKEN | grep -o 'https://[^"]*' > artifacts.txt
-
-<artifacts.txt xargs -P4 -I % wget %?circle-token=$CIRCLE_TOKEN
-```
+### Description of Commands
 
 First,
 the CIRCLE_TOKEN environment variable is created.

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -150,7 +150,8 @@ and copy it to a clipboard.
 
 2. In a Terminal window,
 `cd` to a directory
-where you want the artifact files.
+where you want
+to store the artifacts.
 
 3. Run the commands below,
 replacing all variables starting with a `:` with real values for your project.

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -171,7 +171,7 @@ Placeholder   | Meaning                                                         
 `:your_token` | The personal API token you created above.
 `:vcs-type`   | The version control system (VCS) you are using. Either `github` or `bitbucket`.
 `:username`   | The VCS project account username or organization name for the target project. Located at the top left of the screen in the CircleCI application.
-`:project`    | The name of the target project.
+`:project`    | The name of the target VCS repository.
 `:build_num`  | The number for the build for which you want to download artifacts.
 {: class="table table-striped"}
 

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -157,8 +157,9 @@ to store the artifacts.
 You must substitute actual values
 for all variables beginning with `:`.
 
+`:vcs-type` = your version control system (`github` or `bitbucket`)
+
 `:your_token` should be replaced with the token you copied earlier.
-`:vcs-type` is dependent on your version control system (either `github` or `bitbucket`).
 
 ```bash
 export CIRCLE_TOKEN=':your_token'

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -143,7 +143,7 @@ a link to the core dump file appears in the Artifacts tab of the **Job page**.
 ## Downloading All Artifacts for a Build on CircleCI
 
 To download your artifacts with `curl`,
-follow these steps.
+follow the steps below.
 
 1. [Create a personal API token]({{ site.baseurl }}/2.0/managing-api-tokens/#creating-a-personal-api-token)
 and copy it to a clipboard.

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -175,12 +175,21 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_n
 <artifacts.txt xargs -P4 -I % wget %?circle-token=$CIRCLE_TOKEN
 ```
 
-The `curl` command fetches all artifact details for a build
-and pipes it to `grep` to extract the URLs.
-The results are saved to the `artifacts.txt` file.
-Finally, `xargs` reads the file
-and downloads each artifact to the current directory.
+First,
+the CIRCLE_TOKEN environment variable is created.
+Then,
+the `curl` command fetches all artifact details for a build
+and pipes them to `grep`
+to extract the URLs.
+These URLs are saved to the `artifacts.txt` file.
+Finally,
+`xargs` reads the text file,
+downloading artifacts using `wget`.
+All artifacts are downloaded to the current directory.
 
-In this example, `xargs` runs four processes
-to download files in parallel via `wget`.
-Adjust the value given to `-P` to fit your needs.
+**Note:**
+In the above example,
+`xargs` runs four processes
+to download artifacts in parallel.
+Adjust the number following `-P`
+to fit your needs.

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -157,7 +157,10 @@ to store the artifacts.
 You must substitute actual values
 for all variables beginning with `:`.
 
-`:vcs-type` = your version control system (`github` or `bitbucket`)
+Placeholder | Meaning                                                                       |
+------------|-------------------------------------------------------------------------------|
+`:vcs-type` | The version control system (VCS) you are using. Either `github` or `bitbucket`.
+{: class="table table-striped"}
 
 `:your_token` should be replaced with the token you copied earlier.
 

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -170,7 +170,7 @@ Placeholder   | Meaning                                                         
 --------------|-------------------------------------------------------------------------------|
 `:your_token` | The personal API token you created above.
 `:vcs-type`   | The version control system (VCS) you are using. Either `github` or `bitbucket`.
-`:username`   | The VCS project account username for the target project. Located at the top left of the screen in the CircleCI application.
+`:username`   | The VCS project account username or organization name for the target project. Located at the top left of the screen in the CircleCI application.
 `:project`    | The name of the target project.
 `:build_num`  | The number for the build for which you want to download artifacts.
 {: class="table table-striped"}

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -158,15 +158,14 @@ Use the table below
 to substitute actual values
 for all variables that start with `:`.
 
-Placeholder  | Meaning                                                                       |
--------------|-------------------------------------------------------------------------------|
-`:vcs-type`  | The version control system (VCS) you are using. Either `github` or `bitbucket`.
-`:username`  | The VCS project account username for the target project. Located at the top left of the screen in the CircleCI application.
-`:project`   | The name of the target project.
-`:build_num` | The number for the build for which you want to download artifacts.
+Placeholder   | Meaning                                                                       |
+--------------|-------------------------------------------------------------------------------|
+`:your_token` | The personal API token you created above.
+`:vcs-type`   | The version control system (VCS) you are using. Either `github` or `bitbucket`.
+`:username`   | The VCS project account username for the target project. Located at the top left of the screen in the CircleCI application.
+`:project`    | The name of the target project.
+`:build_num`  | The number for the build for which you want to download artifacts.
 {: class="table table-striped"}
-
-`:your_token` should be replaced with the token you copied earlier.
 
 ```bash
 export CIRCLE_TOKEN=':your_token'


### PR DESCRIPTION
# Description
This PR clarifies how to download all artifacts for a build by cleaning up language and adding a table that maps substitute values for their actual values.

# Reasons
A user stumbled while attempting to download all artifacts for a build. (See GitHub issue).

# Context
Fixes #2472 and resolves [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-12355).

@felicianotech for technical accuracy.
@michelle-luna for copyedits.