### PR TITLE
correct usage of when in workflows

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1304,22 +1304,17 @@ ignore | N | String, or List of Strings | Either a single tag specifier, or a li
 
 For more information, see the [Executing Workflows For a Git Tag]({{ site.baseurl }}/2.0/workflows/#executing-workflows-for-a-git-tag) section of the Workflows document.
 
-##### **`when` in Workflows**
+##### **Using `when` in Workflows**
 
-## Using 'when' in Workflows
+With CircleCI API v2, you may use a `when` clause (the inverse clause `unless` is also supported) under a workflow declaration with a boolean value to determine whether or not to run that workflow. The most common use of `when` in API v2 is to use a pipeline parameter as the value, allowing an API trigger to pass that parameter to determine which workflows to run.
 
-When using CircleCI API v2, you may use a `when` clause (the inverse clause is also supported) under a workflow declaration with a boolean value to determine whether or not to run that workflow. The most common use of `when` in API v2 is to use a pipeline parameter as the value, allowing an API trigger to pass that parameter to determine which workflows to run.
-
-The example below shows an example configuration using two different pipeline parameters. You may use one of the parameters to drive a particular workflow, while you may use the other parameter to determine whether a particular step will run.
+The example configuration below uses a pipeline parameter, `run_integration_tests` to drive the `integration_tests` workflow.
 
 ```yaml
 version: 2.1
 
 parameters:
   run_integration_tests:
-    type: boolean
-    default: false
-  deploy:
     type: boolean
     default: false
 
@@ -1329,16 +1324,12 @@ workflows:
     when: << pipeline.parameters.run_integration_tests >>
     jobs:
       - mytestjob
-      - when:
-          condition: << pipeline.parameters.deploy >>
-          steps:
-            - deploy
 
 jobs:
 ...
 ```
  
-This example prevents the workflow `integration_tests` from being triggered unless the tests were invoked explicitly when the pipeline is triggered with the following in the `POST` body:
+This example prevents the workflow `integration_tests` from running unless the tests are invoked explicitly when the pipeline is triggered with the following in the `POST` body:
 
 ```
 {
@@ -1346,25 +1337,6 @@ This example prevents the workflow `integration_tests` from being triggered unle
         "run_integration_tests": true
     }
 }
-```
-
-###### *Example*
-
-```
-workflows:
-  version: 2
-
-  build_test_deploy:
-    jobs:
-      - flow
-      - downstream:
-          requires:
-            - flow
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /v.*/
 ```
 
 Refer to the [Orchestrating Workflows]({{ site.baseurl }}/2.0/workflows) document for more examples and conceptual information.

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1306,7 +1306,7 @@ For more information, see the [Executing Workflows For a Git Tag]({{ site.baseur
 
 ##### **Using `when` in Workflows**
 
-With CircleCI API v2, you may use a `when` clause (the inverse clause `unless` is also supported) under a workflow declaration with a boolean value to determine whether or not to run that workflow. The most common use of `when` in API v2 is to use a pipeline parameter as the value, allowing an API trigger to pass that parameter to determine which workflows to run.
+With CircleCI API v2, you may use a `when` clause (the inverse clause `unless` is also supported) under a workflow declaration with a truthy or falsy value to determine whether or not to run that workflow. The most common use of `when` in API v2 is to use a pipeline parameter as the value, allowing an API trigger to pass that parameter to determine which workflows to run.
 
 The example configuration below uses a pipeline parameter, `run_integration_tests` to drive the `integration_tests` workflow.
 


### PR DESCRIPTION
Update use of `when` in workflows in the config reference