### PR TITLE
Update Jira instructions to work more widely

### DIFF
--- a/jekyll/_cci2/jira-plugin.md
+++ b/jekyll/_cci2/jira-plugin.md
@@ -51,7 +51,9 @@ in Jira. To do this, you will need to:
 
 1. Make sure you followed the steps above to connect Jira with CircleCI.
 1. Make sure that you are using version `2.1` at the top of your `.circleci/config.yml` file.
-1. If you do not already have pipelines enabled, go to **Project Settings -> Advanced Settings** and enable them.
+1. If you do not already have pipelines enabled, go to **Project Settings -> Build Settings -> Advanced Settings** and enable them.
+1. To get an API token for build information retrieval, go to **Project Settings -> Permissions -> API Permissions** and create a token with **Scope: all**. Copy the token.
+1. To allow the integration to then use that key, go to **Project Settings -> Build Settings -> Environment Variables** and add a variable named _CIRCLE_TOKEN_ with the value being the token you just made.
 1. Add the orb stanza, invoking the Jira orb.
 1. Use the Jira orb in a step.
 
@@ -66,7 +68,7 @@ jobs:
     steps:
       - run: echo "hello"
 orbs:
-  jira: circleci/jira@1.0.0
+  jira: circleci/jira@1.0.5
 version: 2.1
 workflows:
   build:


### PR DESCRIPTION
# Description
* Use the latest stable orb v1.0.5 which auto-fixes missing `jq` - https://github.com/CircleCI-Public/jira-connect-orb/pull/11
* Walk through setting up a suitable CircleCI API token

# Reasons
I found these changes were needed to get the integration working with a non-CircleCI image (`docker: - image: python:3`). I assume they will work more widely than the current suggestion.