### PR TITLE
Fix "Personal API Token tab" link in Creating Orbs document

### DIFF
--- a/jekyll/_cci2/creating-orbs.md
+++ b/jekyll/_cci2/creating-orbs.md
@@ -499,7 +499,7 @@ circleci update install
 
 Now that you have installed the CircleCI CLI, you will want to configure the CLI for use. The process for configuring the CLI is simple and straightforward, requiring you only to follow a few steps.
 
-Before you can configure the CLI, you may need to first generate a CircleCI API token from the [Personal API Token tab](https://circleci.com/accounts/api):
+Before you can configure the CLI, you may need to first generate a CircleCI API token from the [Personal API Token tab](https://circleci.com/account/api):
 
 ```
 $ circleci setup


### PR DESCRIPTION
# Description
I updated the "Personal API Token tab" link from https://circleci.com/accounts/api to https://circleci.com/account/api

# Reasons
The former links to a blank page, and the latter seems to be the correct link.