### PR TITLE
Prevent line wraps when using base64 encoding

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -291,7 +291,7 @@ If you are having difficulty adding a multiline environment variable,
 use `base64` to encode it.
 
 ```bash
-$ echo "foobar" | base64
+$ echo "foobar" | base64 --wrap=0
 Zm9vYmFyCg==
 ```
 


### PR DESCRIPTION
# Description

This avoids line wraps in base64-encoded environment variables.

# Reasons

Line wraps in base64-encoded variables seem to cause problems when decoding in build steps.
