### PR TITLE
Fix typo in "Using the API to Trigger Jobs"

### DIFF
--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -1,13 +1,13 @@
 ---
 layout: classic-docs
-title: "Using the APi to Trigger Jobs"
+title: "Using the API to Trigger Jobs"
 short-title: "Using the API to Trigger Jobs"
 description: "How to define and trigger non-build jobs"
 categories: [configuring-jobs]
 order: 80
 ---
 
- 
+
 This document describes
 how to trigger jobs using the CircleCI API.
 
@@ -57,7 +57,7 @@ Instead, define these variables at the [Project level]({{ site.baseurl }}/2.0/en
 
 ## Conditionally Running Jobs With the API
 
-The next example demonstrates a configuration for building docker images with `setup_remote_docker` only for builds that should be deployed. 
+The next example demonstrates a configuration for building docker images with `setup_remote_docker` only for builds that should be deployed.
 
 ```yaml
 version: 2


### PR DESCRIPTION
# Description
Fixes a typo in the title of the page ["Using the APi to Trigger Jobs"](https://circleci.com/docs/2.0/api-job-trigger/#section=jobs)

# Reasons
![image](https://user-images.githubusercontent.com/1631487/44796442-02236000-ab7b-11e8-8e0d-3a4634c1f66b.png)
