### PR TITLE
indicate what content is only for server admin

### DIFF
--- a/jekyll/_cci2/admin-faq.adoc
+++ b/jekyll/_cci2/admin-faq.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 This chapter answers frequently asked questions and provides installation troubleshooting tips.
 
 toc::[]

--- a/jekyll/_cci2/architecture.adoc
+++ b/jekyll/_cci2/architecture.adoc
@@ -8,6 +8,8 @@
 //:circle-warning: image:circle-warning.png[]
 //:circle-failure: image:circle-failure.png[]
 
+{% include snippets/server-only.adoc %}
+
 This document outlines the containerized services that run on the Services machine within a CircleCI Server installation. This is provided both to give an overview of service operation, and to help with troubleshooting in the event of service outages. Supplementary notes and a key are provided below the following table.
 
 toc::[]
@@ -128,7 +130,7 @@ WARNING: If migrator services are down at startup connected services will fail.
 
 | `frontend`
 | CircleCI web app and www-api proxy.
-| The UI and REST API will be unavailable and no jobs will be triggered by Github/Enterprise. Running builds will be OK but no updates will be seen.
+| The UI and REST API will be unavailable and no jobs will be triggered by GitHub/Enterprise. Running builds will be OK but no updates will be seen.
 | icon:exclamation-triangle[]
 | `postgres`
 
@@ -182,7 +184,7 @@ WARNING: If migrator services are down at startup connected services will fail.
 
 | `outputRunningRedis` / `redis` *
 | The Redis key/value store.
-| Lose output from currently-running job steps. API calls out to github may also fail.
+| Lose output from currently-running job steps. API calls out to GitHub may also fail.
 | icon:exclamation-triangle[]
 | None
 

--- a/jekyll/_cci2/authentication.adoc
+++ b/jekyll/_cci2/authentication.adoc
@@ -5,11 +5,13 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 This document describes the various ways users of your CircleCI Server installation can get access and authenticate their accounts. Currently OAuth and LDAP are supported as authentication methods.
 
 toc::[]
 
-== OAuth with Github/GHE
+== OAuth with GitHub/GHE
 
 The default method for user account authentication in CircleCI Server is through GitHub.com/GitHub Enterprise OAuth.
 

--- a/jekyll/_cci2/backup.adoc
+++ b/jekyll/_cci2/backup.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 This chapter describes failover or replacement of the services machine. Refer to the Backup section below for information about possible backup strategies and procedures for implementing a regular backup image or snapshot of the services machine.
 
 toc::[]

--- a/jekyll/_cci2/build-artifacts.adoc
+++ b/jekyll/_cci2/build-artifacts.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 Build artifacts persist data after a job is completed. They can be used for longer-term storage of your build process outputs. For example, when a Java build/test process finishes, the output of the process is saved as a `.jar` file. CircleCI can store this file as an artifact, keeping it available long after the process has finished.
 
 toc::[]

--- a/jekyll/_cci2/certificates.adoc
+++ b/jekyll/_cci2/certificates.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 This document provides a script for using a custom Root Certificate Authority and the process for using an Elastic Load Balancing certificate.
 
 toc::[]
@@ -129,7 +131,7 @@ NOTE: The sources below are left open so that anybody can access the instance ov
 
 . Next, in the management console for CircleCI, upload a valid certificate and key file to the `Privacy` Section. These don't need to be externally signed or even current certs as the actual cert management is done at the ELB. But, to use HTTPS requests, CircleCI requires a certificate and key in which the "Common Name (FQDN)" matches the hostname configured in the admin console.
 
-. It is now possible to set your Github Authorization Callback to `https` rather than `http`.
+. It is now possible to set your GitHub Authorization Callback to `https` rather than `http`.
 
 === Using Self-Signed Certificates
 
@@ -190,4 +192,4 @@ More information is available https://letsencrypt.readthedocs.io/en/latest/using
 
 Ensure the hostname is properly configured from the Management Console (`http://<circleci-hostname>.com:8800`) **and** that the hostname used matches the DNS records associated with the TLS certificates.
 
-Make sure the Auth Callback URL in Github/Github Enterprise matches the domain name pointing to the Services machine, including the protocol used, for example `**https**://info-tech.io/`.
+Make sure the Auth Callback URL in GitHub/GHE matches the domain name pointing to the Services machine, including the protocol used, for example `**https**://info-tech.io/`.

--- a/jekyll/_cci2/customizations.adoc
+++ b/jekyll/_cci2/customizations.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 The following sections summarize the key files and variables that impact CircleCI Server behavior, and configuration options for your Server installation.
 
 toc::[]

--- a/jekyll/_cci2/gpu.adoc
+++ b/jekyll/_cci2/gpu.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 This document outlines how to run GPU (graphics processing unit) machine executors using CircleCI Server.
 
 toc::[]

--- a/jekyll/_cci2/jvm-heap-size-configuration.adoc
+++ b/jekyll/_cci2/jvm-heap-size-configuration.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 The JVM heap size is configurable for the following containers: `frontend`, `test-results`, `output-processing` and `contexts-service`. You might want to consider increasing the heap size if you see "out of memory" errors, such as: `Terminating due to java.lang.OutOfMemoryError: Java heap space`.
 
 == Setting up

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -185,7 +185,7 @@ The following keys represent actions performed after the multi-line command is e
 ```
 
 Below is an explanation of the preceding example:
-- [`checkout`]({{ site.baseurl }}/2.0/configuration-reference/#checkout): basically git clones the project repo from github into the container 
+- [`checkout`]({{ site.baseurl }}/2.0/configuration-reference/#checkout): basically git clones the project repo from GitHub into the container 
 - [`restore_cache`]({{ site.baseurl }}/2.0/configuration-reference/#restore_cache) key: specifies the name of the cache files to restore. The key name is specified in the save_cache key that is found later in the schema. If the key specified is not found then nothing is restored and continues to process.
 - [`run`]({{ site.baseurl }}/2.0/configuration-reference/#run) command `cat /dev/null | sbt clean update dist`: executes the sbt compile command that generates the package .zip file.
 - [`store_artifacts`]({{ site.baseurl }}/2.0/configuration-reference/#store_artifacts) path: specifies the path to the source file to copy to the ARTIFACT zone in the image.

--- a/jekyll/_cci2/monitoring.adoc
+++ b/jekyll/_cci2/monitoring.adoc
@@ -6,6 +6,8 @@
 :toc-title:
 :sectanchors:
 
+{% include snippets/server-only.adoc %}
+
 This section includes information on metrics for monitoring your CircleCI Server installation.
 
 toc::[]

--- a/jekyll/_cci2/nomad-metrics.adoc
+++ b/jekyll/_cci2/nomad-metrics.adoc
@@ -6,6 +6,8 @@
 :toc-title:
 :sectanchors:
 
+{% include snippets/server-only.adoc %}
+
 Nomad Metrics is a helper service used to collect metrics data from the <<nomad#basic-terminology-and-architecture,Nomad server and clients>> running on the Services and Nomad instances respectively.  Metrics are collected and sent using the https://docs.datadoghq.com/developers/dogstatsd/[DogStatsD] protocol and sent to the Services machine.
 
 == Nomad Metrics Server

--- a/jekyll/_cci2/nomad-metrics.adoc
+++ b/jekyll/_cci2/nomad-metrics.adoc
@@ -18,7 +18,7 @@ The Nomad Metrics container is run on the services host using the server flag an
 
 The Nomad Metrics client is installed and run on all Nomad client instances. You will need to update your AWS Launch Configuration in order to install and configure it.  Additionally, you will need to modify the AWS security group to ensure that UDP port 8125 is open on the Services machine. Steps for both configuration changes are explained below.
 
-NOTE: Before proceeding, you should be logged into the EC2 Service section of the AWS Console.  Make sure that you logged into the region you use to run CircleCI Server.
+NOTE: Before proceeding, you should be logged into the EC2 Service section of the AWS Console. Make sure that you logged into the region you use to run CircleCI Server.
 
 === Updating the Services machine Security Group
 

--- a/jekyll/_cci2/nomad.adoc
+++ b/jekyll/_cci2/nomad.adoc
@@ -6,6 +6,8 @@
 :toc-title:
 :sectanchors:
 
+{% include snippets/server-only.adoc %}
+
 CircleCI 2.0 uses https://www.hashicorp.com/blog/nomad-announcement/[Nomad] as the primary job scheduler. This chapter provides a basic introduction to Nomad for understanding how to operate the Nomad Cluster in your CircleCI 2.0 installation.
 
 toc::[]

--- a/jekyll/_cci2/ops.adoc
+++ b/jekyll/_cci2/ops.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 This chapter describes system checks and the basics of user management.
 
 toc::[]

--- a/jekyll/_cci2/overview.adoc
+++ b/jekyll/_cci2/overview.adoc
@@ -118,7 +118,7 @@ The following table describes the ports used on Nomad clients:
 === GitHub
 CircleCI uses GitHub or GitHub Enterprise credentials for authentication which, in turn, may use LDAP, SAML, or SSH for access. This means CircleCI will inherit the authentication supported by your central SSO infrastructure.
 
-NOTE: CircleCI does not support changing the URL or backend Github instance after it has been set up. The following table describes the ports used on machines running GitHub to communicate with the Services and Nomad Client instances.
+NOTE: CircleCI does not support changing the URL or backend GitHub instance after it has been set up. The following table describes the ports used on machines running GitHub to communicate with the Services and Nomad Client instances.
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]

--- a/jekyll/_cci2/proxy.adoc
+++ b/jekyll/_cci2/proxy.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %} 
+
 This section describes how to configure CircleCI to use an HTTP proxy.
 
 toc::[]

--- a/jekyll/_cci2/security.adoc
+++ b/jekyll/_cci2/security.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 This document outlines security features built into CircleCI and related integrations.
 
 toc::[]

--- a/jekyll/_cci2/server-ports.adoc
+++ b/jekyll/_cci2/server-ports.adoc
@@ -306,7 +306,7 @@ Below all ports required by a CircleCI 2.0 installation are listed for each mach
 | TCP
 | Outbound
 | GitHub Enterprise / GitHub.com (whichever applies)
-| Download Code From Github.
+| Download Code From GitHub.
 |
 
 | 4647

--- a/jekyll/_cci2/single-box.md
+++ b/jekyll/_cci2/single-box.md
@@ -101,7 +101,7 @@ The steps in this section walk you through installing CircleCI on a single EC2 V
 - Enter your hostname, or IP address if you didn't set one, and click Test Hostname Resolution.
 - Under Execution Engines, if you do not need 1.0 build functionality, leave the box for it unchecked. Most users should check the box for 2.0 functionality.
 - Under 2.0 Builders Configuration, select "Single Box".
-- Follow the Github integration instructions. **Note:** If you get an *"Unknown error authenticating via GitHub. Try again, or contact us."* message, try using `http:` instead of `https:` for the Homepage URL and callback URL.
+- Follow the GitHub integration instructions. **Note:** If you get an *"Unknown error authenticating via GitHub. Try again, or contact us."* message, try using `http:` instead of `https:` for the Homepage URL and callback URL.
 - Ensure that "None" is selected in the "Storage" section. In production installations, other object stores may be used but will require corresponding IAM permissions.
 - Ensure that the "VM Provider" is set to "None". If you would like to allow CircleCI to dynamically provision VMs (e.g. to support doing Docker builds) you may change this setting, but it will require additional IAM permissions. [Contact us](https://support.circleci.com/hc/en-us) if you have questions.
 - Agree to the license agreement, save and head to your Dashboard. The application start up process begins by downloading the ~160 MB Docker image, so it may take some time to complete.

--- a/jekyll/_cci2/troubleshooting.adoc
+++ b/jekyll/_cci2/troubleshooting.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 This document describes an initial set of troubleshooting steps to take if you are having problems with your CircleCI installation on your private server. If your issue is not addressed below, please https://help.replicated.com/docs/native/packaging-an-application/support-bundle/[generate a support bundle] and contact our Support Engineers by https://support.circleci.com/hc/en-us/requests/new[opening a support ticket].
 
 toc::[]

--- a/jekyll/_cci2/usage-stats.adoc
+++ b/jekyll/_cci2/usage-stats.adoc
@@ -5,6 +5,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %} 
+
 This chapter is for System Administrators who want to automatically send some aggregate usage statistics to CircleCI. Usage statistics data enhances visibility into CircleCI installations and is used to better support you and ensure a smooth transition from CircleCI 1.0 to CircleCI 2.0.
 
 toc::[]

--- a/jekyll/_cci2/user-accounts.adoc
+++ b/jekyll/_cci2/user-accounts.adoc
@@ -41,7 +41,7 @@ image::activate_user.png[Reactivate existing users]
 
 == Controlling Account Access
 
-Any user associated with your GitHub.com or Github Enterprise organization can create a user account for your CircleCI installation. In order to control who has access, you can automatically suspend **all** new users, requiring an administrator to activate them before they can log in. To access this feature:
+Any user associated with your GitHub.com or GitHub Enterprise organization can create a user account for your CircleCI installation. In order to control who has access, you can automatically suspend **all** new users, requiring an administrator to activate them before they can log in. To access this feature:
 
 1. Navigate to your CircleCI Admin Settings
 2. Select System Settings from the Admin Settings menu
@@ -62,9 +62,9 @@ To activate an **new** account that was automatically suspended, and allow the a
 .Activate a Suspended New User
 image::unsuspend.png[Activate New Users]
 
-=== Limit User Registrations by Github Organization
+=== Limit User Registrations by GitHub Organization
 
-When using Github.com, you can limit who can register with your CircleCI install to people with *some* connection to your approved organizations list. To access this feature:
+When using github.com, you can limit who can register with your CircleCI install to people with *some* connection to your approved organizations list. To access this feature:
 
 1. Navigate to your CircleCI Admin Settings page
 2. Select System Settings from the Admin Setting menu
@@ -87,7 +87,7 @@ circleci dev-console
 
 === Deleting a User
 
-If you need to remove a user from your installation of CircleCI Server, you will need to SSH into the services machine first and then delete using the following command, substituting the user's github username:
+If you need to remove a user from your installation of CircleCI Server, you will need to SSH into the services machine first and then delete using the following command, substituting the user's GitHub username:
 
 ```shell
 circleci dev-console

--- a/jekyll/_cci2/user-accounts.adoc
+++ b/jekyll/_cci2/user-accounts.adoc
@@ -6,6 +6,8 @@
 :toc: macro
 :toc-title:
 
+{% include snippets/server-only.adoc %}
+
 This section provides information to help system administrators of self-hosted CircleCI Server installations manage accounts for their users. For an overview of user accounts, view the Admin settings overview from the CircleCI app by clicking on your profile in the top right corner and selecting Admin. This overview provides the active user count and the total number of licensed users.
 
 toc::[]

--- a/jekyll/_cci2/v.2.17-overview.md
+++ b/jekyll/_cci2/v.2.17-overview.md
@@ -30,7 +30,7 @@ This document provides a summary of features and product notes for the release o
 * Fixed a bug causing Workflows to get stuck when infrastructure_failure happens after a job fails.
 * Fixed a bug causing duplicate docker networks on same nomad client (if running build using machine:true AND vm-provider=on_host).
 * Improved performance when using local storage. Previously, caching issues had been experienced when local storage was used rather than the default option of using S3 (selecting None under * Storage Driver options from the Management Console).
-* We have added more error checking and validation around Github’s API so the existing list commit endpoint no longer causes issues.
+* We have added more error checking and validation around GitHub’s API so the existing list commit endpoint no longer causes issues.
 * Datadog API token field was stored in plaintext, now set as a password field.
 * Fixed issue where workflows were constrained from fanning out to large number of jobs.
 

--- a/jekyll/_cci2/v.2.18-overview.md
+++ b/jekyll/_cci2/v.2.18-overview.md
@@ -33,7 +33,7 @@ Metric | Description
 `circle.backend.action.upload-artifact-error` | Tracks how many times an artifact has failed to upload
 `circle.build-queue.runnable.builds` | Track how many builds flowing through the system are considered runnable
 `circle.dispatcher.find-containers-failed` | Track how many 1.0 builds 
-`circle.github.api_call` | Tracks how many api calls CircleCI is making to github
+`circle.github.api_call` | Tracks how many api calls CircleCI is making to GitHub
 `circle.http.request` | Tracks the response codes to CircleCi requests
 `circle.nomad.client_agent.*` | Tracks nomad client metrics
 `circle.nomad.server_agent.*` | Tracks how many nomad servers there are 

--- a/jekyll/_cci2/vm-service.adoc
+++ b/jekyll/_cci2/vm-service.adoc
@@ -6,6 +6,8 @@
 :toc-title:
 :sectanchors:
 
+{% include snippets/server-only.adoc %}
+
 This section outlines how to set up and customize VM service for your CircleCI installation, to be used for `machine` executor and remote Docker jobs.
 
 NOTE: This is only available for installations on AWS, please contact your CircleCI account representative to request this for a static installation.

--- a/jekyll/_includes/snippets/server-only.adoc
+++ b/jekyll/_includes/snippets/server-only.adoc
@@ -1,0 +1,1 @@
+[.serveronly]_This document is intended for system administrators of self-hosted installations of CircleCI Server._

--- a/jekyll/assets/css/asciidoc.css
+++ b/jekyll/assets/css/asciidoc.css
@@ -51,3 +51,5 @@ span.icon>.fa {
 .green{
   color: #43C78A;
 }
+
+

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -386,3 +386,7 @@ pre {
 	border-color: #f5f5f5;
 	margin-bottom: 10px;
 }
+
+.serveronly{
+	color: #4e9eb3; 
+  }


### PR DESCRIPTION
Some cloud users are finding their way to server docs, probably through keyword search, and finding info not relevant to them. This PR is an idea to more clearly show which content is only for server system admins.

In practice, looks like this:

<img width="1035" alt="Screenshot 2019-12-06 at 16 28 41" src="https://user-images.githubusercontent.com/24589403/70338843-92a02400-1845-11ea-88c1-dcf8668c15b9.png">
