### PR TITLE
Clarify google service account doc

### DIFF
--- a/jekyll/_cci2/google-auth.md
+++ b/jekyll/_cci2/google-auth.md
@@ -109,11 +109,6 @@ jobs:
           command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
 ```
 
-**Note:**
-To use certain services (like Google Cloud Datastore),
-you will also need
-to set the CircleCI `$GOOGLE_APPLICATION_CREDENTIALS` environment variable to `${HOME}/gcloud-service-key.json`.
-
 ### Authorizing the Google Cloud SDK
 
 Use `gcloud` to authorize the Google Cloud SDK
@@ -143,3 +138,9 @@ by adding the following command before authorizing the SDK.
 ```bash
 sudo gcloud --quiet components update
 ```
+
+## Adding Credentials for Server Applications
+
+To use certain services (like Google Cloud Datastore),
+you will also need
+to set the CircleCI `$GOOGLE_APPLICATION_CREDENTIALS` environment variable to `${HOME}/gcloud-service-key.json`.

--- a/jekyll/_cci2/google-auth.md
+++ b/jekyll/_cci2/google-auth.md
@@ -55,10 +55,9 @@ Using this particular name is not required,
 but it will be used throughout the examples in this document.
 
 3. For convenience, add three more environment variables to your CircleCI project:
+    - `GOOGLE_APPLICATION_CREDENTIALS`: `${HOME}/gcloud-service-key.json`
     - `GOOGLE_PROJECT_ID`: the ID of your GCP project.
     - `GOOGLE_COMPUTE_ZONE`: the default [compute zone](https://cloud.google.com/compute/docs/regions-zones/).
-    - `GOOGLE_CLUSTER_NAME`: the target cluster for all deployments.
-
 
 ### Authenticating to Google Container Registry
 
@@ -138,9 +137,3 @@ by adding the following command before authorizing the SDK.
 ```bash
 sudo gcloud --quiet components update
 ```
-
-## Adding Credentials for Server Applications
-
-To use certain services (like Google Cloud Datastore),
-you will also need
-to set the CircleCI `$GOOGLE_APPLICATION_CREDENTIALS` environment variable to `${HOME}/gcloud-service-key.json`.

--- a/jekyll/_cci2/google-auth.md
+++ b/jekyll/_cci2/google-auth.md
@@ -133,7 +133,6 @@ jobs:
           sudo gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
           sudo gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
           sudo gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-          sudo gcloud --quiet container clusters get-credentials ${GOOGLE_CLUSTER_NAME}
 ```
 
 **Note:**


### PR DESCRIPTION
# Description
- removes unnecessary Kubernetes cluster-checking command
- highlights the more important `GOOGLE_APPLICATION_CREDENTIALS` env var

# Reasons
Fixes #2589 and resolves [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-13058).