### PR TITLE
Explain what `FL_OUTPUT_DIR:` does.

### DIFF
--- a/jekyll/_cci2/ios-codesigning.md
+++ b/jekyll/_cci2/ios-codesigning.md
@@ -253,6 +253,8 @@ workflows:
             - build-and-test
 ```
 
+By setting the `FL_OUTPUT_DIR:` env, that will tell Fastlane to output the XCode and Fastlane logs to that directory, so they get uploaded as artifacts for ease in troubleshooting.
+
 ## Example Application on GitHub
 
 See the [`circleci-demo-ios` GitHub repository](https://github.com/CircleCI-Public/circleci-demo-ios)


### PR DESCRIPTION


# Description
We tell customers to set the `FL_OUTPUT_DIR:` env in their config. This explains why and what it does.

# Reasons
We tell customers to set the `FL_OUTPUT_DIR:` env in their config. This explains why and what it does.