### PR TITLE
Fix CSS selector for highlighted search terms

### DIFF
--- a/jekyll/_sass/_instantsearch.scss
+++ b/jekyll/_sass/_instantsearch.scss
@@ -65,7 +65,7 @@
     font-size: $font-size-micro;
   }
 
-  .custom_highlight {
+  em {
     font-style: normal;
     font-weight: bold;
   }


### PR DESCRIPTION
## Overview

Fixes search term highlighting of search results.

Looks like setting the `escapeHits: true` option on the hits widget changed the CSS selector for highlighted search terms in results.

## How to test

Do a search - the search term should be highlighted in bold and not italicized.