### PR TITLE
ECS/ECR Deployment documentation: Add missing quote

### DIFF
--- a/jekyll/_cci2/ecs-ecr.md
+++ b/jekyll/_cci2/ecs-ecr.md
@@ -106,7 +106,7 @@ workflows:
           aws-region: ${AWS_DEFAULT_REGION}
           family: "${AWS_RESOURCE_NAME_PREFIX}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX}-cluster"
-          container-image-name-updates: container=${AWS_RESOURCE_NAME_PREFIX}-service,tag=${CIRCLE_SHA1}"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX}-service,tag=${CIRCLE_SHA1}"
 ```
 
 ### Set Up a Workflow


### PR DESCRIPTION
# Description
A quote was added at the end of the string. It is missing its start companion

# Reasons
It's not syntactically correct without the beginning quote.