### PR TITLE
Multiple SSH keys with no hostnames considerations

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -78,7 +78,7 @@ that have been added through the CircleCI application.
 
 ## Adding multiple keys with blank hostnames
 
-If you need to add multiple SSH keys with blank hostnames to your project you will need to make some changes to the default SSH configuration provided by CircleCI. In the scenario where you have multiple SSH keys that have access to the same hostss, but are for different purposes the default `IdentitiesOnly no` is set causing connections to use ssh-agent. This will always cause the first key to be used, even if that is the incorrect key. If you have added the SSH key to a container you will need to either set `IdentitiesOnly no` in the appropriate block, or you can remove all keys from the ssh-agent for this job using `ssh-agent -D`, and readding the key added with `ssh-add /path/to/key`.
+If you need to add multiple SSH keys with blank hostnames to your project you will need to make some changes to the default SSH configuration provided by CircleCI. In the scenario where you have multiple SSH keys that have access to the same hostss, but are for different purposes the default `IdentitiesOnly no` is set causing connections to use ssh-agent. This will always cause the first key to be used, even if that is the incorrect key. If you have added the SSH key to a container you will need to either set `IdentitiesOnly no` in the appropriate block, or you can remove all keys from the ssh-agent for this job using `ssh-agent -D`, and reading the key added with `ssh-add /path/to/key`.
 
 ## See Also
 

--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -76,6 +76,10 @@ All fingerprints in the `fingerprints` list
 must correspond to keys
 that have been added through the CircleCI application.
 
+## Adding multiple keys with blank hostnames
+
+If you need to add multiple SSH keys with blank hostnames to your project you will need to make some changes to the default SSH configuration provided by CircleCI. In the scenario where you have multiple SSH keys that have access to the same hostss, but are for different purposes the default `IdentitiesOnly no` is set causing connections to use ssh-agent. This will always cause the first key to be used, even if that is the incorrect key. If you have added the SSH key to a container you will need to either set `IdentitiesOnly no` in the appropriate block, or you can remove all keys from the ssh-agent for this job using `ssh-agent -D`, and readding the key added with `ssh-add /path/to/key`.
+
 ## See Also
 
 [GitHub and Bitbucket Integration]({{ site.baseurl }}/2.0/gh-bb-integration/)


### PR DESCRIPTION
# Description

Currently users can add multiple SSH keys with blank hostnames. In the edge case where multiple of these keys can access the same hosts, but function for different purposes this will lead to the first key added to always be used unless explicitly changing the SSH config or removing keys from a containers ssh-agent

# Reasons
See CIRCLE-18579 for more info.
Multiple SSH keys without hostnames will set IdentitiesOnly no, and use ssh-agent instead. This isn't clearly documented and can cause confusion if a user isn't familiar with ssh-agent, or expects the `IdentitiesOnly yes` setting to be the default when injecting a key into a build. 