### PR TITLE
Update configuration-reference.md

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -36,7 +36,7 @@ The `version` field is intended to be used in order to issue warnings for deprec
 
 Key | Required | Type | Description
 ----|-----------|------|------------
-orbs | N | Map | A map of user-selected names to either: orb references (strings) or orb definitions (maps). Orb definitions must be the orb-relevant subset of 2.1 config. See the [Creating Orbs]({{ site.baseurl }}/2.0/creating-orbs/) documentation for details.
+orbs | N | Map | A map of user-selected names to either: orb references (strings) or orb definitions (maps). See the [Creating Orbs]({{ site.baseurl }}/2.0/creating-orbs/) documentation for details.
 executors | N | Map | A map of strings to executor definitions. See the Executors Syntax section below.
 commands | N | Map | A map of command names to command definitions. See the Commands Syntax section below.
 {: class="table table-striped"}
@@ -52,6 +52,7 @@ workflows:
         jobs:
           - hello/hello-build
 ```
+In the above example, `hello` is considered the orbs reference; whereas `circleci/hello-build@0.0.5` is the fully-qualified orb reference.
 
 ## **`commands`** (requires version: 2.1)
 


### PR DESCRIPTION
Added note in Orbs section to better define what an orb reference & fully qualified orb reference is. This is based on customer feedback.

# Description
We received a comment from a customer who was did not understand what an "orb reference" was, so content was added to better define what an "orb reference" and "fully qualified orb reference" means in the context of orbs.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.