### PR TITLE
fix typo in writing yaml documentation

### DIFF
--- a/jekyll/_cci2/writing-yaml.md
+++ b/jekyll/_cci2/writing-yaml.md
@@ -159,7 +159,7 @@ harry_data:
 ```
 
 **Note**:
-As mentionned in [a YAML repository issue](https://github.com/yaml/yaml/issues/35), it is possible to merge maps, but not sequences (also called arrays or lists).
+As mentioned in [a YAML repository issue](https://github.com/yaml/yaml/issues/35), it is possible to merge maps, but not sequences (also called arrays or lists).
 
 For a more complex example,
 see [this gist](https://gist.github.com/bowsersenior/979804).


### PR DESCRIPTION
# Description
just fixing a typo in the docs about writing yaml

# Reasons
was just reading through and thought I'd leave it better than how I found it