### PR TITLE
add output-processor jvm_heap_size customizations

### DIFF
--- a/jekyll/_cci2/jvm-heap-size-configuration.md
+++ b/jekyll/_cci2/jvm-heap-size-configuration.md
@@ -4,7 +4,7 @@ title: "Configuring Java Virtual Machine Heap Size"
 description: "How to configure Java virtual Machine Heap Size in CircleCI Server."
 ---
 
-JVM_HEAP_SIZE is configurable for frontend and test-result containers
+JVM_HEAP_SIZE is configurable for frontend, test-result and picard-output-processor containers
 
 ## Setting up
 To customize JVM_HEAP_SIZE value, you will need to create customizations file in your services box
@@ -12,6 +12,7 @@ To customize JVM_HEAP_SIZE value, you will need to create customizations file in
 ```sh
 /etc/circleconfig/frontend/customizations
 /etc/circleconfig/test-results/customizations
+/etc/circleconfig/output-processor/customizations
 ```
 
 2. In the file, add the line below to export desire JVM_HEAP_SIZE in the file
@@ -34,6 +35,10 @@ sudo docker exec -it frontend lein repl :connect 6005
 ```sh
 sudo docker exec -it test-result lein repl :connect 2719
 ```
+#### For picard-output-processor container
+```sh
+sudo docker exec -it picard-output-processor lein repl :connect 6007
+```
 
 verify JVM_HEAP_SIZE has reset.
 ```clojure
@@ -42,3 +47,4 @@ verify JVM_HEAP_SIZE has reset.
 ```clojure
 (-> (java.lang.Runtime/getRuntime) (.totalMemory)) ;; return value should match with JVM_HEAP_SIZE
 ```
+


### PR DESCRIPTION
# Description
A brief description of the changes.
as part of 2.15.0 release, OX team finish validating output-processor's jvm heap size configuration but it's missing in the documentation. adding instruction to correct them

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.atlassian.net/browse/CIRCLE-13249 is worked on but the document was not published to inform the customer.