### PR TITLE
Update: Android also installs additional tools.

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -210,7 +210,7 @@ use the `circleci/postgres:9.5-postgis-ram` image.
 
 ## Pre-installed Tools
 
-All convenience images have been extended with additional tools, installed with `apt-get`
+All convenience images have been extended with additional tools, installed with `apt-get`:
 
 - `bzip2`
 - `ca-certificates`

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -210,10 +210,7 @@ use the `circleci/postgres:9.5-postgis-ram` image.
 
 ## Pre-installed Tools
 
-All convenience images have been extended with additional tools.
-
-With the exception of [Android images](https://hub.docker.com/r/circleci/android),
-all images include the following packages, installed via `apt-get`:
+All convenience images have been extended with additional tools, installed with `apt-get`
 
 - `bzip2`
 - `ca-certificates`


### PR DESCRIPTION
Android docker images seem to also include the tools that other convenience images have, as noted in #3497 . @iynere do you mind confirming this?