### PR TITLE
Parallelism config typos

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -35,10 +35,12 @@ set the `parallelism` key to a value greater than 1.
 # ~/.circleci/config.yml
 version: 2
 jobs:
-  docker:
-    - image: circleci/<language>:<version TAG>
   test:
+    docker:
+      - image: circleci/<language>:<version TAG>
     parallelism: 4
+    steps:
+      - run: echo ""
 ```
 
 For more information,
@@ -79,6 +81,7 @@ jobs:
   test:
     docker:
       - image: circleci/<language>:<version TAG>
+    parallelism: 4
     steps:
       - run:
           command: |

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -39,8 +39,6 @@ jobs:
     docker:
       - image: circleci/<language>:<version TAG>
     parallelism: 4
-    steps:
-      - run: echo ""
 ```
 
 For more information,


### PR DESCRIPTION
# Description

Fixed minor typo in sample config on the parallelism /test splitting page
- docker should be property of a specific job
- include parallelism in 2nd example  for consitency

# Reasons
- The first sample config is invalid due to nesting level of the docker property (should belong to the job named `tests` as seen in the 2nd example
- Added `parallelism` attribute to the 2nd example for consistency.

# Context

Current example when validated with out CLI
```
 circleci config validate

* Error migrating config to version 2: 2 errors occurred:

* Config file is invalid:
  at jobs: jobs: Invalid type. Expected: object, given: array
  at jobs: jobs: Must validate one and only one schema (oneOf)
  at jobs: machine: machine is required
  at jobs: steps: steps is required

* Error in config file: The schema/shape of the YAML is incorrect: json: cannot unmarshal array into Go struct field UserConfig.Jobs of type config.JobDescription
```