### PR TITLE
Update the Windows docs to use the `default` executor

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -105,7 +105,7 @@ orbs:
 
 jobs:
   build:
-    executor: win/vs2019
+    executor: win/default
     steps:
       - checkout
       - run: dotnet tool install --global PowerShell


### PR DESCRIPTION
The `vs2019` executor was renamed into `default`.