### PR TITLE
Fix filepath for CIRCLE_DISPATCHER_RESOURCE_DEF

### DIFF
--- a/jekyll/_cci2/customizations.adoc
+++ b/jekyll/_cci2/customizations.adoc
@@ -147,7 +147,7 @@ WARNING: It is important to use the IDs listed in the example below for both `ma
 . Run:
 +
 ```shell
-echo 'export CIRCLE_DISPATCHER_RESOURCE_DEF=/circleconfig/picard-dispatcher/resource-definitions.edn' | sudo tee /etc/circleconfig/picard-dispatcher/customizations
+echo 'export CIRCLE_DISPATCHER_RESOURCE_DEF=/etc/circleconfig/picard-dispatcher/resource-definitions.edn' | sudo tee /etc/circleconfig/picard-dispatcher/customizations
 ```
 . Restart the CircleCI Server application. The application can be stopped and started again from the Management Console Dashboard (for example, `<circleci-hostname>.com:8800`).
 


### PR DESCRIPTION
path should be prepended by "/etc"

# Description
Add /etc to beginning of filepath for CIRCLE_DISPATCHER_RESOURCE_DEF

# Reasons
Incorrect filepath