### PR TITLE
Point to iOS tutorial for basic macos setup

### DIFF
--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -11,7 +11,7 @@ This document describes how to configure your Linux, Android or macOS project to
 
 1. Create a directory called `.circleci` in the root directory of your local GitHub or Bitbucket code repository. 
 
-2. Add a [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file in the `.circleci` directory with the following lines, replacing `node:4.8.2` with any [Docker image]({{ site.baseurl }}/2.0/circleci-images/) you want: 
+2. Add a [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file in the `.circleci` directory with the following lines. For Docker executors, replace `node:4.8.2` with any [Docker image]({{ site.baseurl }}/2.0/circleci-images/) you want: 
 
 ```yaml
 version: 2
@@ -23,6 +23,8 @@ jobs:
       - checkout # check out the code in the project directory
       - run: echo "hello world" # run the `echo` command
 ```
+
+**Note**: For `macos` executors, some setup is different. If you want to setup for an iOS project, please check out [the iOS tutorial]({{ site.baseurl }}/2.0/ios-tutorial/) for an example of a simple `macos` config file. 
 
 Commit and push the changes to trigger a build. If this is your first project on CircleCI, go to the Projects page, click the **Add Projects** button and then click the **Build Project** button next to your project.
 


### PR DESCRIPTION
# Description
Adds note to "Hello, World" tutorial pointing people to a macos `config.yml` sample. 

# Reasons

For iOS developers who don't work with Docker or Linux, they may not understand that the `Docker` portion of setup does not apply to them. This change points them to the iOS-specific setup instructions for a sample of a `macos` config file.
