### PR TITLE
fix markdown syntax error at context.md

### DIFF
--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -36,7 +36,7 @@ For any GitHub Enterprise (GHE) installation that includes multiple organization
 
 3. Click the Add Environment Variable button and copy/paste in the variable name and value. Click the Add Variable button to save it.
 
-4. Add the `context: <context name>` key to the [`workflows`]({{ site.baseurl }}/2.0/configuration-reference/#workflows section of your [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file for every job in which you want to use the variable. In the following example, the `run-tests` job will use the variables set in the `org-global` context.
+4. Add the `context: <context name>` key to the [`workflows`]({{ site.baseurl }}/2.0/configuration-reference/#workflows) section of your [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file for every job in which you want to use the variable. In the following example, the `run-tests` job will use the variables set in the `org-global` context.
 
 ```
 workflows:


### PR DESCRIPTION
# Description
fix syntax error at cotext.md , Creating and Using Context section 4. (see image below)
![image](https://user-images.githubusercontent.com/29997565/44956151-48215080-aefa-11e8-956a-65a12f40cac3.png)

# Reasons
to activate link to https://circleci.com/docs/2.0/configuration-reference/#workflows