### PR TITLE
Fix typo in Creating Orbs: Example Inline Template

### DIFF
--- a/jekyll/_cci2/creating-orbs.md
+++ b/jekyll/_cci2/creating-orbs.md
@@ -199,7 +199,7 @@ orbs:
         executor: my_inline_executor
         steps:
           - my_inline_command:
-              name: <<parameters.greeting_name>>
+              greeting_name: <<parameters.greeting_name>>
     commands:
       my_inline_command:
         parameters:


### PR DESCRIPTION
# Description

The step `my_inline_command` should receive `greeting_name` parameter in order to work properly:

```
steps:
  - my_inline_command:
       greeting_name: <<parameters.greeting_name>>
```

# Reasons

There's a typo inside `my_inline_job` on step `my_inline_command` parameter which causes `circleci config process` to return:

```
Error: Error calling workflow: 'build-test-deploy'
Error calling job: 'inline_example/my_inline_job'
Error calling command: 'my_inline_command'
Missing required argument(s): greeting_name
```