### PR TITLE
Should be "persist_to_workspace"

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -79,7 +79,7 @@ CircleCI has several built-in commands available to all [circleci.com](http://ci
 
   * `checkout`
   * `setup_remote_docker`
-  * `save_to_workspace`
+  * `persist_to_workspace`
 
 **Note:** It is possible to override the built-in commands with a custom command.
 


### PR DESCRIPTION
# Description
Typo: Change reference to `save_to_workspace` to `persist_to_workspace`

# Reasons

`save_to_workspace` is not a valid command according to [this](https://circleci.com/docs/2.0/configuration-reference/)- I think it should be `persist_to_workspace`
