### PR TITLE
Fix a couple typographical issues in API docs

### DIFF
--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -150,7 +150,7 @@ All CircleCI API endpoints begin with `https://circleci.com/api/v1.1/`
 
 **API** | **Description**
 ------- | -------------
-/project/:vcs-type/:username/:project/follow | Follow a new project on CircleCI..
+/project/:vcs-type/:username/:project/follow | Follow a new project on CircleCI.
 /project/:vcs-type/:username/:project/:build\_num/retry | Retries the build, returns a summary of the new build.
 /project/:vcs-type/:username/:project/:build\_num/cancel | Cancels the build, returns a summary of the build.
 /project/:vcs-type/:username/:project/:build_num/ssh-users | Adds a user to the build's SSH permissions.

--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -155,7 +155,7 @@ All CircleCI API endpoints begin with `https://circleci.com/api/v1.1/`
 /project/:vcs-type/:username/:project/:build\_num/cancel | Cancels the build, returns a summary of the build.
 /project/:vcs-type/:username/:project/:build_num/ssh-users | Adds a user to the build's SSH permissions.
 /project/:vcs-type/:username/:project/tree/:branch | Triggers a new build, returns a summary of the build. Optional 1.0 [build parameters](https://circleci.com/docs/2.0/parallelism-faster-jobs/) can be set as well and Optional 2.0 [build parameters](https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-the-api).
-/project/:vcs-type/:username/:project/ssh-key | Creates an ssh key used to access external systems that require SSH key-based authentication
+/project/:vcs-type/:username/:project/ssh-key | Creates an ssh key used to access external systems that require SSH key-based authentication.
 /project/:vcs-type/:username/:project/checkout-key | Creates a new checkout key.
 
 ### DELETE Requests


### PR DESCRIPTION
----

# Description
Added/removed full stops in API endpoint descriptions.

# Reasons
Typographical consistency.