### PR TITLE
add instructions to glob golang packages

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -227,3 +227,7 @@ suite. These applications are not developed or supported by CircleCI. Please che
   a helper CLI tool that queries `phpunit.xml` files to get a list of test
   filenames and print them. This is useful if you want to split tests to run
   them in parallel based on timings on CI tools.
+- **[go list](https://golang.org/cmd/go/#hdr-List_packages_or_modules)** - Use the built-in Go command `go list ./...` to glob Golang packages. This allows splitting package tests across multiple containers.
+    ```
+    go test -v $(go list ./... | circleci tests split)
+    ```


### PR DESCRIPTION
# Description
add instructions to glob golang packages in parallel containers

# Reasons
no golang instructions included