### PR TITLE
Issue #2523 - Adds page for configuring CAs on 2.0, refrences from tr…

### DIFF
--- a/jekyll/_cci2/certificate-authorities.md
+++ b/jekyll/_cci2/certificate-authorities.md
@@ -1,0 +1,25 @@
+---
+layout: classic-docs
+title: "Custom Certificate Authorities"
+category: [resources]
+order: 56
+description: "Using a custom Root Certificate Authority (CA) with CircleCI."
+categories: [administration]
+---
+
+## Supporting Custom Root CA
+
+Some installation environments use internal root certificate authorities for encrypting and establishing trust between servers.  If using a root certificate, you will need to import and mark it as a trusted certificate at CircleCI Enterprise instances. CircleCI will respect such trust when communicating with GitHub and webhook API calls.
+
+CA Certificates must be in a format understood by Java Keystore, and include the entire chain.
+
+The following script provides the necessary steps.
+
+```
+GHE_DOMAIN=github.example.com
+
+# Grab the CA chain from your GitHub Enterprise deployment.
+openssl s_client -connect ${GHE_DOMAIN}:443 -showcerts < /dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /usr/local/share/ca-certificates/ghe.crt
+```
+
+Then navigate to the system console at port 8800 - now you can change the protocol to upgraded, you can change the protocol to "HTTPS (TLS/SSLEnabled)"setting and restart the services.  When trying "Test GitHub Authentication" you should get Success now rather than x509 related error.

--- a/jekyll/_cci2/single-box.md
+++ b/jekyll/_cci2/single-box.md
@@ -90,8 +90,7 @@ this access with `iptables` rules in a production setup, [contact support](https
 
 ### Configure CircleCI
 1. Choose an SSL certificate option. By default, all machines in a CircleCI installation verify SSL certificates for the GitHub Enterprise instance. 
-- Note: If you are using a self-signed cert, or using a custom CA root, select the HTTPS (with self-signed certificate) option in the System Console at port 8800.
-You also need to export `CIRCLE_IGNORE_CERT_HOST=insecure-ghe.example.com` on builder machines replacing `insecure-ghe.example.com` with the host of your GitHub Enterprise instance. See [this doc]({{site.baseurl}}/enterprise/docker-builder-config/) for details on setting builder machine environment variables.
+- Note: If you are using a self-signed cert, or using a custom CA root, please see [certificate authorities doc]({{site.baseurl}}/docs/2.0/certificate-authorities) for instructions adding the information to CircleCI's truststore.
 2. Upload the CircleCI license file and set the admin password.
 3. If you do not need 1.0 build functionality, leave the box for it unchecked. Most users should check the box for 2.0 functionality.
 4. Select "Single Box" in the "Builders Configuration" section(s).


### PR DESCRIPTION
This addresses issue #2523.  Current steps on trial page are wrong, and internal CAs are not covered anywhere else.

# Description
- Adds a dedicated "Certificate Authorities" page (retooled from 1.0 docs)
- Links to new page from Trial Install page

# Reasons
We have support for custom CAs, but it is totally undocumented on 2,0 installs.

# Context
Issue #2523 
