### PR TITLE
Update Java language guide

### DIFF
--- a/jekyll/_cci2/language-java-maven.md
+++ b/jekyll/_cci2/language-java-maven.md
@@ -1,0 +1,160 @@
+---
+layout: classic-docs
+title: "Language Guide: Java (with Maven)"
+short-title: "Java with Maven"
+description: "Building and Testing with Java and Maven on CircleCI 2.0"
+categories: [language-guides]
+order: 4
+---
+
+This guide will help you get started with a Java application building with Maven on CircleCI. 
+
+* TOC
+{:toc}
+
+## Overview
+{:.no_toc}
+
+If you’re in a rush, just copy the sample configuration below into a [`.circleci/config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) in your project’s root directory and start building.
+
+We're going to make a few assumptions here:
+
+* You are using [Maven](https://maven.apache.org/). A [Gradle](https://gradle.org/) version of this guide is available [here](https://circleci.com/docs/2.0/language-java/).
+* You are using Java 8. 
+* You are using the Spring Framework. This project was generated using the [Spring Initializer](https://start.spring.io/). 
+* Your application can be distributed as an all-in-one uberjar.
+
+
+## Sample Configuration
+
+{% raw %}
+```yaml
+version: 2 # use CircleCI 2.0
+jobs: # a collection of steps
+  build: # runs not using Workflows must have a `build` job as entry point
+    
+    working_directory: ~/circleci-demo-java-spring # directory where steps will run
+
+    docker: # run the steps with Docker
+      - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
+
+    steps: # a collection of executable commands
+
+      - checkout # check out source code to working directory
+
+      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
+      
+      - run: mvn dependency:go-offline # gets the project dependencies
+      
+      - save_cache: # saves the project dependencies
+          paths:
+            - ~/.m2
+          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
+      
+      - run: mvn package # run the actual tests
+      
+      - store_test_results: # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
+      # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: target/surefire-reports
+      
+      - store_artifacts: # store the uberjar as an artifact
+      # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: target/demo-java-spring-0.0.1-SNAPSHOT.jar
+      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples    
+```
+{% endraw %}
+
+## Get the Code
+
+The configuration above is from a demo Java app, which you can access at [https://github.com/CircleCI-Public/circleci-demo-java-spring/tree/maven](https://github.com/CircleCI-Public/circleci-demo-java-spring/tree/maven), which is the `maven` branch of the repository.
+
+If you want to step through it yourself, you can fork the project on GitHub and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
+
+Now we’re ready to build a `config.yml` from scratch.
+
+## Config Walkthrough
+
+We always start with the version.
+
+```yaml
+version: 2
+```
+
+Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deploy process. Our sample app only needs a `build` job, so everything else is going to live under that key.
+
+In each job, we must specify a `working_directory`. In this sample config, we’ll name it after the project in our home directory.
+
+```yaml
+version: 2
+jobs:
+  build:
+    working_directory: ~/circleci-demo-java-spring
+```
+
+This path will be used as the default working directory for the rest of the `job` unless otherwise specified.
+
+Directly beneath `working_directory`, we can specify container images under a `docker` key.
+
+```yaml
+version: 2
+...
+    docker:
+      - image: circleci/openjdk:8-jdk-stretch
+```
+
+We use the [CircleCI OpenJDK Convenience images](https://hub.docker.com/r/circleci/openjdk/) tagged to version `8-jdk-stretch`.
+
+Now we’ll add several `steps` within the `build` job.
+
+We start with `checkout` so we can operate on the codebase.
+
+Next we pull down the cache, if present. If this is your first run, or if you've changed `pom.xml`, this won't do anything. We run `mvn dependency:go-offline` next to pull down the project's dependencies. This allows us to insert a `save_cache` step that will store the dependencies in order to speed things up for next time.
+
+<div class="alert alert-info" role="alert">
+  <strong>Tip:</strong> <code class="highlighter-rouge">mvn dependency:go-offline</code> may not work if you are running a multi-module
+project build. If this is the case, consider using the <a href="https://github.com/qaware/go-offline-maven-plugin">go-offline-maven-plugin</a>.
+</div>
+
+Then `mvn package` runs the actual tests, and if they succeed, it creates an "uberjar" file containing the application source along with all its dependencies.
+
+Next `store_test_results` uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
+
+Finally we store the uberjar as an [artifact](https://circleci.com/docs/2.0/artifacts/) using the `store_artifacts` step. From there this can be tied into a continuous deployment scheme of your choice.
+
+{% raw %}
+```yaml
+...
+    steps:
+
+      - checkout
+
+      - restore_cache:
+          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
+      
+      - run: mvn dependency:go-offline
+      
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
+      
+      - run: mvn package
+      
+      - store_test_results:
+          path: target/surefire-reports
+      
+      - store_artifacts:
+          path: target/demo-java-spring-0.0.1-SNAPSHOT.jar
+```
+{% endraw %}
+
+Nice! You just set up CircleCI for a Java app using Maven and Spring.
+
+## See Also
+{:.no_toc}
+
+- See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for example deploy target configurations.
+- See the [Debugging Java OOM errors]({{ site.baseurl }}/2.0/java-oom/) document
+for details on handling Java memory issues.

--- a/jekyll/_cci2/language-java.md
+++ b/jekyll/_cci2/language-java.md
@@ -19,8 +19,8 @@ If you’re in a rush, just copy the sample configuration below into a [`.circle
 
 We're going to make a few assumptions here:
 
-* You are using [Maven](https://maven.apache.org/).
-* You are using Java 8. 
+* You are using [Gradle](https://gradle.org/).
+* You are using Java 11. 
 * You are using the Spring Framework. This project was generated using the [Spring Initializer](https://start.spring.io/). 
 * Your application can be distributed as an all-in-one uberjar.
 
@@ -31,38 +31,71 @@ We're going to make a few assumptions here:
 ```yaml
 version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
-  build: # runs not using Workflows must have a `build` job as entry point
-    
-    working_directory: ~/circleci-demo-java-spring # directory where steps will run
-
+  build:
+    # Remove if parallelism is not desired
+    parallelism: 2
+    environment:
+      # Configure the JVM and Gradle to avoid OOM errors
+      _JAVA_OPTIONS: "-Xmx3g"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
     docker: # run the steps with Docker
-      - image: circleci/openjdk:8-jdk-browsers # ...with this image as the primary container; this is where all `steps` will run
-
+      - image: circleci/openjdk:11.0.3-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
+      - image: circleci/postgres:12-alpine
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: circle_test
     steps: # a collection of executable commands
-
       - checkout # check out source code to working directory
-
-      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
-          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
-      
-      - run: mvn dependency:go-offline # gets the project dependencies
-      
-      - save_cache: # saves the project dependencies
+      # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+      - restore_cache:
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - restore_cache:
+          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - run:
+          name: Run tests in parallel
+          # Use "./gradlew test" instead if tests are not run in parallel
+          command: |
+            cd src/test/java
+            # Get list of classnames of tests that should run on this node
+            CLASSNAMES=$(circleci tests glob "**/*.java" \
+              | cut -c 1- | sed 's@/@.@g' \
+              | sed 's/.\{5\}$//' \
+              | circleci tests split --split-by=timings --timings-type=classname)
+            cd ../../..
+            # Format the arguments to "./gradlew test"
+            GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
+            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            ./gradlew test $GRADLE_ARGS
+      - save_cache:
           paths:
-            - ~/.m2
-          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
-      
-      - run: mvn package # run the actual tests
-      
-      - store_test_results: # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
+            - ~/.gradle/wrapper
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - store_test_results: # uploads the test metadata from the `build/test-results/test` directory so that it can show up in the CircleCI dashboard. 
       # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
-          path: target/surefire-reports
-      
-      - store_artifacts: # store the uberjar as an artifact
-      # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-          path: target/demo-java-spring-0.0.1-SNAPSHOT.jar
-      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples    
+          path: build/test-results/test
+      - store_artifacts: # Upload test results for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: build/test-results/test
+          when: always
+      - run:
+          name: Assemble JAR
+          command: |
+            # Skip this for other nodes
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+              ./gradlew assemble
+            fi
+      # This will be empty for all nodes except the first one
+      - store_artifacts:
+          path: build/libs
+      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
+workflows:
+  version: 2
+  workflow:
+    jobs:
+    - build 
 ```
 {% endraw %}
 
@@ -84,42 +117,48 @@ version: 2
 
 Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deploy process. Our sample app only needs a `build` job, so everything else is going to live under that key.
 
-In each job, we must specify a `working_directory`. In this sample config, we’ll name it after the project in our home directory.
-
 ```yaml
 version: 2
 jobs:
   build:
-    working_directory: ~/circleci-demo-java-spring
+    # Remove if parallelism is not desired
+    parallelism: 2
+    environment:
+      # Configure the JVM and Gradle to avoid OOM errors
+      _JAVA_OPTIONS: "-Xmx3g"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 ```
 
-This path will be used as the default working directory for the rest of the `job` unless otherwise specified.
+An optional `parallelism` value of 2 is specified as we would like to run tests in [parallel](https://circleci.com/docs/2.0/parallelism-faster-jobs/) to speed up the job.
 
-Directly beneath `working_directory`, we can specify container images under a `docker` key.
+We also use the `environment` key to configure the JVM and Gradle to [avoid OOM errors](https://circleci.com/blog/how-to-handle-java-oom-errors/).
 
 ```yaml
 version: 2
 ...
     docker:
-      - image: circleci/openjdk:8-jdk-browsers
+      - image: circleci/openjdk:11.0.3-jdk-stretch
+      - image: circleci/postgres:12-alpine
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: circle_test
 ```
 
-We use the [CircleCI OpenJDK Convenience images](https://hub.docker.com/r/circleci/openjdk/) tagged to version `8-jdk-browsers` which includes browsers for performing end-to-end testing.
+We use the [CircleCI OpenJDK Convenience images](https://hub.docker.com/r/circleci/openjdk/) tagged to version `11.0.3-jdk-stretch`.
 
 Now we’ll add several `steps` within the `build` job.
 
 We start with `checkout` so we can operate on the codebase.
 
-Next we pull down the cache, if present. If this is your first run, or if you've changed `pom.xml`, this won't do anything. We run `mvn dependency:go-offline` next to pull down the project's dependencies. This allows us to insert a `save_cache` step that will store the dependencies in order to speed things up for next time.
+Next we pull down the caches for the Gradle wrapper and dependencies, if present. If this is your first run, or if you've changed `gradle/wrapper/gradle-wrapper.properties` and `build.gradle`, this won't do anything. We run `./gradlew test` with additional arguments, which will pull down Gradle and/or the project's dependencies if the cache(s) were empty, and run a subset of tests on each build container. The subset of tests run on each parallel build container is determined with the help of the built-in [`circleci tests split`](https://circleci.com/docs/2.0/parallelism-faster-jobs/#using-the-circleci-cli-to-split-tests) command. Next we use the `save_cache` step to store the Gradle wrapper and dependencies in order to speed things up for next time.
 
 <div class="alert alert-info" role="alert">
-  <strong>Tip:</strong> <code class="highlighter-rouge">mvn dependency:go-offline</code> may not work if you are running a multi-module
-project build. If this is the case, consider using the <a href="https://github.com/qaware/go-offline-maven-plugin">go-offline-maven-plugin</a>.
+  <strong>Tip:</strong> Dependency caching may not work fully if there are multiple `build.gradle` files in your project. If this is the case, consider computing a checksum based on the contents of all the `build.gradle` files, and incorporating it into the cache key.
 </div>
 
-Then `mvn package` runs the actual tests, and if they succeed, it creates an "uberjar" file containing the application source along with all its dependencies.
+Next `store_test_results` uploads the JUnit test metadata from the `build/test-results/test` directory so that it can show up in the CircleCI dashboard. We also upload the test metadata as artifacts via the `store_artifacts` in case there is a need to examine them.
 
-Next `store_test_results` uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
+The `./gradlew assemble` creates an "uberjar" file containing the compiled application along with all its dependencies. We run this only on the first build container instead of on all the build containers running in parallel, as we only need one copy of the uberjar.
 
 Finally we store the uberjar as an [artifact](https://circleci.com/docs/2.0/artifacts/) using the `store_artifacts` step. From there this can be tied into a continuous deployment scheme of your choice.
 
@@ -127,30 +166,59 @@ Finally we store the uberjar as an [artifact](https://circleci.com/docs/2.0/arti
 ```yaml
 ...
     steps:
-
       - checkout
-
       - restore_cache:
-          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
-      
-      - run: mvn dependency:go-offline
-      
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - restore_cache:
+          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - run:
+          name: Run tests in parallel
+          # Use "./gradlew test" instead if tests are not run in parallel
+          command: |
+            cd src/test/java
+            # Get list of classnames of tests that should run on this node
+            CLASSNAMES=$(circleci tests glob "**/*.java" \
+              | cut -c 1- | sed 's@/@.@g' \
+              | sed 's/.\{5\}$//' \
+              | circleci tests split --split-by=timings --timings-type=classname)
+            cd ../../..
+            # Format the arguments to "./gradlew test"
+            GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
+            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
+            ./gradlew test $GRADLE_ARGS
       - save_cache:
           paths:
-            - ~/.m2
-          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
-      
-      - run: mvn package
-      
+            - ~/.gradle/wrapper
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+          key: v1-gradle-cache-{{ checksum "build.gradle" }}
       - store_test_results:
-          path: target/surefire-reports
-      
+          path: build/test-results/test
       - store_artifacts:
-          path: target/demo-java-spring-0.0.1-SNAPSHOT.jar
+          path: build/test-results/test
+          when: always
+      - run:
+          name: Assemble JAR
+          command: |
+            # Skip this for other nodes
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+              ./gradlew assemble
+            fi
+      # This will be empty for all nodes except the first one
+      - store_artifacts:
+          path: build/libs
+workflows:
+  version: 2
+  workflow:
+    jobs:
+    - build
+
 ```
 {% endraw %}
 
-Nice! You just set up CircleCI for a Java app using Maven and Spring.
+Nice! You just set up CircleCI for a Java app using Gradle and Spring.
 
 ## See Also
 {:.no_toc}

--- a/jekyll/_cci2/language-java.md
+++ b/jekyll/_cci2/language-java.md
@@ -52,7 +52,7 @@ jobs: # a collection of steps
       - restore_cache:
           key: v1-gradle-cache-{{ checksum "build.gradle" }}
       - run:
-          name: Run tests in parallel
+          name: Run tests in parallel # See: https://circleci.com/docs/2.0/parallelism-faster-jobs/
           # Use "./gradlew test" instead if tests are not run in parallel
           command: |
             cd src/test/java
@@ -175,7 +175,7 @@ Next we pull down the caches for the Gradle wrapper and dependencies, if present
 ...
     steps:
       - run:
-          name: Run tests in parallel # https://circleci.com/docs/2.0/parallelism-faster-jobs/
+          name: Run tests in parallel # See: https://circleci.com/docs/2.0/parallelism-faster-jobs/
           # Use "./gradlew test" instead if tests are not run in parallel
           command: |
             cd src/test/java

--- a/jekyll/_cci2/language-java.md
+++ b/jekyll/_cci2/language-java.md
@@ -7,7 +7,7 @@ categories: [language-guides]
 order: 4
 ---
 
-This guide will help you get started with a Java application on CircleCI. 
+This guide will help you get started with a Java application building with Gradle on CircleCI. 
 
 * TOC
 {:toc}


### PR DESCRIPTION
Update java language guide in conjunction with changes to sample project

# Description
Update java language guide in conjunction with changes to sample project to use Gradle: https://github.com/CircleCI-Public/circleci-demo-java-spring/pull/9. The original Maven-based language guide will still be available via the https://circleci.com/docs/2.0/language-java-maven/ link and will link to the `maven` branch of the sample project at https://github.com/CircleCI-Public/circleci-demo-java-spring/tree/maven

# Reasons
The Java sample project has just gone through a major update to use Gradle.