### PR TITLE
use :your_token in both instances we refer to it

### DIFF
--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -170,7 +170,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/$build_n
 Similarly, if you want to download the _latest_ artifacts of a build, replace the curl call with a URL that follows this scheme:
 
 ```bash
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts?circle-token=:token
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts?circle-token=:your_token
 ```
 
 You can read more about using CircleCI's API to interact with artifacts in our [API reference guide](https://circleci.com/docs/api/#artifacts).


### PR DESCRIPTION
# Description
Minor edit for consistency - the doc was using both `:your_token` and `:token` but I think `:your_token` used consistently would be preferred.

# Reasons
I just saw a slight inconsistency in the name of the circleci token and I suggest this edit. You used `:your_token` twice and `:token` once, in between those two usages of `:your_token`.