### PR TITLE
Fix minor typo and missing links

### DIFF
--- a/jekyll/__glossary/layer_caching.md
+++ b/jekyll/__glossary/layer_caching.md
@@ -2,4 +2,4 @@
 term: Docker Layer Caching
 ---
 
-The CircleCI Docker Layer Caching feature allows builds to reuse Docker image layers from previous builds. Image layers are stored in separate volumes in the cloud and are not shared between projects. Layers may only be used by builds from the same project. For additional information about how the secure environment is created, see the [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching/) and [Running Docker Commands](({{ site.baseurl }}/2.0/building-docker-images/) documents. 
+The CircleCI Docker Layer Caching feature allows builds to reuse Docker image layers from previous builds. Image layers are stored in separate volumes in the cloud and are not shared between projects. Layers may only be used by builds from the same project. For additional information about how the secure environment is created, see the [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching/) and [Running Docker Commands]({{ site.baseurl }}/2.0/building-docker-images/) documents. 

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -256,3 +256,4 @@ Thanks to ryansch for contributing this example.
 
 [job-space]: {{ site.baseurl }}/2.0/glossary/#job-space
 [primary-container]: {{ site.baseurl }}/2.0/glossary/#primary-container
+[docker-layer-caching]: {{ site.baseurl }}/2.0/glossary/#docker-layer-caching

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -30,7 +30,7 @@ mkdir .circleci/
 touch .circleci/config.yml
 ```
 
-These commands create a directory named `.circleci` & the next command creates a new file named `config.yml` within the `.circleci` directory.  Again you **must** use the names .circleci for the dir and config.yml.  Learn more about the [version 2.0 prerequisites here]({{ site.baseurl }}/2.0/migrating-from-1-2/#steps-to-configure-required-20-keys).
+These commands create a directory named `.circleci` & the next command creates a new file named `config.yml` within the `.circleci` directory.  Again you **must** use the names .circleci for the dir and config.yml.  Learn more about the [version 2.0 prerequisites here]({{ site.baseurl }}/2.0/migrating-from-1-2/).
 
 ### Scala config.yml File
 

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -30,7 +30,7 @@ mkdir .circleci/
 touch .circleci/config.yml
 ```
 
-These commands create a directory named `.circleci` & the next command creates a new file named `config.yml` within the `.circleci` directory.  Again you **must** use the names .circleci for the dir and config.yml.  Learn more about the [version 2.0 prerequisites here](({{ site.baseurl }}/2.0/migrating-from-1-2/#steps-to-configure-required-20-keys).
+These commands create a directory named `.circleci` & the next command creates a new file named `config.yml` within the `.circleci` directory.  Again you **must** use the names .circleci for the dir and config.yml.  Learn more about the [version 2.0 prerequisites here]({{ site.baseurl }}/2.0/migrating-from-1-2/#steps-to-configure-required-20-keys).
 
 ### Scala config.yml File
 

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -17,7 +17,7 @@ This document provides instructions for installing and using the CircleCI CLI.
 
 The `circleci` commands enable you to reproduce the CircleCI environment locally and run jobs as if they were running on the hosted application for more efficient debugging and configuration in the initial setup phase. 
 
-You can also run `circleci` commands in your [`.circleci/config.yml`]]({{ site.baseurl }}/2.0/configuration-reference/) file for jobs that use the primary container image. This is particularly useful for globbing or splitting tests among containers. 
+You can also run `circleci` commands in your [`.circleci/config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file for jobs that use the primary container image. This is particularly useful for globbing or splitting tests among containers.
 
 **Note:** There are currently two versions of the CLI that you may install. The Local CLI available at [https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci] is an older version that does not yet support Workflows.
 The Local CLI version available at [https://github.com/CircleCI-Public/circleci-cli] has a different set of options, some of which are still in active development, and will be the replacement for the old CLI.


### PR DESCRIPTION
# Description
Fix typo relates to Markdown syntax

# Reasons

- Excess parenthesis
- Insufficient links to glossary