### PR TITLE
add note about interpolation to built-in env vars section

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -278,6 +278,15 @@ Start a run with the POST API call, see the [new build]( {{ site.baseurl }}/api/
 The following environment variables are exported in each build
 and can be used for more complex testing or deployment.
 
+**Note:**
+You cannot use a built-in environment variable
+to define another environment variable.
+Instead,
+you must use a `run` step
+to export the new environment variables using `BASH_ENV`.
+For more details,
+see [Setting an Environment Variable in a Shell Command](#setting-an-environment-variable-in-a-shell-command).
+
 Variable                    | Type    | Value
 ----------------------------|---------|-----------------------------------------------
 `CI`                        | Boolean | `true` (represents whether the current environment is a CI environment)


### PR DESCRIPTION
# Description
Adds a note to remind people in the Built-in Environment Variables section that they CAN NEVER INTERPOLATE. Also links to the section discussing the workaround.

# Reasons
This PR (hopefully) fixes #2510. 

@felicianotech for tech review.
@michelle-luna for copy review.