### PR TITLE
Use lein 2.9.1 in examples

### DIFF
--- a/jekyll/_cci2/language-clojure.md
+++ b/jekyll/_cci2/language-clojure.md
@@ -34,7 +34,7 @@ jobs: # basic units of work in a run
   build: # runs not using Workflows must have a `build` job as entry point
     working_directory: ~/cci-demo-clojure # directory where steps will run
     docker: # run the steps with Docker
-      - image: circleci/clojure:lein-2.7.1 # ...with this image as the primary container; this is where all `steps` will run
+      - image: circleci/clojure:lein-2.9.1 # ...with this image as the primary container; this is where all `steps` will run
     environment: # environment variables for primary container
       LEIN_ROOT: nbd
       JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
@@ -91,7 +91,7 @@ Directly beneath `working_directory`, we can specify container images under a `d
 version: 2
 ...
     docker:
-      - image: circleci/clojure:lein-2.7.1
+      - image: circleci/clojure:lein-2.9.1
 ```
 
 We use the [CircleCI-provided Clojure image](https://circleci.com/docs/2.0/circleci-images/#clojure) with the `lein-2.7.1` tag.
@@ -148,4 +148,3 @@ See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for e
 The app described in this guide illustrates the simplest possible setup for a Clojure web app. Real-world projects tend to be more complex, so you may find this more detailed example useful as you configure your own projects:
 
 * [Syme](https://github.com/technomancy/syme/blob/master/.circleci/config.yml), a site which configures disposable virtual machines for remote collaboration (uses PostgreSQL, continuously deployed to Heroku)
-

--- a/jekyll/_cci2_ja/language-clojure.md
+++ b/jekyll/_cci2_ja/language-clojure.md
@@ -36,7 +36,7 @@ jobs: # 1回の実行の基本作業単位
   build: # Workflows を使用しない実行では、エントリポイントとして `build` ジョブが必要
     working_directory: ~/cci-demo-clojure # ステップが実行されるディレクトリ
     docker: # Docker でステップを実行します
-      - image: circleci/clojure:lein-2.7.1 # このイメージをすべての `steps` が実行されるプライマリコンテナとして使用します
+      - image: circleci/clojure:lein-2.9.1 # このイメージをすべての `steps` が実行されるプライマリコンテナとして使用します
     environment: # プライマリコンテナの環境変数
       LEIN_ROOT: nbd
       JVM_OPTS: -Xmx3200m # メモリ不足エラーを回避するために最大ヒープサイズを制限します
@@ -93,7 +93,7 @@ jobs:
 version: 2
 ...
     docker:
-      - image: circleci/clojure:lein-2.7.1
+      - image: circleci/clojure:lein-2.9.1
 ```
 
 `lein-2.7.1` タグを指定して [CircleCI 提供の Clojure イメージ](https://circleci.com/docs/ja/2.0/circleci-images/#clojure)を使用します。


### PR DESCRIPTION
# Description
Update the Clojure examples to use a recent Leiningen image.

# Reasons
Clpjurians Slack conversation: https://clojurians.slack.com/archives/CJR0NB4MS/p1564997463001300