### PR TITLE
CircleCI Docker イメージ link

### DIFF
--- a/jekyll/_cci2_ja/language-ruby.md
+++ b/jekyll/_cci2_ja/language-ruby.md
@@ -28,7 +28,7 @@ CircleCI は、以下のページで Ruby on Rails サンプルプロジェク�
 
 このアプリケーションでは、最新の安定した Rails バージョン 5.1 (`rspec-rails`)、[RspecJunitFormatter](https://github.com/sj26/rspec_junit_formatter)、および PostgreSQL データベースを使用しています。
 
-このアプリケーションのビルドには、ビルド済み [CircleCI Docker イメージ](http://circleci.com/docs/ja/2.0/circleci-images)の 1つを使用しています。
+このアプリケーションのビルドには、ビルド済み [CircleCI Docker イメージ](https://circleci.com/docs/ja/2.0/circleci-images/)の 1つを使用しています。
 
 ## CircleCI のビルド済み Docker イメージ
 

--- a/jekyll/_cci2_ja/language-ruby.md
+++ b/jekyll/_cci2_ja/language-ruby.md
@@ -28,7 +28,7 @@ CircleCI は、以下のページで Ruby on Rails サンプルプロジェク�
 
 このアプリケーションでは、最新の安定した Rails バージョン 5.1 (`rspec-rails`)、[RspecJunitFormatter](https://github.com/sj26/rspec_junit_formatter)、および PostgreSQL データベースを使用しています。
 
-このアプリケーションのビルドには、ビルド済み [CircleCI Docker イメージ](https://circleci.com/docs/ja/2.0/circleci-images/)の 1つを使用しています。
+このアプリケーションのビルドには、ビルド済み [CircleCI Docker イメージ]({{site.baseurl}}/ja/2.0/circleci-images)の 1つを使用しています。
 
 ## CircleCI のビルド済み Docker イメージ
 


### PR DESCRIPTION
SEO audit - causing redirect chain issue

# Description
Updated link for "CircleCI Docker イメージ" from **http://circleci.com/docs/ja/2.0/circleci-images** to **https://circleci.com/docs/ja/2.0/circleci-images/**

# Reasons
We ran an SEO audit through https://ahrefs.com/ and it reported the link was causing a redirect chain.