### PR TITLE
remove incorrect ref to resource class use

### DIFF
--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -125,7 +125,7 @@ Read more in-depth about splitting tests in our [document on parallelism]({{site
 
 **Note:** An eligible plan is required to use the [`resource_class`]({{site.baseurl}}/2.0/configuration-reference#resource_class) feature. If you are on a container-based plan you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) to enable this feature on your account.
 
-Using `resource_class`, it is possible to configure CPU and RAM resources for each job as described in [this table](https://circleci.com/docs/2.0/configuration-reference/#resource_class). If `resource_class` is not specified or an invalid class is specified, the default `resource_class: medium` will be used. The `resource_class` key is currently only available for use with the `docker` executor.
+Using `resource_class`, it is possible to configure CPU and RAM resources for each job as described in [this table](https://circleci.com/docs/2.0/configuration-reference/#resource_class). If `resource_class` is not specified or an invalid class is specified, the default `resource_class: medium` will be used.
 
 Below is an example use case of the `resource_class` feature.
 


### PR DESCRIPTION
fixes #3870 
Remove text stating resource_class only available for `machine`.