### PR TITLE
docs(get-start): fix indent in step 1 of Using the Workflows Functionality

### DIFF
--- a/jekyll/_cci2/getting-started.md
+++ b/jekyll/_cci2/getting-started.md
@@ -81,22 +81,22 @@ Edit your `config.yml` file in the GitHub editor for simplicity and replace `ech
 
 1. To see Workflows in action, edit your `.circleci/config.yml` file. After you have the file in edit mode in your browser window, select the text from `build` and onwards in your file and copy and paste the text to duplicate that section. That should look similar to the code block below:
 
-```yml
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/ruby:2.4.1
-    steps:
-      - checkout
-      - run: echo "A first hello"
-  build:
-    docker:
-      - image: circleci/ruby:2.4.1
-    steps:
-      - checkout
-      - run: echo "A first hello"      
-```
+    ```yml
+    version: 2
+    jobs:
+      build:
+        docker:
+          - image: circleci/ruby:2.4.1
+        steps:
+          - checkout
+          - run: echo "A first hello"
+      build:
+        docker:
+          - image: circleci/ruby:2.4.1
+        steps:
+          - checkout
+          - run: echo "A first hello"
+    ```
 
 2. Next, rename your two jobs so that they have different names. In this example they are named `one` and `two`. Change the contents of the echo statements to something different. To make the {% comment %} TODO: Job {% endcomment %}build take a longer period of time we can add a system `sleep` command.
 


### PR DESCRIPTION
# Description
Fix indent in step 1 of Using the Workflows Functionality

# Reasons

Right now the order number of steps is wrong like below:

<img width="595" alt="Screen Shot 2019-08-29 at 13 27 17" src="https://user-images.githubusercontent.com/759107/63910210-bf7fb680-ca60-11e9-9a8d-0f5a6df93ef5.png">
