### PR TITLE
Change resource_class enable requirements

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -382,10 +382,9 @@ A job that was not executed due to configured rules will show up in the list of 
 
 #### **`resource_class`**
 
-**Note:** A paid performance plan is required to use the `resource_class` feature. If you are on a paid 
-performance plan you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) to have a CircleCI Sales representative contact you about enabling this feature on your account.
+**Note:** The `resource_class` feature is automatically enabled on Performance Plans. If you are on a container or unpaid plan you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) to have a CircleCI Sales representative contact you about enabling this feature on your account.
 
-After this feature is added to your paid performance plan, it is possible to configure CPU and RAM resources for each job as described in the following table. If `resource_class` is not specified or an invalid class is specified, the default `resource_class: medium` will be used. The `resource_class` key is currently only available for use with the `docker` executor.
+It is possible to configure CPU and RAM resources for each job as described in the following table. If `resource_class` is not specified or an invalid class is specified, the default `resource_class: medium` will be used. The `resource_class` key is currently only available for use with the `docker` executor.
 
 Class       | vCPUs       | RAM
 ------------|-----------|------


### PR DESCRIPTION
Fixes #3462 
Performance Plans have resource_class and DLC automatically enabled. Container and unpaid plans must contact Support in order to change their plan for these features to be used.

# Description
Removed call to action for customers with Performance Plans as resource_class is automatically enabled.

# Reasons
Resource Class and DLC are automatic features for Performance Plan customers. Container Plan customers and unpaid customers need to contact Support to enable these features.