### PR TITLE
Fix invalid indentation in config example

### DIFF
--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -168,13 +168,13 @@ workflows:
     jobs:
       - build1
       - build2:
-        requires:
-           - build1 # wait for build1 job to complete successfully before starting
-           # see circleci.com/docs/2.0/workflows/ for more examples.
+          requires:
+             - build1 # wait for build1 job to complete successfully before starting
+             # see circleci.com/docs/2.0/workflows/ for more examples.
       - build3:
-        requires:
-           - build1 # wait for build1 job to complete successfully before starting
-           # run build2 and build3 in parallel to save time.
+          requires:
+             - build1 # wait for build1 job to complete successfully before starting
+             # run build2 and build3 in parallel to save time.
 ```
 {% endraw %}
 


### PR DESCRIPTION
# Description
I changed the indentation in the YAML example.

# Reasons
It does not seem to be valid YAML (fails `cicreci config check`).