### PR TITLE
Remove incorrect formatted "naming convention"

### DIFF
--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -38,13 +38,6 @@ A collection best practices and strategies for authoring orbs. CircleCI orbs are
 - It is possible not all CLI commands need to be transformed into an orb command. Single line commands with no parameters do not necessarily need to have an orb command alias.
 - Command descriptions should call out any dependencies or assumptions, particularly if you intend for the command to run outside of a provided executor in your orb.
 
-### Suggested Naming Conventions
-
-- CLI Orbs
-- Install
-- Check for and install the tool if it is not currently installed
-- Setup
-
 ### Parameters
 
 When possible, use defaults for parameters unless a user input is essential. Utilize the [“env_var_name” parameter type](https://circleci.com/docs/2.0/reusing-config/#environment-variable-name) to secure API keys or other sensitive data. 


### PR DESCRIPTION


# Description
The naming convention area is outdated and incorrectly formatted. Will return with a new PR if we implement new naming practices.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.