### PR TITLE
[configuration-reference] Enhance the jobs example

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1172,6 +1172,8 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /v.*/
 ```
 
 Refer to the [Orchestrating Workflows]({{ site.baseurl }}/2.0/workflows) document for more examples and conceptual information.


### PR DESCRIPTION
# Description

Add the `tags` filter to the jobs example.

Closes #3529 

# Reasons

The `tags` are described above the example, but not actually showcased, which is confusing. This PR should fix it! 