### PR TITLE
Docs: Fix markdown formatting

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -198,4 +198,4 @@ for more details.
 
 ## See Also
 
-[Using Containers]({{ site.baseurl }}/2.0/containers/
+[Using Containers]({{ site.baseurl }}/2.0/containers/)


### PR DESCRIPTION
Fixes link at bottom of https://circleci.com/docs/2.0/parallelism-faster-jobs/ since it's not properly formatted in markdown. 