### PR TITLE
Fix a typo in the JavaScript section

### DIFF
--- a/jekyll/_cci2/code-coverage.md
+++ b/jekyll/_cci2/code-coverage.md
@@ -255,7 +255,7 @@ jobs:
 
 [Istanbul](https://github.com/gotwarlost/istanbul) is a popular library for generating code coverage reports for
 JavaScript projects. Another popular testing tool, Jest, uses Istanbul to
-generage reports. Consider this example:
+generate reports. Consider this example:
 
 ```yaml
 version: 2


### PR DESCRIPTION
“Generage” should be “generate”.

# Description
I fixed a typo in the JavaScript section of the Code Coverage docs.

# Reasons
I propose this change because “generage” is almost certainly a typo.