### PR TITLE
Removed ambiguous phrasing for contexts, Config Ref

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1094,7 +1094,7 @@ Jobs may be configured to use global environment variables set for an organizati
 
 Key | Required | Type | Description
 ----|-----------|------|------------
-context | N | String | The name of the context. The initial default name was `org-global`. With the ability to use multiple contexts, each context name must be unique.
+context | N | String | The name of the context. The initial default name was `org-global`. Each context name must be unique.
 {: class="table table-striped"}
 
 ###### **`type`**


### PR DESCRIPTION
# Description
Modified this description regarding contexts.

# Reasons
We don't support using multiple contexts per job yet, so this phrasing seems misleading. Both I and a customer I was with on a call today misunderstood this. Idea for multiple contexts here: https://ideas.circleci.com/ideas/CCI-I-761