### PR TITLE
Fix typo of the word "sample"

### DIFF
--- a/jekyll/_cci2/browser-testing.md
+++ b/jekyll/_cci2/browser-testing.md
@@ -79,7 +79,7 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
       # the working dir is github repo that you need to fork to become owner.
-    working_directory: ~/nightwatch-saple-for-circleci
+    working_directory: ~/nightwatch-sample-for-circleci
     steps:
       - checkout
       


### PR DESCRIPTION
# Description

nightwatch-saple-for-circleci

->

nightwatch-sample-for-circleci


# Reasons

Typo