### PR TITLE
Added new partners for Wave 5-CryptoMove, Probely

### DIFF
--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -63,7 +63,7 @@ Partner Orb Registry Link | Orb Reference String
 [Anchore](https://circleci.com/orbs/registry/orb/anchore/anchore-engine) | `anchore: anchore/anchore-engine@1.0.0`
 [Aqua Security](https://circleci.com/orbs/registry/orb/aquasecurity/microscanner) | `aqua: aquasecurity/microscanner@0.0.1`
 [Codecov](https://circleci.com/orbs/registry/orb/codecov/codecov) | `codecov: codecov/codecov@1.0.1`
-[CryptoMove](https://circleci.com/orbs/registry/orb/cryptomove/tholos) | 'cryptomove: cryptomove/tholos@0.0.11`
+[CryptoMove](https://circleci.com/orbs/registry/orb/cryptomove/tholos) | `cryptomove: cryptomove/tholos@0.0.11`
 [Cypress-io](https://circleci.com/orbs/registry/orb/cypress-io/cypress) | `cypress-io: cypress-io/cypress@1.0.0`
 [Datree](https://circleci.com/orbs/registry/orb/datree/version-alignment-rule) | `datree: datree/version-alignment-rule@1.0.0`
 [DeployHub](https://circleci.com/orbs/registry/orb/deployhub/deployhub-orb) | `deployhub: deployhub/deployhub-orb@1.2.0`
@@ -74,7 +74,7 @@ Partner Orb Registry Link | Orb Reference String
 [Packagecloud](https://circleci.com/orbs/registry/orb/packagecloud/packagecloud) | `packagecloud: packagecloud/packagecloud@0.1.0`
 [Percy](https://circleci.com/orbs/registry/orb/percy/agent) | `percy: percy/agent@0.1.2`
 [Postman](https://circleci.com/orbs/registry/orb/postman/newman) | `postman: postman/newman@0.0.1`
-[Probely](https://circleci.com/orbs/registry/orb/probely/security-scan) | 'probely: probely/security-scan@1.0.0`
+[Probely](https://circleci.com/orbs/registry/orb/probely/security-scan) | `probely: probely/security-scan@1.0.0`
 [Pulumi](https://circleci.com/orbs/registry/orb/pulumi/pulumi) | `pulumi: pulumi/pulumi@1.0.0`
 [Rocro](https://circleci.com/orbs/registry/orb/rocro/inspecode) | `rocro: rocro/inspecode@1.0.0`
 [Rollbar](https://circleci.com/orbs/registry/orb/rollbar/deploy) | `rollbar: rollbar/deploy@1.0.0`

--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -63,6 +63,7 @@ Partner Orb Registry Link | Orb Reference String
 [Anchore](https://circleci.com/orbs/registry/orb/anchore/anchore-engine) | `anchore: anchore/anchore-engine@1.0.0`
 [Aqua Security](https://circleci.com/orbs/registry/orb/aquasecurity/microscanner) | `aqua: aquasecurity/microscanner@0.0.1`
 [Codecov](https://circleci.com/orbs/registry/orb/codecov/codecov) | `codecov: codecov/codecov@1.0.1`
+[CryptoMove](https://circleci.com/orbs/registry/orb/cryptomove/tholos) | 'cryptomove: cryptomove/tholos@0.0.11`
 [Cypress-io](https://circleci.com/orbs/registry/orb/cypress-io/cypress) | `cypress-io: cypress-io/cypress@1.0.0`
 [Datree](https://circleci.com/orbs/registry/orb/datree/version-alignment-rule) | `datree: datree/version-alignment-rule@1.0.0`
 [DeployHub](https://circleci.com/orbs/registry/orb/deployhub/deployhub-orb) | `deployhub: deployhub/deployhub-orb@1.2.0`
@@ -73,6 +74,7 @@ Partner Orb Registry Link | Orb Reference String
 [Packagecloud](https://circleci.com/orbs/registry/orb/packagecloud/packagecloud) | `packagecloud: packagecloud/packagecloud@0.1.0`
 [Percy](https://circleci.com/orbs/registry/orb/percy/agent) | `percy: percy/agent@0.1.2`
 [Postman](https://circleci.com/orbs/registry/orb/postman/newman) | `postman: postman/newman@0.0.1`
+[Probely](https://circleci.com/orbs/registry/orb/probely/security-scan) | 'probely: probely/security-scan@1.0.0`
 [Pulumi](https://circleci.com/orbs/registry/orb/pulumi/pulumi) | `pulumi: pulumi/pulumi@1.0.0`
 [Rocro](https://circleci.com/orbs/registry/orb/rocro/inspecode) | `rocro: rocro/inspecode@1.0.0`
 [Rollbar](https://circleci.com/orbs/registry/orb/rollbar/deploy) | `rollbar: rollbar/deploy@1.0.0`


### PR DESCRIPTION
# Description
Added new partners to the docs page. 

# Reasons
https://circleci.atlassian.net/browse/MKTG-1112
These new partners are part of the Wave 5 release for April.
This change can go live as soon as it's ready. 