### PR TITLE
Fix deprecated jest junit instructions

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -318,14 +318,14 @@ A working `.circleci/config.yml` section might look like this:
 // karma.conf.js
 
 // additional config...
-
-reporters: ['junit'],
-
-junitReporter: {
-  outputDir: process.env.JUNIT_REPORT_PATH,
-  outputFile: process.env.JUNIT_REPORT_NAME,
-  useBrowserName: false
-},
+{
+  reporters: ['junit'],
+  junitReporter: {
+    outputDir: process.env.JUNIT_REPORT_PATH,
+    outputFile: process.env.JUNIT_REPORT_NAME,
+    useBrowserName: false
+  },
+}
 // additional config...
 ```
 

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -356,12 +356,6 @@ steps:
         JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
 ```
 
-To collect Jest data, add a JUnit coverage reporter by running:
-
-    yarn add --dev jest-junit
-
-In your configuration, form a command to output using the reporter:
-
 For a full walkthrough, refer to this article by Viget: [Using JUnit on CircleCI 2.0 with Jest and ESLint](https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint).
 
 **Note:** When running Jest tests, please use the `--runInBand` flag. Without this flag, Jest will try to allocate the CPU resources of the entire virtual machine in which your job is running. Using `--runInBand` will force Jest to use only the virtualized build environment within the virtual machine.

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -353,7 +353,7 @@ steps:
       name: Run tests with JUnit as reporter
       command: jest --ci --reporters=default --reporters=jest-junit
       environment:
-        JEST_JUNIT_OUTPUT: "reporters/junit/js-test-results.xml"
+        JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
 ```
 
 To collect Jest data, add a JUnit coverage reporter by running:

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -331,19 +331,36 @@ junitReporter: {
 
 #### Jest
 
+To collect Jest data,
+first create a Jest config file called `jest.config.js` with the following:
+
+```javascript
+// jest.config.js
+{
+  reporters: ["default", "jest-junit"],
+}
+```
+
+In your `.circleci/config.yml`,
+add the following `run` steps:
+
+```yaml
+steps:
+  - run:
+      name: Install JUnit coverage reporter
+      run: yarn add --dev jest-junit
+  - run:
+      name: Run tests with JUnit as reporter
+      command: jest --ci --reporters=default --reporters=jest-junit
+      environment:
+        JEST_JUNIT_OUTPUT: "reporters/junit/js-test-results.xml"
+```
+
 To collect Jest data, add a JUnit coverage reporter by running:
 
     yarn add --dev jest-junit
 
 In your configuration, form a command to output using the reporter:
-
-```yaml
- - run:
-      name: Jest Suite
-      command: yarn jest tests --ci --testResultsProcessor="jest-junit"
-      environment:
-        JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
-```
 
 For a full walkthrough, refer to this article by Viget: [Using JUnit on CircleCI 2.0 with Jest and ESLint](https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint).
 


### PR DESCRIPTION
# Description
`jest-junit` is deprecating its `testResultsProcessor` flag. This updates the jest-junit to use its updated syntax.

# Reasons
Fixes #2539.
