### PR TITLE
Update Docker Compose setup.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/ruby:2.6.1-node-browsers
+      - image: circleci/ruby:2.6.3-node-browsers
     working_directory: ~/circleci-docs
     environment:
       JEKYLL_ENV: production
@@ -127,7 +127,7 @@ jobs:
 
   reindex-search:
     docker:
-      - image: circleci/ruby:2.6.1-node-browsers
+      - image: circleci/ruby:2.6.3-node-browsers
     working_directory: ~/circleci-docs
     environment:
       JEKYLL_ENV: production
@@ -146,7 +146,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cibuilds/aws:1.16.118
+      - image: cibuilds/aws:1.16.185
     steps:
       - attach_workspace:
           at: ./generated-site

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.6.1'
+ruby '2.6.3'
 
 gem 'jekyll', "3.8.5"
 gem 'html-proofer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ DEPENDENCIES
   rack (>= 2.0.6)
 
 RUBY VERSION
-   ruby 2.6.2p47
+   ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: "3"
 services:
   jekyll:
-    command: jekyll serve --incremental --livereload
+    command: jekyll serve -s jekyll --incremental --livereload
     image: jekyll/jekyll:3.8.5
     volumes:
-      - "./jekyll:/srv/jekyll"
+      - ".:/srv/jekyll"
     ports:
       - 4000:4000
       - 35729:35729


### PR DESCRIPTION
I was having trouble getting the Docker Compose local dev setup to work. This PR fixes it for me.

The Jekyll image contains Ruby v2.6.3 so this makes the Gemfile match it.
Then Ruby for each job.
Then it copies the whole repo into the image instead of just the jekyll directory.
Updates the AWS image.