### PR TITLE
Update server version from 2.17 to 2.18

### DIFF
--- a/jekyll/_cci2/aws.adoc
+++ b/jekyll/_cci2/aws.adoc
@@ -6,7 +6,7 @@
 :toc: macro
 :toc-title:
 
-Following is a step by step guide to installing CircleCI Server v2.17 with Terraform.
+Following is a step by step guide to installing CircleCI Server v2.18 with Terraform.
 
 toc::[]
 


### PR DESCRIPTION
This page was under the heading for 2.18 server installation

# Description
Keep the server version consistent.

# Reasons
The instructions should be clear about which server version is being installed