### PR TITLE
Update Crystal doc links to transferred repo.

### DIFF
--- a/jekyll/_cci2/demo-apps.md
+++ b/jekyll/_cci2/demo-apps.md
@@ -14,7 +14,7 @@ Language Guide | Framework | GitHub Repo Name
  [Android]({{ site.baseurl }}/2.0/language-android/){:target="_blank"} | Gradle | 
  [Android](https://github.com/CircleCI-Public/circleci-demo-react-native/blob/master/README.md){:target="_blank"} | React Native | [circleci-demo-react-native]{:target="_blank"}
  [Clojure]{:target="_blank"} | Luminus | [circleci-demo-clojure-luminus]{:target="_blank"}
- [Crystal]({{ site.baseurl }}/2.0/language-crystal/) | Kemal | [circleci-demo-crystal](https://github.com/teesloane/circleci-demo-crystal)
+ [Crystal]({{ site.baseurl }}/2.0/language-crystal/) | Kemal | [circleci-demo-crystal](https://github.com/CircleCI-Public/circleci-demo-crystal)
  [Elixir]{:target="_blank"} | Phoenix | [circleci-demo-elixir-phoenix]{:target="_blank"}
  [Go]{:target="_blank"} | Go | [circleci-demo-go]{:target="_blank"}
  [iOS]{:target="_blank"} | Xcode | [circleci-demo-ios]{:target="_blank"}

--- a/jekyll/_cci2/language-crystal.md
+++ b/jekyll/_cci2/language-crystal.md
@@ -17,10 +17,10 @@ If you’re in a rush, just copy the sample configuration below into a `.circlec
 
 You can view an example Crystal project at the following link:
 
-- <a href="https://github.com/teesloane/circleci-demo-crystal" 
+- <a href="https://github.com/CircleCI-Public/circleci-demo-crystal"
 target="_blank">Demo Crystal Project on Github</a>
 
-In the project you will find a commented CircleCI configuration file <a href="https://github.com/teesloane/circleci-demo-crystal/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>.
+In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-crystal/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>.
 
 The application uses Crystal 0.26 and Kemal 0.24. Both Crystal and Kemal are
 developing quickly. Altering the Docker image to the `:latest` version may cause

--- a/jekyll/_cci2/tutorials.md
+++ b/jekyll/_cci2/tutorials.md
@@ -24,7 +24,7 @@ Language in which your App is written | Framework | GitHub Repo Name
  [Android] | Gradle | [android-image](https://github.com/circleci/circleci-images/tree/master/android)
  [Android](https://github.com/CircleCI-Public/circleci-demo-react-native/blob/master/README.md) | React Native | [circleci-demo-react-native]
  [Clojure] | Luminus | [circleci-demo-clojure-luminus]
- [Crystal]({{ site.baseurl }}/2.0/language-crystal/) | Kemal | [circleci-demo-crystal](https://github.com/teesloane/circleci-demo-crystal)
+ [Crystal]({{ site.baseurl }}/2.0/language-crystal/) | Kemal | [circleci-demo-crystal](https://github.com/CircleCI-Public/circleci-demo-crystal)
  [Elixir] | Phoenix | [circleci-demo-elixir-phoenix]
  [Go] | Go | [circleci-demo-go]
  [iOS] | Xcode | [circleci-demo-ios]


### PR DESCRIPTION
# Description
Update Crystal language guide to go to [transferred repo](https://github.com/CircleCI-Public/circleci-demo-crystal/).

Relevant project [card](https://github.com/circleci/circleci-docs/projects/6#card-14181500).
