### PR TITLE
add back entrypoint section

### DIFF
--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -119,18 +119,23 @@ ADD ./db/migrations /migrations
 
 To run the container as an exectuable,
 use the [`ENTRYPOINT` instruction](https://docs.docker.com/engine/reference/builder/#entrypoint).
+Since CircleCI does not preserve entrypoints by default,
+use the [`LABEL` instruction](https://docs.docker.com/engine/reference/builder/#label)
+as shown below.
 
 ```Dockerfile
 LABEL com.circleci.preserve-entrypoint=true
 
 ENTRYPOINT contacts
 ```
+
 **Note:**
-By default,
-CircleCI does not preserve entrypoints.
-To change this behavior,
-use the [`LABEL` instruction](https://docs.docker.com/engine/reference/builder/#label)
-as shown in the above example.
+Entrypoints should be commands
+that run forever without failing.
+If the entrypoint fails or terminates in the middle of a build,
+the build will also terminate.
+If you need to access logs or build status,
+consider using a background step instead of an entrypoint.
 
 ### Building the Image
 


### PR DESCRIPTION
# Description
This PR adds back the section discussing entrypoints and labels. This was originally in #2480 and has been modified slightly to include some warnings around lack of logging and build status for the entrypoint route.

# Reasons
Turns out these were indeed correct changes. Just leftover cleanup from a previous PR.