### PR TITLE
Enable multi-language search

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -15,6 +15,7 @@ plugins:
 
 algolia:
   application_id: U0RXNGRK45
+  api_key: dd49f5b81d238d474b49645a4daed322 # search-only API Key; safe for front-end code
   index_name: documentation
   settings:
     highlightPreTag: '<strong>'

--- a/jekyll/_includes/js-config.html
+++ b/jekyll/_includes/js-config.html
@@ -1,0 +1,9 @@
+<script type="text/javascript">
+  window.circleJsConfig = {
+    algolia: {
+      appId:     {{ site.algolia.application_id | jsonify }},
+      apiKey:    {{ site.algolia.api_key | jsonify }},
+      indexName: {{ site.algolia.index_name | jsonify }}
+    }
+  }
+</script>

--- a/jekyll/_includes/js-config.html
+++ b/jekyll/_includes/js-config.html
@@ -4,6 +4,9 @@
       appId:     {{ site.algolia.application_id | jsonify }},
       apiKey:    {{ site.algolia.api_key | jsonify }},
       indexName: {{ site.algolia.index_name | jsonify }}
+    },
+    page: {
+      lang: {{ page.lang | jsonify }}
     }
   }
 </script>

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -37,6 +37,7 @@
 		</div><!-- .article-container -->
 	</div><!-- .main-body -->
 	{% include global-footer.html %}
+	{% include js-config.html %}
 	{% asset vendor.min.js %}
   <script>
    var _rollbarConfig = {

--- a/src-js/instantsearch.js
+++ b/src-js/instantsearch.js
@@ -4,6 +4,14 @@ import * as get from 'lodash.get';
 const ALGOLIA_APP_ID     = window.circleJsConfig.algolia.appId;
 const ALGOLIA_API_KEY    = window.circleJsConfig.algolia.apiKey;
 const ALGOLIA_INDEX_NAME = window.circleJsConfig.algolia.indexName;
+const ALGOLIA_COLLECTION = ((lang) => {
+  // Page language is default language or missing, use default collection
+  if (typeof lang !== 'string' || lang === 'en') {
+    return 'cci2';
+  } else {
+    return `cci2_${lang}`;
+  }
+})(get(window.circleJsConfig, 'page.lang'));
 
 const formatResultSnippet = (snippet) => {
   const title = get(snippet, ['title', 'value'], '(untitled)');
@@ -28,7 +36,7 @@ export function init () {
   // adding conditions to filter search
   search.addWidget(
     instantsearch.widgets.configure({
-      filters: "collection: cci2"
+      filters: `collection: ${ALGOLIA_COLLECTION}`
     })
   );
 

--- a/src-js/instantsearch.js
+++ b/src-js/instantsearch.js
@@ -1,6 +1,10 @@
 import * as debounce from 'lodash.debounce';
 import * as get from 'lodash.get';
 
+const ALGOLIA_APP_ID     = window.circleJsConfig.algolia.appId;
+const ALGOLIA_API_KEY    = window.circleJsConfig.algolia.apiKey;
+const ALGOLIA_INDEX_NAME = window.circleJsConfig.algolia.indexName;
+
 const formatResultSnippet = (snippet) => {
   const title = get(snippet, ['title', 'value'], '(untitled)');
   const content = get(snippet, ['content', 'value'], '');
@@ -14,9 +18,9 @@ const formatResultSnippet = (snippet) => {
 // Instant search initialization
 export function init () {
   var search = instantsearch({
-    appId: 'U0RXNGRK45',
-    apiKey: 'dd49f5b81d238d474b49645a4daed322', // search-only API Key; safe for front-end code
-    indexName: 'documentation',
+    appId:     ALGOLIA_APP_ID,
+    apiKey:    ALGOLIA_API_KEY,
+    indexName: ALGOLIA_INDEX_NAME,
     routing: true,
     searchParameters: { hitsPerPage: 25 }
   });


### PR DESCRIPTION
## Changes

Currently Japanese language pages are not searchable. We want to make them searchable from Japanese docs pages under `/docs/ja` while not including those results in searches from English pages.

We're already indexing Japanese pages in the `cci2_ja` collection, and we were already filtering search results by collection, so enabling this was fairly simple.

We just need to:

1. Dynamically switch which collection we filter on at page load.
2. Write the page language into the JS config to drive some collection selection logic.


## Also includes:

#### Provide a way to pass config data from Jekyll to JS (https://github.com/circleci/circleci-docs/commit/98dc3013e0a6f1168c4a233b978b0a21501370ba)

There are cases where we need to expose data that we have in the Ruby/Jekyll context to the JS context.

This enables that by building a `circleJsConfig` JS object in an HTML/JS snippet that gets included on every page.

In this initial usage, we use it to pass Algolia config data stored in `_config.yml` to instantsearch.js.