### PR TITLE
Fix curl call syntax for api triggers

### DIFF
--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -25,7 +25,7 @@ how to trigger the `deploy_docker` job
 by using `curl`.
 
 ```bash
-curl -u ${CIRCLE_API_USER_TOKEN} \
+curl -u ${CIRCLE_API_USER_TOKEN}: \
      -d build_parameters[CIRCLE_JOB]=deploy_docker \
      https://circleci.com/api/v1.1/project/<vcs-type>/<org>/<repo>/tree/<branch>
 ```
@@ -80,7 +80,7 @@ jobs:
           command: |
             # replace this with your build/deploy check (i.e. current branch is "release")
             if [[ true ]]; then
-              curl --user ${CIRCLE_API_USER_TOKEN} \
+              curl --user ${CIRCLE_API_USER_TOKEN}: \
                 --data build_parameters[CIRCLE_JOB]=deploy_docker \
                 --data revision=$CIRCLE_SHA1 \
                 https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH


### PR DESCRIPTION
# Description
There is a mismatch in examples to call api triggers.
https://circleci.com/docs/2.0/api-job-trigger/#overview
```
curl -u ${CIRCLE_API_USER_TOKEN} \
     -d build_parameters[CIRCLE_JOB]=deploy_docker \
     https://circleci.com/api/v1.1/project/<vcs-type>/<org>/<repo>/tree/<branch>
```

In this case, Curl will ask for the user password https://ec.haxx.se/http-auth.html
Another doc page represents the right syntax: `curl -u ${CIRCLE_API_USER_TOKEN}: \`
https://circleci.com/docs/2.0/triggers/

CIRCLE_API_USER_TOKEN variable should end in a colon which means a blank password.

# Reasons
Current the description causes not working code.
```
Enter host password for user '--data':
curl: (3) [globbing] bad range in column 18
{
  "message" : "Project not found"
}
```