### PR TITLE
Add link to FYAML under the config pack docs

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -128,7 +128,7 @@ Where the above command will look for an orb called `my_orb.yml` in the `/tmp` f
 
 ## Packing A Config
 
-The CLI provides a `pack` command, allowing you to create a single YAML file from several separate files. This is particularly useful for breaking up source code for large orbs and allows custom organization of your orbs' YAML configuration. `circleci config pack` converts a filesystem tree into a single YAML file based on directory structure and file contents. How you **name** and **organize** your files when using the `pack` command will determine the final outputted `orb.yml`. Consider the following example folder structure:
+The CLI provides a `pack` command, allowing you to create a single YAML file from several separate files. The `pack` command implements [FYAML](https://github.com/CircleCI-Public/fyaml), a scheme for breaking YAML documents across files in a directory tree. This is particularly useful for breaking up source code for large orbs and allows custom organization of your orbs' YAML configuration. `circleci config pack` converts a filesystem tree into a single YAML file based on directory structure and file contents. How you **name** and **organize** your files when using the `pack` command will determine the final outputted `orb.yml`. Consider the following example folder structure:
 
 ```sh
 $ tree


### PR DESCRIPTION
# Description
Add link to FYAML under the config pack docs

# Reasons
We have a repo that describes the FYAML scheme at https://github.com/CircleCI-Public/fyaml, so linking to it from here makes sense to let users better understand the abstraction at work in config packing.