### PR TITLE
Update Jest example in "Collect test data"

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -490,7 +490,7 @@ steps:
       name: Run tests with JUnit as reporter
       command: jest --ci --runInBand --reporters=default --reporters=jest-junit
       environment:
-        JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+        JEST_JUNIT_OUTPUT_DIR: "reports/junit/js-test-results.xml"
 ```
 
 For a full walkthrough, refer to this article by Viget: [Using JUnit on CircleCI 2.0 with Jest and ESLint](https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint).

--- a/jekyll/_cci2_ja/collect-test-data.md
+++ b/jekyll/_cci2_ja/collect-test-data.md
@@ -449,7 +449,7 @@ steps:
       name: JUnit をレポーターとしてテストを実行
       command: jest --ci --runInBand --reporters=default --reporters=jest-junit
       environment:
-        JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+        JEST_JUNIT_OUTPUT_DIR: "reports/junit/js-test-results.xml"
 ```
 
 全体の手順については、Viget の記事「[Using JUnit on CircleCI 2.0 with Jest and ESLint (Jest および ESLint と共に CircleCI 2.0 で JUnit を使用する)](https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint)」を参照してください。


### PR DESCRIPTION
# Description
Change `JEST_JUNIT_OUTPUT` to `JEST_JUNIT_OUTPUT_DIR`. 
Such change was introduced in jest-junit 2 months ago:
https://github.com/jest-community/jest-junit/commit/3e135819528f0bdbae19b0ed37d3c043fcff0caf

# Reasons
JEST_JUNIT_OUTPUT environment variable is not longer recognised by jest-junit.