### PR TITLE
fix #3852: Changed the wrong link to "Enabling Pipelines"

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -184,7 +184,7 @@ en:
         - name: Using Contexts
           link: 2.0/contexts/
         - name: Enabling Pipelines
-          link: 2.0/build-processing/
+          link: 2.0/pipelines/
         - name: Setting Up iOS Code Signing
           link: 2.0/ios-codesigning/
     - name: Optimizations


### PR DESCRIPTION
# Description
Changed the wrong link to "Enabling Pipelines"
2.0/build-processing/  ->  2.0/pipelines/

# Reasons
Issue: https://github.com/circleci/circleci-docs/issues/3852