### PR TITLE
Upgrade Markdown Proofer.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,19 +57,10 @@ jobs:
       - run:
           name: "Test Markdown Files"
           command: |
-            wget https://github.com/felicianotech/md-proofer/releases/download/v0.1.0/md-proofer-v0.1.0-linux-amd64.tar.gz
-            tar xfz md-proofer-v*.tar.gz
+            wget https://github.com/felicianotech/md-proofer/releases/download/v0.3.0/md-proofer--v0.3.0--linux-amd64.tar.gz
+            tar xfz md-proofer--v*.tar.gz
             sudo chmod +x ./md-proofer
-
-            echo "Test CircleCI 2.0 Markdown files"
-            echo "===================================================================================="
-            ./md-proofer lint jekyll/_cci2/
-            echo "\n\nTest CircleCI API Markdown files"
-            echo "===================================================================================="
-            ./md-proofer lint jekyll/_api/
-            echo "\n\nTest CircleCI 1.0 Markdown files"
-            echo "===================================================================================="
-            ./md-proofer lint jekyll/_cci1/
+            ./md-proofer lint jekyll/_cci2/ jekyll/_api/ jekyll/_cci1/
       - restore_cache:
           key: circleci-docs-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
       - run:


### PR DESCRIPTION
Upgrades Markdown Proofer to v0.3. The new version allows users to specify multiple directories to check on the same line, saving the Docs config 9 lines.