### PR TITLE
expand store_artifacts example

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -969,9 +969,12 @@ There can be multiple `store_artifacts` steps in a job. Using a unique prefix fo
 ###### Example
 
 ``` YAML
+- run:
+    name: Build the Jekyll site
+    command: bundle exec jekyll build --source jekyll --destination jekyll/_site/docs/
 - store_artifacts:
-    path: /code/test-results
-    destination: prefix
+    path: jekyll/_site/docs/
+    destination: circleci-docs
 ```
 
 ##### **`store_test_results`**


### PR DESCRIPTION
Example expanded to show the `store_artifacts` step comes after the step that creates the artifact, after customer survey response: "store_artifacts should be place before or after commands reproducing artifacts?"