### PR TITLE
add autofit option to auto shink text in PDF output

### DIFF
--- a/jekyll/_cci2/_aws-install.adoc
+++ b/jekyll/_cci2/_aws-install.adoc
@@ -11,6 +11,7 @@ docs@circleci.com
 :idprefix:
 :idseparator: -
 :sectanchors:
+:autofit-option:
 
 :leveloffset: +1
 

--- a/jekyll/_cci2/_ops-guide.adoc
+++ b/jekyll/_cci2/_ops-guide.adoc
@@ -12,6 +12,7 @@ docs@circleci.com
 :idprefix:
 :idseparator: -
 :sectanchors:
+:autofit-option:
 
 :leveloffset: +1
 


### PR DESCRIPTION
Some code blocks run off the PDF page and it's not handled well. Ends up with badly formatted code. This option attempts to resize the text to make it fit.