### PR TITLE
Update macOS Docs

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -519,7 +519,13 @@ Each `run` declaration represents a new shell. It's possible to specify a multi-
 
 ###### _Default shell options_
 
-The default value of shell option is `/bin/bash -eo pipefail` if `/bin/bash` is present in the build container. Otherwise it is `/bin/sh -eo pipefail`. The default shell is not a login shell (`--login` or `-l` are not specified by default). Hence, the default shell will **not** source your `~/.bash_profile`, `~/.bash_login`, `~/.profile` files. Descriptions of the `-eo pipefail` options are provided below.
+For jobs that run on **Linux**, the default value of the `shell` option is `/bin/bash -eo pipefail` if `/bin/bash` is present in the build container. Otherwise it is `/bin/sh -eo pipefail`. The default shell is not a login shell (`--login` or `-l` are not specified). Hence, the shell will **not** source your `~/.bash_profile`, `~/.bash_login`, `~/.profile` files.
+
+For jobs that run on **macOS**, the default shell is `/bin/bash --login -eo pipefail`. The shell is a non-interactive login shell. The shell will execute `/etc/profile/` followed by `~/.bash_profile` before every step.
+
+For more information about which files are executed when bash is invocated, [see the `INVOCATION` section of the `bash` manpage](https://linux.die.net/man/1/bash).
+
+Descriptions of the `-eo pipefail` options are provided below.
 
 `-e`
 
@@ -840,7 +846,7 @@ In general `deploy` step behaves just like `run` with two exceptions:
 
 - In a job with `parallelism`, the `deploy` step will only be executed by node #0 and only if all nodes succeed. Nodes other than #0 will skip this step.
 - In a job that runs with SSH, the `deploy` step will not execute, and the following action will show instead:
-  > **skipping deploy**  
+  > **skipping deploy**
   > Running in SSH mode.  Avoid deploying.
 
 ###### Example

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -29,7 +29,8 @@ We announce the availability of new macOS containers in the [annoucements sectio
 
 The currently available Xcode versions are:
 
-* `11.0.0`: Xcode 11.0 (GM Seed 1) (Build 11A419c) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v1136/index.html)
+* `11.1.0`: Xcode 11.1 (GM Seed) (Build 11A1027) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v1226/index.html)
+* `11.0.0`: Xcode 11.0 (Build 11A420a) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v1136/index.html)
 * `10.3.0`: Xcode 10.3 (Build 10G8) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-903/index.html)
 * `10.2.1`: Xcode 10.2.1 (Build 10E1001) [installed software]( https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-594/index.html)
 * `10.1.0`: Xcode 10.1 (Build 10B61) [installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-474/index.html)
@@ -240,7 +241,6 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
-    shell: /bin/bash --login -o pipefail
     steps:
       - checkout
       - run: bundle install
@@ -258,7 +258,6 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
-    shell: /bin/bash --login -o pipefail
     steps:
       - checkout
       - run: bundle install
@@ -281,7 +280,7 @@ workflows:
             - build-and-test
 ```
 
-The environment variable `FL_OUTPUT_DIR` is the artifact directory where FastLane logs should be stored. Use this to set the path in the `store_artifacts` step to automatically save logs such as Gym and Scan. 
+The environment variable `FL_OUTPUT_DIR` is the artifact directory where FastLane logs should be stored. Use this to set the path in the `store_artifacts` step to automatically save logs such as Gym and Scan.
 
 ### Reducing Testing Time
 
@@ -371,20 +370,11 @@ It is also possible to use the `sudo` command if necessary to perform customizat
 ### Using Custom Ruby Versions
 {:.no_toc}
 
-Our macOS containers contain multiple versions of Ruby. The default version is  the system-installed Ruby. The containers also include the latest stable versions of Ruby at the time that the container is built. We determine the stable versions of Ruby using the [Ruby-Lang.org downloads page](https://www.ruby-lang.org/en/downloads/). The version of Ruby that are  installed in each image are listed in the [software manifests of each container](#supported-xcode-versions).
+Our macOS containers contain multiple versions of Ruby. The default version is the system-installed Ruby. The containers also include the latest stable versions of Ruby at the time that the container is built. We determine the stable versions of Ruby using the [Ruby-Lang.org downloads page](https://www.ruby-lang.org/en/downloads/). The version of Ruby that are installed in each image are listed in the [software manifests of each container](#supported-xcode-versions).
 
-If you want to run steps with a version of Ruby that is listed as "available to chruby" in the manifest, then you can use [`chruby`](https://github.com/postmodern/chruby) to do so. To activate `chruby`, you **must** change the `shell` parameter of your job to be a login shell (adding `--login`).
+If you want to run steps with a version of Ruby that is listed as "available to chruby" in the manifest, then you can use [`chruby`](https://github.com/postmodern/chruby) to do so.
 
-```yaml
-version: 2
-jobs:
-  build:
-    macos:
-      xcode: "10.2.0"
-    shell: /bin/bash --login -eo pipefail
-```
-
- To specify a version of Ruby to use, there are two options. You can [create a file named `.ruby-version` and commit it to your repository, as documented by `chruby`](https://github.com/postmodern/chruby#auto-switching). If you do not want to commit a `.ruby-version` file to source control, then you can create the file from a job step:
+To specify a version of Ruby to use, there are two options. You can [create a file named `.ruby-version` and commit it to your repository, as documented by `chruby`](https://github.com/postmodern/chruby#auto-switching). If you do not want to commit a `.ruby-version` file to source control, then you can create the file from a job step:
 
 ```yaml
 run:
@@ -445,19 +435,19 @@ the app is easy with one of the following:
 
 Then you should set up environment variables for your service of choice:
 
-### Hockey App 
+### Hockey App
 {:.no_toc}
 
 1. Log in to Hockey app and create a new API token on the [Tokens page](
 https://rink.hockeyapp.net/manage/auth_tokens). Your token will need at
-least upload permission to upload new builds to Hockey App. 
+least upload permission to upload new builds to Hockey App.
 
 2. Give your
 new API token a name specific to CircleCI such as "CircleCI
-Distribution". 
+Distribution".
 
 3. Copy the token, and log into CircleCI and go to the
-Project Settings page for your app. 
+Project Settings page for your app.
 
 4. Create a new Environment Variable with
 the name `HOCKEY_APP_TOKEN` and paste the token as the value. You can now
@@ -469,7 +459,7 @@ access this token in any job.
 1. Log in to Fabric.io and visit your organization's settings page.
 ![Fabric.io loging image](  {{ site.baseurl }}/assets/img/docs/fabric-org-settings-page.png)
 
-2. Click your organization (CircleCI in the image above), and click 
+2. Click your organization (CircleCI in the image above), and click
 the API key and Build Secret links to reveal the items.
 ![Fabric.io org image](  {{ site.baseurl }}/assets/img/docs/fabric-api-creds-page.png)
 
@@ -533,7 +523,7 @@ projects. Here are the most frequent of those:
 
 * **Xcode version is not available.** We install
   a few different versions of Xcode in each build
-  image and keep those updated with the latest point releases. For version `10.0.0`, 
+  image and keep those updated with the latest point releases. For version `10.0.0`,
   you must specify the full version, down to the point release number. However,
   to use the latest Xcode 8.3, for example, which is `8.3.3`, it is
   sufficient to specify `8.3` in your `config.yml`. If a newer point


### PR DESCRIPTION
The shell is now always a login shell, so we remove the instructions to
add --login on the 'testing on ios' page.

We also need to make this clear on the config references page.

Add docs for Xcode 11.1 and update the 11.0 docs to remove the "GM"
designation, since GM 2 _was_ the final release.