### PR TITLE
Add realitycheck to some server docs

### DIFF
--- a/jekyll/_cci2/aws.md
+++ b/jekyll/_cci2/aws.md
@@ -115,6 +115,7 @@ Have available the following information and policies before starting the Previe
 8. Configure the vm-service if you plan to use [Remote Docker]({{site.baseurl}}/2.0/building-docker-images/) or `machine` executor features (you can configure it later if necessary). Again, it is best to use an instance profile for authentication (no additional configuration required).
 9. After applying settings you will be redirected to the Management Console Dashboard. It will take a few minutes to download all of the necessary Docker containers. If the Management Console reports that `Failure reported from operator: no such image` click Start again and it should continue.
 10. After the application has started, log in to CircleCI and start running 2.0 builds!
+11. You can use [our realitycheck repo](https://github.com/circleci/realitycheck) to check basic CircleCI functionality.
 
 ## Validating your Installation
 

--- a/jekyll/_cci2/troubleshooting.md
+++ b/jekyll/_cci2/troubleshooting.md
@@ -13,6 +13,10 @@ please [generate a support bundle](https://help.replicated.com/docs/native/packa
 and contact our Support Engineers
 by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
 
+## Testing Server Functionality
+
+We recommend running using [our realitycheck repo](https://github.com/circleci/realitycheck) to check basic CircleCI functionality. Please note the contexts test will fail without the given contexts existing in the system.
+
 ## Debugging Queuing Builds
 
 If your Services component is fine, but builds are not running or all builds are queueing, follow the steps below.


### PR DESCRIPTION
Adding references to realitycheck for more visibility. Customers should have that readily available to test their installation after they're done provisioning the system.