### PR TITLE
Update ruby executor

### DIFF
--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -91,7 +91,7 @@ orbs:
     executors:
       specialthingsexecutor:
         docker:
-          - image: circleci/ruby:1.4.2
+          - image: circleci/ruby:2.7.0
     commands:
       dospecialthings:
         steps:


### PR DESCRIPTION
# Description
Update tag of ruby executor from 1.4.2 to 2.7.0

# Reasons
I tried to run this example inline code as it stands and received the following error:
`Error response from daemon: manifest for circleci/ruby:1.4.2 not found`
Red build: https://circleci.com/gh/annapamma/training_01_Hello_World/203

I updated the Ruby version and was able to run the sample code as expected.
Green build: https://circleci.com/gh/annapamma/training_01_Hello_World/205
