### PR TITLE
Update the Windows orb version to something more recent

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -120,7 +120,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@1.0.0
+  win: circleci/windows@2.2.0
 
 jobs:
   build:


### PR DESCRIPTION
The only occurrence of 1.0.0 left in that doc, replacing with 2.2.0 (more recent).