### PR TITLE
Fix markdown syntax in concepts.md (ja)

### DIFF
--- a/jekyll/_cci2_ja/concepts.md
+++ b/jekyll/_cci2_ja/concepts.md
@@ -112,7 +112,7 @@ jobs:
     steps:
       - restore_cache: # キャッシュされた依存関係を復元します。
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
-          ```
+```
 
 {% endraw %}
 


### PR DESCRIPTION
# Description
Removed unnecessary spaces in japanese concepts.md.

# Reasons
The code block looked broken.