### PR TITLE
Document ordering info for api lists

### DIFF
--- a/jekyll/_api/v1-reference.md
+++ b/jekyll/_api/v1-reference.md
@@ -189,6 +189,19 @@ This is the GitHub or Bitbucket project account username for the target project 
 
 If you have a Free / Open Source Software ([F/OSS](https://www.gnu.org/philosophy/free-sw.html)) project, and have the setting turned on in Advanced Settings in your project dashboard, some read-only /project endpoints will return the requested data without the need for a token. People will also be able to view the build results dashboard for the project as well.
 
+## List Ordering
+
+There are two API endpoints
+where the list order is significant:
+
+- [Recent Builds Across All Projects](#recent-builds)
+- [Recent Builds For a Project](#recent-builds-project)
+
+In both cases,
+builds are returned in the order that they were created.
+For all other endpoints,
+the order has no special significance.
+
 ## Accept header
 
 If you specify no accept header, we'll return human-readable JSON with comments.

--- a/jekyll/_data/api.yml
+++ b/jekyll/_data/api.yml
@@ -122,7 +122,7 @@ follow:
 
 project:
   url: "/api/v1.1/project/:vcs-type/:username/:project"
-  description: "Build summary for each of the last 30 builds for a single git repo."
+  description: "Build summary for each of the last 30 builds for a single git repo, ordered by build_num."
   method: "GET"
   params:
     - {name: "limit", description: "The number of builds to return. Maximum 100, defaults to 30.", example: 20}


### PR DESCRIPTION
# Description
Adds notes about the lack of significance of ordering in our API responses. Except for 2 endpoints where it actually does matter. 🙄 

# Reasons
Fixes #2562 and [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-12897).