### PR TITLE
Better cache restoring for haskell

### DIFF
--- a/jekyll/_cci2/language-haskell.md
+++ b/jekyll/_cci2/language-haskell.md
@@ -115,13 +115,14 @@ compiler as specified in the `stack.yaml` config.
       - restore_cache:
           name: Restore Cached Dependencies
           keys:
-            - cci-demo-haskell-v1-{{ checksum "package.yaml" }}-{{ checksum "stack.yaml" }}
+            - cci-demo-haskell-v1-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+            - cci-demo-haskell-v1-{{ checksum "stack.yaml" }}
       - run:
           name: Resolve/Update Dependencies
           command: stack setup
       - save_cache:
           name: Cache Dependencies
-          key: cci-demo-haskell-v1-{{ checksum "package.yaml" }}-{{ checksum "stack.yaml" }}
+          key: cci-demo-haskell-v1-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
           paths:
             - ~/.stack
             - ~/.stack-work
@@ -131,7 +132,9 @@ compiler as specified in the `stack.yaml` config.
 Note: It's also possible to use a `cabal` build file for caching dependencies.
 `stack`, however, is commonly recommended, especially for those new to the Haskell ecosystem. Because this
 demo app leverages `stack.yaml` and `package.yaml`, we use these two files as the
-cache key for our dependencies. You can read more about the differences between
+cache key for our dependencies. `package.yaml` is more often updated than `stack.yaml` so that two keys are
+used to restore cache.
+You can read more about the differences between
 `stack` and `cabal` on [The Haskell Tool Stack docs](https://docs.haskellstack.org/en/stable/stack_yaml_vs_cabal_package_file/).
 
 Finally, we can run our application build commands. We'll run our tests first

--- a/jekyll/_cci2/language-haskell.md
+++ b/jekyll/_cci2/language-haskell.md
@@ -133,7 +133,7 @@ Note: It's also possible to use a `cabal` build file for caching dependencies.
 `stack`, however, is commonly recommended, especially for those new to the Haskell ecosystem. Because this
 demo app leverages `stack.yaml` and `package.yaml`, we use these two files as the
 cache key for our dependencies. `package.yaml` is more often updated than `stack.yaml` so that two keys are
-used to restore cache.
+used to restore the cache.
 You can read more about the differences between
 `stack` and `cabal` on [The Haskell Tool Stack docs](https://docs.haskellstack.org/en/stable/stack_yaml_vs_cabal_package_file/).
 

--- a/jekyll/_cci2/language-haskell.md
+++ b/jekyll/_cci2/language-haskell.md
@@ -41,7 +41,8 @@ jobs:
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           name: Restore Cached Dependencies
           keys:
-            - cci-demo-haskell-v1-{{ checksum "package.yaml" }}-{{ checksum "stack.yaml" }}
+            - cci-demo-haskell-v1-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
+            - cci-demo-haskell-v1-{{ checksum "stack.yaml" }}
       - run:
           name: Resolve/Update Dependencies
           command: stack setup
@@ -53,7 +54,7 @@ jobs:
           command: stack install
       - save_cache:
           name: Cache Dependencies
-          key: cci-demo-haskell-v1-{{ checksum "package.yaml" }}-{{ checksum "stack.yaml" }}
+          key: cci-demo-haskell-v1-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
           paths:
             - "/root/.stack"
             - ".stack-work"


### PR DESCRIPTION
# Description
Change the cache keys to save and restore to increase the chance of the cache being reused.

# Reasons
When you use `stack`,  `package.yaml` is updated every time you add, remove , or change the version of your application. Because of this, using `package.yaml` as the cache restore key will decrease the change of using cache. For example, if you add a new dependent package in `package.yaml`,   CircleCI will start building all the libraries from the scratch since it can't find the previous cache.

On the other hand, `stack.yaml` won't change much unless you change the version of LTS to use, so that we can add a secondary cache restore key using `stack.yaml`, to reuse the previous caches even when `package.yaml` is changed. 
