### PR TITLE
Fix the indentation for the resource class statement for Windows on Server

### DIFF
--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -87,7 +87,7 @@ jobs:
   build: # name of your job
     machine:
       image: windows-default # Windows machine image
-      resource_class: windows.medium
+    resource_class: windows.medium
     steps:
       # Commands are run in a Windows virtual machine environment
       - checkout

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -190,7 +190,7 @@ jobs:
   build: # name of your job
     machine:
       image: windows-default # Windows machine image
-      resource_class: windows.medium
+    resource_class: windows.medium
     steps:
       # Commands are run in a Windows virtual machine environment
         - checkout

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -74,7 +74,7 @@ jobs:
   build: # name of your job
     machine:
       image: windows-default # Windows machine image
-      resource_class: windows.medium
+    resource_class: windows.medium
     steps:
       # Commands are run in a Windows virtual machine environment
         - checkout


### PR DESCRIPTION
`resource_class` is only available under `machine` in 2.1 config, in 2.0 it's required to be at the same level as the executor.