### PR TITLE
[CIRCLE-23725] Add v2 insights API docs heading

### DIFF
--- a/widdershins.apiv2.yml
+++ b/widdershins.apiv2.yml
@@ -20,4 +20,7 @@ tagGroups:
 - title: Job (Preview)
   tags:
   - Job
+- title: Insights (Preview)
+  tags:
+  - Insights
 search: false


### PR DESCRIPTION
# Description
Adds a heading to the API docs for the v2 insights endpoints.

# Reasons
We've added the insights endpoints to the OpenAPI spec, and we'd like it to show up as "Insights (Preview)".

NOTE: Don't merge this until https://github.com/circleci/circle/pull/10616 is merged.