### PR TITLE
adding link to sidenave for JVM heap, removing mongodb ha info

### DIFF
--- a/jekyll/_cci2/update-2.14.1-to-2.15.0.md
+++ b/jekyll/_cci2/update-2.14.1-to-2.15.0.md
@@ -6,8 +6,9 @@ order: 12
 description: "How to upgrading MongoDB from 3.2 to 3.6 when using externalized MongoDB"
 ---
 
-This document provides links to instructions for upgrading MongoDB to v3.6. If you are running an external MongoDB with your CircleCI installation, this MongoDB upgrade is required for use with CircleCI v2.15.0.
+If you are running an external MongoDB with your CircleCI installation, multiple MongoDB upgrades are required for use with CircleCI v2.15.0. Work with a CircleCI Solutions Engineer to complete the required upgrades to your custom HA configuration (requires Platinum Support). Get started by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
 
+<!---
 * TOC
 {:toc}
 
@@ -41,3 +42,4 @@ Follow the upgrade procedures outlined by MongoDb [documentation](https://docs.m
 You can again verify it is set properly to `3.4` by running:
 
 ```db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1})```
+--->

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -217,6 +217,8 @@
           link: 2.0/authentication/
         - name: Monitoring
           link: 2.0/monitoring/
+        - name: Configuring JVM Heap Size
+          link: 2.0/jvm-heap-size-configuration/
         - name: Nomad
           link: 2.0/nomad/
         - name: Backup


### PR DESCRIPTION
# Description
need to refer server customers to support for upgrade/HA info

# Reasons
using HA requires support contract and making changes without SE could create issues