### PR TITLE
link to performance plan pricing for those with queueing builds

### DIFF
--- a/jekyll/_cci2/status.md
+++ b/jekyll/_cci2/status.md
@@ -17,7 +17,7 @@ Integrations enable you to [include status badges in other web pages]({{ site.ba
 
 Queuing |
 ------------------------|------------------
-If your jobs are queuing, you can upgrade your plan for [using containers]({{ site.baseurl }}/2.0/containers/). |  
+If your jobs are queuing, you can switch to either a [performance or custom plan](https://circleci.com/pricing/). For further infomration see our guide to [using credits]({{ site.baseurl }}/2.0/credits/). |  
 
 <hr>
 
@@ -25,7 +25,7 @@ If your jobs are queuing, you can upgrade your plan for [using containers]({{ si
 
 CircleCI provides an integrated dashboard showing job status:
 
-- PASSED: All jobs passed successfully
+- SUCCESS: All jobs passed successfully
 - FAILED: One or more jobs failed
 
 If you are using [workflows]({{ site.baseurl}}/2.0/workflows/#overview) you may


### PR DESCRIPTION
Currently we are directing people to info on our legacy container plan when they are having performance issues. This PR points them to the pricing page and our docs info on using credits instead.