### PR TITLE
typo - megabits to megabytes

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -155,7 +155,7 @@ For example, you may want to clear the cache in the following scenarios by incre
 </div>
 
 ## Cache Size
-We recommend keeping cache sizes under 500Mb. This is our upper limit for corruption checks because above this limit check times would be excessively long. You can view the cache size from the CircleCI Jobs page within the `restore_cache` step.
+We recommend keeping cache sizes under 500MB. This is our upper limit for corruption checks because above this limit check times would be excessively long. You can view the cache size from the CircleCI Jobs page within the `restore_cache` step.
 Larger cache sizes are allowed but may cause problems due to a higher chance of decompression issues and corruption during download.
 To keep cache sizes down, consider splitting into multiple distinct caches.
 


### PR DESCRIPTION
# Description
Change Mb -> MB

# Reasons
I really hope the recommendation is 500MB max cache and not 500Mb (~62MB) max cache.