### PR TITLE
ORBS: make the call to the required steps stand out more

### DIFF
--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -24,7 +24,7 @@ Before you create your first orb, please see the following notes:
 * To use the orbs you create, you will need to enable the "Allow Uncertified Orbs" setting in the Security section of CircleCI's Organization Settings page for your organization (`https://circleci.com/[vcs]/organizations/[org-name]/settings#security`).
 * If you are creating an orb, you can use development versions to avoid having your orb publicly/permanently listed in CircleCI's orb registry before it is ready.
 
-The following high-level steps will enable you to publish your first orb:
+### The following high-level steps will enable you to publish your first orb:
 
 1) Claim a namespace (assuming you don't yet have one). For example:
 

--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -34,7 +34,7 @@ In this example we are creating the `sandbox` namespace, which will be linked to
 
 **Note:** When creating a namespace via the CircleCI CLI, be sure to specify the VCS provider.
 
-2) Create the orb inside your namespace. For example:
+2) Create the orb inside your namespace. This doesn't generate any content, but rather reserves the naming for when the orb is published. For example:
 
 `circleci orb create sandbox/hello-world`
 

--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -24,7 +24,7 @@ Before you create your first orb, please see the following notes:
 * To use the orbs you create, you will need to enable the "Allow Uncertified Orbs" setting in the Security section of CircleCI's Organization Settings page for your organization (`https://circleci.com/[vcs]/organizations/[org-name]/settings#security`).
 * If you are creating an orb, you can use development versions to avoid having your orb publicly/permanently listed in CircleCI's orb registry before it is ready.
 
-### The following high-level steps will enable you to publish your first orb:
+### The following high-level steps are needed to publish your first orb:
 
 1) Claim a namespace (assuming you don't yet have one). For example:
 


### PR DESCRIPTION
# Description 
The block of text for "quickstart" wasn't highlighting that these steps are actually required. And these steps were only documented one other place (that isn't clear either). 

# Reasons
My personal opinion is that the content in this "publish your first orb" section should instead be moved to the [Validate and Publish](https://circleci.com/docs/2.0/orb-author-validate-publish/) page. 
But I lost a lot of time not finding this info when I was finally ready to publish. _(I also assume most people don't "quick" start with publishing, but rather start with inline orbs)_