### PR TITLE
Remove Version from 2.1 Workflows

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -72,7 +72,6 @@ jobs:
       - checkout
       - run: <command>
 workflows:
-  version: 2
   build_and_test:
     jobs:
       - build
@@ -92,7 +91,6 @@ The following `config.yml` snippet is an example of a workflow configured for se
 ```yaml
 version: 2.1
 workflows:
-  version: 2
   build-test-and-deploy:
     jobs:
       - build
@@ -123,7 +121,6 @@ The following `config.yml` snippet is an example of a workflow configured for fa
 ```yaml
 version: 2.1
 workflows:
-  version: 2
   build_accept_deploy:
     jobs:
       - build
@@ -162,7 +159,6 @@ version: 2.1
 # ...
 
 workflows:
-  version: 2
   build-test-and-approval-deploy:
     jobs:
       - build  # your custom job from your config, that builds your code
@@ -220,7 +216,6 @@ In the example below, the `nightly` workflow is configured to run every day at 1
 ```yaml
 version: 2.1
 workflows:
-  version: 2
   commit:
     jobs:
       - test
@@ -270,7 +265,6 @@ The following `config.yml` snippet is an example of a sequential job workflow co
 ```yaml
 version: 2.1
 workflows:
-  version: 2
   build-test-and-deploy:
     jobs:
       - build
@@ -301,7 +295,6 @@ The following `config.yml` snippet is an example of a workflow configured for br
 ```yaml
 version: 2.1
 workflows:
-  version: 2
   dev_stage_pre-prod:
     jobs:
       - test_dev:
@@ -338,7 +331,6 @@ In the example below, two workflows are defined:
 ```yaml
 version: 2.1
 workflows:
-  version: 2
   untagged-build:
     jobs:
       - build
@@ -358,7 +350,6 @@ In the example below, two jobs are defined within the `build-n-deploy` workflow:
 ```yaml
 version: 2.1
 workflows:
-  version: 2
   build-n-deploy:
     jobs:
       - build:
@@ -384,7 +375,6 @@ In the example below, three jobs are defined with the `build-test-deploy` workfl
 ```yaml
 version: 2.1
 workflows:
-  version: 2
   build-test-deploy:
     jobs:
       - build:
@@ -483,7 +473,6 @@ jobs:
           fi
 
 workflows:
-  version: 2
 
   btd:
     jobs:


### PR DESCRIPTION
According to this: https://discuss.circleci.com/t/circleci-2-1-config-overview/26057
The version key should be removed from workflows in 2.1 configs.

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.