### PR TITLE
fix and update version number of hello-build orb

### DIFF
--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -19,7 +19,7 @@ This document describes how to get started with a basic build of your Linux, And
 version: 2.1
 
 orbs:
-    hello: circleci/hello-build@.0.0.5 # uses the circleci/buildpack-deps Docker image
+    hello: circleci/hello-build@0.0.7 # uses the circleci/buildpack-deps Docker image
 
 workflows:
     "Hello Workflow":


### PR DESCRIPTION
# Description
fix and update orb version number `.0.0.5` -> `0.0.7`

# Reasons
No dot(.) is required for the first part of version num.
