### PR TITLE
Document disabling git's auto-gc in checkout step

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -656,6 +656,12 @@ In the case of `checkout`, the step type is just a string with no additional att
 - run: git submodule sync
 - run: git submodule update --init
 ```
+**Note:** The `checkout` step will configure Git to skip automatic garbage
+collection. If you are caching your `.git` directory with
+[restore_cache](#restore_cache) and would like to use garbage collection to
+reduce its size, you may wish to use a [run](#run) step with command `git gc`
+before doing so.
+
 ##### **`setup_remote_docker`**
 
 Creates a remote Docker environment configured to execute Docker commands. See [Running Docker Commands]({{ site.baseurl }}/2.0/building-docker-images/) for details.


### PR DESCRIPTION
We are disabling automatic garbage collection because it is unnecessary in most
cases and in some cases (when it runs in the background for performance reasons)
can cause a cached `.git` directory to be corrupted.