### PR TITLE
Fix typo in status-badges.md

### DIFF
--- a/jekyll/_cci2/status-badges.md
+++ b/jekyll/_cci2/status-badges.md
@@ -50,4 +50,4 @@ in the link you generated above.
 
 ## See Also
 
-[Status]({{ site.baseurl }}/2.0/status/
+[Status]({{ site.baseurl }}/2.0/status/)


### PR DESCRIPTION
# Description
A small typo in this file where a link was not fully closed. 

# Reasons
I was reading the documentation and saw this. 