### PR TITLE
Fix quotes in description.

### DIFF
--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -2,7 +2,7 @@
 layout: classic-docs
 title: "CircleCI API Developer's Guide"
 short-title: "Developer's Guide"
-description: "API "cookbook" for internal and external CircleCI developers"
+description: "API &quot;cookbook&quot; for internal and external CircleCI developers"
 categories: [getting-started]
 order: 1
 ---


### PR DESCRIPTION
The Docs site doesn't currently support having raw double quotes in a page description. Either we need to remove the quotes completely or use HTML entities (which is what I do in this PR).