### PR TITLE
Added link to machine executor docs

### DIFF
--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -64,7 +64,7 @@ See the [Example docker-compose Project](https://github.com/circleci/cci-demo-do
 
 ## Using Docker Compose with Machine Executor
 
-If you want to use docker compose to manage a multi-container setup with a docker-compose file, use the `machine` key in your `config.yml` file and use docker-compose as you would normally. That is, if you have a docker-compose file that shares local directories with a container, this will work as expected. Refer to Docker's documentation of [Your first docker-compose.yml file](https://docs.docker.com/get-started/part3/#your-first-docker-composeyml-file) for details. **Note: There is an overhead for provisioning a machine executor as a result of spinning up a private Docker server. Use of the `machine` key may require additional fees in a future pricing update.**
+If you want to use docker compose to manage a multi-container setup with a docker-compose file, use the `machine` key in your `config.yml` file and use docker-compose as you would normally (see machine executor documentation [here](https://circleci.com/docs/2.0/executor-types/#using-machine) for more details). That is, if you have a docker-compose file that shares local directories with a container, this will work as expected. Refer to Docker's documentation of [Your first docker-compose.yml file](https://docs.docker.com/get-started/part3/#your-first-docker-composeyml-file) for details. **Note: There is an overhead for provisioning a machine executor as a result of spinning up a private Docker server. Use of the `machine` key may require additional fees in a future pricing update.**
 
 
 ## Using Docker Compose with Docker Executor


### PR DESCRIPTION
# Description
The section describing the usage of machine executor was not clear enough, I added a link to the documentation to help others better understand how to enable this feature.
