### PR TITLE
Do not reference irrelevant add-ssh-key page

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -71,7 +71,7 @@ Integrated status also appears on the pull request screen, to show that all test
 If your testing process refers to multiple repositories, CircleCI will need a
 GitHub user key in addition to the deploy key because each deploy key is valid
 for only _one_ repository while a GitHub user key has access to _all_ of your
-GitHub repositories. Refer to the [adding ssh keys]({{ site.baseurl }}/2.0/add-ssh-key) document to learn more.
+GitHub repositories.
 
 Provide CircleCI with a GitHub user key on your project's
 **Project Settings > Checkout SSH keys** page.


### PR DESCRIPTION
# Description
Remove reference to the [adding ssh keys document](https://circleci.com/docs/2.0/add-ssh-key) document from the "Enable Your Project to Check Out Additional Private Repositories" section.

# Reasons
The [adding ssh keys document](https://circleci.com/docs/2.0/add-ssh-key) is not relevant to enabling of a project to check out additional private repositories.  That document describes the addition of an SSH key *for deploying to one's server*, not for checking out repositories.