### PR TITLE
[CIRCLE-14872] Don’t assume search results have content or title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3353,6 +3353,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "dependencies": {
     "js-cookie": "^2.2.0",
-    "lodash.debounce": "^4.0.8"
+    "lodash.debounce": "^4.0.8",
+    "lodash.get": "^4.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",

--- a/src-js/instantsearch.js
+++ b/src-js/instantsearch.js
@@ -1,10 +1,13 @@
 import * as debounce from 'lodash.debounce';
+import * as get from 'lodash.get';
 
 const formatResultSnippet = (snippet) => {
-  const titleTag = `<strong>${snippet.title.value}</strong>`;
+  const title = get(snippet, ['title', 'value'], '(untitled)');
+  const content = get(snippet, ['content', 'value'], '');
+  const titleTag = `<strong>${title}</strong>`;
   const contextTag = snippet.headings ?
     `<p class="context">${snippet.headings.map(h => h.value).join(' > ')}</p>` : '';
-  const contentTag = `<p class="content">${snippet.content.value}</p>`;
+  const contentTag = `<p class="content">${content}</p>`;
   return `<div class="result-item-wrap">${titleTag + contextTag + contentTag}</div>`;
 }
 


### PR DESCRIPTION
JIRA ticket: [CIRCLE-14872](https://circleci.atlassian.net/browse/CIRCLE-14872)

# Overview
Looks like there are some items in our index that have no content. Our code for formatting the results is expecting some content to be there, and is throwing exceptions when it isn't, causing issues like the one described in this ticket.

# How to Test
Spin up the app (don't forget to run webpack :wink:). Search for "Language Guides". There should be no console errors, and you should see an entry with just the title called "Language Guides". Search for "Go cace" - your first result should be the go language guide.