### PR TITLE
Section heading with correct semantics

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -89,7 +89,7 @@ ERROR: Repository not found.
 Permission denied (publickey).
 ```
 
-## Creating a Machine User
+## Controlling Access Via a Machine User
 
 For fine-grained access to multiple repositories,
 consider creating a machine user


### PR DESCRIPTION
# Description
Change section heading

# Reasons
The section is not about "Creating a Machine User". Rather, it's about "using a machine user to control Circle's access to GitHub repos". But that's too long.