### PR TITLE
machine: Update image lists

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -123,12 +123,16 @@ The currently supported versions are:
 - `17.06.0-ce`
 - `17.06.1-ce`
 - `17.09.0-ce`
+- `18.03.0-ce`
+- `18.03.1-ce`
+- `18.05.0-ce`
 
 [Edge releases](https://download.docker.com/linux/static/edge/x86_64/)
 - `17.05.0-ce`
 - `17.07.0-ce`
 - `17.10.0-ce`
 - `17.11.0-ce`
+- `18.06.0-ce`
 
 If you need a Docker image that installs Docker and has Git, use `17.05.0-ce-git`. **Note:** The `version` key is not currently supported on CircleCI installed in your private cloud or datacenter. Contact your system administrator for information about the Docker version installed in your remote Docker environment.
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -218,6 +218,7 @@ CircleCI supports multiple machine images that can be specified in the `image` f
 * `circleci/classic:201710-01` – docker 17.09.0-ce, docker-compose 1.14.0
 * `circleci/classic:201710-02` – docker 17.10.0-ce, docker-compose 1.16.1
 * `circleci/classic:201711-01` – docker 17.11.0-ce, docker-compose 1.17.1
+* `circleci/classic:201808-01` – docker 18.06.0-ce, docker-compose 1.22.0
 
 You can use one of the `year-month` versioned images to pin the version used by your jobs. Please [subscribe to our Announcements](https://discuss.circleci.com/t/how-to-subscribe-to-announcements-and-notifications-from-circleci-email-rss-json/5616) to be notified when new images are released.
 


### PR DESCRIPTION
This updates the references for currently available machine: and remote_docker:
executor images with 18.x docker versions