### PR TITLE
Remove yarn from sidenav; reference in optimization see-also section.

### DIFF
--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -164,3 +164,4 @@ Learn more about [Docker Layer Caching]({{site.baseurl}}/2.0/docker-layer-cachin
 
 - For a complete list of customizations that can be made your build, consider reading our [configuration reference]({{ site.baseurl}}/2.0/configuration-reference/).
 - Coinbase published an article titled [Continuous Integration at Coinbase: How we optimized CircleCI for speed and cut our build times by 75%](https://blog.coinbase.com/continuous-integration-at-coinbase-how-we-optimized-circleci-for-speed-cut-our-build-times-by-378c8b1d7161)
+- Using Yarn for speeding up builds with [caching]({{site.baseurl}}/2.0/yarn)

--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: "Using Yarn (the npm replacement) on CircleCI"
+title: "Using Yarn (an NPM alternative) on CircleCI"
 short-title: "Yarn Package Manager"
 categories: [how-to]
 description: "How to use the Yarn package manager on CircleCI."

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -239,8 +239,6 @@ en:
           link: 2.0/deployment-integrations/
         - name: Deploying to AWS ECR/ECS
           link: 2.0/ecs-ecr/
-        - name: Using Yarn on CircleCI
-          link: 2.0/yarn/
         - name: Publishing Snap Packages
           link: 2.0/build-publish-snap-packages/
         - name: Using Artifactory


### PR DESCRIPTION
As pointed out by @rosieyohannan, the Yarn document might not be the best fit under "Configuring Deploys"; this PR removes it from the sidebar (open for discussion!) and also links to the Yarn doc from the optimizations section.