### PR TITLE
[CIRCLE-19876] Document scheduled workflow delays

### DIFF
--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -187,7 +187,7 @@ Yes!
 
 ### Can workflows be scheduled to run at a specific time of day?
 {:.no_toc}
-Yes, for the CircleCI hosted application. For example, to run a workflow at 4 PM use `"0 16 * * *"` as the value for the `cron:` key. Times are interpreted in the UTC time zone. Next on the roadmap is to enable scheduled workflows in an installable CircleCI release.
+Yes, for the CircleCI hosted application. For example, to run a workflow at 4 PM use `"0 16 * * *"` as the value for the `cron:` key. Times are interpreted in the UTC time zone.
 
 ### What time zone is used for schedules?
 {:.no_toc}

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -225,6 +225,8 @@ By default, a workflow is triggered on every `git push`. To trigger a workflow o
 
 In the example below, the `nightly` workflow is configured to run every day at 12:00am UTC. The `cron` key is specified using POSIX `crontab` syntax, see the [crontab man page](https://www.unix.com/man-page/POSIX/1posix/crontab/) for `cron` syntax basics. The workflow will be run on the `master` and `beta` branches.
 
+**Note:** Scheduled workflows may be delayed by up to 15 minutes. This is done to maintain reliability during busy times such as 12:00am UTC. Scheduled workflows should not assume they are started with to-the-minute accuracy.
+
 ```yaml
 workflows:
   version: 2


### PR DESCRIPTION
This has always been in the FAQ, but should be called out directly in the
scheduled workflows documentation.