### PR TITLE
Link to test splitting info

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -20,7 +20,7 @@ things you can do with the CircleCI CLI include:
 
 This document will cover the installation and usage of the CLI tool. **Note:**
 the new CLI is currently not available on server installations of CircleCI. The
-legacy CLI does work in Server and can be installed. Read more below: 
+legacy CLI does work in Server and can be installed. 
 
 * TOC
 {:toc}
@@ -313,6 +313,10 @@ Further, not all commands may work on your local machine as they do online. For 
 **Environment Variables**
 
 For security reasons, encrypted environment variables configured in the UI will not be imported into local builds. As an alternative, you can specify env vars to the CLI with the `-e` flag. See the output of `circleci help build` for more information. If you have multiple environment variables, you must use the flag for each variable, for example, `circleci build -e VAR1=FOO -e VAR2=BAR`.
+
+## Test Splitting
+
+The CircleCI CLI is also used for some advanced features during job runs, for example [test splitting](https://circleci.com/docs/2.0/parallelism-faster-jobs/#using-the-circleci-cli-to-split-tests) for build time optimization.
 
 ## Using the CLI on CircleCI Server
 


### PR DESCRIPTION
Add link to test splitting doc from the CLI doc to address survery repsonse: "I was looking for a way to have multiple machines to run tests in parallel. Sorry as I couldn't find it. ”