### PR TITLE
Remove redundant 'Context' section

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,5 @@
 A brief description of the changes.
 
 # Reasons
-Why did you make these changes?
-
-# Context
 A link to a GitHub and/or JIRA issue (if applicable).
+Otherwise, a brief sentence about why you made these changes.


### PR DESCRIPTION
# Description
Removes redundant section from pull request template.

# Reasons
More often than not, I find myself deleting the Context section during pull requests. Two sections for **what** and **why** should be sufficient.