### PR TITLE
Fixes incorrect command in "Adding an SSH Key to CircleCI" that will break build

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -83,7 +83,7 @@ that have been added through the CircleCI application.
 
 ## Adding multiple keys with blank hostnames
 
-If you need to add multiple SSH keys with blank hostnames to your project you will need to make some changes to the default SSH configuration provided by CircleCI. In the scenario where you have multiple SSH keys that have access to the same hostss, but are for different purposes the default `IdentitiesOnly no` is set causing connections to use ssh-agent. This will always cause the first key to be used, even if that is the incorrect key. If you have added the SSH key to a container you will need to either set `IdentitiesOnly no` in the appropriate block, or you can remove all keys from the ssh-agent for this job using `ssh-agent -D`, and reading the key added with `ssh-add /path/to/key`.
+If you need to add multiple SSH keys with blank hostnames to your project you will need to make some changes to the default SSH configuration provided by CircleCI. In the scenario where you have multiple SSH keys that have access to the same hostss, but are for different purposes the default `IdentitiesOnly no` is set causing connections to use ssh-agent. This will always cause the first key to be used, even if that is the incorrect key. If you have added the SSH key to a container you will need to either set `IdentitiesOnly no` in the appropriate block, or you can remove all keys from the ssh-agent for this job using `ssh-add -D`, and reading the key added with `ssh-add /path/to/key`.
 
 ## See Also
 


### PR DESCRIPTION
# Description
Running `ssh-agent -D` puts `ssh-agent` into foreground mode, which will cause a build to run until timeout.

Running `ssh-add -D` drops all agent keys, which is what the docs is actually suggesting.

# Reasons
The command suggested is totally wrong.