### PR TITLE
Start localizing into Japanese

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,9 @@ jobs:
             mkdir -p /tmp/workspace/js
             mv /tmp/workspace/js/ jekyll/assets/js/dist/
       - run:
+          name: Shim untranslated Japanese pages
+          command: ./scripts/shim-translation.sh jekyll/_cci2 jekyll/_cci2_ja
+      - run:
           name: Build the Jekyll site
           command: bundle exec jekyll build --config jekyll/_config.yml,jekyll/_config_production.yml --source jekyll --destination jekyll/_site/docs/ 2>&1 | tee $JOB_RESULTS_PATH/build-results.txt
       - run:

--- a/jekyll/_cci2/authentication.md
+++ b/jekyll/_cci2/authentication.md
@@ -1,10 +1,10 @@
 ---
- layout: classic-docs
- title: "Authentication"
- short-title: "Authentication"
- description: "Configuring LDAP Authentication"
- categories: [administration]
- order: 9
+layout: classic-docs
+title: "Authentication"
+short-title: "Authentication"
+description: "Configuring LDAP Authentication"
+categories: [administration]
+order: 9
 ---
 
 This document describes how to enable, configure, and test CircleCI to authenticate users with OpenLDAP or Active Directory credentials.

--- a/jekyll/_cci2_ja/index.md
+++ b/jekyll/_cci2_ja/index.md
@@ -1,0 +1,72 @@
+---
+untranslated: true
+layout: classic-docs
+title: "Welcome to CircleCI Documentation"
+description: "Welcome to CircleCI Documentation"
+permalink: /ja/2.0/
+---
+
+Use the tutorials, samples, how-to, and reference documentation to learn CircleCI.
+
+<hr>
+<div>
+<table>
+  <tr>
+    <th><h2>Get Started</h2></th>
+    <th><h2>Examples</h2></th>
+
+  </tr>
+  <tr>
+    <td>Get started with CircleCI automated builds.&nbsp;&nbsp;</td>
+    <td>Check out some of our popular examples.&nbsp;&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td><ul>
+		<li><a href="/docs/2.0/first-steps/">Sign Up & Try</a></li>
+		<li><a href="/docs/2.0/getting-started/">Your First Green Build</a></li>
+		<li><a href="/docs/2.0/hello-world/">Hello World</a></li>
+		<li><a href="/docs/2.0/faq/">FAQ</a></li>
+	        <li><a href="/docs/2.0/orb-intro/">Orbs</a></li>
+		</ul></td>
+    <td><ul><li><a href="/docs/2.0/example-configs/">Open Source Projects that use CircleCI</a></li>
+		<li><a href="/docs/2.0/postgres-config">Database Config Examples</a></li>
+		<li><a href="/docs/2.0/sample-config/">Sample config.yml Files</a></li>
+		<li><a href="/docs/2.0/tutorials/">Tutorials and Sample Apps</a></li>
+	        <li><a href="/docs/2.0/using-orbs/">Using Orbs</a></li>
+	        </ul></td>
+  </tr>
+</table>
+</div>
+
+<hr>
+
+<div>
+<table>
+  <tr>
+    <th><h2>Config</h2></th>
+    <th><h2>Workflows</h2></th>
+
+  </tr>
+  <tr>
+    <td>Set up and debug your build configuration.&nbsp;&nbsp;</td>
+    <td>CircleCI Workflows are used to schedule and sequence jobs.&nbsp;&nbsp;</td>
+  </tr>
+  <tr>
+    <td><ul>
+			<li><a href="{{ site.baseurl }}/ja/2.0/configuration-reference/">Configuration Reference</a></li>
+	                <li><a href="{{ site.baseurl }}/ja/2.0/writing-yaml/">Writing YAML</a></li>
+			<li><a href="{{ site.baseurl }}/ja/2.0/env-vars/">Using Environment Variables</a></li>
+			<li><a href="{{ site.baseurl }}/ja/2.0/ssh-access-jobs/">Debugging with SSH</a></li>
+	                <li><a href="/docs/2.0/reusing-config/">Reusing Config</a></li>
+		</ul></td>
+    <td><ul>
+			<li><a href="/docs/2.0/workflows/">Using Workflows to Schedule Jobs</a></li>
+			<li><a href="/docs/2.0/workflows/#workflows-configuration-examples">Example Workflow Configs</a></li>
+		<li><a href="/docs/2.0/workflows/#scheduling-a-workflow">Scheduling a Workflow</a></li>
+		<li><a href="/docs/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and Filtering in Your Workflows</a></li>
+	    <li><a href="/docs/2.0/creating-orbs/">Creating Orbs</a></li>
+	    </ul></td>
+  </tr>
+</table>
+</div>

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -29,7 +29,7 @@ algolia:
       'headings',
       'title'
     ]
-    
+
 sass:
   sass_dir: _sass
 
@@ -80,6 +80,13 @@ collections:
     permalink: /api/:path/
     prefix: "/api"
     selectorName: "API"
+  cci2_ja:
+    name: "2.0 Docs"
+    site_section: true
+    output: true
+    permalink: /ja/2.0/:path/
+    prefix: "/ja/2.0"
+    selectorName: "2.0"
 
 twitter_username: circleci
 github_username: circleci
@@ -88,9 +95,27 @@ defaults:
   -
     scope:
       path: ""
+      type: "cci2"
+    values:
+      lang: "en"
+
+  -
+    scope:
+      path: ""
+      type: "cci2_ja"
+    values:
+      lang: "ja"
+
+  -
+    scope:
+      path: ""
     values:
       hide: false
       search: true
+
+t:
+    translation_in_progress:
+        ja: "このページはただいま翻訳中です"
 
 segment: 'mAJ9W2SwLHgmJtFkpaXWCbwEeNk9D8CZ'
 

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -1,10 +1,11 @@
+en:
 - name: Welcome
-  link: 
+  link:
   icon: docs/welcome.svg
-  children: 
+  children:
     - name: Introduction
       link: 2.0/
-      children: 
+      children:
         - name: CI/CD Overview
           link: 2.0/about-circleci/
         - name: Supported Languages
@@ -12,10 +13,10 @@
 
 - name: Getting Started
   icon: docs/start.svg
-  children: 
+  children:
     - name: Introduction
       link: 2.0/getting-started/
-      children: 
+      children:
         - name: Sign Up & Try CircleCI
           link: 2.0/first-steps/
         - name: Hello World
@@ -24,7 +25,7 @@
           link: 2.0/faq/
     - name: Concepts
       link: 2.0/concepts/
-      children: 
+      children:
         - name: Projects and Builds
           link: 2.0/project-build/
         - name: Orbs, Jobs, Steps, and Workflows
@@ -35,7 +36,7 @@
           link: 2.0/security/
     - name: Migration
       link: 2.0/migration-intro/
-      children: 
+      children:
         - name: Tips for Migrating to 2.0
           link: 2.0/migration/
         - name: Migrating a Linux Project
@@ -49,10 +50,10 @@
 
 - name: Configuration
   icon: docs/config.svg
-  children: 
+  children:
     - name: Introduction
       link: 2.0/config-intro/
-      children: 
+      children:
         - name: Configuration Reference
           link: 2.0/configuration-reference/
         - name: Writing YAML
@@ -62,19 +63,19 @@
         - name: Testing Config Locally
           link: 2.0/examples/
     - name: Orbs
-      link: 2.0/orb-intro/    
+      link: 2.0/orb-intro/
       children:
         - name: Using Orbs
-          link: 2.0/using-orbs/     
+          link: 2.0/using-orbs/
         - name: Reusing Config
           link: 2.0/reusing-config/
         - name: Orbs FAQ
-          link: 2.0/orbs-faq/   
+          link: 2.0/orbs-faq/
         - name: Creating Orbs
-          link: 2.0/creating-orbs/           
+          link: 2.0/creating-orbs/
     - name: Examples
       link: 2.0/examples-intro/
-      children: 
+      children:
         - name: Sample config.yml Files
           link: 2.0/sample-config/
         - name: Tutorials
@@ -87,7 +88,7 @@
           link: 2.0/testing-ios/
     - name: EXECUTORS & IMAGES
       link: 2.0/executor-intro/
-      children: 
+      children:
         - name: Choosing an Executor Type
           link: 2.0/executor-types/
         - name: CircleCI Docker Images
@@ -98,7 +99,7 @@
           link: 2.0/private-images/
     - name: ADVANCED CONFIG
       link: 2.0/adv-config/
-      children: 
+      children:
         - name: Using Shell Scripts
           link: 2.0/using-shell-scripts/
         - name: Setting up Browser Testing
@@ -112,14 +113,14 @@
 
 - name: Projects
   icon: docs/project.svg
-  children: 
+  children:
     - name: settings
       link: 2.0/settings/
-      children: 
+      children:
         - name: GitHub and Bitbucket
           link: 2.0/gh-bb-integration/
-        - name: Enabling GitHub Checks  
-          link: 2.0/enable-checks/ 
+        - name: Enabling GitHub Checks
+          link: 2.0/enable-checks/
         - name: Building Open Source Projects
           link: 2.0/oss/
         - name: Using Notifications
@@ -131,22 +132,22 @@
         - name: Using Contexts
           link: 2.0/contexts/
         - name: Enabling Build Processing
-          link: 2.0/build-processing/  
+          link: 2.0/build-processing/
         - name: Setting Up iOS Code Signing
           link: 2.0/ios-codesigning/
     - name: Optimizations
       link: 2.0/optimizations/
-      children: 
+      children:
         - name: Caching Dependencies
           link: 2.0/caching/
         - name: Running Tests in Parallel
           link: 2.0/parallelism-faster-jobs/
         - name: Using Docker Layer Caching
           link: 2.0/docker-layer-caching/
-  
+
 - name: Jobs
   icon: docs/builds.svg
-  children: 
+  children:
     - name: Status
       link: 2.0/status/
       children:
@@ -163,23 +164,23 @@
         - name: Collecting Test Metadata
           link: 2.0/collect-test-data/
         - name: Using Insights
-          link: 2.0/insights/          
+          link: 2.0/insights/
     - name: Triggers
       link: 2.0/triggers/
-      children: 
+      children:
         - name: Skip and Cancel Builds
           link: 2.0/skip-build/
         - name: Using the API to Trigger Jobs
           link: 2.0/api-job-trigger/
         - name: Using Workflows to Schedule Jobs
-          link: 2.0/workflows/  
+          link: 2.0/workflows/
 
 - name: Deployment
   icon: docs/deploy.svg
-  children: 
+  children:
     - name: Configuring Deploys
       link: 2.0/deployment-integrations/
-      children: 
+      children:
         - name: Deploying to AWS ECR/ECS
           link: 2.0/ecs-ecr/
         - name: Using Yarn on CircleCI
@@ -193,7 +194,7 @@
 
 - name: Reference
   icon: docs/reference.svg
-  children: 
+  children:
     - children:
         - name: Configuration Reference
           link: 2.0/configuration-reference/
@@ -208,10 +209,10 @@
 
 - name: Administration
   icon: docs/admin.svg
-  children: 
+  children:
     - name: Overview
       link: 2.0/overview/
-      children: 
+      children:
         - name: Trial
           link: 2.0/single-box/
         - name: Faq
@@ -244,3 +245,356 @@
           link: 2.0/vm-service/
         - name: Acknowledgments
           link: 2.0/open-source/
+
+ja:
+- name: Welcome
+  i18n_name: ようこそ
+  link:
+  icon: docs/welcome.svg
+  children:
+    - name: Introduction
+      i18n_name: イントロダクション
+      link: ja/2.0/
+      children:
+        - name: CI/CD Overview
+          i18n_name: CI/CD概要
+          link: ja/2.0/about-circleci/
+        - name: Supported Languages
+          i18n_name: サポートされている言語
+          link: ja/2.0/demo-apps/
+
+- name: Getting Started
+  i18n_name: はじめよう
+  icon: docs/start.svg
+  children:
+    - name: Introduction
+      i18n_name: イントロダクション
+      link: ja/2.0/getting-started/
+      children:
+        - name: Sign Up & Try CircleCI
+          i18n_name: CircleCIを始める
+          link: ja/2.0/first-steps/
+        - name: Hello World
+          i18n_name: Hello World
+          link: ja/2.0/hello-world/
+        - name: FAQ
+          i18n_name: FAQ
+          link: ja/2.0/faq/
+    - name: Concepts
+      i18n_name: コンセプト
+      link: ja/2.0/concepts/
+      children:
+        - name: Projects and Builds
+          i18n_name: プロジェクトとビルド
+          link: ja/2.0/project-build/
+        - name: Orbs, Jobs, Steps, and Workflows
+          i18n_name: Orbs, ジョブ、ステップ、ワークフロー
+          link: ja/2.0/jobs-steps/
+        - name: Differences from Jenkins
+          i18n_name: Jenkinsとの違い
+          link: ja/2.0/migrating-from-jenkins/
+        - name: Security
+          i18n_name: セキュリティ
+          link: ja/2.0/security/
+    - name: Migration
+      i18n_name: マイグレーション
+      link: ja/2.0/migration-intro/
+      children:
+        - name: Tips for Migrating to 2.0
+          i18n_name: 2.0への移行のヒント
+          link: ja/2.0/migration/
+        - name: Migrating a Linux Project
+          i18n_name: Linuxプロジェクトの移行
+          link: ja/2.0/migrating-from-1-2/
+        - name: Migrating an iOS Project
+          i18n_name: iOSプロジェクトの移行
+          link: ja/2.0/ios-migrating-from-1-2/
+        - name: Using the config-translator
+          i18n_name: config-translatorを使う
+          link: ja/2.0/config-translation/
+
+- name: Configuration
+  i18n_name: 設定
+  icon: docs/config.svg
+  children:
+    - name: Introduction
+      i18n_name: イントロダクション
+      link: ja/2.0/config-intro/
+      children:
+        - name: Configuration Reference
+          i18n_name: 設定リファレンス
+          link: ja/2.0/configuration-reference/
+        - name: Writing YAML
+          i18n_name: YAMLを書く
+          link: ja/2.0/writing-yaml/
+        - name: Using the CircleCI CLI
+          i18n_name: CircleCI CLIを使う
+          link: ja/2.0/local-cli/
+        - name: Testing Config Locally
+          i18n_name: ローカルでコンフィグのテスト
+          link: ja/2.0/examples/
+    - name: Orbs
+      i18n_name: Orbs
+      link: ja/2.0/orb-intro/
+      children:
+        - name: Using Orbs
+          i18n_name: Orbsを使う
+          link: ja/2.0/using-orbs/
+        - name: Reusing Config
+          i18n_name: コンフィグの再利用
+          link: ja/2.0/reusing-config/
+        - name: Orbs FAQ
+          i18n_name: Orbs FAQ
+          link: ja/2.0/orbs-faq/
+        - name: Creating Orbs
+          i18n_name: Orbsを作る
+          link: ja/2.0/creating-orbs/
+    - name: Examples
+      i18n_name: サンプル
+      link: ja/2.0/examples-intro/
+      children:
+        - name: Sample config.yml Files
+          i18n_name: config.ymlの設定
+          link: ja/2.0/sample-config/
+        - name: Tutorials
+          i18n_name: チュートリアル
+          link: ja/2.0/tutorials/
+        - name: Database Config Examples
+          i18n_name: データベースの設定例
+          link: ja/2.0/postgres-config/
+        - name: Example Public Repos
+          i18n_name: パブリックなサンプルリポジトリ
+          link: ja/2.0/example-configs/
+        - name: Testing iOS Applications
+          i18n_name: iOSアプリをテストする
+          link: ja/2.0/testing-ios/
+    - name: EXECUTORS & IMAGES
+      i18n_name: Executorとイメージ
+      link: ja/2.0/executor-intro/
+      children:
+        - name: Choosing an Executor Type
+          i18n_name: Executorを選ぶ
+          link: ja/2.0/executor-types/
+        - name: CircleCI Docker Images
+          i18n_name: CircleCI Dockerイメージ
+          link: ja/2.0/circleci-images/
+        - name: Using Custom Images
+          i18n_name: カスタムイメージを使う
+          link: ja/2.0/custom-images/
+        - name: Using Private Images
+          i18n_name: プライベートイメージを使う
+          link: ja/2.0/private-images/
+    - name: ADVANCED CONFIG
+      i18n_name: 高度な設定
+      link: ja/2.0/adv-config/
+      children:
+        - name: Using Shell Scripts
+          i18n_name: シェルスクリプトを使う
+          link: ja/2.0/using-shell-scripts/
+        - name: Setting up Browser Testing
+          i18n_name: ブラウザテストのセットアップ
+          link: ja/2.0/browser-testing/
+        - name: Configuring Databases
+          i18n_name: データベースを設定する
+          link: ja/2.0/databases/
+        - name: Running Docker Commands
+          i18n_name: Dockerコマンドを実行
+          link: ja/2.0/building-docker-images/
+        - name: Using Docker Compose
+          i18n_name: Docker Composeを使う
+          link: ja/2.0/docker-compose/
+
+- name: Projects
+  i18n_name: プロジェクト
+  icon: docs/project.svg
+  children:
+    - name: settings
+      i18n_name: セッティング
+      link: ja/2.0/settings/
+      children:
+        - name: GitHub and Bitbucket
+          i18n_name: GitHubとBitbucket
+          link: ja/2.0/gh-bb-integration/
+        - name: Enabling GitHub Checks
+          i18n_name: GitHub Checksを有効化する
+          link: ja/2.0/enable-checks/
+        - name: Building Open Source Projects
+          i18n_name: オープンソースプロジェクトをビルド
+          link: ja/2.0/oss/
+        - name: Using Notifications
+          i18n_name: 通知を使う
+          link: ja/2.0/notifications/
+        - name: Managing API tokens
+          i18n_name: APIトークンの管理
+          link: ja/2.0/managing-api-tokens/
+        - name: Using Environment Variables
+          i18n_name: 環境変数を使う
+          link: ja/2.0/env-vars/
+        - name: Using Contexts
+          i18n_name: Contextsを使う
+          link: ja/2.0/contexts/
+        - name: Enabling Build Processing
+          i18n_name: Build Processingの有効化
+          link: ja/2.0/build-processing/
+        - name: Setting Up iOS Code Signing
+          i18n_name: iOSコードサインの設定
+          link: ja/2.0/ios-codesigning/
+    - name: Optimizations
+      i18n_name: 最適化
+      link: ja/2.0/optimizations/
+      children:
+        - name: Caching Dependencies
+          i18n_name: 依存関係のキャッシュ
+          link: ja/2.0/caching/
+        - name: Running Tests in Parallel
+          i18n_name: テストの並列実行
+          link: ja/2.0/parallelism-faster-jobs/
+        - name: Using Docker Layer Caching
+          i18n_name: Docker Layer Cachingを使う
+          link: ja/2.0/docker-layer-caching/
+
+- name: Jobs
+  i18n_name: ジョブ
+  icon: docs/builds.svg
+  children:
+    - name: Status
+      i18n_name: ステータス
+      link: ja/2.0/status/
+      children:
+        - name: Using Containers
+          i18n_name: コンテナを使う
+          link: ja/2.0/containers/
+        - name: Adding Status Badges
+          i18n_name: ステータスバッジを追加する
+          link: ja/2.0/status-badges/
+        - name: Storing Build Artifacts
+          i18n_name: ビルドアーティファクトの保存
+          link: ja/2.0/artifacts/
+        - name: Debugging with SSH
+          i18n_name: SSHデバッグ
+          link: ja/2.0/ssh-access-jobs/
+        - name: Debugging Java Memory Errors
+          i18n_name: Javaのメモリエラーのデバッグ
+          link: ja/2.0/java-oom/
+        - name: Collecting Test Metadata
+          i18n_name: テストメタデータの収集
+          link: ja/2.0/collect-test-data/
+        - name: Using Insights
+          i18n_name: Insightsを使う
+          link: ja/2.0/insights/
+    - name: Triggers
+      i18n_name: トリガー
+      link: ja/2.0/triggers/
+      children:
+        - name: Skip and Cancel Builds
+          i18n_name: ビルドのスキップとキャンセル
+          link: ja/2.0/skip-build/
+        - name: Using the API to Trigger Jobs
+          i18n_name: APIを使ってジョブをトリガーする
+          link: ja/2.0/api-job-trigger/
+        - name: Using Workflows to Schedule Jobs
+          i18n_name: ワークフローでジョブをスケジュールする
+          link: ja/2.0/workflows/
+
+- name: Deployment
+  i18n_name: デプロイメント
+  icon: docs/deploy.svg
+  children:
+    - name: Configuring Deploys
+      i18n_name: デプロイメントの設定
+      link: ja/2.0/deployment-integrations/
+      children:
+        - name: Deploying to AWS ECR/ECS
+          i18n_name: AWS ECR/ECSにデプロイする
+          link: ja/2.0/ecs-ecr/
+        - name: Using Yarn on CircleCI
+          i18n_name: YarnをCircleCIで使う
+          link: ja/2.0/yarn/
+        - name: Publishing Snap Packages
+          i18n_name: Snapのパッケージを公開する
+          link: ja/2.0/build-publish-snap-packages/
+        - name: Using Artifactory
+          i18n_name: Artifactoryを使う
+          link: ja/2.0/artifactory/
+        - name: Publishing Packages to packagecloud
+          i18n_name: Packagecloudに公開する
+          link: ja/2.0/packagecloud/
+
+- name: Reference
+  i18n_name: リファレンス
+  icon: docs/reference.svg
+  children:
+    - children:
+        - name: Configuration Reference
+          i18n_name: 設定リファレンス
+          link: ja/2.0/configuration-reference/
+        - name: API Reference
+          i18n_name: APIリファレンス
+          link: api/
+        - name: Prebuilt Images
+          i18n_name: CircleCI公式イメージ
+          link: ja/2.0/circleci-images/
+        - name: Glossary
+          i18n_name: 用語集
+          link: ja/2.0/glossary/
+        - name: Help and Support
+          i18n_name: ヘルプとサポート
+          link: ja/2.0/help-and-support/
+
+- name: Administration
+  i18n_name: アドミニストレーション
+  icon: docs/admin.svg
+  children:
+    - name: Overview
+      i18n_name: 概要
+      link: ja/2.0/overview/
+      children:
+        - name: Trial
+          i18n_name: トライアル
+          link: ja/2.0/single-box/
+        - name: Faq
+          i18n_name: FAQ
+          link: ja/2.0/admin-faq/
+        - name: Upgrade
+          i18n_name: アップグレード
+          link: ja/2.0/upgrading/
+        - name: Security
+          i18n_name: セキュリティ
+          link: ja/2.0/security/
+        - name: Certificates
+          i18n_name: 証明書
+          link: ja/2.0/certificates/
+        - name: Proxies
+          i18n_name: プロキシー
+          link: ja/2.0/proxy/
+        - name: Installation
+          i18n_name: インストーレーション
+          link: ja/2.0/aws/
+        - name: Authentication
+          i18n_name: 認証
+          link: ja/2.0/authentication/
+        - name: Monitoring
+          i18n_name: モニタリング
+          link: ja/2.0/monitoring/
+        - name: Configuring JVM Heap Size
+          i18n_name: JVMヒープサイズの調整
+          link: ja/2.0/jvm-heap-size-configuration/
+        - name: Nomad
+          i18n_name: Nomad
+          link: ja/2.0/nomad/
+        - name: Backup
+          i18n_name: バックアップ
+          link: ja/2.0/backup/
+        - name: Troubleshooting
+          i18n_name: トラブルシューティング
+          link: ja/2.0/troubleshooting/
+        - name: GPU Builders
+          i18n_name: GPUビルダー
+          link: ja/2.0/gpu/
+        - name: Configuring VM Service
+          i18n_name: VMサービスの設定
+          link: ja/2.0/vm-service/
+        - name: Acknowledgments
+          i18n_name: Acknowledgments
+          i18n_name:
+          link: ja/2.0/open-source/

--- a/jekyll/_includes/mobile-sidebar.html
+++ b/jekyll/_includes/mobile-sidebar.html
@@ -2,14 +2,21 @@
 <div class="sidebar-mobile-wrapper">
   <!-- DISPLAY ITEM /-->
   <div class="current-item">
-    {% assign items = site.data.sidenav %}
+    {% assign lang = page.lang %}
+    {% assign items = site.data.sidenav[lang] %}
     {% for item in items %}
       <div class="mobile-sidebar-item {% if forloop.index != 1 %} hidden {% endif %}" data-id="{{ item.name | slugify }}">
-        {% if item.icon %} 
-          {% asset '{{ item.icon }}' class=icon %} 
+        {% if item.icon %}
+          {% asset '{{ item.icon }}' class=icon %}
         {% endif %}
-        
-        <span class="nav-span"><strong>{{ item.name }}</strong></span>
+
+        {% if item.i18n_name %}
+          {% assign display_name = item.i18n_name %}
+        {% else %}
+          {% assign display_name = item.name %}
+        {% endif %}
+
+        <span class="nav-span"><strong>{{ display_name }}</strong></span>
 
         {% asset docs/arrow-right.svg class="arrow" %}
       </div>
@@ -19,38 +26,54 @@
   <!-- DROPDOWN /-->
   <div class="sidebar-mobile-dropdown">
     <nav class="mobile-sidebar hidden">
-      {% assign sidenav = site.data.sidenav %}
+      {% assign sidenav = site.data.sidenav[lang] %}
 
       {% for main-item in sidenav %}
         <ul>
           <li class="main-nav-item closed" data-section="{{ main-item.name | slugify }}">
             <div class="list-wrap">
-              {% if main-item.icon %} 
-                {% asset '{{ main-item.icon }}' class=icon %} 
+              {% if main-item.icon %}
+                {% asset '{{ main-item.icon }}' class=icon %}
               {% endif %}
-              
-              {% if main-item.link %}
-                <a class="{% if page.url == main-item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ main-item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ main-item.name}}</a>
+
+              {% if main-item.i18n_name %}
+                {% assign display_name = main-item.i18n_name %}
               {% else %}
-                <span class="nav-span">{{ main-item.name}}</span>
+                {% assign display_name = main-item.name %}
+              {% endif %}
+
+              {% if main-item.link %}
+                <a class="{% if page.url == main-item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ main-item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ display_name}}</a>
+              {% else %}
+                <span class="nav-span">{{ display_name}}</span>
               {% endif %}
 
               {% if main-item.children %}
                 {% asset docs/arrow-right.svg class=arrow %}
               {% endif %}
             </div>
-            
+
             {% if main-item.children %}
             <ul class="subnav">
               {% for item in main-item.children %}
                 {% if item.name %}
-                  <li class="nav-item"><a class="{% if page.url == item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ item.name }}</a></li>
+                  {% if item.i18n_name %}
+                    {% assign display_name = item.i18n_name %}
+                  {% else %}
+                    {% assign display_name = item.name %}
+                  {% endif %}
+                <li class="nav-item"><a class="{% if page.url == item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ display_name }}</a></li>
                 {% endif %}
 
                 {% if item.children %}
                   <ul>
                     {% for sub-item in item.children %}
-                      <li class="subnav-item"><a class="{% if page.url == sub-item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ sub-item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ sub-item.name }}</a></li>
+                      {% if sub-item.i18n_name %}
+                        {% assign display_name = sub-item.i18n_name %}
+                      {% else %}
+                        {% assign display_name = sub-item.name %}
+                      {% endif %}
+                      <li class="subnav-item"><a class="{% if page.url == sub-item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ sub-item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ display_name }}</a></li>
                     {% endfor %}
                   </ul>
                 {% endif %}

--- a/jekyll/_includes/sidebar.html
+++ b/jekyll/_includes/sidebar.html
@@ -1,39 +1,56 @@
 <!-- FULL SCREEN /-->
 <div class="sidebar-wrapper">
 	<nav class="sidebar fixed">
-		{% assign sidenav = site.data.sidenav %}
+		{% assign lang = page.lang %}
+		{% assign sidenav = site.data.sidenav[lang] %}
 		{% assign current_url = page.url | slice: 1, page.url.size %}
 
 		{% for main-item in sidenav %}
 			<ul>
 				<li class="main-nav-item closed" data-section="{{ main-item.name | slugify }}">
 					<div class="list-wrap">
-						{% if main-item.icon %} 
-							{% asset '{{ main-item.icon }}' class=icon %} 
+						{% if main-item.icon %}
+							{% asset '{{ main-item.icon }}' class=icon %}
 						{% endif %}
-						
+
+            {% if main-item.i18n_name %}
+              {% assign display_name = main-item.i18n_name %}
+            {% else %}
+              {% assign display_name = main-item.name %}
+            {% endif %}
+
 						{% if main-item.link %}
-							<a class="{% if current_url == main-item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ main-item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ main-item.name}}</a>
-						{% else %}
-							<span class="nav-span">{{ main-item.name}}</span>
+							<a class="{% if current_url == main-item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ main-item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ display_name}}</a>
+            {% else %}
+							<span class="nav-span">{{ display_name }}</span>
 						{% endif %}
 
 						{% if main-item.children %}
 							{% asset docs/arrow-right.svg class=arrow %}
 						{% endif %}
 					</div>
-					
+
 					{% if main-item.children %}
 					<ul class="subnav">
 						{% for item in main-item.children %}
 						  {% if item.name %}
-								<li class="nav-item"><a class="{% if current_url == item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ item.name }}</a></li>
+                {% if item.i18n_name %}
+                  {% assign display_name = item.i18n_name %}
+                {% else %}
+                  {% assign display_name = item.name %}
+                {% endif %}
+								<li class="nav-item"><a class="{% if current_url == item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ display_name }}</a></li>
 							{% endif %}
 
 							{% if item.children %}
 								<ul>
 									{% for sub-item in item.children %}
-										<li class="subnav-item"><a class="{% if current_url == sub-item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ sub-item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ sub-item.name }}</a></li>
+                    {% if sub-item.i18n_name %}
+                      {% assign display_name = sub-item.i18n_name %}
+                    {% else %}
+                      {% assign display_name = sub-item.name %}
+                    {% endif %}
+										<li class="subnav-item"><a class="{% if current_url == sub-item.link %} active {% endif %}" href="{{ site.baseurl }}/{{ sub-item.link }}#section={{ main-item.name | slugify }}" data-proofer-ignore>{{ display_name }}</a></li>
 									{% endfor %}
 								</ul>
 							{% endif %}

--- a/jekyll/_includes/translation_in_progress.html
+++ b/jekyll/_includes/translation_in_progress.html
@@ -1,0 +1,3 @@
+<div class="alert alert-info" role="alert">
+    <strong> {{site.t['translation_in_progress'][page.lang]}}</strong><br>
+</div>

--- a/jekyll/_layouts/cci2.html
+++ b/jekyll/_layouts/cci2.html
@@ -3,4 +3,3 @@ layout: classic-docs
 section: cci2
 ---
 {{content}}
-

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -27,6 +27,9 @@
 			{% if page.page-type == "index" %}<h2>{{ page.title }}</h2>{% endif %}
 			<article>
 				{% if page.page-type != "index" and page.page-type != "homepage" %}<h1>{{ page.title }}</h1>{% endif %}
+        {% if page.untranslated %}
+          {% include translation_in_progress.html %}
+        {% endif %}
 				{{ content }}
 				{% if page.collection != 'cci1' and page.page-type != "index" and page.layout == "classic-docs" or page.layout == "enterprise" %}
 					{% include doc-footer.html %}

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -1,4 +1,3 @@
-<!-- Don't forget to also update per-language index.html e.g. /ja/index.html -->
 ---
 layout: classic-docs
 page-type: homepage

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -4,6 +4,7 @@ page-type: homepage
 title: Welcome to CircleCI Documentation
 lang: en
 ---
+<!-- Don't forget to also update per-language index.html e.g. /ja/index.html -->
 
 <h1>Welcome to CircleCI Documentation</h1>
 

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -1,3 +1,4 @@
+<!-- Don't forget to also update per-language index.html e.g. /ja/index.html -->
 ---
 layout: classic-docs
 page-type: homepage

--- a/jekyll/ja/index.html
+++ b/jekyll/ja/index.html
@@ -1,62 +1,62 @@
 ---
 layout: classic-docs
 page-type: homepage
-title: Welcome to CircleCI Documentation
+title: CircleCIのドキュメントへようこそ
 lang: ja
 ---
 
-<h1>Welcome to CircleCI Documentation</h1>
+<h1>CircleCIのドキュメントへようこそ</h1>
 
-Use the tutorials, samples, how-to, and reference documentation to learn CircleCI.
+ここに掲載されているチュートリアル、サンプル、how-to、そしてリファレンスからCircleCIについて学ぶことができます。
 
 <hr class="hidden-xs" />
 
 <div class="row">
   <div class="col-xs-12 col-sm-6">
-    <h2>Get Started</h2>
-    <p>Get started with CircleCI automated builds.</p>
+    <h2>はじめよう</h2>
+    <p>自動化ビルドをCircleCIではじめよう</p>
     <ul>
-      <li><a href="/docs/2.0/first-steps/">Sign Up & Try</a></li>
-      <li><a href="/docs/2.0/getting-started/">Your First Green Build</a></li>
-      <li><a href="/docs/2.0/hello-world/">Hello World</a></li>
-      <li><a href="/docs/2.0/faq/">FAQ</a></li>
-      <li><a href="/docs/2.0/orb-intro/">Orbs</a></li>
+      <li><a href="/docs/ja/2.0/first-steps/">サインアップしてはじめる</a></li>
+      <li><a href="/docs/ja/2.0/getting-started/">最初の成功ビルド</a></li>
+      <li><a href="/docs/ja/2.0/hello-world/">Hello World</a></li>
+      <li><a href="/docs/ja/2.0/faq/">FAQ</a></li>
+      <li><a href="/docs/ja/2.0/orb-intro/">Orbs</a></li>
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">
-    <h2>Examples</h2>
-    <p>Check out some of our popular examples.</p>
+    <h2>サンプル集</h2>
+    <p>人気のあるサンプルの一覧</p>
     <ul>
-      <li><a href="/docs/2.0/example-configs/">Open Source Projects that use CircleCI</a></li>
-        <li><a href="/docs/2.0/postgres-config/">Database Config Examples</a></li>
-        <li><a href="/docs/2.0/sample-config/">Sample config.yml Files</a></li>
-        <li><a href="/docs/2.0/tutorials/">Tutorials and Sample Apps</a></li>
-        <li><a href="/docs/2.0/using-orbs/">Using Orbs</a></li>
+      <li><a href="/docs/ja/2.0/example-configs/">CircleCIを使っているオープンソースのプロジェクト</a></li>
+        <li><a href="/docs/ja/2.0/postgres-config/">データベース設定のサンプル</a></li>
+        <li><a href="/docs/ja/2.0/sample-config/">config.ymlのサンプル</a></li>
+        <li><a href="/docs/ja/2.0/tutorials/">チュートリアルとサンプル・アプリケーション</a></li>
+        <li><a href="/docs/ja/2.0/using-orbs/">Orbsを使う</a></li>
       </ul>
   </div>
   <div class="col-xs-12">
     <hr />
   </div>
   <div class="col-xs-12 col-sm-6">
-    <h2>Config</h2>
-    <p>Set up and debug your build configuration.</p>
+    <h2>コンフィグ</h2>
+    <p>ビルドの設定とデバッグ</p>
     <ul>
-      <li><a href="{{ site.baseurl }}/2.0/configuration-reference/">Configuration Reference</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/writing-yaml/">Writing YAML</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/env-vars/">Using Environment Variables</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/ssh-access-jobs/">Debugging with SSH</a></li>
-      <li><a href="/docs/2.0/reusing-config/">Reusing Config</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/configuration-reference/">設定リファレンス</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/writing-yaml/">YAMLを書く</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/env-vars/">環境変数を使う</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/ssh-access-jobs/">SSHデバッグ</a></li>
+      <li><a href="/docs/ja/2.0/reusing-config/">コンフィグの再利用</a></li>
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">
-    <h2>Workflows</h2>
-    <p>CircleCI Workflows are used to schedule and sequence jobs.</p>
+    <h2>ワークフロー</h2>
+    <p>ジョブのスケジューリングとシーケンシャルな実行</p>
     <ul>
-      <li><a href="/docs/2.0/workflows/">Using Workflows to Schedule Jobs</a></li>
-      <li><a href="/docs/2.0/workflows/#workflows-configuration-examples">Example Configs</a></li>
-      <li><a href="/docs/2.0/workflows/#scheduling-a-workflow">Scheduling a Workflow</a></li>
-      <li><a href="/docs/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and Filtering in Your Workflows</a></li>
-      <li><a href="/docs/2.0/creating-orbs/">Creating Orbs</a></li>
+      <li><a href="/docs/ja/2.0/workflows/">ワークフローでジョブをスケジューリングする</a></li>
+      <li><a href="/docs/ja/2.0/workflows/#workflows-configuration-examples">コンフィグの例</a></li>
+      <li><a href="/docs/ja/2.0/workflows/#scheduling-a-workflow">ワークフローのスケジューリング</a></li>
+      <li><a href="/docs/ja/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Contexts とフィルタリングを使う</a></li>
+      <li><a href="/docs/ja/2.0/creating-orbs/">Orbsを作成する</a></li>
     </ul>
   </div>
 </div>

--- a/jekyll/ja/index.html
+++ b/jekyll/ja/index.html
@@ -2,7 +2,7 @@
 layout: classic-docs
 page-type: homepage
 title: Welcome to CircleCI Documentation
-lang: en
+lang: ja
 ---
 
 <h1>Welcome to CircleCI Documentation</h1>

--- a/scripts/shim-translation.sh
+++ b/scripts/shim-translation.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script will copy pages that exists in English but missing in foreign languages (e.g. Japanese)
+# 'Missing' in this case means the pages are not translated yet, so we want to copy from English pages.
+SOURCE_DIR=$1
+DEST_DIR=$2
+
+for file in $(diff -qr $SOURCE_DIR/ $DEST_DIR | grep "Only in $SOURCE_DIR" | awk '{print $4}'); do
+  cp $SOURCE_DIR/$file $DEST_DIR/$file
+  sed -i -e '2s/^/untranslated: true\n/g' $DEST_DIR/$file
+  sed -i -e 's|{{ site.baseurl }}/2.0/|{{ site.baseurl }}/ja/2.0/|g' $DEST_DIR/$file
+done

--- a/scripts/shim-translation.sh
+++ b/scripts/shim-translation.sh
@@ -8,5 +8,5 @@ for file in $(diff -qr $SOURCE_DIR/ $DEST_DIR | grep "Only in $SOURCE_DIR" | awk
   cp $SOURCE_DIR/$file $DEST_DIR/$file
   # '$done ||=' is for only matching the first occurance of '---'
   perl -i -pe '$done ||= s/^---/---\nuntranslated: true/' $DEST_DIR/$file
-  perl -i -pe 's/{{ site.baseurl }}\/2.0/{{ site.baseurl }}\/ja\/2.0/' $DEST_DIR/$file
+  perl -i -pe 's/\{\{ site.baseurl \}\}\/2.0/{{ site.baseurl }}\/ja\/2.0/' $DEST_DIR/$file
 done

--- a/scripts/shim-translation.sh
+++ b/scripts/shim-translation.sh
@@ -6,6 +6,6 @@ DEST_DIR=$2
 
 for file in $(diff -qr $SOURCE_DIR/ $DEST_DIR | grep "Only in $SOURCE_DIR" | awk '{print $4}'); do
   cp $SOURCE_DIR/$file $DEST_DIR/$file
-  sed -i -e '2s/^/untranslated: true\n/g' $DEST_DIR/$file
-  sed -i -e 's|{{ site.baseurl }}/2.0/|{{ site.baseurl }}/ja/2.0/|g' $DEST_DIR/$file
+  perl -i -pe '$done ||= s/^---/---\nuntranslated: true/' $DEST_DIR/$file
+  perl -i -pe 's/{{ site.baseurl }}\/2.0/{{ site.baseurl }}\/ja\/2.0/' $DEST_DIR/$file
 done

--- a/scripts/shim-translation.sh
+++ b/scripts/shim-translation.sh
@@ -6,6 +6,7 @@ DEST_DIR=$2
 
 for file in $(diff -qr $SOURCE_DIR/ $DEST_DIR | grep "Only in $SOURCE_DIR" | awk '{print $4}'); do
   cp $SOURCE_DIR/$file $DEST_DIR/$file
+  # '$done ||=' is for only matching the first occurance of '---'
   perl -i -pe '$done ||= s/^---/---\nuntranslated: true/' $DEST_DIR/$file
   perl -i -pe 's/{{ site.baseurl }}\/2.0/{{ site.baseurl }}\/ja\/2.0/' $DEST_DIR/$file
 done


### PR DESCRIPTION
Adding Japanese translation

This change is the base for localizing docs into Japanese.

Here are a few design considerations:

- All translated pages live under https://circleci.com/docs/ja
- Duplication must be avoided as much as possible
- English and Japanese versions can be maintained separately

A few notes about implementation

- We create a new collection `cci2_ja` that lives under `/ja/2.0`
- We add `lang:` metadata to specify language with default set in config.yml so that we don't need to add the metadata manually for all pages.
- We run `shim-translation.sh` only in CI. This allows us to keep untranslated pages for Japanese while avoiding having two same pages.
