### PR TITLE
Use Python 3 to install awscli

### DIFF
--- a/jekyll/_cci2/deployment-integrations.md
+++ b/jekyll/_cci2/deployment-integrations.md
@@ -83,7 +83,7 @@ jobs:
   # build job omitted for brevity
   deploy:
     docker:
-      - image: circleci/python:2.7-jessie
+      - image: circleci/python:3.7-stretch
     working_directory: ~/circleci-docs
     steps:
       - run:


### PR DESCRIPTION
# Description

Use Python 3 to install awscli.

# Reasons

Read this article: https://dev.to/methane/use-pip3-to-install-awscli-44pk

Please recommend people to use Python 3 as possible.