### PR TITLE
Add the missing resource_class part to the Windows Server snippet

### DIFF
--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -87,6 +87,7 @@ jobs:
   build: # name of your job
     machine:
       image: windows-default # Windows machine image
+      resource_class: windows.medium
     steps:
       # Commands are run in a Windows virtual machine environment
       - checkout

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -190,6 +190,7 @@ jobs:
   build: # name of your job
     machine:
       image: windows-default # Windows machine image
+      resource_class: windows.medium
     steps:
       # Commands are run in a Windows virtual machine environment
         - checkout

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -74,6 +74,7 @@ jobs:
   build: # name of your job
     machine:
       image: windows-default # Windows machine image
+      resource_class: windows.medium
     steps:
       # Commands are run in a Windows virtual machine environment
         - checkout


### PR DESCRIPTION
The `resource_class` part is important as otherwise the jobs will try to run on Linux VMs with a Windows image which won’t work.