### PR TITLE
Describe disabling test report generation to speed up ios testing.

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -283,6 +283,10 @@ workflows:
 
 The environment variable `FL_OUTPUT_DIR` is the artifact directory where FastLane logs should be stored. Use this to set the path in the `store_artifacts` step to automatically save logs such as Gym and Scan. 
 
+### Reducing Testing Time
+
+By default, Fastlane Scan generates test output reports in `html` and `junit` formats. If your tests are taking a long time and you do not need these reports, consider disabling them by altering the `output_type` parameter as described in the [fastlane docs](https://docs.fastlane.tools/actions/run_tests/#parameters).
+
 ### Using CocoaPods
 {:.no_toc}
 


### PR DESCRIPTION
[Fixes 20139](https://circleci.atlassian.net/browse/CIRCLE-20139)