### PR TITLE
Added trx2junit for Visual Studio / .NET Core Tests

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -74,6 +74,7 @@ This section provides the following test runner examples:
 * [pytest]( {{ site.baseurl }}/2.0/collect-test-data/#pytest)
 * [RSpec]( {{ site.baseurl }}/2.0/collect-test-data/#rspec)
 * [test2junit]( {{ site.baseurl }}/2.0/collect-test-data/#test2junit-for-clojure-tests)
+* [trx2junit]( {{ site.baseurl }}/2.0/collect-test-data/#trx2junit-for-vs-tests)
 * [Karma]( {{ site.baseurl }}/2.0/collect-test-data/#karma)
 * [Jest]( {{ site.baseurl }}/2.0/collect-test-data/#jest)
 
@@ -413,6 +414,30 @@ See the [minitest-ci README](https://github.com/circleci/minitest-ci#readme) for
 #### test2junit for Clojure Tests
 {:.no_toc}
 Use [test2junit](https://github.com/ruedigergad/test2junit) to convert Clojure test output to XML format. For more details, refer to the [sample project](https://github.com/kimh/circleci-build-recipies/tree/clojure-test-metadata-with-test2junit).
+
+#### trx2junit for Visual Studio / .NET Core Tests
+{:.no_toc}
+Use [trx2junit](https://github.com/gfoidl/trx2junit) to convert Visual Studio / .NET Core trx output to XML format. 
+
+A working `.circleci/config.yml` section might look like this:
+
+```yaml
+    steps:
+      - checkout
+      - run: dotnet build
+      - run: dotnet test --no-build --logger "trx"
+      - run:
+          name: test results
+          command: |
+              dotnet tool install -g trx2junit
+              export PATH="$PATH:/root/.dotnet/tools"
+              trx2junit tests/**/TestResults/*.trx
+      - store_test_results:
+          path: tests/TestResults
+      - store_artifacts:
+          path: tests/TestResults
+          destination: TestResults
+```
 
 #### Karma
 {:.no_toc}

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -74,7 +74,7 @@ This section provides the following test runner examples:
 * [pytest]( {{ site.baseurl }}/2.0/collect-test-data/#pytest)
 * [RSpec]( {{ site.baseurl }}/2.0/collect-test-data/#rspec)
 * [test2junit]( {{ site.baseurl }}/2.0/collect-test-data/#test2junit-for-clojure-tests)
-* [trx2junit]( {{ site.baseurl }}/2.0/collect-test-data/#trx2junit-for-vs-tests)
+* [trx2junit]( {{ site.baseurl }}/2.0/collect-test-data/#trx2junit-for-visual-studio--net-core-tests)
 * [Karma]( {{ site.baseurl }}/2.0/collect-test-data/#karma)
 * [Jest]( {{ site.baseurl }}/2.0/collect-test-data/#jest)
 


### PR DESCRIPTION
# Description

Added [trx2junit](https://github.com/gfoidl/trx2junit) for Visual Studio / .NET Core Tests conversion to JUnit XML.

# Reasons

`dotnet test` doesn't have a logger for JUnit XML, so some kind of post-processing must be applied to show test summary in CircleCI. This PR adds such a tool to the documentation.

Disclaimer: I'm the author of that tool.