### PR TITLE
Add note about OpenSSH key formats.

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -47,6 +47,7 @@ you are adding.
 **Note:**
 Since CircleCI cannot decrypt SSH keys,
 every new key must have an empty passphrase.
+CircleCI also will not accept OpenSSH's default file format - use `ssh-keygen -m pem` if you are using OpenSSH to generate your key.
 
 ## Advanced Usage
 


### PR DESCRIPTION
# Description
If you create an SSH key with OpenSSH's default options, it fails mysteriously upon being added to CircleCI - the "Add SSH Key" button briefly changes to say "Saving..." then changes again to say "Failed", which should probably be filed as a bug.

# Reasons
I'm hoping that a note here will save someone else the trouble of solving the error.