### PR TITLE
added note on using halt 

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -601,6 +601,19 @@ step that needs to upload logs or code-coverage data somewhere.
 
 A value of `on_fail` means that the step will run only if one of the preceding steps has failed (returns a non-zero exit code). It is common to use `on_fail` if you want to store some diagnostic data to help debug test failures, or to run custom notifications about the failure, such as sending emails or triggering alerts in chatrooms.
 
+###### Ending a Job from within a `step`
+
+A job can exit without failing by using using `run: circleci-agent step halt`. This can be useful in situations where jobs need to conditionally execute. 
+
+Here is an example where `halt` is used to avoid running a job on the `develop` branch:
+
+``` YAML
+run: |
+    if [ "$CIRCLE_BRANCH" = "develop" ]; then
+        circleci-agent step halt
+    fi
+```
+
 ###### Example
 
 ```yaml


### PR DESCRIPTION
# Description
Included some documentation on using halt to end a job from within a step

# Reasons
Resolves https://ideas.circleci.com/ideas/CCI-I-260
and also pulls from https://support.circleci.com/hc/en-us/articles/360015562253-Conditionally-end-a-running-job-gracefully and https://discuss.circleci.com/t/ability-to-return-successfully-from-a-job-before-completing-all-the-next-steps/12969/5