### PR TITLE
Fix minor typo on deployment integrations page

### DIFF
--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -144,7 +144,7 @@ For more detailed information about the AWS S3 orb, refer to the [CircleCI AWS S
 
 ##### AWS ECR
 
-This orb enables you to log into AWS, build, and then push image to Amazon ECS.
+This orb enables you to log into AWS, build, and then push image to Amazon ECR.
 
 ```
 orbs:


### PR DESCRIPTION
# Description
Fixes a minor typo. This orb definition pushes an image to ECR, not ECS.