### PR TITLE
Update api-job-trigger.md

### DIFF
--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -7,10 +7,9 @@ categories: [configuring-jobs]
 order: 80
 ---
 
-
 This document describes how to trigger jobs using the CircleCI API.
 
-**Note:** Triggering jobs from the API is **not** supported with v2.1.
+**Note:** You cannot currently trigger jobs that use 2.1 config from the API.
 
 * TOC
 {:toc}


### PR DESCRIPTION
Re-worded note in document to state correctly "You cannot currently trigger jobs that use 2.1 config from the API."

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.