### PR TITLE
Fix broken link to "add projects" page

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -133,7 +133,7 @@ When GitHub prompts you
 to authorize CircleCI,
 click the **Authorize application** button.
 
-4. On the [Add Projects](https://circleci.com/add-projects/gh){:rel="nofollow"} page,
+4. From the Add Projects page,
 follow all projects
 you want the machine user to have access to.
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -133,7 +133,7 @@ When GitHub prompts you
 to authorize CircleCI,
 click the **Authorize application** button.
 
-4. On the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page,
+4. On the [Add Projects](https://circleci.com/add-projects/gh){:rel="nofollow"} page,
 follow all projects
 you want the machine user to have access to.
 


### PR DESCRIPTION
# Description
Fix broken link to "add projects" page.

# Reasons
A request for [circleci.com/add-projects](https://circleci.com/add-projects) results in a 404 redirect to [onboarding.circleci.com/project-dashboard//](https://onboarding.circleci.com/project-dashboard//).  The URL for adding GitHub projects is [circleci.com/add-projects/gh](https://circleci.com/add-projects/gh).
