### PR TITLE
Use name of timezone, not path

### DIFF
--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -155,10 +155,10 @@ jobs:
       - image: your/primary-image:version-tag
       - image: mysql:5.7
         environment:
-           TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+           TZ: "America/Los_Angeles"
     working_directory: ~/your-dir
     environment:
-      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+      TZ: "America/Los_Angeles"
 ```
 
 In this example, the timezone is set for both the primary image and an additional mySQL image.

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -152,7 +152,7 @@ To increase the speed of your software development through faster feedback, shor
 
 ```yaml
     environment:
-      TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+      TZ: "America/Los_Angeles"
 ```
 
 - If your configuration modifies $PATH, add the path to your `.bashrc` file and replace 

--- a/jekyll/_cci2/migration.md
+++ b/jekyll/_cci2/migration.md
@@ -37,7 +37,7 @@ When starting to migrate to CircleCI 2.0 you don't have to migrate everything ri
 - Conditionally halt the build at that step with `circleci-agent step halt`
 	- Allows you to use `setup_remote_docker` conditionally by halting
 - The Timezone can be changed just by defining an environment variable
-	- `TZ: /usr/share/zoneinfo/America/New_York`
+	- `TZ: America/New_York`
 - Running the build out of `/dev/shm` (for example, `/dev/shm/project`) can speed up certain projects
 	- Some things like Ruby gems can't be loaded out of shared memory. They can be installed elsewhere in the system (for example, `~/vendor`) and symlinked in.
 - Instead of prefixing a lot of commands with sudo, consider setting the shell to sudo for that `run`


### PR DESCRIPTION
This is what I have inferred from debugging:
Path values are invalid and ignored.
The default is GMT, not UTC.

replace /usr/share/zoneinfo/America/ America/ -- jekyll/_cci2/*.md

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.