### PR TITLE
update for new lambdatest download url

### DIFF
--- a/jekyll/_cci2/browser-testing.md
+++ b/jekyll/_cci2/browser-testing.md
@@ -129,7 +129,7 @@ build:
       - run:
        	name: "Downloading tunnel binary"
           command: |
-          wget https://s3.amazonaws.com/lambda-tunnel/LT_Linux.zip
+          wget http://downloads.lambdatest.com/tunnel/linux/64bit/LT_Linux.zip
       - run:
        	name: "Extracting tunnel binary"
           command: |
@@ -185,7 +185,7 @@ commands:
       - run: 
           name: "Downloading tunnel binary"
           command: |
-            wget https://s3.amazonaws.com/lambda-tunnel/LT_Linux.zip
+            wget http://downloads.lambdatest.com/tunnel/linux/64bit/LT_Linux.zip
       
       - run: 
           name: "Extracting tunnel binary"


### PR DESCRIPTION
# Description
Updates to download URL for LambdaTest binaries in the samples, per partner's request.

# Reasons
Partner has changed the download location for their binaries.