### PR TITLE
Removed `sudo` from command

### DIFF
--- a/jekyll/_cci2/google-auth.md
+++ b/jekyll/_cci2/google-auth.md
@@ -111,7 +111,7 @@ jobs:
       - image: google/cloud-sdk
     steps:
       - run: |
-          echo $GCLOUD_SERVICE_KEY | sudo gcloud auth activate-service-account --key-file=-
+          echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
           gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 ```


### PR DESCRIPTION
# Description

Having `sudo` in command was failing the build.

# Reasons

With `sudo`, the build fails with the message "command not found".