### PR TITLE
Link to gh-bb integration page from ssh keys page.

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -18,7 +18,7 @@ to add SSH keys to CircleCI:
 2. To enable running processes to access other services.
 
 If you are adding an SSH key for the first reason,
-refer to the [GitHub and Bitbucket Integration](https://circleci.com/docs/2.0/gh-bb-integration/#enable-your-project-to-check-out-additional-private-repositories) document.
+refer to the [GitHub and Bitbucket Integration]({{ site.baseurl }}/2.0/gh-bb-integration/#enable-your-project-to-check-out-additional-private-repositories) document.
 Otherwise,
 follow the steps below to add an SSH key to your project.
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -56,7 +56,10 @@ Integrated status also appears on the pull request screen, to show that all test
 
 ## Enable Your Project to Check Out Additional Private Repositories
 
-If your testing process refers to multiple repositories, CircleCI will need a GitHub user key in addition to the deploy key because each deploy key is valid for only _one_ repository while a GitHub user key has access to _all_ of your GitHub repositories.
+If your testing process refers to multiple repositories, CircleCI will need a
+GitHub user key in addition to the deploy key because each deploy key is valid
+for only _one_ repository while a GitHub user key has access to _all_ of your
+GitHub repositories. Refer to the [adding ssh keys]({{ site.baseurl }}/2.0/add-ssh-key) document to learn more.
 
 Provide CircleCI with a GitHub user key on your project's
 **Project Settings > Checkout SSH keys** page.


### PR DESCRIPTION
# Description
fixes #2807 

Note: The gh-bb-integration page was linking to the production url of the docs site so I swapped in the `site.baseurl` var. 