### PR TITLE
Fixed bundle install to use --deployment

### DIFF
--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -76,7 +76,7 @@ jobs: # a collection of steps
 
       - run: # Install Ruby dependencies
           name: Bundle Install
-          command: bundle check || bundle install
+          command: bundle check --path vendor/bundle || bundle install --deployment
 
       # Store bundle cache for Ruby dependencies
       - save_cache:
@@ -203,7 +203,7 @@ steps:
 
 This step tells CircleCI to checkout the project code into the working directory.
 
-Next CircleCI pulls down the cache, if present. If this is your first run, or if you've changed `Gemfile.lock`, this won't do anything. The `bundle install` command runs next to pull down the project's dependencies. Normally, you never call this task directly since it's done automatically when it's needed, but calling it directly allows a `save_cache` step that will store the dependencies to speed things up for next time.
+Next CircleCI pulls down the cache, if present. If this is your first run, or if you've changed `Gemfile.lock`, this won't do anything. The `bundle install` command runs next to pull down the project's dependencies. Normally, you never call this task directly since it's done automatically when it's needed, but calling it directly allows a `save_cache` step that will store the dependencies to speed things up for next time.  Using the `--deployment` flag for `bundle install` installs into `./vendor/bundle` rather than a system location. 
 
 {% raw %}
 ```yaml
@@ -218,7 +218,7 @@ steps:
 
   - run:
       name: Bundle Install
-      command: bundle check || bundle install
+      command: bundle check --path vendor/bundle || bundle install --deployment
 
   # Store bundle cache
   - save_cache:


### PR DESCRIPTION
The old instructions used `bundle install` without the `--deployment` flag, but this installed into `/usr/local/bundle` and then the `save_cache` step doesn't do anything.  This commit adds the `--deployment` flag and also uses `--path` for `bundle check`.

Without this change the cache doesn't install into `./vendor/bundle` so the save_cache step stores an empty directory (because the libraries are installed elsewhere).  So the restore_cache step looks like it works, but since it is restoring an empty directory the libraries always need to be installed.

Given that other people have not proposed this change, maybe there was a better way to achieve what I did.  But for me the default instructions did not work "out of the box", so I wanted to provide this feedback so that others don't use the default and have their caching not work.