### PR TITLE
fix typo in skip-build.md

### DIFF
--- a/jekyll/_cci2/skip-build.md
+++ b/jekyll/_cci2/skip-build.md
@@ -96,7 +96,7 @@ Your project's default branch will never auto cancel builds.
 This feature only applies to non-workflow builds, builds triggered by pushes to GitHub, or workflow builds that use the new [build processing]({{ site.baseurl }}/2.0/build-processing/) feature.
 
 
-### Steps to Enable Auto-Cancel for New Builds Triggered by Pushes to GitHub without Worklfows
+### Steps to Enable Auto-Cancel for New Builds Triggered by Pushes to GitHub without Workflows
 
 1. In the CircleCI application,
 go to your project's settings


### PR DESCRIPTION
# Description
`Worklfows` -> `Workflows`