### PR TITLE
add jekyll cache and alphabetize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-_site/
-run-results/
-jekyll/environments/
-.sass-cache/
-.jekyll-metadata
-.vagrant/
 .DS_Store
 .bundle/
+.jekyll-metadata
 .ruby-version
+.sass-cache/
+.vagrant/
+_site/
+jekyll/.jekyll-cache/
+jekyll/environments/
+run-results/


### PR DESCRIPTION
# Description
Jekyll cache was being tracked in Git. This adds the `jekyll/.jekyll-cache/` directory to `.gitignore` and organizes the `.gitignore` file.

# Reasons
Seeing the cache update is not a noteworthy or committable change.