### PR TITLE
Updating Travis Migration Docs

### DIFF
--- a/jekyll/_cci2/migrating-from-travis.md
+++ b/jekyll/_cci2/migrating-from-travis.md
@@ -47,7 +47,7 @@ root of your repository.
 | deploy:           | [deploy:](https://circleci.com/docs/2.0/configuration-reference/#deploy)                     | Use the deploy: step to deploy build artifacts                                                    |
 | env:              | [environment:](https://circleci.com/docs/2.0/configuration-reference/#environment)                | Use the environment: element to specify environment variables                                     |
 | matrix:           | [workflows:](https://circleci.com/docs/2.0/configuration-reference/#workflows)                  | Workflows are used on CircleCI to orchestrate multiple jobs                                       |
-| stage:            | [requires:](https://circleci.com/docs/2.0/configuration-reference/#requires)                   | Use the requires: element to explicitly require any job dependencies and control parallel builds. |
+| stage:            | [requires:](https://circleci.com/docs/2.0/configuration-reference/#requires)                   | Use the requires: element to explicitly require any job dependencies and control parallel builds. |{: class="table table-striped"}
 
 ### On Using Containers
 

--- a/jekyll/_cci2/migrating-from-travis.md
+++ b/jekyll/_cci2/migrating-from-travis.md
@@ -33,6 +33,31 @@ configuration will live in a `.travis.yml` file in the root of your repository.
 With CircleCI, your configuration will live in `.circleci/config.yml` at the
 root of your repository.
 
+| Travis CI         | Circle CI                   | Description                                                                                       |
+|-------------------|-----------------------------|---------------------------------------------------------------------------------------------------|
+| language:         | [docker.image](https://circleci.com/docs/2.0/configuration-reference/#docker)                | Use the Docker executor to specify an appropriate Docker image for the target language            |
+| dist:             | [docker, machine, macos](https://circleci.com/docs/2.0/executor-types/)      | If your build must run in a fully virtualized environment, or on a macOS builder                  |
+| cache components: | [restore_cache:,](https://circleci.com/docs/2.0/configuration-reference/#restore_cache) [save_cache:](https://circleci.com/docs/2.0/configuration-reference/#restore_cache) | Use the restore and save cache features to control caching in the builds                          |
+| before_cache      | [restore_cache:,](https://circleci.com/docs/2.0/configuration-reference/#restore_cache) [save_cache:](https://circleci.com/docs/2.0/configuration-reference/#restore_cache) | Use the restore and save cache features to control caching in the builds                          |
+| before_install:   | [run:](https://circleci.com/docs/2.0/configuration-reference/#run)                        | Use the run: step to specify pre install commands                                                 |
+| install:          | [run:](https://circleci.com/docs/2.0/configuration-reference/#run)                        | Use the run: step to specify install commands                                                     |
+| before_script     | [run:](https://circleci.com/docs/2.0/configuration-reference/#run)                        | Use the run: step to specify pre-execution commands                                               |
+| script:           | [run:](https://circleci.com/docs/2.0/configuration-reference/#run)                        | Use the run: step to specify execution commands                                                   |
+| after_script:     | [run:](https://circleci.com/docs/2.0/configuration-reference/#run)                        | Use the run: step to specify post-execution commands                                              |
+| deploy:           | [deploy:](https://circleci.com/docs/2.0/configuration-reference/#deploy)                     | Use the deploy: step to deploy build artifacts                                                    |
+| env:              | [environment:](https://circleci.com/docs/2.0/configuration-reference/#environment)                | Use the environment: element to specify environment variables                                     |
+| matrix:           | [workflows:](https://circleci.com/docs/2.0/configuration-reference/#workflows)                  | Workflows are used on CircleCI to orchestrate multiple jobs                                       |
+| stage:            | [requires:](https://circleci.com/docs/2.0/configuration-reference/#requires)                   | Use the requires: element to explicitly require any job dependencies and control parallel builds. |
+
+### On Using Containers
+
+With CircleCI, the context in which your checked out code executes (builds,
+tests, etc) is known as an [Executor]({{ site.baseurl }}/2.0/executor-intro/). 
+
+If you're coming from Travis CI, using Docker will be the closest means to running
+a build based on a language. While you can use any custom Docker Images, CircleCI maintains several [Docker Images]({{ site.baseurl
+}}/2.0/circleci-images/) tailored for common `.config` scenarios.
+
 ## Building on Pushing Code
 
 The example repository linked above is a basic application for creating, reading, updating, and deleting articles. The
@@ -114,15 +139,6 @@ caching](https://docs.travis-ci.com/user/caching/) occurs in your build after th
 `script` phase and is tied to the language you are using. In our
 case, by using the `cache: npm` key in `.travis.yml`, dependencies will default
 to caching `node_modules`.
-
-### On Using Containers
-
-With CircleCI, the context in which your checked out code executes (builds,
-tests, etc) is known as an [Executor]({{ site.baseurl }}/2.0/executor-intro/). 
-
-If you're coming from TravisCI, using Docker will be the closest means to running
-a build based on a language. While you can use any custom Docker Images, CircleCI maintains several [Docker Images]({{ site.baseurl
-}}/2.0/circleci-images/) tailored for common `.config` scenarios.
 
 ## Environment Variables
 


### PR DESCRIPTION
# Description
I moved the "On Using Containers" section to be higher up, so it's one of the first things customers moving over from Travis and checking our docs see- since all Travis builds are based on specifying a language and CircleCI builds are done in docker containers, and that's information customers need before they can really take any other steps forward, I think having it earlier up in the table of contents makes sense. I've also included a table translating terms from Travis's yml configuration into the equivalent CircleCI terms with links to the relevant sections for quick reference.

# Reasons
I'm making these changes to help make it easier for Travis users to migrate to CircleCI.