### PR TITLE
adding a header so it will be found in docs

### DIFF
--- a/jekyll/_cci2/jvm-heap-size-configuration.md
+++ b/jekyll/_cci2/jvm-heap-size-configuration.md
@@ -1,3 +1,9 @@
+---
+layout: classic-docs
+title: "Configuring Java virtual Machine Heap Size"
+description: "How to configure Java virtual Machine Heap Size in CircleCI Server."
+---
+
 # Configurable Java virtual Machine Heap Size
 
 JVM_HEAP_SIZE is configurable for frontend and test-result containers


### PR DESCRIPTION
# Description
Header is missing for doc.

# Reasons
Not showing or searchable in docs