### PR TITLE
Fix: inline orb example missing `orb` stanza.

### DIFF
--- a/jekyll/_cci2/creating-orbs.md
+++ b/jekyll/_cci2/creating-orbs.md
@@ -108,8 +108,9 @@ To write inline orbs, you need to place the orb elements under that orb's key in
 description: # The purpose of this orb
 
 orbs:
-  codecov: circleci/codecov-clojure@0.0.4
   my-orb:
+    orbs:
+      codecov: circleci/codecov-clojure@0.0.4
     executors:
       specialthingsexecutor:
         docker:


### PR DESCRIPTION
# Description
[relevant discussion](https://discuss.circleci.com/t/unable-to-find-orb-with-inline-orb/27145)