### PR TITLE
Update sidenav.yml

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -163,7 +163,7 @@
   icon: docs/deploy.svg
   children: 
     - name: Configuring Deploys
-      link: 2.0/deployment-integrations
+      link: 2.0/deployment-integrations/
       children: 
         - name: Using Yarn on CircleCI
           link: 2.0/yarn/
@@ -210,7 +210,7 @@
         - name: Installation
           link: 2.0/aws/
         - name: Authentication
-          link: 2.0/authentication
+          link: 2.0/authentication/
         - name: Monitoring
           link: 2.0/monitoring/
         - name: Nomad


### PR DESCRIPTION
# Description
sidebar links missing training slash

# Reasons
all links to docs need the trailing slash