### PR TITLE
Removing Typo: Redundant "Machine" Word

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -7,7 +7,7 @@ categories: [optimization]
 order: 60
 ---
 
-The more tests your project has, the longer it will take for them to complete on a single machine machine. To reduce this time, you can run tests in parallel by spreading them across multiple separate executors. This requires specifying a parallelism level to define how many separate executors get spun up for the test job. Then, you can use either the CircleCI CLI to split test files, or use environment variables to configure each parallel machine individually.
+The more tests your project has, the longer it will take for them to complete on a single machine. To reduce this time, you can run tests in parallel by spreading them across multiple separate executors. This requires specifying a parallelism level to define how many separate executors get spun up for the test job. Then, you can use either the CircleCI CLI to split test files, or use environment variables to configure each parallel machine individually.
 
 * TOC
 {:toc}


### PR DESCRIPTION
# Description
Removing Typo: Redundant use of "Machine" word.

# Reasons
I think it will look good this way.