### PR TITLE
[CIRCLE-14271] update-algolia

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,11 @@ jobs:
           root: ~/circleci-docs/jekyll/_site
           paths:
             - docs
+      - run:
+          name: Update Algolia Index
+          command: |
+            ALGOLIA_API_KEY=$ALGOLIA_PRIVATE_KEY bundle exec jekyll algolia --source jekyll --config jekyll/_config.yml
+
   deploy:
     docker:
       - image: cibuilds/aws:1.15.73


### PR DESCRIPTION
Ticket: https://circleci.atlassian.net/browse/CIRCLE-14271

# Description
The prior implementation of automating algolia with the build process caused it to replace our existing index with a blank one. Upon SSHing into the build, we discovered this was due to not targeting the right subdirectory for indexing. 

To solve the problem, we specified the site source with `--source jekyll` so that it will index properly.