### PR TITLE
Updated some details on pipeline settings

### DIFF
--- a/jekyll/_cci2/build-processing.md
+++ b/jekyll/_cci2/build-processing.md
@@ -10,7 +10,7 @@ order: 1
 This document describes how to enable the pipelines engine if you need to trigger workflows from the CircleCI API or auto-cancel workflows.
 
 ## Getting Started
-Enable pipelines at the bottom of the Advanced section of Settings page for your project in the CircleCI app. **Note:** Pipelines require v2.1 configuration and are not yet supported for private CircleCI Server installations.
+Most projects will have Pipelines enabled by default. Verify the project pipeline setting in the Advanced section of your project's Settings page in the CircleCI app. **Note:** Pipelines are compatible with v2 and v2.1 configurations and are not yet supported for private CircleCI Server installations.
 
 ## Benefits of Pipelines
 

--- a/jekyll/_cci2/build-processing.md
+++ b/jekyll/_cci2/build-processing.md
@@ -10,7 +10,7 @@ order: 1
 This document describes how to enable the pipelines engine if you need to trigger workflows from the CircleCI API or auto-cancel workflows.
 
 ## Getting Started
-Most projects will have Pipelines enabled by default. Verify the project pipeline setting in the Advanced section of your project's Settings page in the CircleCI app. **Note:** Pipelines are compatible with v2 and v2.1 configurations and are not yet supported for private CircleCI Server installations.
+Most projects will have Pipelines enabled by default. Verify the project pipeline setting in the Advanced section of your project's Settings page in the CircleCI app. **Note:** Pipelines are compatible with v2 and v2.1 configurations of CircleCI. Currently, Pipelines are not yet supported for private CircleCI Server installations.
 
 ## Benefits of Pipelines
 


### PR DESCRIPTION
Turns out that pipelines are enabled by default for most project, added that detail and changed the wording 
Also turns out that pipelines are compatible with config.yml 2 and 2.1

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.