### PR TITLE
Fix broken markdown on a link

### DIFF
--- a/jekyll/_cci2/testing-orbs.md
+++ b/jekyll/_cci2/testing-orbs.md
@@ -171,7 +171,7 @@ There are several different approaches you can use to test your orbs (for exampl
 
 One of the easiest ways to test your orbs locally is to create an inline orb. Creating an inline orb enables you to test your orb while in active development. Inline orbs can be useful when developing your orb, or as a convenience for name-spacing jobs and commands in lengthy configurations.
 
-For more detailed information on how to create an inline orb, refer to the [Creating Orbs]({{site.baseurl}}/creating-orbs/#creating-inline-orbs) page in the CircleCI technical documentation.
+For more detailed information on how to create an inline orb, refer to the [Creating Orbs]({{site.baseurl}}/2.0/creating-orbs/#creating-inline-orbs) page in the CircleCI technical documentation.
 
 ### Testing Orbs Automatically
 

--- a/jekyll/_cci2/testing-orbs.md
+++ b/jekyll/_cci2/testing-orbs.md
@@ -171,7 +171,7 @@ There are several different approaches you can use to test your orbs (for exampl
 
 One of the easiest ways to test your orbs locally is to create an inline orb. Creating an inline orb enables you to test your orb while in active development. Inline orbs can be useful when developing your orb, or as a convenience for name-spacing jobs and commands in lengthy configurations.
 
-For more detailed information on how to create an inline orb, refer to the [Creating Orbs](({{site.baseurl}}/creating-orbs/#creating-inline-orbs) page in the CircleCI technical documentation.
+For more detailed information on how to create an inline orb, refer to the [Creating Orbs]({{site.baseurl}}/creating-orbs/#creating-inline-orbs) page in the CircleCI technical documentation.
 
 ### Testing Orbs Automatically
 


### PR DESCRIPTION
# Description
It's just a broken link here: https://circleci.com/docs/2.0/testing-orbs/#testing-orbs-locally

# Reasons
`[](()` -> `[]()`, and it was also missing the `/2.0/` part.