### PR TITLE
Fix broken link

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -25,7 +25,7 @@ jobs:
       - setup_remote_docker
 ```
 
-When `setup_remote_docker` executes, a remote environment will be created, and your current [primary container][primary-container] will be configured to use it. Then, any docker-related commands you use will be safely executed in this new environment.
+When `setup_remote_docker` executes, a remote environment will be created, and your current [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) will be configured to use it. Then, any docker-related commands you use will be safely executed in this new environment.
 
 **Note:** The use of the `setup_remote_docker` key is reserved for configs in
 which your primary executor _is_ a docker container. If your executor is


### PR DESCRIPTION
# Description

Fix broken link

# Reasons

Instead of a link, `[primary container][primary-container]` is displayed on https://circleci.com/docs/2.0/building-docker-images/