### PR TITLE
mysql-client is not available no longer

### DIFF
--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -245,7 +245,7 @@ jobs:
       - run:
           name: Install MySQL CLI; Import dummy data; run an example query
           command: |
-            sudo apt-get install mysql-client
+            sudo apt-get install default-mysql-client
             mysql -h 127.0.0.1 -u user -ppassw0rd test_db < sql-data/dummy.sql
             mysql -h 127.0.0.1 -u user -ppassw0rd --execute="SELECT * FROM test_db.Persons"
 workflows:


### PR DESCRIPTION
Refer: https://github.com/circleci/circleci-docs/issues/3536

# Description
mysql-client is not available no longer. So change the package from `mysql-client` to `default-mysql-client` .

# Reasons
https://github.com/circleci/circleci-docs/issues/3536