### PR TITLE
Fix incorrect title for link

### DIFF
--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -215,7 +215,7 @@ workflows:
 For more detailed information about the AWS ECS, AWS ECR, & AWS CodeDeploy orbs, refer to the following Orb registry pages:
 - [AWS ECR](https://circleci.com/orbs/registry/orb/circleci/aws-ecr)
 - [AWS ECS](https://circleci.com/orbs/registry/orb/circleci/aws-ecs)
-- [AWS ECS](https://circleci.com/orbs/registry/orb/circleci/aws-code-deploy)
+- [AWS CodeDeploy](https://circleci.com/orbs/registry/orb/circleci/aws-code-deploy)
 
 ## Azure
 


### PR DESCRIPTION
# Description
Change link title to reflect its content.

# Reasons
This link points to documentation for the CodeDeploy orb, but is titled "AWS ECS".