### PR TITLE
Add note to compress if uploading many artifacts

### DIFF
--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -74,7 +74,9 @@ jobs:
           path: /tmp/artifacts
 ```
 
-The `store_artifacts` step uploads two build artifacts: a file (`/tmp/artifact-1`) and a directory (`/tmp/artifacts`). After the artifacts successfully upload, view them in the **Artifacts** tab of the **Job page** in your browser. There is no limit on the number of `store_artifacts` steps a job can run.
+The `store_artifacts` step uploads two build artifacts: a file (`/tmp/artifact-1`) and a directory (`/tmp/artifacts`). After the artifacts successfully upload, view them in the **Artifacts** tab of the **Job page** in your browser. If you're uploading hundreds of artifacts, then consider [compressing and uploading as a single compressed file](https://support.circleci.com/hc/en-us/articles/360024275534?input_string=store_artifacts+step) to accelerate this step.  
+There is no limit on the number of `store_artifacts` steps a job can run.  
+
 
 Currently, `store_artifacts` has two keys: `path` and `destination`.
 


### PR DESCRIPTION
# Description
Adds a note to docs that compressing artifacts and uploading them as a single file will significantly speed up artifact uploading step if there are hundreds of artifacts.

# Reasons
This note isn't currently surfaced in _docs_ and is only visible in 'known issues' section of support site.
This PR helps folks understand this sooner and prevents them from experiencing slow artifact uploads.

# Background
If there are hundreds of small artifacts then uploading them separately [seems to be significantly slower](https://support.circleci.com/hc/en-us/articles/360024275534?input_string=store_artifacts+step) than uploading a single, compressed file with all these artifacts.
