### PR TITLE
Add executor footnote for executor selection limit

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -103,7 +103,7 @@ working_directory | N | String | In which directory to run the steps.
 environment | N | Map | A map of environment variable names and values.
 {: class="table table-striped"}
 
-<sup>(1)</sup> exactly one of them should be specified. It is an error to set more than one.
+<sup>(1)</sup> One executor type should be specified per job. If more than one is set you will recieve an error.
 
 Example:
 
@@ -152,7 +152,7 @@ branches | N | Map | A map defining rules to allow/block execution of specific b
 resource_class | N | String | Amount of CPU and RAM allocated to each container in a job. **Note:** A paid account is required to access this feature. Customers on paid container-based plans can request access by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
 {: class="table table-striped"}
 
-<sup>(1)</sup> exactly one of them should be specified. It is an error to set more than one.
+<sup>(1)</sup> One executor type should be specified per job. If more than one is set you will recieve an error.
 
 #### `environment`
 A map of environment variable names and values. These will override any environment variables you set in the CircleCI application.

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -80,7 +80,7 @@ commands:
 ```
 
 ## **`parameters`** (requires version: 2.1)
-Pipeline parameters declared for use in the configuration. See [Pipeline Variables]({{ site.baseurl }}/2.0/pipeline-variables#pipeline-parameters-in-configuration) for usage details. 
+Pipeline parameters declared for use in the configuration. See [Pipeline Variables]({{ site.baseurl }}/2.0/pipeline-variables#pipeline-parameters-in-configuration) for usage details.
 
 Key | Required  | Type | Description
 ----|-----------|------|------------
@@ -102,6 +102,8 @@ shell | N | String | Shell to use for execution command in all steps. Can be ove
 working_directory | N | String | In which directory to run the steps.
 environment | N | Map | A map of environment variable names and values.
 {: class="table table-striped"}
+
+<sup>(1)</sup> exactly one of them should be specified. It is an error to set more than one.
 
 Example:
 
@@ -941,7 +943,7 @@ In general `deploy` step behaves just like `run` with two exceptions:
 - In a job that runs with SSH, the `deploy` step will not execute, and the following action will show instead:
   > **skipping deploy**
   > Running in SSH mode.  Avoid deploying.
-  
+
 When using the `deploy` step, it is also helpful to understand how you can use workflows to orchestrate jobs and trigger jobs. For more information about using workflows, refer to the following pages:
 
 - [Workflows](https://circleci.com/docs/2.0/workflows-overview/)
@@ -1354,7 +1356,7 @@ workflows:
 jobs:
 ...
 ```
- 
+
 This example prevents the workflow `integration_tests` from running unless the tests are invoked explicitly when the pipeline is triggered with the following in the `POST` body:
 
 ```


### PR DESCRIPTION
# Description
Added a footnote below the executors info table to explain the superscripted `(1)` note which indicates that there is a selection limit of one for choosing an executor

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

The options `docker` `machine` `macos` and `windows` all have a `(1)` superscript but no close footnote to explain its meaning. Looking at other similar footnotes, it can be deduced that this is supposed to mean that there is a selection limit of exactly 1 for a chosen executor.