### PR TITLE
Typo correction in config example for Jest

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -348,7 +348,7 @@ add the following `run` steps:
 steps:
   - run:
       name: Install JUnit coverage reporter
-      run: yarn add --dev jest-junit
+      command: yarn add --dev jest-junit
   - run:
       name: Run tests with JUnit as reporter
       command: jest --ci --reporters=default --reporters=jest-junit


### PR DESCRIPTION
In current config example is written ''run" instead "command" which incorrect and causes error: "No command given".