### PR TITLE
Clarify docker compose exists on machine

### DIFF
--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -12,7 +12,7 @@ This document describes how to install and use `docker-compose`.
 * TOC 
 {:toc}
 
-The `docker-compose` utility is [pre-installed in the CircleCI convenience images][pre-installed]. If you're using another image, you can install it into your [primary container][primary-container] during the job execution with the Remote Docker Environment activated by adding the following to your [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file:
+The `docker-compose` utility is [pre-installed in the CircleCI convenience images][pre-installed] and machine executors. If you're using another image, you can install it into your [primary container][primary-container] during the job execution with the Remote Docker Environment activated by adding the following to your [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file:
 
 ``` 
 - run:


### PR DESCRIPTION
Customer thought they had to install it since docs only said it was on our images.

# Description
Specify docker compose is on machine too.

# Reasons
Customer was avoiding machine because they thought they would have to waste time installing compose every run.