### PR TITLE
Clarify the behaviour of the relative paths.

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -887,8 +887,8 @@ For example, the following step syntax persists the specified paths from `/tmp/d
 After this step completes, the following directories are added to the workspace:
 
 ```
-foo/bar
-baz
+/tmp/dir/foo/bar
+/tmp/dir/baz
 ```
 
 ###### _Example for paths Key_


### PR DESCRIPTION
# Description
Show the absolute paths of the directories which are persisted, rather than the relative paths from `/tmp/dir`.

# Reasons
It's a trivial change that better demonstrates how to use the feature.