### PR TITLE
fix typo in custom images documentation

### DIFF
--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -132,7 +132,7 @@ ADD ./db/migrations /migrations
 ### Adding an Entrypoint
 {:.no_toc}
 
-To run the container as an exectuable,
+To run the container as an executable,
 use the [`ENTRYPOINT` instruction](https://docs.docker.com/engine/reference/builder/#entrypoint).
 Since CircleCI does not preserve entrypoints by default,
 use the [`LABEL` instruction](https://docs.docker.com/engine/reference/builder/#label)


### PR DESCRIPTION
# Description
just fixing a typo in the custom images documentation

# Reasons
was just reading through and wanted to leave it better than I found it