### PR TITLE
Update nokogiri to address security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem 'jekyll-assets'
 # https://nvd.nist.gov/vuln/detail/CVE-2018-16470
 gem "rack", ">= 2.0.6"
 
+# https://nvd.nist.gov/vuln/detail/CVE-2018-14404
+gem "nokogiri", ">= 1.8.5"
+
 group :jekyll_plugins do
   gem 'jekyll-algolia', '~> 1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     mercenary (0.3.6)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     pathutil (0.16.1)
@@ -136,6 +136,7 @@ DEPENDENCIES
   jekyll-algolia (~> 1.0)
   jekyll-assets
   jekyll-sitemap
+  nokogiri (>= 1.8.5)
   rack (>= 2.0.6)
 
 RUBY VERSION


### PR DESCRIPTION
# Description
GitHub is warning us about a vulnerability in the nokogiri gem version 1.8.4; this upgrades it to 1.8.5 to address the issue.

# How to Test
Verify that you can still build the site with jekyll.