### PR TITLE
Fixing haiku example in writing-yaml.md

### DIFF
--- a/jekyll/_cci2/writing-yaml.md
+++ b/jekyll/_cci2/writing-yaml.md
@@ -41,9 +41,9 @@ If the value is a multi-line string, use the `>` character, followed by any numb
 
 ```yaml
 haiku: >
-  Consider me
+  Please consider me
   As one who loved poetry
-  And persimmons.
+  Oh, and persimmons.
 ```
 
 **Note**: Quotes are not necessary when using multiline strings.


### PR DESCRIPTION
# Description
Update the multi-line string example showing a haiku to have the correct number of syllables per line

# Reasons
A haiku follows the format of 5-7-5: [wikipedia](https://en.wikipedia.org/wiki/Haiku) 🤓