### PR TITLE
Update Xcode 10.0.0 documentation

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -21,7 +21,7 @@ CircleCI offers support for building and testing iOS and macOS projects. Refer t
 
 The currently available Xcode versions are:
 
-* `10.0.0`: Xcode 10.0 (Build 10A254a) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-449/index.html)
+* `10.0.0`: Xcode 10.0 (Build 10A255) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-456/index.html)
 * `9.4.1`: Xcode 9.4.1 (Build 9F2000) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-430/index.html)
 * `9.4.0`: Xcode 9.4 (Build 9F1027a) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-422/index.html)
 * `9.3.1`: Xcode 9.3.1 (Build 9E501) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-419/index.html)


### PR DESCRIPTION
We overwrote the Xcode 10.0.0 image with an upgraded base operating
system and replaced the Xcode GM with the actual released version.

This updates the documentation reference to point to the correct image
specification.