### PR TITLE
Add "How to parallelize tests in SBT on CircleCI"

### DIFF
--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -206,3 +206,4 @@ The deploy command is another multi-line execution.
 
 - Refer to the [Migrating Your Scala/sbt Schema from CircleCI 1.0 to CircleCI 2.0](https://circleci.com/blog/migrating-your-scala-sbt-schema-from-circleci-1-0-to-circleci-2-0/) for the original blog post.
 - See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for more example deploy target configurations.
+- How to [parallelize tests in SBT on CircleCI](https://tanin.nanakorn.com/technical/2018/09/10/parallelise-tests-in-sbt-on-circle-ci.html)


### PR DESCRIPTION
# Description
A guide to parallelize tests in SBT on CircleCI. Here are the steps:

1. Modify SBT to print all classes to a file
2. Feed the file to circleci command line tool
3. Run `sbt testOnly`
4. Store test results

# Reasons
It took me a while to parallelize tests in SBT on CircleCI. So, I wrote it up and would like to share it.