### PR TITLE
add link to Docker container overview

### DIFF
--- a/jekyll/_cci2/containers.md
+++ b/jekyll/_cci2/containers.md
@@ -5,7 +5,7 @@ categories: [how-to]
 description: How to leverage CircleCI containers
 ---
 
-This document describes the basics of containers and how to leverage the containers in your plan to speed up your job and workflow runs.
+This document describes the basics of containers and how to leverage the containers in your plan to speed up your job and workflow runs. For more information on what containers are and why they are useful, see this [Docker overview](https://www.docker.com/resources/what-container).
 
 ## Overview
 


### PR DESCRIPTION
# Description
Add a link to a Docker guide to the basics of containers for people who come to our Containers guide and need some context.
