### PR TITLE
Fix SSH wait timeout

### DIFF
--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -36,7 +36,7 @@ the 'Rebuild' dropdown menu:
 that you use for GitHub or Bitbucket) to perform whatever troubleshooting
 you need to.
 
-The build VM will remain available for **30 minutes after the build finishes running**
+The build VM will remain available for **10 minutes after the build finishes running**
 and then automatically shut down. (Or you can cancel it.)
 
 **Note**: If your job has parallel steps, CircleCI launches more than one VM


### PR DESCRIPTION
We wait for 10 mins until users ssh or cancel the job as you can see in the screenshot.

<img width="719" alt="screen shot 2018-10-09 at 7 38 58" src="https://user-images.githubusercontent.com/924390/46637308-8c0d1280-cb96-11e8-8739-f2c26f2b08a0.png">
