### PR TITLE
fix yml code block typo in DLC page

### DIFF
--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -30,7 +30,8 @@ Docker Layer Caching can be used with both the [`machine` executor]({{ site.base
 
 DLC is only useful when creating your own Docker image  with docker build, docker compose, or similar docker commands), it does not decrease the wall clock time that all builds take to spin up the initial environment. 
 
-```version: 2 
+```YAML
+version: 2 
 jobs: 
  build: 
    docker: 

--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -30,7 +30,7 @@ Docker Layer Caching can be used with both the [`machine` executor]({{ site.base
 
 DLC is only useful when creating your own Docker image  with docker build, docker compose, or similar docker commands), it does not decrease the wall clock time that all builds take to spin up the initial environment. 
 
-```YAML
+``` YAML
 version: 2 
 jobs: 
  build: 


### PR DESCRIPTION
# Description
Looks like the code block on DLC page is unhappy
![screen shot 2018-08-21 at 4 43 06 pm](https://user-images.githubusercontent.com/5262154/44428210-b9a7e900-a561-11e8-8eb6-33c4ed60165a.png)


# Reasons
This adds the newline under ``` required for code highlighting, and marks it as YAML type 

# Context
A link to a GitHub and/or JIRA issue (if applicable).