### PR TITLE
Replaced the repository from GitHub.com to GitLab.com on migrating-from-gitlab.adoc

### DIFF
--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -22,7 +22,7 @@ If you are using GitLab's SCM, you will first need to migrate your source code t
 Following are the steps required for using the git command line tool to import your GitLab repo into GitHub Enterprise:
 
 . Create an empty repository on your GitHub Enterprise instance.
-. Create a bare clone of your GitHub.com repository on your local machine, fetching all remote tags (refs/tags/\*) and copying all remote branch heads (refs/heads/\*) directly to their corresponding local branch heads:
+. Create a bare clone of your GitLab.com repository on your local machine, fetching all remote tags (refs/tags/\*) and copying all remote branch heads (refs/heads/\*) directly to their corresponding local branch heads:
 +
 ```
 git clone git@gitlab.com:[owner]/[repo-name].git --bare
@@ -61,7 +61,7 @@ Some differences that are worth calling out:
 [cols=2*, options="header", stripes=even]
 [cols="5,5"]
 |===
-| Gitlab | CircleCI
+| GitLab | CircleCI
 
 2+h| Define a job that executes a single build step. 
 


### PR DESCRIPTION
# Description
1. Fixed the repository from GitHub.com to GitLab.com at 2nd step for migration of the GitHub Enterprise section.
2. Minor typo fixed from Gitlab to GitLab in the header of a different table in the Build Configuration section.

# Reasons
1. The 'git clone' command shows the cloning of a repository from gitlab.com in the GitHub Enterprise section. But the 2nd step describes GitHub.com instead of GitLab.com.
![image](https://user-images.githubusercontent.com/8275663/67547247-7df64980-f739-11e9-9cbf-eab6705b59ab.png)

2. **GitLab** is more correct word instead **Gitlab** in the header of a different table in the Build Configuration section. It is similar to that **CircleCI** is the correct one instead of **Circleci** on the published documentation.