### PR TITLE
Improve .NET example to always convert test results

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -416,6 +416,7 @@ A working `.circleci/config.yml` section might look like this:
       - run: dotnet test --no-build --logger "trx"
       - run:
           name: test results
+          when: always
           command: |
               dotnet tool install -g trx2junit
               export PATH="$PATH:/root/.dotnet/tools"


### PR DESCRIPTION
# Description
Improve the .NET `trx2junit` example by specifying the test conversion step should always run. In the current example if `dotnet test` fails, the test results won't get converted

# Reasons
https://support.circleci.com/hc/en-us/requests/60383