### PR TITLE
[WIP] update recommended machine image

### DIFF
--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -32,7 +32,7 @@ Find out more about using the `docker` executor [here]({{ site.baseurl }}/2.0/ex
 jobs:
   build: # name of your job
     machine: # executor type
-      image: ubuntu-1604:201903-01 # image includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+      image: ubuntu-1604:201903-01 # # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
 
       steps:
         # Commands run in a Linux virtual machine environment

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -27,11 +27,22 @@ Find out more about using the `docker` executor [here]({{ site.baseurl }}/2.0/ex
 
 ## Machine
 
+{:.tab.windowsblock.Cloud}
 ```
 jobs:
   build: # name of your job
     machine: # executor type
-      image: circleci/classic:201708-01 # VM will run Ubuntu 14.04 for this release date
+      image: ubuntu-1604:201903-01 # image includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+
+      steps:
+        # Commands run in a Linux virtual machine environment
+```
+
+{:.tab.windowsblock.Server}
+```
+jobs:
+  build: # name of your job
+    machine: true # executor type
 
       steps:
         # Commands run in a Linux virtual machine environment
@@ -41,7 +52,7 @@ Find out more about using the `machine` executor [here]({{ site.baseurl }}/2.0/e
 
 ## macOS
 
-_Available on CircleCI Cloud - not currently available on self-hosted installations of CircleCI Server._
+_Available on CircleCI.com - not currently available on self-hosted installations of CircleCI Server._
 
 ```
 jobs:

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -105,7 +105,7 @@ version: 2
 jobs:
   build:
     machine:
-      image: ubuntu-1604:201903-01    # pins image to specific version
+      image: ubuntu-1604:201903-01    # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
 ```
 
 {:.tab.machineblock.Server}
@@ -116,13 +116,7 @@ jobs:
     machine: true # uses default image
 ```
 
-The default image for the machine executor is `circleci/classic:latest`.  If you don't specify an image, jobs will run on the default image - which is currently circleci/classic:201710-01 but may change in future.
-
-The `image` key accepts one of three image types, refer to the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#machine) for additional details about classic versions:
-
-- `circleci/classic:latest`: This is the default image. Changes to this image are announced at least one week in advance.
-- `circleci/classic:edge`: This image receives the latest updates. Changes to this image occur frequently.
-- `circleci/classic:{YYYY-MM}`: This image is pinned to a specific version to prevent breaking changes.
+**Note:** The default image for the machine executor is `circleci/classic:latest`.  If you don't specify an image, jobs will run on the default image - which is currently circleci/classic:201710-01 but may change in future.
 
 All images have common language tools preinstalled. Refer to the [specification script for the VM](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh) for more information.
 

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -113,14 +113,10 @@ jobs:
 version: 2
 jobs:
   build:
-    machine: true
+    machine: true # uses default image
 ```
 
 The default image for the machine executor is `circleci/classic:latest`.  If you don't specify an image, jobs will run on the default image - which is currently circleci/classic:201710-01 but may change in future.
-
-**Note:** The `image` key is not required on self-hosted installations of CircleCI Server (see example above) but if it is used, it should be set to: `image: default`.
-
-Cloud users can specify other images using the `image` key.
 
 The `image` key accepts one of three image types, refer to the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#machine) for additional details about classic versions:
 
@@ -129,6 +125,8 @@ The `image` key accepts one of three image types, refer to the [Configuration Re
 - `circleci/classic:{YYYY-MM}`: This image is pinned to a specific version to prevent breaking changes.
 
 All images have common language tools preinstalled. Refer to the [specification script for the VM](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh) for more information.
+
+**Note:** The `image` key is not required on self-hosted installations of CircleCI Server (see example above) but if it is used, it should be set to: `image: default`.
 
 The following example uses the default machine image and enables [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or Workflow. **Note:** You must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.
 


### PR DESCRIPTION
fix inconsistency in docs - we were recommending two different linux images for `machine` including an old default.

Slack convo here: https://circleci.slack.com/archives/C0KBNJGRH/p1578482968001900