### PR TITLE
Fix link label

### DIFF
--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -263,4 +263,4 @@ The top level `examples` key is optional. Usage example maps nested below it can
 ## Next Steps
 {:.no_toc}
 
-- Refer to [Test and Publish Your Orb]({{site.baseurl}}/2.0/orb-author-validate-publish/) for next steps.
+- Refer to [Validate and Publish Your Orb]({{site.baseurl}}/2.0/orb-author-validate-publish/) for next steps.


### PR DESCRIPTION
# Description

Changes a link label from "Test and Publish Your Orb" to "Validate and Publish Your Orb"

# Reasons

The title of [the linked page](https://github.com/circleci/circleci-docs/blob/master/jekyll/_cci2/orb-author-validate-publish.md) is "Orb Author - Validate and Publish Orbs."