### PR TITLE
Change cache folder

### DIFF
--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -162,7 +162,7 @@ Now we know that our unit tests succeeded we can start our service and validate 
       - save_cache:
           key: v1-pkg-cache
           paths:
-            - "/go/pkg"
+            - ~/.cache/go-build
 
       - run:
           name: Start service
@@ -195,5 +195,3 @@ Success! You just set up CircleCI 2.0 for a Go app. Check out our [Job page](htt
 See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for example deploy target configurations.
 
 Refer to the [Caching Dependencies]({{ site.baseurl }}/2.0/caching/) document for more caching strategies.
-
-


### PR DESCRIPTION
# Description
Change the path related to go cache directory

# Reasons
The go cache directory is given with the command ```go env GOCACHE``` which is "/home/circleci/.cache/go-build" when we log in a container (see: https://golang.org/cmd/go/#hdr-Build_and_test_caching)

After changing this path, the caching feature is working as expected.