### PR TITLE
Added thumbs.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ run-results/
 node_modules/
 
 src-api/build/
+thumbs.db


### PR DESCRIPTION
# Description
`thumbs.db` is a windows directory cache file which sometimes gets pushed to repos, comes in commits, and can trouble other users. Now windows users can send PRs without having to worry about `thumbs.db`.

# Reasons
Now windows users can send PRs without having to worry about `thumbs.db` and other windows users will not get affected.