### PR TITLE
Fix incomplete link in Sample Config.yml Files

### DIFF
--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -302,4 +302,4 @@ workflows:
 
 ## See Also
 
-See the [Example Public Repos] document for a list of public projects that use CircleCI.
+See the [Example Public Repos]({{ site.baseurl }}/2.0/example-configs/) document for a list of public projects that use CircleCI.


### PR DESCRIPTION
At the "See Also" section, the "Example Public Repos" wasn't pointing to that page itself.

# Description
Added the correct redirect to an incomplete link element.

# Reasons
Better navigation flow.