### PR TITLE
Update executor-types.md

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -113,7 +113,7 @@ jobs:
 
 ### Using macOS
 
-Using the `macos` executor allows you to run your job in a macOS environment on a VM (4CPU 8GB RAM). You can also specify which version of Xcode should be used. See the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) document for the complete list of version numbers. See the "Installed Software" links in that document for specific information about technical specifications (CPU, RAM, HD) for the VMs running each particular version of Xcode.
+Using the `macos` executor allows you to run your job in a macOS environment on a VM. You can also specify which version of Xcode should be used. See the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) document for the complete list of version numbers. See the "Installed Software" links in that document for specific information about technical specifications (CPU, RAM, HD) for the VMs running each particular version of Xcode.
 
 ```
 jobs:

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -113,10 +113,7 @@ jobs:
 
 ### Using macOS
 
-Using the `macos` executor allows you
-to run your job in a macOS environment on a VM (4CPU 8GB RAM).
-You can also specify which version of Xcode should be used.
-See the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) document for the complete list of version numbers.
+Using the `macos` executor allows you to run your job in a macOS environment on a VM (4CPU 8GB RAM). You can also specify which version of Xcode should be used. See the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) document for the complete list of version numbers. See the "Installed Software" links in that document for specific information about technical specifications (CPU, RAM, HD) for the VMs running each particular version of Xcode.
 
 ```
 jobs:


### PR DESCRIPTION
add info on macos vm specs to the executor types doc

( also fix some weird formatting that i'm not sure how it got there ? )