### PR TITLE
Cleanup: Remove redundant link

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -587,8 +587,6 @@ Go to Settings > Branches in GitHub and click the Edit button on the protected b
 
 - For demonstration apps configured with Workflows, see the [CircleCI Demo Workflows](https://github.com/CircleCI-Public/circleci-demo-workflows) on GitHub.
 
-- For troubleshooting a workflow with Waiting for Status in GitHub, see [Workflows Waiting for Status in GitHub]({{ site.baseurl }}/2.0/workflows-waiting-status).
-
 ## Video: Configure Multiple Jobs with Workflows
 {:.no_toc}
 


### PR DESCRIPTION

# Description

This link is covered with https://circleci.com/docs/2.0/workflows/#workflows-waiting-for-status-in-github and the entire `https://circleci.com/docs/2.0/workflows-waiting-status/` page can probably be removed and redirected back to the above anchor.

# Reasons

Removal of duplicated information.