### PR TITLE
Resolve incorrect variable interpolation in env vars documentation.

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -108,8 +108,8 @@ steps:
   - run:
       name: Setup Environment Variables
       command: |
-        echo 'export PATH="$GOPATH/bin:$PATH"' >> $BASH_ENV
-        echo 'export GIT_SHA1="$CIRCLE_SHA1"' >> $BASH_ENV
+        echo "export PATH=$GOPATH/bin:$PATH" >> $BASH_ENV
+        echo "export GIT_SHA1=$CIRCLE_SHA1" >> $BASH_ENV
 ```
 
 In every step, CircleCI uses `bash` to source `BASH_ENV`. This means that `BASH_ENV` is automatically loaded and run,

--- a/jekyll/_cci2_ja/env-vars.md
+++ b/jekyll/_cci2_ja/env-vars.md
@@ -58,8 +58,8 @@ steps:
   - run:
       name: 環境変数の設定
       command: |
-        echo 'export PATH="$GOPATH/bin:$PATH"' >> $BASH_ENV
-        echo 'export GIT_SHA1="$CIRCLE_SHA1"' >> $BASH_ENV
+        echo "export PATH=$GOPATH/bin:$PATH" >> $BASH_ENV
+        echo "export GIT_SHA1=$CIRCLE_SHA1" >> $BASH_ENV
 ```
 
 CircleCI は `bash` コマンドを用いて、ステップごとにその都度 `BASH_ENV` の内容を読み込みます。 これはつまり、`BASH_ENV` の読み込みと実行が自動的に行われ、インターポレーションを可能にし、`run` ステップ間で環境変数を共有できるということです。


### PR DESCRIPTION
# Description

Customer noted our example for filling env variables within bash was incorrect, this addresses that.

# Reasons

https://circleci.zendesk.com/agent/tickets/55507