### PR TITLE
Change machine `Configurable resources (CPU/RAM)` to Yes

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -45,7 +45,7 @@ Virtual Environment | `docker` | `machine`
  Layer caching | Yes | Yes
  Run privileged containers | No | Yes
  Use docker compose with volumes | No | Yes
- [Configurable resources (CPU/RAM)]({{ site.baseurl }}/2.0/configuration-reference/#resource_class) | Yes | No
+ [Configurable resources (CPU/RAM)]({{ site.baseurl }}/2.0/configuration-reference/#resource_class) | Yes | Yes
 {: class="table table-striped"}
 
 <sup>(1)</sup> Requires using [Remote Docker][building-docker-images].


### PR DESCRIPTION
It seems this may be out-of-date, as the machine executor can now accept the resource_class key with the options medium and large.

Reference:
https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux

# Description
In the table comparing the Docker to Machine executor, I changed the value of the cell for Configurable resources (CPU/RAM), Machine from 'No' to 'Yes'.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.