### PR TITLE
Remove extraneous indents in config example

### DIFF
--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -17,16 +17,16 @@ This example adds a job called `build` that spins up a container running a [pre-
 
 1. Create a [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file with the following lines: 
 
-     ```yaml
-     version: 2.1
-     jobs:
-       build:
-         docker: 
-           - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
-         steps:
-           - checkout # check out the code in the project directory
-           - run: echo "hello world" # run the `echo` command
-     ```
+   ```yaml
+   version: 2.1
+   jobs:
+     build:
+       docker: 
+         - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
+       steps:
+         - checkout # check out the code in the project directory
+         - run: echo "hello world" # run the `echo` command
+   ```
 
 1. Commit and push the changes. 
 


### PR DESCRIPTION
# Description
Remove extraneous indents in "Hello World" config example

# Reasons
## The issue

I've recently hosted a CircleCI 101 training, and about 2/3 of the participants (including myself when I prepared the training 😳) fell for the following inconsistency in the documentation :

1. In order to create a new CircleCI config file, participants would copy paste the config example of "Echo Hello World on Linux" into a new file in their IDE
2. Unfortunately, all copy-pasted lines would be indented by two extraneous spaces
3. The participants would assume only the leading spaces of the first line were extraneous, and would remove them
4. As such, the `jobs` line would be indented by 2 more spaces than the `version` line, which is not a valid configuration.
5. Participants would push the commit with the invalid config, a job would be triggered on CircleCI and they would be welcomed by this cryptic error message in the job logs:

   ```
   # Unable to parse YAML
   # mapping values are not allowed here
   #  in 'string', line 2, column 7:
   #       jobs:
   #           ^
   ```

6. (participants would eventually fix their configuration after I've helped them)

## The fix

Before this commit, each line of the fenced block of the Hello World config example was indented by 5 spaces.
However, according to this [StackOverflow issue](https://stackoverflow.com/questions/34987908/embed-a-code-block-in-a-list-item-with-proper-indentation-in-kramdown), they should only be indented by 3 spaces, assuming CircleCI elected to keep kramdown as the default markdown renderer for Jekyll.
I'm guessing the 2 extraneous spaces come from the 5 in the documentation before this commit, minus the recommended 3.