### PR TITLE
Update version of Ruby and Jekyll used.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/ruby:2.5.1
+      - image: circleci/ruby:2.6.1
     working_directory: ~/circleci-docs
     environment:
       JEKYLL_ENV: production
@@ -114,7 +114,7 @@ jobs:
 
   reindex-search:
     docker:
-      - image: circleci/ruby:2.5.1
+      - image: circleci/ruby:2.6.1
     working_directory: ~/circleci-docs
     environment:
       JEKYLL_ENV: production

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-ruby '2.5.1'
+ruby '2.6.1'
 
-gem 'jekyll', "3.8.4"
-gem 'html-proofer', "3.9.1"
+gem 'jekyll', "3.8.5"
+gem 'html-proofer'
 gem 'jekyll-sitemap'
 
 gem 'jekyll-assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     algolia_html_extractor (2.6.1)
       json (~> 2.0)
@@ -16,7 +16,7 @@ GEM
       json (>= 1.5.1)
     colorator (1.1.0)
     colorize (0.8.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -27,7 +27,7 @@ GEM
     extras (0.3.0)
       forwardable-extended (~> 2.5)
     fastimage (2.1.4)
-    ffi (1.9.25)
+    ffi (1.10.0)
     filesize (0.2.0)
     forwardable-extended (2.6.0)
     html-proofer (3.9.1)
@@ -43,7 +43,7 @@ GEM
     httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.4)
+    jekyll (3.8.5)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -82,7 +82,7 @@ GEM
       sass (~> 3.4)
     jekyll-sitemap (1.2.0)
       jekyll (~> 3.3)
-    jekyll-watch (2.1.1)
+    jekyll-watch (2.1.2)
       listen (~> 3.0)
     json (2.1.0)
     kramdown (1.17.0)
@@ -100,18 +100,18 @@ GEM
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
-    pathutil (0.16.1)
+    pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     progressbar (1.10.0)
     public_suffix (3.0.3)
     rack (2.0.6)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
     rouge (3.3.0)
     ruby_dep (1.5.0)
-    safe_yaml (1.0.4)
-    sass (3.6.0)
+    safe_yaml (1.0.5)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -131,8 +131,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer (= 3.9.1)
-  jekyll (= 3.8.4)
+  html-proofer
+  jekyll (= 3.8.5)
   jekyll-algolia (~> 1.0)
   jekyll-assets
   jekyll-sitemap
@@ -140,7 +140,7 @@ DEPENDENCIES
   rack (>= 2.0.6)
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.6.1p33
 
 BUNDLED WITH
-   1.16.3
+   1.17.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   jekyll:
     command: jekyll serve --incremental --livereload
-    image: jekyll/jekyll:3.8.3
+    image: jekyll/jekyll:3.8.5
     volumes:
       - "./jekyll:/srv/jekyll"
     ports:


### PR DESCRIPTION
A regular maintenance PR.

This updates the version of Ruby used to v2.6.1. This also updated Jekyll to v3.8.5.