### PR TITLE
Tweak A Document About The API Endpoint To Delete SSH Key

### DIFF
--- a/jekyll/_api/index.html
+++ b/jekyll/_api/index.html
@@ -1308,7 +1308,7 @@ Learn how to set up your 2.0 builds to <a href="https://circleci.com/docs/2.0/co
 <p>Deletes an SSH key from the system.</p>
 <h3 id='method-26'>Method</h3>
 <p>DELETE</p>
-<h3 id='example-call-26'>Example Call</h3><pre class="highlight plaintext"><code>curl -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fingerprint", "hostname":"Hostname"}
+<h3 id='example-call-26'>Example Call</h3><pre class="highlight plaintext"><code>curl -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fingerprint", "hostname":"Hostname"} https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key?circle-token=:token
 </code></pre><h3 id='example-response-26'>Example Response</h3>
 <p>no response expected</p>
 <h2 id='heroku-keys'>Heroku Keys</h2>

--- a/jekyll/_api/index.html
+++ b/jekyll/_api/index.html
@@ -504,6 +504,10 @@ the colon ":" tells curl that there's no password.
 <td>DELETE: /project/:vcs-type/:username/:project/build-cache</td>
 <td>Clears the cache for a project.</td>
 </tr>
+<tr>
+<td>DELETE: /project/:vcs-type/:username/:project/ssh-key</td>
+<td>Delete the SSH key from a project.</td>
+</tr>
 </tbody></table>
 <h2 id='user'>User</h2>
 <p>Provides information about the user that is currently signed in.</p>


### PR DESCRIPTION
# Description

Added some information about the endpoint to delete SSH key.

# Reasons

* The endpoint is not listed in the summary of endpoints
* The example command lacks URL