### PR TITLE
Tell CircleCI to do a nightly build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,3 +161,18 @@ workflows:
           filters:
             branches:
               only: master
+  nightly-build:
+    triggers:
+      - schedule:
+          cron: "0 8 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - js_build
+      - build:
+          requires:
+            - js_build
+      - deploy:
+          requires:
+            - build


### PR DESCRIPTION
This PR sets up a scheduled workflow on CircleCI. It will cause this repo to build every night at 8am UTC.

This allows for dynamic content in Docs such as the Docker Tags JSON file to be rebuild and kept fresh even if Docs doesn't get a normal push/merge to master that day.

The time is 8am UTC because that is very early morning for both Eastern and Pacific Timezones as well as many hours after the nightly build for CircleCI Images (allowing that repo time to build).

Inspired to do this via this GitHub comment: https://github.com/circleci/circleci-images/issues/343#issuecomment-473717797