### PR TITLE
Add a note about the Cocoapods 1.8 CDN

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -70,7 +70,7 @@ example of a minimal config in the
 ### Best Practices
 {:.no_toc}
 
-In addition to the basic setup steps, it is best practice to include
+In addition to the basic setup steps, if you are using Cocoapods 1.7 and lower, it is best practice to include
 downloading CocoaPods specs from the CircleCI mirror (up to 70% faster)
 and linting the Swift code together with the `build-and-test` job:
 
@@ -110,6 +110,14 @@ workflows:
   build-and-test:
     jobs:
       - build-and-test
+```
+
+As of Cocoapods 1.8, cloning the Cocoapods Specs repo is no longer required and has been superseeded by using a CDN. This has the advantage of speeding up job execution times.
+
+To enable the Cocoapods CDN, remove the `Fetch CocoaPods Specs` step from your CircleCI config and replace the `source` directive (which points to the Specs repo) in the Podfile with the following:
+
+```
+source 'https://cdn.cocoapods.org/'
 ```
 
 ## Advanced Setup

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -70,54 +70,18 @@ example of a minimal config in the
 ### Best Practices
 {:.no_toc}
 
-In addition to the basic setup steps, if you are using Cocoapods 1.7 and lower, it is best practice to include
-downloading CocoaPods specs from the CircleCI mirror (up to 70% faster)
-and linting the Swift code together with the `build-and-test` job:
+In addition to the basic setup steps, it is best practice to use Cocoapods 1.8 or newer which allows the use of the CDN, rather than having to clone the entire Specs repo. If you are using Cocoapods 1.7 or older, consider upgrading to 1.8 or newer as this change allows for much faster job execution of the `pod install` step.
 
-```yaml
-# .circleci/config.yml
-version: 2
-jobs:
-  build-and-test:
-    macos:
-      xcode: "10.2.0"
-    environment:
-      FL_OUTPUT_DIR: output
-    steps:
-      - checkout
-      - run:
-          name: Fetch CocoaPods Specs
-          command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
-      - run:
-          name: Install CocoaPods
-          command: pod install --verbose
-
-      - run:
-          name: Build and run tests
-          command: fastlane scan
-          environment:
-            SCAN_DEVICE: iPhone 8
-            SCAN_SCHEME: WebTests
-
-      - store_test_results:
-          path: output/scan
-      - store_artifacts:
-          path: output
-
-workflows:
-  version: 2
-  build-and-test:
-    jobs:
-      - build-and-test
-```
-
-As of Cocoapods 1.8, cloning the Cocoapods Specs repo is no longer required and has been superseeded by using a CDN. This has the advantage of speeding up job execution times.
-
-To enable the Cocoapods CDN, remove the `Fetch CocoaPods Specs` step from your CircleCI config and replace the `source` directive (which points to the Specs repo) in the Podfile with the following:
+To enable this, ensure the first line in your Podfile is as follows:
 
 ```
 source 'https://cdn.cocoapods.org/'
+```
+
+If upgrading from Cocoapods 1.7 or older, additionally ensure the following line is removed from your Podfile, along with removing the "Fetch CocoaPods Specs" step in your CircleCI Configuration:
+
+```
+source 'https://github.com/CocoaPods/Specs.git'
 ```
 
 ## Advanced Setup

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -70,7 +70,7 @@ example of a minimal config in the
 ### Best Practices
 {:.no_toc}
 
-In addition to the basic setup steps, it is best practice to use Cocoapods 1.8 or newer which allows the use of the CDN, rather than having to clone the entire Specs repo. If you are using Cocoapods 1.7 or older, consider upgrading to 1.8 or newer as this change allows for much faster job execution of the `pod install` step.
+In addition to the basic setup steps, it is best practice to use Cocoapods 1.8 or newer which allows the use of the CDN, rather than having to clone the entire Specs repo. This will allow you to install pods faster, reducing build times. If you are using Cocoapods 1.7 or older, consider upgrading to 1.8 or newer as this change allows for much faster job execution of the `pod install` step.
 
 To enable this, ensure the first line in your Podfile is as follows:
 


### PR DESCRIPTION
# Description

Added a note about the Cocoapods 1.8 CDN

# Reasons

This will speed up builds and will be less reliant on our hosting of the specs (there have been cases where AWS outages have caused jobs to fail due to relying on the script)