### PR TITLE
Remove comment about Daemon

### DIFF
--- a/jekyll/_cci2/nomad-metrics.md
+++ b/jekyll/_cci2/nomad-metrics.md
@@ -161,8 +161,6 @@ echo "--------------------------------------"
 docker pull $CONTAINER_IMAGE
 docker rm -f $CONTAINER_NAME || true
 
-# Not using --detach so that upstart can perform log management and process
-# monitoring
 docker run -d --name $CONTAINER_NAME \
     --rm \
     --net=host \


### PR DESCRIPTION
# Description
I mistakenly left a comment in not running nomad-metrics in daemon mode.  This is something that we do in our own fleet but the customer doesn't need to do.

# Reasons
https://circleci.zendesk.com/agent/tickets/45273