### PR TITLE
Update circleci-images.md

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -224,6 +224,8 @@ for the Linux distribution/version installed in that variant's base image.
 Most CircleCI convenience images are [Debian Jessie](https://packages.debian.org/jessie)-
 or [Stretch](https://packages.debian.org/stretch)-based images,
 however some extend [Ubuntu](https://packages.ubuntu.com)-based images.
+For details on individual variants of CircleCI images, see the
+[circleci-dockerfiles](https://github.com/circleci-public/circleci-dockerfiles) repository.
 
 The following packages are installed via `curl` or other means.
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -195,26 +195,35 @@ use the `circleci/postgres:9.5-postgis-ram` image.
 
 All convenience images have been extended with additional tools.
 
-The following packages are installed via `apt-get` on every image.
+With the exception of [Android images](https://hub.docker.com/r/circleci/android),
+all images include the following packages, installed via `apt-get`:
 
-- [bzip2](https://packages.debian.org/stretch/bzip2)
-- [ca-certificates](https://packages.debian.org/stretch/ca-certificates)
-- [curl](https://packages.debian.org/stretch/curl)
-- [git](https://packages.debian.org/stretch/git)
-- [gnupg](https://packages.debian.org/stretch/gnupg)
-- [gzip](https://packages.debian.org/stretch/gzip)
-- [locales](https://packages.debian.org/stretch/locales)
-- [mercurial](https://packages.debian.org/stretch/mercurial)
-- [net-tools](https://packages.debian.org/stretch/net-tools)
-- [netcat](https://packages.debian.org/stretch/netcat)
-- [openssh-client](https://packages.debian.org/stretch/openssh-client)
-- [parallel](https://packages.debian.org/stretch/parallel)
-- [sudo](https://packages.debian.org/stretch/sudo)
-- [tar](https://packages.debian.org/stretch/tar)
-- [unzip](https://packages.debian.org/stretch/unzip)
-- [wget](https://packages.debian.org/stretch/wget)
-- [xvfb](https://packages.debian.org/stretch/xvfb)
-- [zip](https://packages.debian.org/stretch/zip)
+- bzip2
+- ca-certificates
+- curl
+- git
+- gnupg
+- gzip
+- locales
+- mercurial
+- net-tools
+- netcat
+- openssh-client
+- parallel
+- sudo
+- tar
+- unzip
+- wget
+- xvfb
+- zip
+
+The specific version of a particular package
+that gets installed in a particular CircleCI image variant
+depends on the default version included in the package directory
+for the Linux distribution/version installed in that variant's base image.
+Most CircleCI convenience images are [Debian Jessie](https://packages.debian.org/jessie)-
+or [Stretch](https://packages.debian.org/stretch)-based images,
+however some extend [Ubuntu](https://packages.ubuntu.com)-based images.
 
 The following packages are installed via `curl` or other means.
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -198,24 +198,24 @@ All convenience images have been extended with additional tools.
 With the exception of [Android images](https://hub.docker.com/r/circleci/android),
 all images include the following packages, installed via `apt-get`:
 
-- bzip2
-- ca-certificates
-- curl
-- git
-- gnupg
-- gzip
-- locales
-- mercurial
-- net-tools
-- netcat
-- openssh-client
-- parallel
-- sudo
-- tar
-- unzip
-- wget
-- xvfb
-- zip
+- `bzip2`
+- `ca-certificates`
+- `curl`
+- `git`
+- `gnupg`
+- `gzip`
+- `locales`
+- `mercurial`
+- `net-tools`
+- `netcat`
+- `openssh-client`
+- `parallel`
+- `sudo`
+- `tar`
+- `unzip`
+- `wget`
+- `xvfb`
+- `zip`
 
 The specific version of a particular package
 that gets installed in a particular CircleCI image variant

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -221,8 +221,8 @@ The specific version of a particular package
 that gets installed in a particular CircleCI image variant
 depends on the default version included in the package directory
 for the Linux distribution/version installed in that variant's base image.
-Most CircleCI convenience images are [Debian Jessie](https://packages.debian.org/jessie)-
-or [Stretch](https://packages.debian.org/stretch)-based images,
+Most CircleCI convenience images are [Debian Jessie](https://packages.debian.org/jessie/)-
+or [Stretch](https://packages.debian.org/stretch/)-based images,
 however some extend [Ubuntu](https://packages.ubuntu.com)-based images.
 For details on individual variants of CircleCI images, see the
 [circleci-dockerfiles](https://github.com/circleci-public/circleci-dockerfiles) repository.


### PR DESCRIPTION
clear up some confusion around how particular version of particular packages get installed in particular variants of particular circleci images

# Description

changes made based on feedback here: https://github.com/circleci/circleci-images/issues/128

# Reasons

currently, this page links to the debian stretch package directory for all packages installed in images via apt-get. however, this is misleading, as not all variants of all images are based on debian stretch, and thus the versions included via the links are not always the actual versions of those packages that we install.

our images are based on upstream images that change over time, including changing the base linux distro and version that they extend, so rather than trying to link to the exact package in the exact package directory for each variant of every image we build (which would be impossible...), let's just explain how this all happens. from there, it's relatively easy for folks to figure out why, for example, git version 2.1.4 is installed in their `circleci/node:8` image.