### PR TITLE
[DONOTMERGE CIRCLE-23110] Remove unsupported notification integration docs

### DIFF
--- a/jekyll/_cci1/configuration.md
+++ b/jekyll/_cci1/configuration.md
@@ -703,7 +703,7 @@ CircleCI sends personalized notifications by email.
 In addition to these per-user emails, CircleCI sends notifications on a per-project basis.
 
 CircleCI supports sending webhooks when your build completes.
-CircleCI also supports Slack, HipChat, Campfire, Flowdock and IRC notifications; you configure these notifications from your project's **Project Settings > Notifications** page.
+CircleCI also supports Slack, Flowdock and IRC notifications; you configure these notifications from your project's **Project Settings > Notifications** page.
 
 This example will POST a JSON packet to the specified URL.
 

--- a/jekyll/_cci1/faq.md
+++ b/jekyll/_cci1/faq.md
@@ -71,7 +71,7 @@ will automatically stop building it.
 
 ### Can I get notifications to team chat applications?
 
-CircleCI supports Slack, HipChat, Campfire, Flowdock and IRC notifications; you configure these notifications from your project’s **Project Settings > Notifications** page.
+CircleCI supports Slack, Flowdock and IRC notifications; you configure these notifications from your project’s **Project Settings > Notifications** page.
 
 ### Can I send Slack / HipChat / IRC notifications for specific branches only?
 

--- a/jekyll/_cci1/index.md
+++ b/jekyll/_cci1/index.md
@@ -14,7 +14,7 @@ CircleCI automates build, test, and deployment of software for mobile, enterpris
 
 ![CircleCI Example Flow with GitHub]({{ site.baseurl }}/assets/img/docs/how_it_works.png)
 
-For example, after a software repository on GitHub or Bitbucket is authorized and added as a project to the circleci.com SaaS application, every new commit triggers a build and notification of success or failure through webhooks. CircleCI also supports Slack, HipChat, Campfire, Flowdock, and IRC notifications. Code coverage results are available from the details page for any project for which a reporting library is added.
+For example, after a software repository on GitHub or Bitbucket is authorized and added as a project to the circleci.com SaaS application, every new commit triggers a build and notification of success or failure through webhooks. CircleCI also supports Slack, Flowdock, and IRC notifications. Code coverage results are available from the details page for any project for which a reporting library is added.
 
 ## Programming Language Support
 

--- a/jekyll/_cci2_ja/about-circleci.md
+++ b/jekyll/_cci2_ja/about-circleci.md
@@ -23,7 +23,7 @@ Linux、macOS、Android の各プラットフォームに加え、SaaS やオン
 
 GitHub もしくは Bitbucket アカウントの認証が完了し、各リポジトリ内のプロジェクトが [circleci.com](https://circleci.com) に追加されると、その後はコードに変更があるたびに、まっさらな状態のコンテナや VM 上で自動的にテストが実行されます。CircleCI は、個別の[コンテナ]({{site.baseurl}}/ja/2.0/glossary/#container)または VM でそれぞれの[ジョブ]({{site.baseurl}}/ja/2.0/glossary/#job)を実行します。つまりジョブを実行するたびに、CircleCI はジョブを実行するためのコンテナまたは VM をスピンアップします。
 
-テスト完了後にはメールで成功・失敗の通知が届くほか、Slack、HipChat、Campfire、Flowdock、IRC などのチャットツールと連携して通知を受け取ることも可能です。テスト通知の内容は、レポートライブラリが追加されているプロジェクトであれば、その詳細ページから確認できます。
+テスト完了後にはメールで成功・失敗の通知が届くほか、Slack、IRC などのチャットツールと連携して通知を受け取ることも可能です。テスト通知の内容は、レポートライブラリが追加されているプロジェクトであれば、その詳細ページから確認できます。
 
 AWS CodeDeploy、AWS EC2 Container Service (ECS)、AWS S3、Google Container Engine (GKE)、Heroku といったデプロイサービスを利用している場合、CircleCI はそれに合わせてデプロイコードを構成します。その他のクラウド型デプロイサービスを使っている場合は、SSH を使うか、ジョブ設定において各サービスの API クライアントを導入することで、簡単にスクリプト化できます。
 

--- a/jekyll/_ccie/overview.md
+++ b/jekyll/_ccie/overview.md
@@ -17,7 +17,7 @@ CircleCI is a modern continuous integration and continuous delivery (CI/CD) plat
 
 ## Basic Features
 
-After a software repository in GitHub or GitHub Enterprise is added as a project to the CircleCI Enterprise application, every new commit triggers a build and notification of success or failure through webhooks with integrations for Slack, HipChat, Campfire, Flowdock, or IRC notifications. Code coverage results are available from the details page for any project for which a reporting library is added.
+After a software repository in GitHub or GitHub Enterprise is added as a project to the CircleCI Enterprise application, every new commit triggers a build and notification of success or failure through webhooks with integrations for Slack, Flowdock, or IRC notifications. Code coverage results are available from the details page for any project for which a reporting library is added.
 
 CircleCI may also be configured to deploy code to various environments, including the following:
 


### PR DESCRIPTION
Reflect our removal of Campfire support in public-facing docs. Do the
same for Hipchat, support for which was removed previously.

# Description
Update 1.0 (and Japanese 2.0) docs to reflect the currently supported list of chat integrations.

Leave archive docs unmodified.

# Reasons
We are in the process of removing support for Campfire from Server 1.0 - see [CIRCLE-23110](https://circleci.atlassian.net/browse/CIRCLE-23110) for more details.

HipChat support was previously removed, so it seems mentions of it should be removed as well.

One final edit was made to the Japanese 2.0 docs, which seem to unintentionally mention all three legacy 1.0 integrations, which should no longer be mentioned in 2.0 docs.