### PR TITLE
One-line fix for number of job environments within executor-types.md

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -16,7 +16,7 @@ This document describes the available executor types (`docker`, `machine`, `wind
 ## Overview
 {:.no_toc}
 
-An *executor type* defines the underlying technology or environment in which to run a job. CircleCI enables you to run jobs in one of three environments:
+An *executor type* defines the underlying technology or environment in which to run a job. CircleCI enables you to run jobs in one of four environments:
 
 - Within Docker images (`docker`)
 - Within a Linux virtual machine (VM) image (`machine`)


### PR DESCRIPTION
Changes: 
 - Updates the number of job environments to match the list

# Description
The docs currently state 3 environment types, immediately followed by a list of 4 environments. This updates the number to be consistent. 

# Reasons
Consistency / accuracy of the docs. 