### PR TITLE
Don't escape YAML strings unnecessarily

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -608,13 +608,13 @@ jobs: # conditional steps may also be defined in `commands:`
     parameters:
       custom_checkout:
         type: string
-        default: \"\"
+        default: ""
     machine: true
     steps:
       - when:
           condition: <<parameters.custom_checkout>>
           steps:
-            - run: echo \"my custom checkout\"
+            - run: echo "my custom checkout"
       - unless:
           condition: <<parameters.custom_checkout>>
           steps:
@@ -623,7 +623,7 @@ workflows:
   build-test-deploy:
     jobs:
       - job_with_optional_custom_checkout:
-          custom_checkout: \"any non-empty string is truthy\"
+          custom_checkout: "any non-empty string is truthy"
       - job_with_optional_custom_checkout
 ```
 


### PR DESCRIPTION
Our docs were wrong here: the YAML we provide as an example makes the default
the literal string `\"\"`, *not* an empty string. See https://discuss.circleci.com/t/problem-with-when-condition-and-empty-string/28375