### PR TITLE
Update env-vars.md

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -116,7 +116,24 @@ In every step, CircleCI uses `bash` to source `BASH_ENV`. This means that `BASH_
 allowing you to use interpolation and share environment variables across `run` steps.
 
 **Note:**
-The `BASH_ENV` workaround only works with `bash`. Other implementations like `sh` will not work. This limitation affects your image options. For example, because [Alpine images](https://alpinelinux.org/) do not include `bash` by default, the `BASH_ENV` workaround will not work without first installing `bash`.
+The `$BASH_ENV` workaround only works with `bash`. 
+Other shells probably won't work.
+
+### Alpine Linux
+
+An image that's based on [Alpine Linux](https://alpinelinux.org/) (like [docker](https://hub.docker.com/_/docker)), uses the `ash` shell. 
+
+To use environment variables with `ash`, just add these 2 parameters to your job.
+
+```yaml
+jobs:
+  build:    
+
+    shell: /bin/sh -leo pipefail
+    environment:
+      - BASH_ENV: /etc/profile
+```
+
 
 ## Setting an Environment Variable in a Shell Command
 


### PR DESCRIPTION
This PR updates the docs, to point users to a workaround for [discuss.circleci.com#20087](https://discuss.circleci.com/t/sourcing-bash-env-in-an-alpine-docker-image/20084).

More info on why this works:
- https://stackoverflow.com/questions/35325856/where-to-set-system-default-environment-variables-in-alpine-linux
- https://askubuntu.com/questions/247738/why-is-etc-profile-not-invoked-for-non-login-shells/247769#247769