### PR TITLE
Change step halt to use circleci-agent, which is now preferred

### DIFF
--- a/jekyll/_cci2/migration.md
+++ b/jekyll/_cci2/migration.md
@@ -34,7 +34,7 @@ When starting to migrate to CircleCI 2.0 you don't have to migrate everything ri
 
 - Conditionally run commands with `bash` `if` statements
 	- `if [ $CIRCLE_BRANCH = `master` ] ; then ./ci.sh ; fi`
-- Conditionally halt the build at that step with `circleci step halt`
+- Conditionally halt the build at that step with `circleci-agent step halt`
 	- Allows you to use `setup_remote_docker` conditionally by halting
 - The Timezone can be changed just by defining an environment variable
 	- `TZ: /usr/share/zoneinfo/America/New_York`


### PR DESCRIPTION
# Description
Use `circleci-agent` instead of `circleci` when calling in-build commands of the build agent.

# Reasons
With the new CLI we are moving to using circleci-agent in the build. This is the most official place we document `step halt`, so it should use the new agent name.