### PR TITLE
Import Variables not available on Server

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -228,6 +228,7 @@ click on **Environment Variables**.
 by clicking the **Import Variable(s)** button.
 Add new variables
 by clicking the **Add Variable** button.
+(**Note:** The **Import Variables(s)** button is not currently available on CircleCI installed in your private cloud or datacenter.)
 
 4. Use your new environment variables in your `.circleci/config.yml` file.
 For an example,


### PR DESCRIPTION
# Description
Add note clarifying that "Import Variable(s)" button is not available on Server.

# Reasons
The button in question is a feature flag that's been exposed on Cloud only. It would require a feature request / engineering work in order to expose this to Server customers.

# Context
A link to a GitHub and/or JIRA issue (if applicable).
