### PR TITLE
Use correct ssh command in docs

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -83,7 +83,7 @@ that have been added through the CircleCI application.
 
 ## Adding multiple keys with blank hostnames
 
-If you need to add multiple SSH keys with blank hostnames to your project you will need to make some changes to the default SSH configuration provided by CircleCI. In the scenario where you have multiple SSH keys that have access to the same hostss, but are for different purposes the default `IdentitiesOnly no` is set causing connections to use ssh-agent. This will always cause the first key to be used, even if that is the incorrect key. If you have added the SSH key to a container you will need to either set `IdentitiesOnly no` in the appropriate block, or you can remove all keys from the ssh-agent for this job using `ssh-agent -D`, and reading the key added with `ssh-add /path/to/key`.
+If you need to add multiple SSH keys with blank hostnames to your project you will need to make some changes to the default SSH configuration provided by CircleCI. In the scenario where you have multiple SSH keys that have access to the same hostss, but are for different purposes the default `IdentitiesOnly no` is set causing connections to use ssh-agent. This will always cause the first key to be used, even if that is the incorrect key. If you have added the SSH key to a container you will need to either set `IdentitiesOnly no` in the appropriate block, or you can remove all keys from the ssh-agent for this job using `ssh-add -D`, and reading the key added with `ssh-add /path/to/key`.
 
 ## See Also
 


### PR DESCRIPTION
`ssh-agent -D` starts a server, `ssh-add -D` deletes known keys, which is what is intended by this section of the docs.

http://man.openbsd.org/ssh-add#D

VS:

http://man.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man1/ssh-agent.1?query=ssh-agent%26sec=1#D