### PR TITLE
Suggested changes on the Migration introduction

### DIFF
--- a/jekyll/_cci2/migration-intro.md
+++ b/jekyll/_cci2/migration-intro.md
@@ -10,6 +10,9 @@ order: 1
 
 Get started by reviewing tips and tricks for migration, learning about the config-translator, and getting specific tutorials for your platform.
 
+> [Migrating from Travis CI]({{ site.baseurl }}/docs/2.0/migrating-from-travis/)
+> [Migrating from Jenkins]({{ site.baseurl }}/docs/2.0/migrating-from-jenkins/#section=getting-started)
+
 <hr>
 
 Config Intro | Scripts

--- a/jekyll/_cci2/migration-intro.md
+++ b/jekyll/_cci2/migration-intro.md
@@ -10,8 +10,8 @@ order: 1
 
 Get started by reviewing tips and tricks for migration, learning about the config-translator, and getting specific tutorials for your platform.
 
-> [Migrating from Travis CI]({{ site.baseurl }}/docs/2.0/migrating-from-travis/)
-> [Migrating from Jenkins]({{ site.baseurl }}/docs/2.0/migrating-from-jenkins/#section=getting-started)
+- [Migrating from Travis CI]({{ site.baseurl }}/2.0/migrating-from-travis/)
+- [Migrating from Jenkins]({{ site.baseurl }}/2.0/migrating-from-jenkins/#section=getting-started)
 
 <hr>
 

--- a/jekyll/_cci2/migration-intro.md
+++ b/jekyll/_cci2/migration-intro.md
@@ -11,7 +11,7 @@ order: 1
 Get started by reviewing tips and tricks for migration, learning about the config-translator, and getting specific tutorials for your platform.
 
 - [Migrating from Travis CI]({{ site.baseurl }}/2.0/migrating-from-travis/)
-- [Migrating from Jenkins]({{ site.baseurl }}/2.0/migrating-from-jenkins/#section=getting-started)
+- [Migrating from Jenkins]({{ site.baseurl }}/2.0/migrating-from-jenkins/)
 
 <hr>
 


### PR DESCRIPTION
Added links to the top section for Travis CI and Jenkins migration pages.

# Description
Added links to children pages for Jenkins and Travis CI.

# Reasons
We are linking from the home page to our migration material. Want to ensure we surface our most popular migration pages.