### PR TITLE
iOS Best Practises Additions

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -96,7 +96,7 @@ Homebrew, by default, will check for updates at the start of any operation. As H
 
 If build speed, or bugs introduced by new Homebrew updates, are of a concern, this can be disabled. On average, this can save 2-5 minutes per job.
 
-To disable this feature, define the `HOMEBREW_NO_AUTO_UPDATE` environment variable config.yml in your job:
+To disable this feature, define the `HOMEBREW_NO_AUTO_UPDATE` environment variable within your job:
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -102,6 +102,15 @@ To disable this feature, add the following line to your config.yml before callin
 - run: echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $BASH_ENV
 ```
 
+#### iOS Simulator Crash Reports
+
+If your iOS app crashes in the Simulator during a test run, the crash report is useful for diagnosing the exact cause of the crash. These can be uploaded as artifacts to assist with debugging the app crash:
+
+```yaml
+- store_artifacts:
+    path: ~/Library/Logs/DiagnosticReports
+```
+
 ## Advanced Setup
 
 For advanced setup, it is possible to run a lint job together with your

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -153,7 +153,6 @@ jobs:
       - run: danger
 
 workflows:
-  version: 2
   build-test-lint:
     jobs:
       - swiftlint

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -74,6 +74,8 @@ example of a minimal config in the
 ### Best Practices
 {:.no_toc}
 
+#### Cocoapods
+
 In addition to the basic setup steps, it is best practice to use Cocoapods 1.8 or newer which allows the use of the CDN, rather than having to clone the entire Specs repo. This will allow you to install pods faster, reducing build times. If you are using Cocoapods 1.7 or older, consider upgrading to 1.8 or newer as this change allows for much faster job execution of the `pod install` step.
 
 To enable this, ensure the first line in your Podfile is as follows:
@@ -86,6 +88,18 @@ If upgrading from Cocoapods 1.7 or older, additionally ensure the following line
 
 ```
 source 'https://github.com/CocoaPods/Specs.git'
+```
+
+#### Homebrew
+
+Homebrew, by default, will check for updates at the start of any operation. As Homebrew has a fairly frequent release cycle, this means that the step execution can take some extra time to complete.
+
+If build speed, or bugs introduced by new Homebrew updates, are of a concern, this can be disabled. On average, this can save 2-5 minutes per job.
+
+To disable this feature, add the following line to your config.yml before calling Homebrew:
+
+```yaml
+- run: echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $BASH_ENV
 ```
 
 ## Advanced Setup

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -94,7 +94,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 Homebrew, by default, will check for updates at the start of any operation. As Homebrew has a fairly frequent release cycle, this means that the step execution can take some extra time to complete.
 
-If build speed, or bugs introduced by new Homebrew updates, are of a concern, this can be disabled. On average, this can save 2-5 minutes per job.
+If build speed or bugs introduced by new Homebrew updates are a concern, this update-check feature can be disabled. On average, this can save 2-5 minutes per job.
 
 To disable this feature, define the `HOMEBREW_NO_AUTO_UPDATE` environment variable within your job:
 

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -113,7 +113,7 @@ jobs:
 
 #### iOS Simulator Crash Reports
 
-If your iOS app crashes in the Simulator during a test run, the crash report is useful for diagnosing the exact cause of the crash. These can be uploaded as artifacts to assist with debugging the app crash:
+If your iOS app crashes in the Simulator during a test run, the crash report is useful for diagnosing the exact cause of the crash. Crash reports can be uploaded as artifacts, as follows:
 
 ```yaml
 steps:

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -96,10 +96,19 @@ Homebrew, by default, will check for updates at the start of any operation. As H
 
 If build speed, or bugs introduced by new Homebrew updates, are of a concern, this can be disabled. On average, this can save 2-5 minutes per job.
 
-To disable this feature, add the following line to your config.yml before calling Homebrew:
+To disable this feature, define the `HOMEBREW_NO_AUTO_UPDATE` environment variable config.yml in your job:
 
 ```yaml
-- run: echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $BASH_ENV
+version: 2
+jobs:
+  build-and-test:
+    macos:
+      xcode: "11.3.0"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - run: brew install wget
 ```
 
 #### iOS Simulator Crash Reports

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -99,11 +99,11 @@ If build speed, or bugs introduced by new Homebrew updates, are of a concern, th
 To disable this feature, define the `HOMEBREW_NO_AUTO_UPDATE` environment variable config.yml in your job:
 
 ```yaml
-version: 2
+version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: "11.3.0"
+      xcode: 11.3.0
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -132,7 +132,7 @@ job as follows:
 
 
 ```yaml
-version: 2
+version: 2.1
 jobs:
   build-and-test:
   swiftlint:
@@ -332,22 +332,22 @@ Doing so generally reduces the number of simulator
 timeouts observed in builds.
 
 To pre-start the simulator, add the following to your
-`config.yml` file, assuming that you are running your tests on an iPhone 7
-simulator with iOS 10.2:
+`config.yml` file, assuming that you are running your tests on an iPhone 11 Pro
+simulator with iOS 13.2:
 
 ```
     steps:
       - run:
           name: pre-start simulator
-          command: xcrun instruments -w "iPhone 7 (10.2) [" || true
+          command: xcrun instruments -w "iPhone 11 Pro (13.3) [" || true
 ```
 
 **Note:** the `[` character is necessary to uniquely identify the iPhone 7
 simulator, as the phone + watch simulator is also present in the build
 image:
 
-* `iPhone 7 (10.2) [<uuid>]` for the iPhone simulator.
-* `iPhone 7 Plus (10.2) + Apple Watch Series 2 - 42mm (3.1) [<uuid>]` for the phone + watch pair.
+* `iPhone 11 Pro (13.3) [<uuid>]` for the iPhone simulator.
+* `iPhone 11 Pro (13.3) + Apple Watch Series 5 - 40mm (6.1.1) [<uuid>]` for the phone + watch pair.
 
 ### Creating a `config.yml` File
 {:.no_toc}

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -116,7 +116,9 @@ jobs:
 If your iOS app crashes in the Simulator during a test run, the crash report is useful for diagnosing the exact cause of the crash. These can be uploaded as artifacts to assist with debugging the app crash:
 
 ```yaml
-- store_artifacts:
+steps:
+  # ...
+  - store_artifacts:
     path: ~/Library/Logs/DiagnosticReports
 ```
 


### PR DESCRIPTION
# Description

Added disabling the Homebrew auto-updater and iOS sim crash report collection to the best practices section

# Reasons

Disabling the Homebrew updater can save users 2-4 minutes per job and, in some instances recently, Homebrew updates have introduced bugs for customers.

Collecting iOS sim crash reports helps both users and support diagnose UITest failures.