### PR TITLE
Fix examples in reusing-config.md

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -393,7 +393,7 @@ commands:
         type: string
         default: docs
     steps:
-      - cp *.md << parameters.destination >>
+      - run: cp *.md << parameters.destination >>
 ```
 
 Strings should be quoted if they would otherwise represent another type (such as boolean or number) or if they contain characters that have special meaning in YAML, particularly for the colon character. In all other instances, quotes are optional. Empty strings are treated as a falsy value in evaluation of `when` clauses, and all other strings are treated as truthy. Using an unquoted string value that YAML interprets as a boolean will result in a type error.
@@ -413,7 +413,7 @@ commands:
         type: boolean
         default: false
     steps:
-      - ls <<# parameters.all >> -a <</ parameters.all >>
+      - run: ls <<# parameters.all >> -a <</ parameters.all >>
 ```
 
 Boolean parameter evaluation is based on the [values specified in YAML 1.1](http://yaml.org/type/bool.html):


### PR DESCRIPTION
# Description
Added `run` keyword to some examples

# Reasons
examples cannot be processed