### PR TITLE
[WIP]Update documentation w/ separate resource_class tables for each executor type

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -86,7 +86,7 @@ Executors define the environment in which the steps of a job will be run, allowi
 Key | Required | Type | Description
 ----|-----------|------|------------
 docker | Y <sup>(1)</sup> | List | Options for [docker executor](#docker)
-resource_class | N | String | Amount of CPU and RAM allocated to each container in a job. (Only available with the `docker` executor) **Note:** A paid account is required to access this feature. Customers on paid container-based plans can request access by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
+resource_class | N | String | Amount of CPU and RAM allocated to each container in a job. **Note:** A paid account is required to access this feature. Customers on paid container-based plans can request access by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
 machine | Y <sup>(1)</sup> | Map | Options for [machine executor](#machine)
 macos | Y <sup>(1)</sup> | Map | Options for [macOS executor](#macos)
 windows | Y <sup>(1)</sup> | Map | Options for [windows executor](#windows)
@@ -139,7 +139,7 @@ working_directory | N | String | In which directory to run the steps. Default: `
 parallelism | N | Integer | Number of parallel instances of this job to run (default: 1)
 environment | N | Map | A map of environment variable names and values.
 branches | N | Map | A map defining rules to allow/block execution of specific branches for a single job that is **not** in a workflow or a 2.1 config (default: all allowed). See [Workflows](#workflows) for configuring branch execution for jobs in a workflow or 2.1 config.
-resource_class | N | String | Amount of CPU and RAM allocated to each container in a job. (Only available with the `docker` executor) **Note:** A paid account is required to access this feature. Customers on paid container-based plans can request access by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
+resource_class | N | String | Amount of CPU and RAM allocated to each container in a job. **Note:** A paid account is required to access this feature. Customers on paid container-based plans can request access by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
 {: class="table table-striped"}
 
 <sup>(1)</sup> exactly one of them should be specified. It is an error to set more than one.

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -404,9 +404,11 @@ A job that was not executed due to configured rules will show up in the list of 
 
 #### **`resource_class`**
 
-**Note:** The `resource_class` feature is automatically enabled on Performance Plan. If you are on a container or unpaid plan you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) to speak with a CircleCI Sales representative about enabling this feature on your account.
+The `resource_class` feature allows configuring CPU and RAM resources for each job. If this config is not specified, or an invalid class is specified, the default `resource_class: medium` will be used. Different resource classes are available for different executors, as described in the tables below. 
 
-It is possible to configure CPU and RAM resources for each job. If `resource_class` is not specified, or an invalid class is specified, the default `resource_class: medium` will be used. Different resource classes are available for different executors, as described in the tables below. 
+We implement soft concurrency limits for each resource class to ensure our system remains stable for all customers. If you are on a Performance or custom plan and experience queuing for certain resource classes, it's possible you are hitting these limits. [Contact CircleCI support](https://support.circleci.com/hc/en-us/requests/new) to request a raise on these limits for your account.
+
+**Note:** This feature is automatically enabled on Performance Plan. If you are on a container or unpaid plan you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) and speak with a CircleCI Sales representative about enabling this feature.
 
 ##### Docker Executor
 
@@ -490,7 +492,7 @@ jobs:
       ... // other config
 ```
 
-\*_Requires review. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
+\*_Requires review by support team. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
 
 **Note**: Java, Erlang and any other languages that introspect the `/proc` directory for information about CPU count may require additional configuration to prevent them from slowing down when using the CircleCI 2.0 resource class feature. Programs with this issue may request 32 CPU cores and run slower than they would when requesting one core. Users of languages with this issue should pin their CPU count to their guaranteed CPU resources.
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -417,23 +417,60 @@ medium (default) | 2     | 4GB
 medium+          | 3     | 6GB
 large            | 4     | 8GB
 xlarge           | 8     | 16GB
+2xlarge\*        | 16    | 32GB
+2xlarge+\*       | 20    | 40GB
 {: class="table table-striped"}
+
+###### Example Usage
+```yaml
+jobs:
+  build:
+    docker:
+      - image: buildpack-deps:trusty
+    resource_class: xlarge
+    steps:
+      ... // other config
+```
 
 ##### Machine Executor (Linux)
 
 Class            | vCPUs | RAM
------------------|-------|------
+-----------------|-------|-------
 medium (default) | 2     | 7.5GB
 large            | 4     | 15GB
+1GPU\*           | 16    | 122GiB
+2GPU\*           | 32    | 244GiB
+4GPU\*           | 64    | 488GiB
 {: class="table table-striped"}
+
+###### Example Usage
+```yaml
+jobs:
+  build:
+    machine: true
+    resource_class: 1GPU
+    steps:
+      ... // other config
+```
 
 ##### macOS Executor
 
 Class            | vCPUs | RAM
 -----------------|-------|-----
 medium (default) | 4     | 8GB
-large*           | 8     | 16GB
+large\*          | 8     | 16GB
 {: class="table table-striped"}
+
+###### Example Usage
+```yaml
+jobs:
+  build:
+    macos:
+      xcode: "11.0.0"
+    resource_class: large
+    steps:
+      ... // other config
+```
 
 ##### Windows Executor
 
@@ -441,23 +478,18 @@ Class             | vCPUs | RAM
 ------------------|-------|-----
 medium (default)  | 4     | 15GB
 
-\*_Requires review. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
-
-Below is an example of specifying a `large` `resource_class` for Docker.
-
+###### Example Usage
 ```yaml
 jobs:
   build:
-    docker:
-      - image: buildpack-deps:trusty
-    environment:
-      FOO: bar
-    parallelism: 3
+    macos:
+      xcode: "11.0.0"
     resource_class: large
     steps:
-      - run: make test
-      - run: make
+      ... // other config
 ```
+
+\*_Requires review. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
 
 **Note**: Java, Erlang and any other languages that introspect the `/proc` directory for information about CPU count may require additional configuration to prevent them from slowing down when using the CircleCI 2.0 resource class feature. Programs with this issue may request 32 CPU cores and run slower than they would when requesting one core. Users of languages with this issue should pin their CPU count to their guaranteed CPU resources.
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -417,8 +417,6 @@ medium (default) | 2     | 4GB
 medium+          | 3     | 6GB
 large            | 4     | 8GB
 xlarge           | 8     | 16GB
-2xlarge\*        | 16    | 32GB
-2xlarge+\*       | 20    | 40GB
 {: class="table table-striped"}
 
 ##### Machine Executor (Linux)
@@ -429,7 +427,7 @@ medium (default) | 2     | 7.5GB
 large            | 4     | 15GB
 {: class="table table-striped"}
 
-##### MacOS Executor
+##### macOS Executor
 
 Class            | vCPUs | RAM
 -----------------|-------|-----
@@ -442,16 +440,6 @@ large*           | 8     | 16GB
 Class             | vCPUs | RAM
 ------------------|-------|-----
 medium (default)  | 4     | 15GB
-
-
-##### GPU (Linux) Executor
-
-Class            | vCPUs | RAM
------------------|-------|-------
-1GPU*            | 16    | 122GiB
-2GPU*            | 32    | 244GiB
-4GPU*            | 64    | 488GiB
-{: class="table table-striped"}
 
 \*_Requires review. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -482,9 +482,10 @@ medium (default)  | 4     | 15GB
 ```yaml
 jobs:
   build:
-    macos:
-      xcode: "11.0.0"
-    resource_class: large
+    machine:
+      image: windows-server-2019-vs2019:201908-06
+    resource_class: windows.medium
+    shell: powershell.exe -ExecutionPolicy Bypass
     steps:
       ... // other config
 ```

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -406,25 +406,57 @@ A job that was not executed due to configured rules will show up in the list of 
 
 **Note:** The `resource_class` feature is automatically enabled on Performance Plans. If you are on a container or unpaid plan you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) to have a CircleCI Sales representative contact you about enabling this feature on your account.
 
-It is possible to configure CPU and RAM resources for each job as described in the following table. If `resource_class` is not specified or an invalid class is specified, the default `resource_class: medium` will be used. The `resource_class` key is currently only available for use with the `docker` executor.
+It is possible to configure CPU and RAM resources for each job. If `resource_class` is not specified, or an invalid class is specified, the default `resource_class: medium` will be used. Different resource classes are available for different executors, as described in the tables below. 
 
-Class       | vCPUs       | RAM
-------------|-----------|------
-small       | 1 | 2GB
-medium (default) | 2 | 4GB
-medium+     | 3 | 6GB
-large       | 4 | 8GB
-xlarge      | 8 | 16GB
-2XL         | 16 | 32GB
-2XL+        | 20 | 40GB
-1GPU        | 16 | 122GiB
-2GPU        | 32 | 244GiB
-4GPU        | 64 | 488GiB
+##### Docker Executor
+
+Class            | vCPUs | RAM
+-----------------|-------|-----
+small            | 1     | 2GB
+medium (default) | 2     | 4GB
+medium+          | 3     | 6GB
+large            | 4     | 8GB
+xlarge\*         | 8     | 16GB
+2XL\*            | 16    | 32GB
+2XL+\*           | 20    | 40GB
 {: class="table table-striped"}
 
-**Note:** Approval from the CircleCI support team is required to gain access to the 2XL, 2XL+, and GPU resource classes.
+##### Machine Executor (Linux)
 
-Below is an example of specifying the `large` `resource_class`.
+Class            | vCPUs | RAM
+-----------------|-------|-----
+medium (default) | 2     | 7.5GB
+large*           | 4     | 15GB
+{: class="table table-striped"}
+
+##### MacOS Executor
+
+Class            | vCPUs | RAM
+-----------------|-------|-----
+small            | 2     | 4GB
+medium (default) | 4     | 8GB
+large*           | 8     | 16GB
+{: class="table table-striped"}
+
+##### Windows Executor
+
+Class             | vCPUs | RAM
+------------------|-------|-----
+medium (default)* | 4     | 15GB
+
+
+##### GPU (Linux) Executor
+
+Class            | vCPUs | RAM
+-----------------|-------|-----
+1GPU*            | 16    | 122GiB
+2GPU*            | 32    | 244GiB
+4GPU*            | 64    | 488GiB
+{: class="table table-striped"}
+
+\*_Access to these resources must be reviewed by the CircleCI support team regardless of your current pricing plan. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
+
+Below is an example of specifying a `large` `resource_class` for Docker.
 
 ```yaml
 jobs:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -404,7 +404,7 @@ A job that was not executed due to configured rules will show up in the list of 
 
 #### **`resource_class`**
 
-**Note:** The `resource_class` feature is automatically enabled on Performance Plans. If you are on a container or unpaid plan you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) to have a CircleCI Sales representative contact you about enabling this feature on your account.
+**Note:** The `resource_class` feature is automatically enabled on Performance Plan. If you are on a container or unpaid plan you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) to speak with a CircleCI Sales representative about enabling this feature on your account.
 
 It is possible to configure CPU and RAM resources for each job. If `resource_class` is not specified, or an invalid class is specified, the default `resource_class: medium` will be used. Different resource classes are available for different executors, as described in the tables below. 
 
@@ -416,24 +416,23 @@ small            | 1     | 2GB
 medium (default) | 2     | 4GB
 medium+          | 3     | 6GB
 large            | 4     | 8GB
-xlarge\*         | 8     | 16GB
-2XL\*            | 16    | 32GB
-2XL+\*           | 20    | 40GB
+xlarge           | 8     | 16GB
+2xlarge\*        | 16    | 32GB
+2xlarge+\*       | 20    | 40GB
 {: class="table table-striped"}
 
 ##### Machine Executor (Linux)
 
 Class            | vCPUs | RAM
------------------|-------|-----
+-----------------|-------|------
 medium (default) | 2     | 7.5GB
-large*           | 4     | 15GB
+large            | 4     | 15GB
 {: class="table table-striped"}
 
 ##### MacOS Executor
 
 Class            | vCPUs | RAM
 -----------------|-------|-----
-small            | 2     | 4GB
 medium (default) | 4     | 8GB
 large*           | 8     | 16GB
 {: class="table table-striped"}
@@ -442,19 +441,19 @@ large*           | 8     | 16GB
 
 Class             | vCPUs | RAM
 ------------------|-------|-----
-medium (default)* | 4     | 15GB
+medium (default)  | 4     | 15GB
 
 
 ##### GPU (Linux) Executor
 
 Class            | vCPUs | RAM
------------------|-------|-----
+-----------------|-------|-------
 1GPU*            | 16    | 122GiB
 2GPU*            | 32    | 244GiB
 4GPU*            | 64    | 488GiB
 {: class="table table-striped"}
 
-\*_Access to these resources must be reviewed by the CircleCI support team. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
+\*_Requires review. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
 
 Below is an example of specifying a `large` `resource_class` for Docker.
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -440,9 +440,6 @@ Class            | vCPUs | RAM
 -----------------|-------|-------
 medium (default) | 2     | 7.5GB
 large            | 4     | 15GB
-1GPU\*           | 16    | 122GiB
-2GPU\*           | 32    | 244GiB
-4GPU\*           | 64    | 488GiB
 {: class="table table-striped"}
 
 ###### Example Usage
@@ -450,7 +447,7 @@ large            | 4     | 15GB
 jobs:
   build:
     machine: true
-    resource_class: 1GPU
+    resource_class: large
     steps:
       ... // other config
 ```
@@ -488,6 +485,25 @@ jobs:
       image: windows-server-2019-vs2019:201908-06
     resource_class: windows.medium
     shell: powershell.exe -ExecutionPolicy Bypass
+    steps:
+      ... // other config
+```
+
+##### GPU Executor (Linux)
+
+Class            | vCPUs | RAM
+-----------------|-------|-------
+1GPU\*           | 16    | 122GiB
+2GPU\*           | 32    | 244GiB
+4GPU\*           | 64    | 488GiB
+{: class="table table-striped"}
+
+###### Example Usage
+```yaml
+jobs:
+  build:
+    machine: true
+    resource_class: 1GPU
     steps:
       ... // other config
 ```

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -404,11 +404,13 @@ A job that was not executed due to configured rules will show up in the list of 
 
 #### **`resource_class`**
 
-The `resource_class` feature allows configuring CPU and RAM resources for each job. If this config is not specified, or an invalid class is specified, the default `resource_class: medium` will be used. Different resource classes are available for different executors, as described in the tables below. 
+The `resource_class` feature allows configuring CPU and RAM resources for each job. If this config is not specified, or an invalid class is specified, the default `resource_class: medium` will be used. Different resource classes are available for different executors, as described in the tables below.
 
 We implement soft concurrency limits for each resource class to ensure our system remains stable for all customers. If you are on a Performance or custom plan and experience queuing for certain resource classes, it's possible you are hitting these limits. [Contact CircleCI support](https://support.circleci.com/hc/en-us/requests/new) to request a raise on these limits for your account.
 
 **Note:** This feature is automatically enabled on Performance Plan. If you are on a container or unpaid plan you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) and speak with a CircleCI Sales representative about enabling this feature.
+
+\* _Items marked with an asterisk require review by our support team. [Open a support ticket](https://support.circleci.com/hc/en-us/requests/new) if you'd like to request access._
 
 ##### Docker Executor
 
@@ -477,14 +479,18 @@ Class             | vCPUs | RAM
 ------------------|-------|-----
 medium (default)  | 4     | 15GB
 
+There is currently only one size of Windows Machine available, please let us know if you find yourself needing more.
+
 ###### Example Usage
 ```yaml
+version: 2.1
+
+orbs:
+  win: circleci/windows@1.0.0
+
 jobs:
   build:
-    machine:
-      image: windows-server-2019-vs2019:201908-06
-    resource_class: windows.medium
-    shell: powershell.exe -ExecutionPolicy Bypass
+    executor: win/vs2019
     steps:
       ... // other config
 ```
@@ -493,24 +499,14 @@ jobs:
 
 Class            | vCPUs | Memory (GiB) | GPUs | GPU Memory (*GiB)
 -----------------|-------|--------------|------|-----------------
-gpu.small\*      | 16    | 122GiB        | 1    | 8
-gpu.medium\*     | 32    | 244GiB       | 2    | 16
-gpu.large\*      | 64    | 488GiB       | 4    | 32
+1GPU\*           | 16    | 122GiB       | 1    | 8
+2GPU\*           | 32    | 244GiB       | 2    | 16
+4GPU\*           | 64    | 488GiB       | 4    | 32
 {: class="table table-striped"}
 
-###### Example Usage
-```yaml
-jobs:
-  build:
-    machine: true
-    resource_class: gpu.small
-    steps:
-      ... // other config
-```
-
-\*_Requires review by support team. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
-
 **Note**: Java, Erlang and any other languages that introspect the `/proc` directory for information about CPU count may require additional configuration to prevent them from slowing down when using the CircleCI 2.0 resource class feature. Programs with this issue may request 32 CPU cores and run slower than they would when requesting one core. Users of languages with this issue should pin their CPU count to their guaranteed CPU resources.
+
+If you want to confirm how much memory you have been allocated, you can check the cgroup memory hierarchy limit with `grep hierarchical_memory_limit /sys/fs/cgroup/memory/memory.stat`.
 
 #### **`steps`**
 
@@ -686,7 +682,7 @@ A value of `on_fail` means that the step will run only if one of the preceding s
 
 ###### Ending a Job from within a `step`
 
-A job can exit without failing by using using `run: circleci-agent step halt`. This can be useful in situations where jobs need to conditionally execute. 
+A job can exit without failing by using using `run: circleci-agent step halt`. This can be useful in situations where jobs need to conditionally execute.
 
 Here is an example where `halt` is used to avoid running a job on the `develop` branch:
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -491,11 +491,11 @@ jobs:
 
 ##### GPU Executor (Linux)
 
-Class            | vCPUs | RAM
------------------|-------|-------
-1GPU\*           | 16    | 122GiB
-2GPU\*           | 32    | 244GiB
-4GPU\*           | 64    | 488GiB
+Class            | vCPUs | Memory (GiB) | GPUs | GPU Memory (*GiB)
+-----------------|-------|--------------|------|-----------------
+gpu.small\*      | 16    | 122GiB        | 1    | 8
+gpu.medium\*     | 32    | 244GiB       | 2    | 16
+gpu.large\*      | 64    | 488GiB       | 4    | 32
 {: class="table table-striped"}
 
 ###### Example Usage
@@ -503,7 +503,7 @@ Class            | vCPUs | RAM
 jobs:
   build:
     machine: true
-    resource_class: 1GPU
+    resource_class: gpu.small
     steps:
       ... // other config
 ```

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -454,7 +454,7 @@ Class            | vCPUs | RAM
 4GPU*            | 64    | 488GiB
 {: class="table table-striped"}
 
-\*_Access to these resources must be reviewed by the CircleCI support team regardless of your current pricing plan. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
+\*_Access to these resources must be reviewed by the CircleCI support team. Open a support ticket [here](https://support.circleci.com/hc/en-us/requests/new)._
 
 Below is an example of specifying a `large` `resource_class` for Docker.
 


### PR DESCRIPTION
# Description
Added information in the docs about the different resource classes for each executor type.

# Reasons
Feedback was given that the information on resource_class was confusing. For example they didn't see information about whether there were different resource classes available for Windows or Mac, and there was a note in the description originally stating that resource_class is only configurable for Docker, which is not true.