### PR TITLE
Update the AWS CLI to v1.15.73.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             - docs
   deploy:
     docker:
-      - image: cibuilds/aws:1.15.44
+      - image: cibuilds/aws:1.15.73
     steps:
       - attach_workspace:
           at: ./generated-site 


### PR DESCRIPTION
# Description
Updating the Docker image that the deploy uses with a newer version of the AWS CLI.

# Reasons
No new changes here, just regular maintenance.

# Context
n/a