### PR TITLE
Make checkout ssh key req more explicit

### DIFF
--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -15,14 +15,14 @@ This document describes how to access a build container using SSH on CircleCI 2.
 {:toc}
 
 ## Overview
-Often the best way to troubleshoot problems is to SSH into a build container and inspect 
+Often the best way to troubleshoot problems is to SSH into a job and inspect
 things like log files, running processes, and directory paths. CircleCI 2.0 gives you the option to access all jobs via SSH.
 
-When you log in with SSH, you are running an interactive login shell. You are also likely to be running the command on top of the directory where the command failed the first time, so you are not starting a clean run. In contrast, CircelCI uses a non-interactive shell for running commands by default. Hence, steps run in interactive mode may succeed, while failing in non-interactive mode.
+When you log in with SSH, you are running an interactive login shell. You are also likely to be running the command on top of the directory where the command failed the first time, so you are not starting a clean run. In contrast, CircleCI uses a non-interactive shell for running commands by default. Hence, steps run in interactive mode may succeed, while failing in non-interactive mode.
 
 ## Steps
 
-1. Ensure that you have already [added an SSH key]({{ site.baseurl }}/2.0/gh-bb-integration/#enable-your-project-to-check-out-additional-private-repositories) for either GitHub or Bitbucket.
+1. Ensure that you have added an SSH key in your GitHub or Bitbucket account.
 
 2. To start a job with SSH enabled, select the 'Rebuild with SSH' option from
 the 'Rebuild' dropdown menu:

--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -18,7 +18,7 @@ This document describes how to access a build container using SSH on CircleCI 2.
 Often the best way to troubleshoot problems is to SSH into a build container and inspect 
 things like log files, running processes, and directory paths. CircleCI 2.0 gives you the option to access all jobs via SSH.
 
-When you log in with SSH, you are running an interactive login shell. You are also likely to be running the command on top of the directory where the command failed the first time, so you are not starting a clean run. In contrast, CircelCI uses a non-interactive shell for running commands by default. Hence, steps run in interactive mode may succeed, while failing in non-interactive mode. 
+When you log in with SSH, you are running an interactive login shell. You are also likely to be running the command on top of the directory where the command failed the first time, so you are not starting a clean run. In contrast, CircelCI uses a non-interactive shell for running commands by default. Hence, steps run in interactive mode may succeed, while failing in non-interactive mode.
 
 1. To start a job with SSH enabled, select the 'Rebuild with SSH' option from
 the 'Rebuild' dropdown menu:

--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -22,7 +22,7 @@ When you log in with SSH, you are running an interactive login shell. You are al
 
 ## Steps
 
-1. Ensure that you have added an SSH key in your GitHub or Bitbucket account.
+1. Ensure that you have added an SSH key to your [GitHub](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/) or [Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html) account.
 
 2. To start a job with SSH enabled, select the 'Rebuild with SSH' option from
 the 'Rebuild' dropdown menu:

--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -20,17 +20,21 @@ things like log files, running processes, and directory paths. CircleCI 2.0 give
 
 When you log in with SSH, you are running an interactive login shell. You are also likely to be running the command on top of the directory where the command failed the first time, so you are not starting a clean run. In contrast, CircelCI uses a non-interactive shell for running commands by default. Hence, steps run in interactive mode may succeed, while failing in non-interactive mode.
 
-1. To start a job with SSH enabled, select the 'Rebuild with SSH' option from
+## Steps
+
+1. Ensure that you have already [added an SSH key]({{ site.baseurl }}/2.0/gh-bb-integration/#enable-your-project-to-check-out-additional-private-repositories) for either GitHub or Bitbucket.
+
+2. To start a job with SSH enabled, select the 'Rebuild with SSH' option from
 the 'Rebuild' dropdown menu:
 ![Rebuild with SSH](  {{ site.baseurl }}/assets/img/docs/rebuild-ssh-dropdown.png)
 
-2. To see the connection details, expand the 'Enable SSH' section in the job output where you will see the SSH command needed to connect:
+3. To see the connection details, expand the 'Enable SSH' section in the job output where you will see the SSH command needed to connect:
 ![SSH connection details](https://circleci-discourse.s3.amazonaws.com/optimized/2X/5/57f50e26ec245d0373c4265ec4375641553bdbdb_1_690x295.png)	
 ![SSH connection details](https://circleci-discourse.s3.amazonaws.com/optimized/2X/5/514e8aec3e8017dac8e8d401d22432026b473161_1_690x281.png)
 
      The details are displayed again in the 'Wait for SSH' section at the end of the job.
 
-3. SSH to the running job (using the same SSH key
+4. SSH to the running job (using the same SSH key
 that you use for GitHub or Bitbucket) to perform whatever troubleshooting
 you need to.
 


### PR DESCRIPTION
# Description
This highlights the need for adding an SSH key with "Checkout SSH Key" for either

# Reasons
Fixes #2594 and resolves [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-13159).