### PR TITLE
[CIRCLE-23110] Remove unsupported notification docs

### DIFF
--- a/jekyll/_cci1/configuration.md
+++ b/jekyll/_cci1/configuration.md
@@ -703,7 +703,7 @@ CircleCI sends personalized notifications by email.
 In addition to these per-user emails, CircleCI sends notifications on a per-project basis.
 
 CircleCI supports sending webhooks when your build completes.
-CircleCI also supports Slack, HipChat, Campfire, Flowdock and IRC notifications; you configure these notifications from your project's **Project Settings > Notifications** page.
+CircleCI also supports Slack, Flowdock and IRC notifications; you configure these notifications from your project's **Project Settings > Notifications** page.
 
 This example will POST a JSON packet to the specified URL.
 

--- a/jekyll/_cci1/faq.md
+++ b/jekyll/_cci1/faq.md
@@ -71,9 +71,9 @@ will automatically stop building it.
 
 ### Can I get notifications to team chat applications?
 
-CircleCI supports Slack, HipChat, Campfire, Flowdock and IRC notifications; you configure these notifications from your project’s **Project Settings > Notifications** page.
+CircleCI supports Slack, Flowdock and IRC notifications; you configure these notifications from your project’s **Project Settings > Notifications** page.
 
-### Can I send Slack / HipChat / IRC notifications for specific branches only?
+### Can I send chat notifications for specific branches only?
 
 There is [experimental support for per branch chat notifications]( {{ site.baseurl }}/1.0/configuration/#per-branch-notifications). 
 

--- a/jekyll/_cci1/index.md
+++ b/jekyll/_cci1/index.md
@@ -14,7 +14,7 @@ CircleCI automates build, test, and deployment of software for mobile, enterpris
 
 ![CircleCI Example Flow with GitHub]({{ site.baseurl }}/assets/img/docs/how_it_works.png)
 
-For example, after a software repository on GitHub or Bitbucket is authorized and added as a project to the circleci.com SaaS application, every new commit triggers a build and notification of success or failure through webhooks. CircleCI also supports Slack, HipChat, Campfire, Flowdock, and IRC notifications. Code coverage results are available from the details page for any project for which a reporting library is added.
+For example, after a software repository on GitHub or Bitbucket is authorized and added as a project to the circleci.com SaaS application, every new commit triggers a build and notification of success or failure through webhooks. CircleCI also supports Slack, Flowdock, and IRC notifications. Code coverage results are available from the details page for any project for which a reporting library is added.
 
 ## Programming Language Support
 

--- a/jekyll/_ccie/overview.md
+++ b/jekyll/_ccie/overview.md
@@ -17,7 +17,7 @@ CircleCI is a modern continuous integration and continuous delivery (CI/CD) plat
 
 ## Basic Features
 
-After a software repository in GitHub or GitHub Enterprise is added as a project to the CircleCI Enterprise application, every new commit triggers a build and notification of success or failure through webhooks with integrations for Slack, HipChat, Campfire, Flowdock, or IRC notifications. Code coverage results are available from the details page for any project for which a reporting library is added.
+After a software repository in GitHub or GitHub Enterprise is added as a project to the CircleCI Enterprise application, every new commit triggers a build and notification of success or failure through webhooks with integrations for Slack, Flowdock, or IRC notifications. Code coverage results are available from the details page for any project for which a reporting library is added.
 
 CircleCI may also be configured to deploy code to various environments, including the following:
 

--- a/jekyll/assets/code/project_import_export.clj
+++ b/jekyll/assets/code/project_import_export.clj
@@ -85,7 +85,6 @@
               :only [:vcs_url :features :github-id :aws :encrypted-ssh-keys
                      :encrypted-checkout-ssh-keys :tokens
                      :encrypted-env-vars-map :setup :dependencies :test :extra
-                     :encrypted-hipchat-settings :encrypted-campfire-settings
                      :encrypted-flowdock-settings :encrypted-slack-settings
                      :encrypted-irc-settings :parallel])
        (->> (map #(do


### PR DESCRIPTION
Reflect our removal of support for several chat notification integrations in docs.

Reopens https://github.com/circleci/circleci-docs/pull/4006 with a few additional edits.

# Description
Update docs to reflect the currently supported list of chat integrations.

Leave archive docs unmodified, and hold on to open-source acknowledgements for `clj-campfire` until the changes are released and made permanent in Server.

# Reasons
We've removed support for Campfire notifications in Cloud and are in the process of removing it from Server, so the docs should be updated to reflect this. We've previously removed HipChat notification support, so mentions of it should also be removed from docs.

Campfire support removal ticket: [CIRCLE-23110](https://circleci.atlassian.net/browse/CIRCLE-23110).

Re: https://github.com/circleci/circleci-docs/pull/4006#discussion_r356604724, I've left out changes to [`jekyll/_cci2_ja/about-circleci.md`](https://github.com/circleci/circleci-docs/blob/master/jekyll/_cci2_ja/about-circleci.md). Those look like 2.0 docs, so I think "HipChat", "Campfire", _and_ "Flowdock" mentions should be removed (Flowdock is only supported in 1.0 now).