### PR TITLE
Synchronize Clojure sample config and walkthrough

### DIFF
--- a/jekyll/_cci2/language-clojure.md
+++ b/jekyll/_cci2/language-clojure.md
@@ -127,7 +127,6 @@ Finally we store the uberjar as an [artifact](https://circleci.com/docs/1.0/buil
       - save_cache:
           paths:
             - ~/.m2
-            - ~/.lein
           key: cci-demo-clojure-{{ checksum "project.clj" }}
       - run: lein do test, uberjar
       - store_artifacts:


### PR DESCRIPTION
# Description
Removed a `~/.lein` cache that was shown in the Clojure config walkthrough, but [removed from the sample config mid-June 2017](https://github.com/circleci/circleci-docs/commit/ed3bd149d182b72355e5901a60dc131b56281135#diff-3d61f9f0003cbef5fb7993bb9fdca4c8).

# Reasons
Noticed the inconsistency, and assumed the sample config was the source of truth. Happy to sync the other way if desired :)