### PR TITLE
Fix invalid branch filter in full config example

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1224,11 +1224,6 @@ jobs:
 
     working_directory: ~/my-project
 
-    branches:
-      ignore:
-        - develop
-        - /feature-.*/
-
     steps:
       - checkout
 
@@ -1298,7 +1293,12 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore:
+                - develop
+                - /feature-.*/
       - deploy-stage:
           requires:
             - build


### PR DESCRIPTION
# Description
Move branch filter to workflow since it's invalid to filter at job level (per [Configuring CircleCI - branches](https://circleci.com/docs/2.0/configuration-reference/#branches)):
> If you are using Workflows, job-level branches will be ignored and must be configured in the Workflows section of your config.yml file

# Reasons
Previously validation of example config failed with:
```
$ circleci config validate
Error: Job "build" has filters configured in the job definition. These filters are incompatible with workflows.
```