### PR TITLE
Clarifying the use `when` under workflows

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1345,7 +1345,7 @@ For more information, see the [Executing Workflows For a Git Tag]({{ site.baseur
 
 ##### **Using `when` in Workflows**
 
-With CircleCI API v2, you may use a `when` clause (the inverse clause `unless` is also supported) under a workflow declaration with a truthy or falsy value to determine whether or not to run that workflow. The most common use of `when` in API v2 is to use a pipeline parameter as the value, allowing an API trigger to pass that parameter to determine which workflows to run.
+With CircleCI configuration v2.1, you may use a `when` clause (the inverse clause `unless` is also supported) under a workflow declaration with a truthy or falsy value to determine whether or not to run that workflow. The most common use of `when` is with CircleCI API v2 pipeline triggering with parameters.
 
 The example configuration below uses a pipeline parameter, `run_integration_tests` to drive the `integration_tests` workflow.
 


### PR DESCRIPTION
The use of `when` under workflows is available in 2.1 config without using the v2 API, though it's most common use is with pipeline parameters passed via the v2 API. This PR updates the language to make that clearer to the reader.