### PR TITLE
Changing image reference cause the current on do not exist

### DIFF
--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -34,7 +34,7 @@ jobs:
     # Primary container image where all commands run
     
     docker:
-      - image: circleci/ruby:2.4.1-node-jessie
+      - image: circleci/ruby:2.4.1-node
         environment:
           RAILS_ENV: test
           PGHOST: 127.0.0.1


### PR DESCRIPTION
The image circleci/ruby:2.4.1-node-jessie is not on the list: https://hub.docker.com/r/circleci/ruby/tags/

So I propose to change to 2.4.4-node