### PR TITLE
[CIRCLE-14895] Only reindex search on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,21 @@ jobs:
           root: ~/circleci-docs/jekyll/_site
           paths:
             - docs
+
+  reindex-search:
+    docker:
+      - image: circleci/ruby:2.5.1
+    working_directory: ~/circleci-docs
+    environment:
+      JEKYLL_ENV: production
+    steps:
+      - checkout
+      - *attach_workspace
+      - restore_cache:
+          key: circleci-docs-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Install Ruby dependencies
+          command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
       - run:
           name: Update Algolia Index
           command: |
@@ -122,7 +137,7 @@ jobs:
       - run:
           name: Deploy to S3 if tests pass and branch is Master
           command: aws s3 sync generated-site/docs s3://circle-production-static-site/docs/ --delete
-
+  
 workflows:
   version: 2
   build-deploy:
@@ -131,6 +146,9 @@ workflows:
       - build:
           requires:
             - js_build
+      - reindex-search:
+          requires:
+            - build
       - deploy:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,9 @@ workflows:
       - reindex-search:
           requires:
             - build
+          filters:
+            branches:
+              only: master
       - deploy:
           requires:
             - build

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -15,7 +15,7 @@ plugins:
 
 algolia:
   application_id: U0RXNGRK45
-  index_name: documentation-dev
+  index_name: documentation
   settings:
     highlightPreTag: '<strong>'
     highlightPostTag: '</strong>'

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -15,7 +15,7 @@ plugins:
 
 algolia:
   application_id: U0RXNGRK45
-  index_name: documentation
+  index_name: documentation-dev
   settings:
     highlightPreTag: '<strong>'
     highlightPostTag: '</strong>'


### PR DESCRIPTION
JIRA ticket: [CIRCLE-14895](https://circleci.atlassian.net/browse/CIRCLE-14895)

# Description
Only run the Algolia search re-indexing with changes to the master branch.

# Reasons
Re-indexing on PR branches is not only unnecessary, but potentially problematic - e.g. if two re-indexing operations were happening at the same time.

# How I Verified This is Working
- I created an empty test index on Algolia, "documentation-dev"
- I made the necessary changes to the CI workflows, set the Algolia index to the the test index, and left the re-indexing running on every branch so that I could test the new re-indexing job with the PR branch.
- As you can see [https://circleci.com/gh/circleci/circleci-docs/24525](here), the re-indexing worked. You can also see in Algolia that the test index matches the production index. This establishes that the work of extracting the re-indexing into its own job is functioning properly.
- I restored the site to use the production index, and changed the workflow set up so that re-indexing only occurs on master. As you can see [here](https://circleci.com/workflow-run/268b0eca-fcd7-4b7f-ac1e-be599dec00f1), re-indexing will not occur on PR branches with the current code.