### PR TITLE
add pre-dexing info to android guide

### DIFF
--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -133,6 +133,12 @@ and macOS capabilities. Please check out [this example React Native
 application](https://github.com/CircleCI-Public/circleci-demo-react-native)
 on GitHub for a full example of a React Native project.
 
+## Disabling Pre-Dexing to Improve Build Performance
+
+Disabling pre-dexing for Android builds on CircleCI can speed up your builds. Refer to the [Disable Android pre dexing on CI builds](http://www.littlerobots.nl/blog/disable-android-pre-dexing-on-ci-builds/) blog post for details.
+
+CircleCI always runs clean builds, so pre-dexing has no benefit. By default, the Gradle Android plugin pre-dexes dependencies. Pre-dexing converts Java bytecode into Android bytecode to speed up development by doing only incremental dexing as you change code. Pre-dexing can make compilation slower and may also use large quantities of memory. 
+
 ## Deploy
 
 See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for example deploy target configurations.


### PR DESCRIPTION
# Description
add predexing info to 2.0 android guide per support request

# Reasons
support request

# Context
A link to a GitHub and/or JIRA issue (if applicable).
