### PR TITLE
Update Xcode Version in all docs

### DIFF
--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -83,8 +83,8 @@ An image is a packaged system that has the instructions for creating a running c
        image: circleci/classic:201708-01
 #...       
    build3:
-     macos: # Specifies a macOS virtual machine with Xcode version 9.0
-       xcode: "9.0"       
+     macos: # Specifies a macOS virtual machine with Xcode version 11.3
+       xcode: "11.3.0"
 # ...          
  ```
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -337,13 +337,13 @@ Key | Required | Type | Description
 xcode | Y | String | The version of Xcode that is installed on the virtual machine, see the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) document for the complete list.
 {: class="table table-striped"}
 
-**Example:** Use a macOS virtual machine with Xcode version `9.0`:
+**Example:** Use a macOS virtual machine with Xcode version 11.3:
 
 ```yaml
 jobs:
   build:
     macos:
-      xcode: "9.0"
+      xcode: "11.3.0"
 ```
 
 #### **`windows`**
@@ -473,7 +473,7 @@ large\*          | 8     | 16GB
 jobs:
   build:
     macos:
-      xcode: "11.0.0"
+      xcode: "11.3.0"
     resource_class: large
     steps:
       ... // other config

--- a/jekyll/_cci2/examples-intro.md
+++ b/jekyll/_cci2/examples-intro.md
@@ -88,7 +88,7 @@ jobs:
 jobs:
   build-and-test:
     macos:
-      xcode: "9.3.0"
+      xcode: "11.3.0"
     steps:
       ...
       - run:

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -58,11 +58,11 @@ _Available on CircleCI.com - not currently available on self-hosted installation
 jobs:
   build: # name of your job
     macos: # executor type
-      xcode: "9.0"
+      xcode: 11.3.0
 
     steps:
       # Commands run in a macOS virtual machine environment
-      # with Xcode 9.0 installed
+      # with Xcode 11.3 installed
 ```
 
 Find out more about using the `macos` executor [here]({{ site.baseurl }}/2.0/executor-types/#using-macos).

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -143,11 +143,11 @@ Using the `macos` executor allows you to run your job in a macOS environment on 
 jobs:
   build:
     macos:
-      xcode: "9.0"
+      xcode: 11.3.0
       
     steps:
       # Commands will execute in macOS container
-      # with Xcode 9.0 installed
+      # with Xcode 11.3 installed
       - run: xcodebuild -version
 ```
 
@@ -251,6 +251,3 @@ Choosing Docker limits your runs to what is possible from within a Docker contai
 ## See Also
 
 [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/)
-
-
-

--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -49,11 +49,11 @@ have a fairly simple `.circleci/config.yml` file. Below, each line is commented
 to indicate what is happening at each step.
 
 ```yaml
-version: 2 # use version 2.0 of CircleCI
+version: 2.1
 jobs: # a basic unit of work in a run
   build: # runs not using `Workflows` must have a `build` job as entry point
     macos:  # indicate that we are using the macOS executor
-      xcode: "10.0.0" # indicate our selected version of Xcode
+      xcode: 11.3.0 # indicate our selected version of Xcode
     steps: # a series of commands to run
       - checkout  # pull down code from your version control system.
       - run:

--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -64,7 +64,7 @@ Using the basics from the Linux and Android examples above, you can add a job th
 jobs: 
   build-macos: 
     macos:  
-      xcode: "10.0.0" 
+      xcode: 11.3.0
 ```      
 
 Refer to the [Hello World on MacOS]({{site.baseurl}}/2.0/hello-world-macos) document for more information and a sample project.

--- a/jekyll/_cci2/ios-codesigning.md
+++ b/jekyll/_cci2/ios-codesigning.md
@@ -149,7 +149,7 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: "9.0"
+      xcode: 11.3.0
     steps:
       ...
       - run: bundle exec fastlane test
@@ -157,7 +157,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: "9.0"
+      xcode: 11.3.0
     steps:
       ...
       - run: bundle exec fastlane adhoc
@@ -204,16 +204,14 @@ end
 
 ```yaml
 # .circleci/config.yml
-version: 2
+version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: "9.0"
-    working_directory: /Users/distiller/project
+      xcode: 11.3.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
-    shell: /bin/bash --login -o pipefail
     steps:
       - checkout
       - run: bundle install
@@ -227,12 +225,10 @@ jobs:
 
   adhoc:
     macos:
-      xcode: "9.0"
-    working_directory: /Users/distiller/project
+      xcode: 11.3.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
-    shell: /bin/bash --login -o pipefail
     steps:
       - checkout
       - run: bundle install
@@ -243,7 +239,6 @@ jobs:
           path: output
 
 workflows:
-  version: 2
   build-test-adhoc:
     jobs:
       - build-and-test

--- a/jekyll/_cci2/ios-migrating-from-1-2.md
+++ b/jekyll/_cci2/ios-migrating-from-1-2.md
@@ -37,8 +37,8 @@ CircleCI 2.0:
 ```yaml
 # .circleci/config.yml
 
-# Specify the config version - version 2 is latest.
-version: 2
+# Specify the config version - version 2.1 is latest.
+version: 2.1
 
 # Define the jobs for the current project.
 jobs:
@@ -46,8 +46,7 @@ jobs:
 
     # Specify the Xcode version to use.
     macos:
-      xcode: "8.3.3"
-    working_directory: /Users/distiller/project
+      xcode: 11.3.0
     environment:
       FL_OUTPUT_DIR: output
 
@@ -57,13 +56,9 @@ jobs:
       # Get the code from the VCS provider.
       - checkout
 
-      # Download CocoaPods specs via HTTPS (faster than Git)
-      # and install CocoaPods.
       - run:
           name: Install CocoaPods
-          command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
-            pod install
+          command: pod install
 
       # Run tests.
       - run:
@@ -80,8 +75,7 @@ jobs:
 
   deploy:
     macos:
-      xcode: "8.3.3"
-    working_directory: /Users/distiller/project
+      xcode: 11.3.0
     environment:
       FL_OUTPUT_DIR: output
 
@@ -108,7 +102,6 @@ jobs:
           command: fastlane spaceship
 
 workflows:
-  version: 2
   build-and-deploy:
     jobs:
       - build-and-test
@@ -160,19 +153,19 @@ The following sections provide examples of 2.0 configuration syntax for an iOS p
 ### Job Name and Xcode Version
 {:.no_toc}
 
-In the 2.0 `.circleci/config.yml` file the first few lines specify the
+In the 2.1 `.circleci/config.yml` file the first few lines specify the
 name of the job and the Xcode version to use:
 
 ```
-version: 2
+version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: "8.3.3"
+      xcode: 11.3.0
 ...
   deploy:
     macos:
-      xcode: "8.3.3"
+      xcode: 11.3.0
 ...
 ```
 
@@ -360,8 +353,7 @@ jobs:
   # add other jobs here
   deploy:
     macos:
-      xcode: 8.3.3
-    working_directory: /Users/distiller/project
+      xcode: 11.3.0
     environment:
       FL_OUTPUT_DIR: output
 

--- a/jekyll/_cci2/ios-tutorial.md
+++ b/jekyll/_cci2/ios-tutorial.md
@@ -40,7 +40,7 @@ For iOS projects, it is possible to run your tests with Fastlane Scan as follows
 jobs:
   build-and-test:
     macos:
-      xcode: "9.3.0"
+      xcode: 11.3.0
     steps:
       ...
       - run:
@@ -89,17 +89,17 @@ The `run` step is also used to run your tests as in the following example of the
 To deploy your application with CircleCI using [Gym](https://github.com/fastlane/fastlane/tree/master/gym) and [Deliver](https://github.com/fastlane/fastlane/tree/master/deliver) from [Fastlane](https://fastlane.tools) specify an identifier, a branch or pattern that the release should run on, and a set of commands to run the release.
 
 ```
-version: 2
+version: 2.1
 jobs:
   test:
     macos:
-      xcode: "9.3.0"
+      xcode: 11.3.0
     steps:
       - checkout
       - run: fastlane scan
   deploy:
     macos:
-      xcode: "9.3.0"
+      xcode: 11.3.0
     steps:
       - checkout
       - deploy:
@@ -107,7 +107,6 @@ jobs:
           command: fastlane release_appstore
 
 workflows:
-  version: 2
   test_release:
     jobs:
       - test

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -58,7 +58,7 @@ The `config-translation` endpoint can help you quickly get started with converti
      See the Using Machine section of the [Choosing an Executor Type](https://circleci.com/docs/2.0/executor-types/#using-machine) document for details about the available VM images.
      ```yaml
          macos: 
-           xcode: "9.0"
+           xcode: 11.3.0
      ```
 See the [Migrating Your iOS Project From 1.0 to 2.0](https://circleci.com/docs/2.0/ios-migrating-from-1-2/) document for details.
 

--- a/jekyll/_cci2/migrating-from-aws.adoc
+++ b/jekyll/_cci2/migrating-from-aws.adoc
@@ -192,7 +192,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: "10.1.0"
+      xcode: 11.3.0
     steps:
       - checkout
       - run: echo "Hello, $USER!"
@@ -243,4 +243,3 @@ For larger and more complex build files, we recommend moving over the build step
 . https://circleci.com/docs/2.0/caching/[Caching]
 . https://circleci.com/docs/2.0/triggers/#section=jobs[Triggers]
 . https://circleci.com/docs/2.0/optimizations/#section=projects[Performance options]
-

--- a/jekyll/_cci2/migrating-from-azuredevops.adoc
+++ b/jekyll/_cci2/migrating-from-azuredevops.adoc
@@ -193,7 +193,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: "10.1.0"
+      xcode: 11.3.0
     steps:
       - checkout
       - run: echo "Hello, $USER!"
@@ -208,4 +208,3 @@ For larger and more complex build files, we recommend moving over the build step
 . https://circleci.com/docs/2.0/caching/[Caching]
 . https://circleci.com/docs/2.0/triggers/#section=jobs[Triggers]
 . https://circleci.com/docs/2.0/optimizations/#section=projects[Performance options]
-

--- a/jekyll/_cci2/migrating-from-buildkite.adoc
+++ b/jekyll/_cci2/migrating-from-buildkite.adoc
@@ -182,7 +182,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: "10.1.0"
+      xcode: 11.3.0
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -125,7 +125,7 @@ machine: true
 
 # macOS Executor
 macos:
-  xcode: "11.0.0"
+  xcode: 11.3.0
 
 # Windows Executor
 # NOTE: Orb declaration needed. See docs

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -183,7 +183,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: "10.1.0"
+      xcode: 11.3.0
     steps:
       - checkout
       - run: echo "Hello, $USER!"
@@ -242,5 +242,3 @@ For larger and more complex build files, we recommend moving over the build step
 . https://circleci.com/docs/2.0/workflows/[Workflows]
 . https://circleci.com/docs/2.0/collect-test-data/[Test results] / test splitting / https://circleci.com/docs/2.0/parallelism-faster-jobs/[parallelism]
 . https://circleci.com/docs/2.0/artifacts/[Artifacts]
-
-

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -243,18 +243,14 @@ will be run in Docker.
 {% raw %}
 
 ```yaml
-version: 2
+version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: "9.0"
+      xcode: 11.3.0
 
     steps:
       - checkout
-      - run:
-          name: Fetch CocoaPods Specs
-          command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
       - run:
           name: Install CocoaPods
           command: pod install --verbose
@@ -294,7 +290,6 @@ jobs:
       - run: danger
 
 workflows:
-  version: 2
   build-test-lint:
     jobs:
       - swiftlint

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -209,11 +209,11 @@ This configuration can be used with the following CircleCI config file:
 
 ```yaml
 # .circleci/config.yml
-version: 2
+version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: "10.2.0"
+      xcode: 11.3.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -230,7 +230,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: "10.2.0"
+      xcode: 11.3.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
@@ -244,7 +244,6 @@ jobs:
           path: output
 
 workflows:
-  version: 2
   build-test-adhoc:
     jobs:
       - build-and-test
@@ -563,21 +562,16 @@ will be run in Docker.
 {% raw %}
 
 ```yaml
-version: 2
+version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: "10.2.0"
-    working_directory: /Users/distiller/project
+      xcode: 11.3.0
     environment:
       FL_OUTPUT_DIR: output
 
     steps:
       - checkout
-      - run:
-          name: Fetch CocoaPods Specs
-          command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
       - run:
           name: Install CocoaPods
           command: pod install --verbose
@@ -613,7 +607,6 @@ jobs:
       - run: danger
 
 workflows:
-  version: 2
   build-test-lint:
     jobs:
       - swiftlint


### PR DESCRIPTION
I'm currently looking at usage of macOS on CircleCI, by version, and
I've found many projects (~100) that have built twice with Xcode 9.3.1 in
the last 3 weeks. I beleive that this is because we have Xcode 9.3.1 as
the version in our 'hello world' example.

I've gone through the docs and updated all macOS snippets to specify
Xcode 11.3 instead.

Other changes:

- I've removed any quotation marks around the Xcode version where they are
  not necessary
- I've changed the config snippets to use config 2.1 where appropriate
- I've removed some references to the cocoapods-specs download script
  that is no longer required with newer versions of CocoaPods.
