### PR TITLE
Fix command in google-auth.md

### DIFF
--- a/jekyll/_cci2/google-auth.md
+++ b/jekyll/_cci2/google-auth.md
@@ -111,7 +111,7 @@ jobs:
       - image: google/cloud-sdk
     steps:
       - run: |
-          echo $GCLOUD_SERVICE_KEY | base64 --decode | sudo gcloud auth activate-service-account --key-file=-
+          echo $GCLOUD_SERVICE_KEY | sudo gcloud auth activate-service-account --key-file=-
           sudo gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
           sudo gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 ```


### PR DESCRIPTION
We don't have to decode $GCLOUD_SERVICE_KEY because it already raw JSON.

# Description
Before #2195 $GCLOUD_SERVICE_KEY was encoded in base64. Now it's not.

# Reasons
Current command with `base64 --decode` fails with error `invalid input`.