### PR TITLE
Adds `type` to list of `job` fields.

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1051,7 +1051,7 @@ ignore | N | String, or List of Strings | Either a single branch specifier, or a
 {: class="table table-striped"}
 
 #### **`jobs`**
-A job can have the keys `requires`, `filters`, and `context`.
+A job can have the keys `requires`, `context`, `type`, and `filters`.
 
 Key | Required | Type | Description
 ----|-----------|------|------------


### PR DESCRIPTION
# Description
A sentence in the docs was missing a field name.

# Reasons
I was thrown off by this briefly when skimming the [docs](https://circleci.com/docs/2.0/configuration-reference/#jobs-1).