### PR TITLE
Clarify which ruby images are used

### DIFF
--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -247,3 +247,7 @@ as you change code.
 CircleCI runs clean builds,
 so pre-dexing actually increases compilation time
 and may also increase memory usage.
+
+## Deployment
+
+See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for examples of deploy target configurations.

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -46,9 +46,8 @@ version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     parallelism: 3 # run three instances of this job in parallel
-    working_directory: ~/circleci-demo-ruby-rails # directory where steps will run
     docker: # run the steps with Docker
-      - image: circleci/ruby:2.4-node # ...with this image as the primary container; this is where all `steps` will run
+      - image: circleci/ruby:2.4.2-jessie-node # ...with this image as the primary container; this is where all `steps` will run
         environment: # environment variables for primary container
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -302,10 +302,6 @@ The `--profile` option reports the slowest examples of each run.
 
 For more on `circleci tests glob` and `circleci tests split` commands, please refer to our documentation on [Parallelism with CircleCI CLI](https://circleci.com/docs/2.0/parallelism-faster-jobs).
 
----
-
-Success! You just set up CircleCI 2.0 for a Ruby on Rails app. Check out our [Job page](https://circleci.com/gh/CircleCI-Public/circleci-demo-ruby-rails){:rel="nofollow"} to see how this looks when building on CircleCI.
-
 ## Deployment
 
 See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for examples of deploy target configurations.

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -302,10 +302,6 @@ The `--profile` option reports the slowest examples of each run.
 
 For more on `circleci tests glob` and `circleci tests split` commands, please refer to our documentation on [Parallelism with CircleCI CLI](https://circleci.com/docs/2.0/parallelism-faster-jobs).
 
-## Deployment
-
-See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for examples of deploy target configurations.
-
 ## Detailed Examples
 
 This app illustrates the simplest possible setup for a Ruby on Rails web app. Real world projects tend to be more complex, so you may find these more detailed examples of real-world apps useful as you configure your own projects:

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -163,7 +163,7 @@ Directly beneath `working_directory`, you can specify container images under a `
 
 ```yaml
     docker:
-      - image: circleci/ruby:2.4.2-jessie-node
+      - image: circleci/ruby:2.4.2-jessie-node  # language image
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
@@ -171,19 +171,23 @@ Directly beneath `working_directory`, you can specify container images under a `
           PGHOST: 127.0.0.1
           PGUSER: circleci-demo-ruby
           RAILS_ENV: test
-      - image: circleci/postgres:9.5-alpine
+      - image: circleci/postgres:9.5-alpine  # service image
         environment:
           POSTGRES_USER: circleci-demo-ruby
           POSTGRES_DB: rails_blog
           POSTGRES_PASSWORD: ""
 ```
 
-The [official Ruby images](https://hub.docker.com/_/ruby/) are tagged
-to use the latest patch-level version of `2.4`
-and with additional packages installed for NodeJS.
+In this example,
+two [CircleCI convenience images]({{ site.baseurl }}/2.0/circleci-images/#image-types) are used:
 
-The [official Postgres image](https://hub.docker.com/_/postgres/) is specified
-for use as the database container.
+- A language image
+that runs on Debian Jessie
+and installs both Ruby 2.4.2 and Node.js.
+
+- A service image
+that runs on Alpine Linux
+and installs PostgreSQL 9.5.
 
 Then, several environment variables are added to connect the application container with the database for testing purposes. The `BUNDLE_*` environment variables are there to ensure proper caching and improve performance and reliability for installing dependencies with Bundler.
 

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -179,9 +179,12 @@ Directly beneath `working_directory`, you can specify container images under a `
           POSTGRES_PASSWORD: ""
 ```
 
-The [official Ruby images](https://hub.docker.com/_/ruby/) are tagged to use the latest patch-level version of `2.4` and with additional packages installed for NodeJS.
+The [official Ruby images](https://hub.docker.com/_/ruby/) are tagged
+to use the latest patch-level version of `2.4`
+and with additional packages installed for NodeJS.
 
-The [official Postgres image](https://hub.docker.com/_/postgres/) is specified for use as the database container.
+The [official Postgres image](https://hub.docker.com/_/postgres/) is specified
+for use as the database container.
 
 Then, several environment variables are added to connect the application container with the database for testing purposes. The `BUNDLE_*` environment variables are there to ensure proper caching and improve performance and reliability for installing dependencies with Bundler.
 

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -163,7 +163,7 @@ Directly beneath `working_directory`, you can specify container images under a `
 
 ```yaml
     docker:
-      - image: circleci/ruby:2.4-node
+      - image: circleci/ruby:2.4.2-jessie-node
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -309,7 +309,5 @@ This app illustrates the simplest possible setup for a Ruby on Rails web app. Re
 * [Discourse](https://github.com/CircleCI-Public/discourse/blob/master/.circleci/config.yml), an open source discussion platform.
 * [Sinatra](https://github.com/CircleCI-Public/circleci-demo-ruby-sinatra), a demo app for the [simple DSL for quickly creating web applications](http://www.sinatrarb.com/).
 
-
-
 [fork-demo-project]: https://github.com/CircleCI-Public/circleci-demo-ruby-rails/fork
 [rspec-junit-formatter]: https://github.com/sj26/rspec_junit_formatter

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -302,6 +302,10 @@ The `--profile` option reports the slowest examples of each run.
 
 For more on `circleci tests glob` and `circleci tests split` commands, please refer to our documentation on [Parallelism with CircleCI CLI](https://circleci.com/docs/2.0/parallelism-faster-jobs).
 
+## Deployment
+
+See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for examples of deploy target configurations.
+
 ## Detailed Examples
 
 This app illustrates the simplest possible setup for a Ruby on Rails web app. Real world projects tend to be more complex, so you may find these more detailed examples of real-world apps useful as you configure your own projects:


### PR DESCRIPTION
# Description
Corrects links to official Ruby and PostgreSQL images and removes confusing language.

# Reasons
Fixes #2558 
