### PR TITLE
Fix Maven/Gradle test metadata setup

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -114,13 +114,13 @@ project.
       - run:
           name: Save test results
           command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
           when: always
       - store_test_results:
-          path: ~/junit
+          path: ~/test-results
       - store_artifacts:
-          path: ~/junit         
+          path: ~/test-results/junit         
 ```
 
 #### <a name="gradle-junit-results"></a>Gradle JUnit Test Results
@@ -136,13 +136,13 @@ project.
       - run:
           name: Save test results
           command: |
-            mkdir -p ~/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
           when: always
       - store_test_results:
-          path: ~/junit
+          path: ~/test-results
       - store_artifacts:
-          path: ~/junit         
+          path: ~/test-results/junit         
 ```
 
 #### <a name="mochajs"></a>Mocha for Node.js


### PR DESCRIPTION
# Description
The test metadata setup for Maven/Gradle is non-optimal, producing the "n tests in unknown" [error](https://support.circleci.com/hc/en-us/articles/115015920668-Why-does-test-summary-show-tests-in-unknown).

# Reasons
As per [these docs](https://circleci.com/docs/2.0/configuration-reference/#store_test_results), the test metadata must be written to a subdirectory of the directory that is uploaded. It looks like the config is wrong for other build systems, but I've only fixed the Java ones.
