### PR TITLE
Fix invalid cucumber command

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -102,7 +102,7 @@ Alternatively, if you want to use Cucumber's JSON formatter, be sure to name the
           name: Save test results
           command: |
             mkdir -p ~/cucumber
-            bundle exec cucumber pretty --format json --out ~/cucumber/tests.cucumber
+            bundle exec cucumber --format pretty --format json --out ~/cucumber/tests.cucumber
           when: always
       - store_test_results:
           path: ~/cucumber


### PR DESCRIPTION
# Description
'pretty' needs to be prepended with the format flag. Otherwise the commands gives error 'No such file or directory - pretty'

# Reasons
The command in the documentation gives an error - mentioned in the paragraph above. This change fixes that error.