### PR TITLE
Adding a workaround of "OUT OF MEMORY" for Haskell

### DIFF
--- a/jekyll/_cci2/language-haskell.md
+++ b/jekyll/_cci2/language-haskell.md
@@ -159,7 +159,7 @@ Excellent! You are now setup on CircleCI with a Haskell app.
 
 ## Common Trouble Shooting
 
-The command `stack test` may fail with an out of memory error. Consider adding the `-j1` flag to the stack test command 
+The command `stack test` may fail with an out of memory error. Consider adding the `-j1` flag to the `stack test` command 
 as seen below (Note: this will reduce test execution to one core, decreasing memory usage as well, but may also increase your test execution time).
 
 ```yaml

--- a/jekyll/_cci2/language-haskell.md
+++ b/jekyll/_cci2/language-haskell.md
@@ -159,9 +159,8 @@ Excellent! You are now setup on CircleCI with a Haskell app.
 
 ## Common Trouble Shooting
 
-If you see `stack test` fails due to `Process exited with code: ExitFailure (-9) (THIS MAY INDICATE OUT OF MEMORY)`, consider adding `-j1` option like the following. This will avoid the build 
-using multiple cores hence reduce its memory usage, while it may lead a longer
-test time.  
+The command `stack test` may fail with an out of memory error. Consider adding the `-j1` flag to the stack test command 
+as seen below (Note: this will reduce test execution to one core, decreasing memory usage as well, but may also increase your test execution time).
 
 ```yaml
       - run:

--- a/jekyll/_cci2/language-haskell.md
+++ b/jekyll/_cci2/language-haskell.md
@@ -159,7 +159,7 @@ Excellent! You are now setup on CircleCI with a Haskell app.
 
 ## Common Trouble Shooting
 
-If you see `stack test` fails due to `Process exited with code: ExitFailure (-9) (THIS MAY INDICATE OUT OF MEMORY)`, add `-j1` option like the following. This will avoid the build 
+If you see `stack test` fails due to `Process exited with code: ExitFailure (-9) (THIS MAY INDICATE OUT OF MEMORY)`, consider adding `-j1` option like the following. This will avoid the build 
 using multiple cores hence reduce its memory usage, while it may lead a longer
 test time.  
 

--- a/jekyll/_cci2/language-haskell.md
+++ b/jekyll/_cci2/language-haskell.md
@@ -157,6 +157,18 @@ Finally, we can take the built executable and store it as an artifact.
 
 Excellent! You are now setup on CircleCI with a Haskell app.
 
+## Common Trouble Shooting
+
+If you see `stack test` fails due to `Process exited with code: ExitFailure (-9) (THIS MAY INDICATE OUT OF MEMORY)`, add `-j1` option like the following. This will avoid the build 
+using multiple cores hence reduce its memory usage, while it may lead a longer
+test time.  
+
+```yaml
+      - run:
+          name: Run tests
+          command: stack test -j1
+```
+
 ## See Also
 {:.no_toc}
 


### PR DESCRIPTION
# Description
Adding a workaround of "OUT OF MEMORY" for Haskell.

# Reasons
I believe this is a common issue and worthwhile noting here.
