### PR TITLE
Document that SSH jobs will not run deploy steps

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -804,7 +804,12 @@ Special step for deploying artifacts.
 
 `deploy` uses the same configuration map and semantics as [`run`](#run) step. Jobs may have more than one `deploy` step.
 
-In general `deploy` step behaves just like `run` with one exception - in a job with `parallelism`, the `deploy` step will only be executed by node #0 and only if all nodes succeed. Nodes other than #0 will skip this step.
+In general `deploy` step behaves just like `run` with two exceptions:
+
+- In a job with `parallelism`, the `deploy` step will only be executed by node #0 and only if all nodes succeed. Nodes other than #0 will skip this step.
+- In a job that runs with SSH, the `deploy` step will not execute, and the following action will show instead:
+  > **skipping deploy**  
+  > Running in SSH mode.  Avoid deploying.
 
 ###### Example
 


### PR DESCRIPTION
# Description
As part of the `deploy` step documentation, mention that SSH-enabled jobs will explicitly skip these steps.

# Reasons
We could not find this behaviour documented anywhere. Example job exhibiting this behaviour: https://circleci.com/gh/ministryofjustice/laa-legal-adviser-api/908

<img width="361" alt="Screen Shot 2019-06-05 at 14 42 48" src="https://user-images.githubusercontent.com/1526295/58962016-31b66700-87a2-11e9-9612-822175f8d0d0.png">
