### PR TITLE
MIssing example for bash improved

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -104,14 +104,16 @@ jobs:
     executor:
       name: win/default
     steps:
-      - checkout
-      - run: ls -lah
+      # default shell is Powershell
+      - run:            
+         command: $(echo hello | Out-Host; $?) -and $(echo world | Out-Host; $?)
+         shell: powershell.exe
       - run:
-          command: ping circleci.com
-          shell: cmd.exe
+         command: echo hello && echo world
+         shell: bash.exe
       - run:
-          command: echo 'This is powershell'
-          shell: powershell.exe
+         command: echo hello & echo world
+         shell: cmd.exe
 ```
 
 **Note** It is possible to install updated or other Windows shell-tooling as well; for example, you could install the latest version of Powershell Core with the `dotnet` cli and use it in a job's successive steps:


### PR DESCRIPTION


# Description
The original code is missing the example for bash because the default shell is Powershell.
Using echo alone does not mean the correct shell is being used, hence the example adds the AND connective that is different in each of the 3 shells.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.