### PR TITLE
Update volume deletion time period from 14 to 7 days

### DIFF
--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -51,7 +51,7 @@ One DLC volume can only be attached to one `machine` or Remote Docker job at a t
 
 Depending on which jobs the volumes are used in, they might end up with different layers saved on them. The volumes that are used less frequently might have older layers saved on them.
 
-The DLC volumes are deleted after 14 days of not being used in a job.
+The DLC volumes are deleted after 7 days of not being used in a job.
 
 CircleCI will create a maximum of 50 DLC volumes per project, so a maximum of 50 concurrent `machine` or Remote Docker jobs per project can have access to DLC. This takes into account the parallelism of the jobs, so a maximum of 1 job with 50x parallelism will have access to DLC per project, or 2 jobs with 25x parallelism, and so on.
 


### PR DESCRIPTION
The volume is removed if the disk has not been used for 7 days (ref: https://github.com/circleci/vm-service/blob/d953738/src/circleci/vm_service/gc.clj#L108).
Associated Slack discussion: https://circleci.slack.com/archives/C4C9J5KHN/p1573029882459000

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.