### PR TITLE
Fix formatting for Add SSH Keys heading

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -307,7 +307,7 @@ Although running jobs locally with `circleci` is very helpful, there are some li
 
 You cannot use the machine executor in local jobs. This is because the machine executor requires an extra VM to run its jobs.
 
-**Add SSH Keys
+**Add SSH Keys**
 
 It is currently not possible to add SSH keys using the `add_ssh_keys` CLI command.
 


### PR DESCRIPTION
# Description

This fixes the formatting for a heading.

# Reasons

It looked wrong:
![image](https://user-images.githubusercontent.com/435066/69444122-50d78f80-0d15-11ea-8463-9721e884da46.png)
