### PR TITLE
change orbs ref to reusable config ref

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -1,13 +1,13 @@
 ---
 layout: classic-docs
-title: "Orbs Reference Guide"
-short-title: "Orbs Reference"
-description: "Reference guide for CircleCI 2.1 orbs"
+title: "Reusable Config Reference Guide"
+short-title: "Reusable Config Reference"
+description: "Reference guide for CircleCI 2.1 Configuration"
 categories: [configuration]
 order: 1
 ---
 
-This Orbs Reference page describes how to version your [.circleci/config.yml]({{ site.baseurl }}/2.0/configuration-reference/) file and get started with reusable orbs, commands, jobs, and executors.
+This reusable config reference page describes how to version your [.circleci/config.yml]({{ site.baseurl }}/2.0/configuration-reference/) file and get started with reusable, commands, jobs, and executors and orbs.
 
 * TOC
 {:toc}

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -78,6 +78,8 @@ en:
           link: 2.0/config-intro/
         - name: Configuration Reference
           link: 2.0/configuration-reference/
+        - name: Reusable Config Reference
+          link: 2.0/reusing-config/
         - name: Writing YAML
           link: 2.0/writing-yaml/
         - name: Using the CircleCI CLI
@@ -91,7 +93,7 @@ en:
           link: 2.0/orbs-faq/
         - name: Orbs Concepts
           link: 2.0/using-orbs/
-        - name: Orbs Reference
+        - name: Reusable Config Reference
           link: 2.0/reusing-config/
         - name: Orb Testing Methodologies
           link: 2.0/testing-orbs/


### PR DESCRIPTION
Orbs reference doesn't seem like the right name for this doc. It covers all reusable content. Changing to reflect this and adding a link outside the orbs section to make it easier to find.