### PR TITLE
Update local CLI docs

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -15,16 +15,20 @@ This document provides instructions for installing and using the CircleCI CLI.
 ## Overview
 {:.no_toc}
 
-The `circleci` commands enable you to reproduce the CircleCI environment locally and run jobs as if they were running on the hosted application for more efficient debugging and configuration in the initial setup phase. 
+The `circleci` command-line tool enables you to reproduce the CircleCI environment locally and run jobs as if they were running on the hosted application for more efficient debugging and configuration in the initial setup phase.
 
 You can also run `circleci` commands in your [`.circleci/config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file for jobs that use the primary container image. This is particularly useful for globbing or splitting tests among containers.
 
-**Note:** There are currently two versions of the CLI that you may install. The Local CLI available at <https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci> is an older version that does not yet support Workflows.
-The Local CLI version available at <https://github.com/CircleCI-Public/circleci-cli> has a different set of options, some of which are still in active development, and will be the replacement for the old CLI.
+**Note:** An older version of the circleci cli has been replaced by a new version available at <https://github.com/CircleCI-Public/circleci-cli>. See upgrading and installation instructions below.
 
-## Updating to the CircleCI-Public CLI
+## Install
 
-The CLI upgrade provides additional functionality through a totally new CLI developed as a [CircleCI-Public open source project](https://github.com/CircleCI-Public/circleci-cli). If you already have installed the circle-downloads CLI previously, run the following commands to update and switch:
+There are a few installation options.
+
+### Updating to the new CLI
+{:.no_toc}
+
+The CLI upgrade provides additional functionality through a totally new CLI developed as a [CircleCI-Public open source project](https://github.com/CircleCI-Public/circleci-cli). If you have the old CLI installed, run the following commands to update and switch to the new CLI:
 
 ```
 circleci update
@@ -33,9 +37,10 @@ circleci switch
 
 This command may prompt you for `sudo` if your user doesn't have write permissions to the install directory, `/usr/local/bin`.
 
-## Installing the CircleCI-Public CLI From Scratch on macOS and Linux Distros
+### Installing the CircleCI CLI on macOS or Linux
+{:.no_toc}
 
-If you haven't already installed `circleci` on your machine, run the following command to install the CircleCI-Public CLI:
+If you haven't already installed `circleci` on your machine, run the following command to install the CircleCI CLI:
 
 ```
 curl https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh \
@@ -46,25 +51,49 @@ The CLI, `circleci`, is downloaded to the `/usr/local/bin` directory.
 
 If you do not have write permissions for `/usr/local/bin`, you might need to run the above commands with `sudo`.
 
-## Manual download
+### [Alternative] Install with snap 
+{:.no_toc}
+
+The following commands will install the CircleCI CLI, Docker, and the security and auto-update features that come along with [Snap packages](https://snapcraft.io/).
+
+```
+sudo snap install docker circleci
+sudo snap connect circleci:docker docker
+```
+
+**Note:** With snap packages, the `docker` command will use the Docker snap, not any version of Docker you may have previously installed. For security purposes, snap packages can only read/write files from within `$HOME`.
+
+### [Alternative] Install on macOS with Homebrew
+{:.no_toc}
+
+If you're using [Homebrew](https://brew.sh/) with macOS, you can install the CLI with the following command:
+
+```
+brew install circleci
+```
+
+**Note:** This will install Docker from Homebrew even if Docker for Mac is installed.
+
+### [Alternative] Manual download
+{:.no_toc}
 
 You can visit the [Github releases](https://github.com/CircleCI-Public/circleci-cli/releases) page for the CLI to manually download and install. This approach is best if you would like the installed CLI to be in a specific path on your system.
 
-### Configuring the CLI
-{:.no_toc}
 
-You may first need to generate a CircleCI API Token from the [Personal API Token tab](https://circleci.com/account/api).
+## Configuring the CLI
+
+Before using the CLI you need to generate a CircleCI API Token from the [Personal API Token tab](https://circleci.com/account/api). Once you have a token configure the CLI by running:
 
 ```
 $ circleci setup
 ```
 
-If you are using this tool on `circleci.com`, accept the provided default `CircleCI API End Point`. If you are using it on you private installation of CircleCI with an administrative console, change the value to your installation address (for example, `circleci.my-org.com`).
+Setup will prompt you for configuration settings. If you are using the CLI with `circleci.com`, use the default `CircleCI Host`. If you are using CircleCI Enterprise change the value to your installation address (for example, `circleci.my-org.com`).
 
 
-## Validate A Build Config
+## Validate A CircleCI config
 
-To ensure that the tool is installed, you can use it to validate a build config file.
+To ensure that the CLI is configured correctly you can use it to validate a CircleCI config file.
 
 1. Change to the root directory of your CIrcleCI project repository.
 
@@ -75,100 +104,23 @@ $ circleci config validate
 Config file at .circleci/config.yml is valid
 ```
 
-## Run a Job in a Container on the Local Machine
-
-```
-$ circleci local execute [flags]
-```
-
-Flags
-
-```
-      --branch string         Git branch
-      --checkout-key string   Git Checkout key (default "~/.ssh/id_rsa")
-  -c, --config string         config file (default ".circleci/config.yml")
-  -e, --env -e VAR=VAL        Set environment variables, e.g. -e VAR=VAL
-  -h, --help                  help for execute
-      --index int             node index of parallelism
-      --job string            job to be executed (default "build")
-      --node-total int        total number of parallel nodes (default 1)
-      --repo-url string       Git Url
-      --revision string       Git Revision
-      --skip-checkout         use local path as-is (default true)
-  -v, --volume strings        Volume bind-mounting
-```  
-
-## Installing the circle-downloads Local CLI on macOS and Linux Distros
-
-1. Install and configure Docker by using the [docker installation instructions](https://docs.docker.com/engine/installation/).
-
-2. To install the CLI, run the following command:
-
-```
-$ curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && chmod +x /usr/local/bin/circleci
-```
-
-The CLI, `circleci`, is downloaded to the `/usr/local/bin` directory. If you do not have write permissions for `/usr/local/bin`, you might need to run the above commands with `sudo`. The CLI automatically checks for updates and will prompt you if one is available. 
-
-### [Alternative] Installing Ubuntu 16.04 or Ubuntu 17.04+
+### Run validate using git hooks
 {:.no_toc}
 
-With Ubuntu, you can optionally install by using Snap. The following commands give you the circle-downloads Local CLI, Docker, and the security and auto-update features that come along with [Snap packages](https://www.ubuntu.com/desktop/snappy).
-
-```
-sudo snap install docker circleci
-sudo snap connect circleci:docker docker
-```
-
-**Note:** With snap packages, the `docker` command will use the Docker snap, not any version of Docker you may have previously installed. For security purposes, snap packages can only read/write files from within `$HOME`.
-
-### [Alternative] Installing on macOS via Homebrew
-{:.no_toc}
-
-If you're using [Homebrew](https://brew.sh/) with macOS, you can install the circle-downloads Local CLI with the following command:
-
-```
-brew install circleci
-```
-
-**Note:** This will install Docker from Homebrew even if Docker for Mac is installed.
-
-
-### Validating 2.0 YAML Syntax with the circleci-downloads CLI
-{:.no_toc}
-
-1. Type `circleci` with one of six available commands (`build`, `config`, `help`, `step`, `tests`, and `version`) followed by a valid flag. For example:
-
-```
-$ circleci config validate -c .circleci/config.yml
-```
-The config validate command checks your local config.yml file for syntax errors.
-
-***Note:*** Local jobs don’t cache dependencies. You may want to comment out dependency sections if you are testing YAML syntax. Or, as in this example, use the `-c` flag to specify a local `config.yml` file that doesn’t pull in large dependencies.
-
-### Validate Every Configuration Change
-{:.no_toc}
-
-To catch CircleCI config errors as you build your full `config.yml` file, it is possible create a Git pre-commit hook to validate `~/.circleci/config.yml` that, when pushing to git, will run the 
-`circleci config validate` command that is available to every build. 
+To catch CircleCI config errors as you build your full `config.yml` file, it is possible create a Git pre-commit hook to validate `~/.circleci/config.yml` that, before pushing to github, will run the `circleci config validate` command that is available to every build. 
 
 Check out [this blog post](https://circleci.com/blog/circleci-hacks-validate-circleci-config-on-every-commit-with-a-git-hook/) about creating the Git hook.
 
 
-### Running A Build
-{:.no_toc}
+## Run a Job in a Container on the Local Machine
 
-To run your build, navigate to your repo and run `circleci build`.
+The CLI allows you to run a single job from the CircleCI on your desktop using docker. 
 
-**Note:** If your _config.yml_ uses Workflows and has a job named `build`, only that `build` job will run. If you are using Workflows and have no jobs named `build`, the CLI will not be able to run your project locally.
-
-To run any job besides `build`,
-add the `--job` flag,
-followed by the name of the job.
-
-```bash
-$ circleci build --job test
 ```
+$ circleci local execute --job JOB_NAME
+```
+
+**Note:** If your _config.yml_ uses Workflows and has a job named `build`, only the `build` job will run. It is not possible to run an entire workflow using the CLI.
 
 ### Troubleshooting Container Configurations Locally
 {:.no_toc}


### PR DESCRIPTION
# Description
Update the local CLI docs

# Reasons
I noticed a few issues with this doc. We still reference the old local cli install instructions and local build was mentioned in two places.

This change moved all the install options into one section and moves the `local execute`instructions all together.