### PR TITLE
Correct writing-yaml.md on merging section

### DIFF
--- a/jekyll/_cci2/writing-yaml.md
+++ b/jekyll/_cci2/writing-yaml.md
@@ -144,15 +144,22 @@ draco:
 You can also merge multiple maps.
 
 ```yaml
-good: &one
-  - harry
-  - ron
-bad: &two
-  - crabbe
-  - goyle
-students:
-  <<: [*one, *two]
+name: &harry_name
+  first_name: Harry
+  last_name: Potter
+  
+address: &harry_address
+  street: 4, Privet Drive
+  district: Little Whinging
+  county: Surrey
+  country: England
+
+harry_data:
+  <<: [*harry_name, *harry_address]
 ```
+
+**Note**:
+As mentionned in [a yaml issue](https://github.com/yaml/yaml/issues/35), it is possible to merge maps, but not sequences (also called arrays or lists).
 
 For a more complex example,
 see [this gist](https://gist.github.com/bowsersenior/979804).


### PR DESCRIPTION
# Description
Update the merging section on `writing-yaml.md` documentation page.

# Reasons
As mentionned by an [issue on the YAML repository](https://github.com/yaml/yaml/issues/35), it is not possible to merge arrays in YAML. The example on the documentation doesn't work in the [suggested YAML validator](http://yaml-online-parser.appspot.com/?yaml=good%3A+%26one%0A++-+harry%0A++-+ron%0Abad%3A+%26two%0A++-+crabbe%0A++-+goyle%0Astudents%3A%0A++%3C%3C%3A+%5B*one%2C+*two%5D&type=json).

The [YAML specification on merge](http://yaml.org/type/merge.html) explains that you can merge some kind of sequences, but I am not experimented enough to understand how to write it correctly. 

Meantime, I think it should be better to update the documentation so that writing the `circle.yml` can be easier for the users.