### PR TITLE
Address "security vulnerabilities"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,14 @@ ruby '2.5.1'
 
 gem 'jekyll', "3.8.4"
 gem 'html-proofer', "3.9.1"
-gem 'jekyll-assets'
 gem 'jekyll-sitemap'
+
+gem 'jekyll-assets'
+# jekyll-assets depends on sprockets, which depends on rack, which has two
+# security vulnerabilities prior to 2.0.6.
+# https://nvd.nist.gov/vuln/detail/CVE-2018-16471
+# https://nvd.nist.gov/vuln/detail/CVE-2018-16470
+gem "rack", ">= 2.0.6"
 
 group :jekyll_plugins do
   gem 'jekyll-algolia', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       forwardable-extended (~> 2.6)
     progressbar (1.10.0)
     public_suffix (3.0.3)
-    rack (2.0.5)
+    rack (2.0.6)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -136,6 +136,7 @@ DEPENDENCIES
   jekyll-algolia (~> 1.0)
   jekyll-assets
   jekyll-sitemap
+  rack (>= 2.0.6)
 
 RUBY VERSION
    ruby 2.5.1p57


### PR DESCRIPTION
# Description
Use a later version of `rack`.

# Reasons
`jekyll-assets` depends on `sprockets`, which depends on `rack`, which has two security vulnerabilities prior to 2.0.6.

We don't really use Rack, at least not in production, but this will satisfy GitHub's security checker.