### PR TITLE
Remove `working_directory` as to work inside GOPATH is not required

### DIFF
--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -39,8 +39,6 @@ jobs: # basic units of work in a run
         environment: # environment variables for primary container
           POSTGRES_USER: circleci-demo-go
           POSTGRES_DB: circle_test
-    # directory where steps are run. Path must conform to the Go Workspace requirements
-    working_directory: /go/src/github.com/CircleCI-Public/circleci-demo-go
 
     environment: # environment variables for the build itself
       TEST_RESULTS: /tmp/test-results # path to where test results will be saved


### PR DESCRIPTION
# Description

The way it's presented is a bit confusing. The example uses go 1.12 (`image: circleci/golang:1.12`) which do not require to work inside the GOPATH, therefore it might lead to understand that it's a CircleCi requirement.

To set `working_directory` is not required, therefore I suggest to remove the lines above from the docs.
Also the [circleci-demo-go](https://github.com/CircleCI-Public/circleci-demo-go/blob/master/.circleci/config.yml) does not set `working_directory` which makes the doc page inconsistent.

# Reasons
Issue  #4102