### PR TITLE
Fix invalid mysql version in config example

### DIFF
--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -222,7 +222,7 @@ jobs:
   build:
     docker:
       - image: circleci/php:7.1-apache-node-browsers # The primary container where steps are run
-      - image: circleci/mysql:8.3
+      - image: circleci/mysql:8.0.4
         environment:
           MYSQL_ROOT_PASSWORD: rootpw
           MYSQL_DATABASE: test_db


### PR DESCRIPTION
# Description
Change mysql version in example config from 8.3 to 8.0.4

# Reason

The mysql version is not available from this list: https://circleci.com/docs/2.0/circleci-images/#mysql

The current example config results in this error:
```
Starting container circleci/mysql:8.3
  image cache not found on this host, downloading circleci/mysql:8.3
Error:
Error response from daemon: manifest for circleci/mysql:8.3 not found
```