### PR TITLE
remove internal doc link to Orb Deployment best practices

### DIFF
--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -85,7 +85,7 @@ When possible, use defaults for parameters unless a user input is essential. Uti
 - Minor: Add new features (backwards compatible)
 - Patch: Minor bug fixes, metadata updates, or other safe actions.
 
-View our Orb Deployment best practices here: [https://docs.google.com/document/d/1MqQCo8aeYjvGJAa0v60L2FJelLFjWP1IgkWuBfMiC3c](https://docs.google.com/document/d/1MqQCo8aeYjvGJAa0v60L2FJelLFjWP1IgkWuBfMiC3c) [NOT COMPLETE]
+View our Orb Deployment best practices here: [coming soon]
 
 This section is handled automatically via the Orb Starter Kit.
 


### PR DESCRIPTION
A link was left in from the originating repo that should not be public-facing. Though no user would have had access to view and the document contains no sensitive information, it is just a matter of presentation.
