### PR TITLE
Create `enable-pipelines` snippet.

### DIFF
--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -456,12 +456,11 @@ To configure your environment to use CircleCI and orbs, perform the following st
 
 `version: 2.1`
 
-2) If you do not already have Pipelines enabled, you'll need to go to **Project Settings -> Advanced Settings** and turn enable pipelines.
+2) {% include snippets/enable-pipelines.md %}
 
 Add the orbs stanza below your version, invoking the orb:
 
-`orbs:
-  aws-eks: circleci/aws-eks@0.2.1`
+`orbs: aws-eks: circleci/aws-eks@0.2.1`
 
 3) Use `aws-eks` elements in your existing workflows and jobs.
 

--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -44,9 +44,7 @@ For more detailed information about CircleCI orbs, please refer to the [Orbs Int
 
 `version: 2.1`
 
-**Note:** If you do not already have pipelines enabled, go to **Settings > Project**, select settings for the project you are currently working on by clicking its cog icon, select **Advanced Settings** and scroll down to use the radio button to enable pipelines.
-
-![Enable Pipelines]( {{ site.baseurl }}/assets/img/docs/enable_pipelines.png))
+**NOTE:** {% include snippets/enable-pipelines.md %}
 
 2) Add the orbs stanza below your version, which in turn imports the orb:
 

--- a/jekyll/_cci2/jira-plugin.md
+++ b/jekyll/_cci2/jira-plugin.md
@@ -51,7 +51,7 @@ in Jira. To do this, you will need to:
 
 1. Make sure you followed the steps above to connect Jira with CircleCI.
 1. Make sure that you are using version `2.1` at the top of your `.circleci/config.yml` file.
-1. If you do not already have pipelines enabled, go to **Project Settings -> Build Settings -> Advanced Settings** and enable them.
+1. {% include snippets/enable-pipelines.md %}
 1. To get an API token for build information retrieval, go to **Project Settings -> Permissions -> API Permissions** and create a token with **Scope: all**. Copy the token.
 1. To allow the integration to then use that key, go to **Project Settings -> Build Settings -> Environment Variables** and add a variable named _CIRCLE_TOKEN_ with the value being the token you just made.
 1. Add the orb stanza, invoking the Jira orb.

--- a/jekyll/_cci2/notifications.md
+++ b/jekyll/_cci2/notifications.md
@@ -91,7 +91,10 @@ You can use Orbs to integrate various kinds of notifications into your configura
 
 ### Prerequisites
 
-Before integrating an orb into your configuration, you will need to perform two steps: increment the `version` key in your config to `2.1` and enable `pipelines` under `Project Settings` > `Advanced Settings` in the CircleCI web application.
+Before integrating an orb into your configuration, you will need to perform two steps: 
+
+1. Increment the `version` key in your config to `2.1` and; 
+2. {% include snippets/enable-pipelines.md %}
 
 ### Using the Slack Orb
 

--- a/jekyll/_cci2/optimization-cookbook.md
+++ b/jekyll/_cci2/optimization-cookbook.md
@@ -47,7 +47,8 @@ To configure the environment for the CircleCI platform and CircleCI orbs, follow
 version: 2.1
 ```
 
-2) If you do not already have pipelines enabled, you'll need to go to **Project Settings -> Advanced Settings** to enable pipelines.
+2) {% include snippets/enable-pipelines.md %}
+
 
 3) Add the `orbs` stanza below your version, invoking the orb. For example:
 

--- a/jekyll/_cci2/orbs-user-config.md
+++ b/jekyll/_cci2/orbs-user-config.md
@@ -17,20 +17,20 @@ The section below describes how you can set your platform version to 2.1 so you 
 
 Setting your platform version to work with orbs is a very simple process, requiring you to perform the following steps:
 
-1) Use CircleCI version 2.1 at the top of your `.circleci/config.yml` file.
+1. Use CircleCI version 2.1 at the top of your `.circleci/config.yml` file.
 
 `version: 2.1`
 
-**Note** If you do not already have Pipelines enabled, you'll need to go to **Project Settings -> Advanced Settings** and turn it on.
+**NOTE:** {% include snippets/enable-pipelines.md %}
 
-2) Add the `orbs` stanza below your version, thereby invoking the orb. The example below shows how you can invoke the `aws-cli` orb.
+2. Add the `orbs` stanza below your version, thereby invoking the orb. The example below shows how you can invoke the `aws-cli` orb.
 
 ```
 orbs:
   aws-cli: circleci/aws-cli@0.1.13
 ```
 
-3) Use the elements specific to your selected orb in your existing workflows and jobs.
+3. Use the elements specific to your selected orb in your existing workflows and jobs.
 
 ### Hello World Example
 
@@ -39,17 +39,18 @@ The example below demonstrates how you can invoke the `hello-build` orb in the `
 ```yaml
 version: 2.1
 orbs:
-    hello: circleci/hello-build@0.0.5
+  hello: circleci/hello-build@0.0.5
 
 workflows:
-    "Hello Workflow":
-        jobs:
-          - hello/hello-build
+  "Hello Workflow":
+    jobs:
+      - hello/hello-build
 ```
 
 **Note:** If your project was added to CircleCI prior to 2.1, you must enable pipelines to use the `orbs` key.
 
 ## Next Steps
+
 {:.no_toc}
 
 - Refer to [Selecting and Using an Orb]({{site.baseurl}}/2.0/orbs-user-select-orb/) for next steps.

--- a/jekyll/_cci2/orbs-user-config.md
+++ b/jekyll/_cci2/orbs-user-config.md
@@ -17,20 +17,20 @@ The section below describes how you can set your platform version to 2.1 so you 
 
 Setting your platform version to work with orbs is a very simple process, requiring you to perform the following steps:
 
-1. Use CircleCI version 2.1 at the top of your `.circleci/config.yml` file.
+1) Use CircleCI version 2.1 at the top of your `.circleci/config.yml` file.
 
 `version: 2.1`
 
 **NOTE:** {% include snippets/enable-pipelines.md %}
 
-2. Add the `orbs` stanza below your version, thereby invoking the orb. The example below shows how you can invoke the `aws-cli` orb.
+2) Add the `orbs` stanza below your version, thereby invoking the orb. The example below shows how you can invoke the `aws-cli` orb.
 
 ```
 orbs:
   aws-cli: circleci/aws-cli@0.1.13
 ```
 
-3. Use the elements specific to your selected orb in your existing workflows and jobs.
+3) Use the elements specific to your selected orb in your existing workflows and jobs.
 
 ### Hello World Example
 

--- a/jekyll/_cci2/orbs-user-config.md
+++ b/jekyll/_cci2/orbs-user-config.md
@@ -47,8 +47,6 @@ workflows:
       - hello/hello-build
 ```
 
-**Note:** If your project was added to CircleCI prior to 2.1, you must enable pipelines to use the `orbs` key.
-
 ## Next Steps
 
 {:.no_toc}

--- a/jekyll/_cci2/pipeline-variables.md
+++ b/jekyll/_cci2/pipeline-variables.md
@@ -7,31 +7,27 @@ categories: [getting-started]
 order: 1
 ---
 
-Pipeline variables can be used to create reusable pipeline configurations. To
-use pipeline variables you must have pipelines enabled and use configuration
-[version]({{ site.baseurl }}/2.0/configuration-reference/#version) `2.1` or
-higher. {% include snippets/enable-pipelines.md %}
+Pipeline variables can be used to create reusable pipeline configurations. To use pipeline variables you must have [pipelines enabled]({{ site.baseurl }}/2.0/build-processing) and use configuration [version]({{ site.baseurl }}/2.0/configuration-reference/#version) `2.1` or higher. 
 
-There are two types of pipeline variables:
+There are two types of pipeline variables: 
 
-- **Pipeline values** represent pipeline metadata that can be used throughout the configuration.
-- **Pipeline parameters** are typed pipeline variables that are declared in the `parameters` key at the top level of a configuration. Users can pass `parameters` into their pipelines when triggering a new run of a pipeline through the API.
+* **Pipeline values** represent pipeline metadata that can be used throughout the configuration.
+* **Pipeline parameters** are typed pipeline variables that are declared in the `parameters` key at the top level of a configuration. Users can pass `parameters` into their pipelines when triggering a new run of a pipeline through the API. 
 
 ## Pipeline Values
 
 Pipeline values are available to all pipeline configurations and can be used without previous declaration.
 
-| Value                      | Description                                        |
-| -------------------------- | -------------------------------------------------- |
-| pipeline.id                | A globally unique id representing for the pipeline |
-| pipeline.number            | A project unique integer id for the pipeline       |
-| pipeline.project.git_url   | E.g. https://github.com/circleci/circleci-docs     |
-| pipeline.project.type      | E.g. "github"                                      |
-| pipeline.git.tag           | The tag triggering the pipeline                    |
-| pipeline.git.branch        | The branch triggering the pipeline                 |
-| pipeline.git.revision      | The current git revision                           |
-| pipeline.git.base_revision | The previous git revision                          |
-
+Value                       | Description
+----------------------------|--------------------------------------------------------
+pipeline.id                 | A globally unique id representing for the pipeline
+pipeline.number             | A project unique integer id for the pipeline
+pipeline.project.git_url    | E.g. https://github.com/circleci/circleci-docs
+pipeline.project.type       | E.g. "github"
+pipeline.git.tag            | The tag triggering the pipeline
+pipeline.git.branch         | The branch triggering the pipeline
+pipeline.git.revision       | The current git revision
+pipeline.git.base_revision  | The previous git revision
 {: class="table table-striped"}
 
 For example:
@@ -53,18 +49,17 @@ jobs:
 
 ## Pipeline Parameters in Configuration
 
-Pipeline parameters are declared using the `parameters` key at the top level of a `.circleci/config.yml` file.
+Pipeline parameters are declared using the `parameters` key at the top level of a `.circleci/config.yml` file. 
 
 Pipeline parameters support the following types:
+* string
+* boolean
+* integer
+* enum
 
-- string
-- boolean
-- integer
-- enum
+See [Parameter Syntax]({{ site.baseurl }}/2.0/reusing-config/#parameter-syntax) for usage details. 
 
-See [Parameter Syntax]({{ site.baseurl }}/2.0/reusing-config/#parameter-syntax) for usage details.
-
-Pipeline parameters can be referenced by value and used as a config variable under the scope `pipeline.parameters`.
+Pipeline parameters can be referenced by value and used as a config variable under the scope `pipeline.parameters`. 
 
 The example below shows a configuration with two pipeline parameters (`image-tag` and `workingdir`) defined at the top of the config, and then subsequently referenced in the `build` job:
 
@@ -107,7 +102,8 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 
 ## The Scope of Pipeline Parameters
 
-Pipeline parameters can only be resolved in the `.circleci/config.yml` file in which they are declared. Pipeline parameters are not available in orbs, including orbs declared locally in your config.yml file. This was done because access to the pipeline scope in orbs would break encapsulation and create a hard dependency between the orb and the calling config, potentially jeopardizing determinism and creating a surface area of vulnerability.
+Pipeline parameters can only be resolved in the `.circleci/config.yml` file in which they are declared. Pipeline parameters are not available in orbs, including orbs declared locally in your config.yml file. This was done because access to the pipeline scope in orbs would break encapsulation and create a hard dependency between the orb and the calling config, potentially jeopardizing determinism and creating a surface area of vulnerability. 
+
 
 ## Config Processing Stages and Parameter Scopes
 
@@ -206,9 +202,9 @@ The example shown above prevents the workflow `integration_tests` from being tri
 
 ```json
 {
-  "parameters": {
-    "run_integration_tests": true
-  }
+    "parameters": {
+        "run_integration_tests": true
+    }
 }
 ```
 

--- a/jekyll/_cci2/pipeline-variables.md
+++ b/jekyll/_cci2/pipeline-variables.md
@@ -7,27 +7,31 @@ categories: [getting-started]
 order: 1
 ---
 
-Pipeline variables can be used to create reusable pipeline configurations. To use pipeline variables you must have [pipelines enabled]({{ site.baseurl }}/2.0/build-processing) and use configuration [version]({{ site.baseurl }}/2.0/configuration-reference/#version) `2.1` or higher. 
+Pipeline variables can be used to create reusable pipeline configurations. To
+use pipeline variables you must have pipelines enabled and use configuration
+[version]({{ site.baseurl }}/2.0/configuration-reference/#version) `2.1` or
+higher. {% include snippets/enable-pipelines.md %}
 
-There are two types of pipeline variables: 
+There are two types of pipeline variables:
 
-* **Pipeline values** represent pipeline metadata that can be used throughout the configuration.
-* **Pipeline parameters** are typed pipeline variables that are declared in the `parameters` key at the top level of a configuration. Users can pass `parameters` into their pipelines when triggering a new run of a pipeline through the API. 
+- **Pipeline values** represent pipeline metadata that can be used throughout the configuration.
+- **Pipeline parameters** are typed pipeline variables that are declared in the `parameters` key at the top level of a configuration. Users can pass `parameters` into their pipelines when triggering a new run of a pipeline through the API.
 
 ## Pipeline Values
 
 Pipeline values are available to all pipeline configurations and can be used without previous declaration.
 
-Value                       | Description
-----------------------------|--------------------------------------------------------
-pipeline.id                 | A globally unique id representing for the pipeline
-pipeline.number             | A project unique integer id for the pipeline
-pipeline.project.git_url    | E.g. https://github.com/circleci/circleci-docs
-pipeline.project.type       | E.g. "github"
-pipeline.git.tag            | The tag triggering the pipeline
-pipeline.git.branch         | The branch triggering the pipeline
-pipeline.git.revision       | The current git revision
-pipeline.git.base_revision  | The previous git revision
+| Value                      | Description                                        |
+| -------------------------- | -------------------------------------------------- |
+| pipeline.id                | A globally unique id representing for the pipeline |
+| pipeline.number            | A project unique integer id for the pipeline       |
+| pipeline.project.git_url   | E.g. https://github.com/circleci/circleci-docs     |
+| pipeline.project.type      | E.g. "github"                                      |
+| pipeline.git.tag           | The tag triggering the pipeline                    |
+| pipeline.git.branch        | The branch triggering the pipeline                 |
+| pipeline.git.revision      | The current git revision                           |
+| pipeline.git.base_revision | The previous git revision                          |
+
 {: class="table table-striped"}
 
 For example:
@@ -49,17 +53,18 @@ jobs:
 
 ## Pipeline Parameters in Configuration
 
-Pipeline parameters are declared using the `parameters` key at the top level of a `.circleci/config.yml` file. 
+Pipeline parameters are declared using the `parameters` key at the top level of a `.circleci/config.yml` file.
 
 Pipeline parameters support the following types:
-* string
-* boolean
-* integer
-* enum
 
-See [Parameter Syntax]({{ site.baseurl }}/2.0/reusing-config/#parameter-syntax) for usage details. 
+- string
+- boolean
+- integer
+- enum
 
-Pipeline parameters can be referenced by value and used as a config variable under the scope `pipeline.parameters`. 
+See [Parameter Syntax]({{ site.baseurl }}/2.0/reusing-config/#parameter-syntax) for usage details.
+
+Pipeline parameters can be referenced by value and used as a config variable under the scope `pipeline.parameters`.
 
 The example below shows a configuration with two pipeline parameters (`image-tag` and `workingdir`) defined at the top of the config, and then subsequently referenced in the `build` job:
 
@@ -102,8 +107,7 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 
 ## The Scope of Pipeline Parameters
 
-Pipeline parameters can only be resolved in the `.circleci/config.yml` file in which they are declared. Pipeline parameters are not available in orbs, including orbs declared locally in your config.yml file. This was done because access to the pipeline scope in orbs would break encapsulation and create a hard dependency between the orb and the calling config, potentially jeopardizing determinism and creating a surface area of vulnerability. 
-
+Pipeline parameters can only be resolved in the `.circleci/config.yml` file in which they are declared. Pipeline parameters are not available in orbs, including orbs declared locally in your config.yml file. This was done because access to the pipeline scope in orbs would break encapsulation and create a hard dependency between the orb and the calling config, potentially jeopardizing determinism and creating a surface area of vulnerability.
 
 ## Config Processing Stages and Parameter Scopes
 
@@ -202,9 +206,9 @@ The example shown above prevents the workflow `integration_tests` from being tri
 
 ```json
 {
-    "parameters": {
-        "run_integration_tests": true
-    }
+  "parameters": {
+    "run_integration_tests": true
+  }
 }
 ```
 

--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -15,7 +15,9 @@ This Orbs Reference page describes how to version your [.circleci/config.yml]({{
 ## Getting Started with Config Reuse
 {:.no_toc}
 
-1. Add your project on the **Add Projects** page if it is a new project. For an existing Project, select **Settings > Projects**, click the cog icon for the project, then select **Advanced Settings** and enable "pipelines" with the radio button. ![Enable Pipelines]( {{ site.baseurl }}/assets/img/docs/enable_pipelines.png) If this radio button is not available, your project is already using pipelines.
+1. Add your project on the **Add Projects** page if it is a new project.
+   Existing projects will need to enable Pipelines. {% include
+   snippets/enable-pipelines.md %}
 
 2. (Optional) Install the CircleCI-Public CLI by following the [Using the CircleCI CLI]({{ site.baseurl }}/2.0/local-cli/) documentation. The `circleci config process` command is helpful for checking reusable config.
 

--- a/jekyll/_includes/snippets/enable-pipelines.md
+++ b/jekyll/_includes/snippets/enable-pipelines.md
@@ -1,0 +1,1 @@
+If you do not already have Pipelines enabled, you will need to go to `Project Settings` > `Advanced Settings` and turn it on.


### PR DESCRIPTION
# Description
This follows along closely after @rosieyohannan 's https://github.com/circleci/circleci-docs/pull/3988 in which we are using a `snippets` folder for commonly used pieces of the docs. In this case, I am creating a snippet that instructs the user on how to enable pipelines for their project, which occurs (as far as I could grep) at least 5 times in our project
