### PR TITLE
Fixed two typos in the Using-Orbs Example stanzas

### DIFF
--- a/jekyll/_cci2/using-orbs.md
+++ b/jekyll/_cci2/using-orbs.md
@@ -49,7 +49,7 @@ jobs
     docker:
       - image: "circleci/node:9.6.1"
     steps:
-      - hello/sayhello:
+      - myorb/sayhello:
           to: "Lev"
 ```
 

--- a/jekyll/_cci2/using-orbs.md
+++ b/jekyll/_cci2/using-orbs.md
@@ -22,7 +22,7 @@ To use an existing orb in your 2.1 [`.circleci/config.yml`]({{ site.baseurl }}/2
 version: 2.1
 
 orbs:
-    hello: circleci/hello-build@v0.0.5
+    hello: circleci/hello-build@0.0.5
 
 workflows:
     "Hello Workflow":
@@ -49,7 +49,7 @@ jobs
     docker:
       - image: "circleci/node:9.6.1"
     steps:
-      - sayhello:
+      - hello/sayhello:
           to: "Lev"
 ```
 


### PR DESCRIPTION
# Description
There are two typos in the Using Orbs example stanzas.  This PR addresses both

# Reasons
Item 1: A "v" was between the Orb name and version in "hello: circleci/hello-build@0.0.5"
Item 2: The "sayhello" command was missing the local namespace "hello/sayhello"