### PR TITLE
[CIRCLE-23271] Suppress blank search requests to Algolia

### DIFF
--- a/src-js/instantsearch.js
+++ b/src-js/instantsearch.js
@@ -30,7 +30,15 @@ export function init () {
     apiKey:    ALGOLIA_API_KEY,
     indexName: ALGOLIA_INDEX_NAME,
     routing: true,
-    searchParameters: { hitsPerPage: 25 }
+    searchParameters: { hitsPerPage: 25 },
+    searchFunction: function(helper) {
+      // don't run search for blank query, including on initial page load
+      // https://stackoverflow.com/a/42321947
+      if (helper.state.query === '') {
+        return;
+      }
+      helper.search();
+    }
   });
 
   // adding conditions to filter search


### PR DESCRIPTION
# Description

97% of our queries from docs to Algolia were blank. This is because instantsearch.js fires a query upon load by default (I think).

This change borrows a customization from circleci.com search to customize the search function and test whether the query is empty before executing it.

# Reasons

https://circleci.atlassian.net/browse/CIRCLE-23271
