### PR TITLE
[CIRCLE-23983] Fix custom resource definitions docs

### DIFF
--- a/jekyll/_cci2/customizations.adoc
+++ b/jekyll/_cci2/customizations.adoc
@@ -150,7 +150,7 @@ WARNING: It is important to use the IDs listed in the example below for both `ma
 . Run:
 +
 ```shell
-echo 'export CIRCLE_DISPATCHER_RESOURCE_DEF=/etc/circleconfig/picard-dispatcher/resource-definitions.edn' | sudo tee /etc/circleconfig/picard-dispatcher/customizations
+echo 'export CIRCLE_DISPATCHER_RESOURCE_DEF=/circleconfig/picard-dispatcher/resource-definitions.edn' | sudo tee /etc/circleconfig/picard-dispatcher/customizations
 ```
 . Restart the CircleCI Server application. The application can be stopped and started again from the Management Console Dashboard (for example, `<circleci-hostname>.com:8800`).
 
@@ -163,13 +163,13 @@ Example config:
 
  :resource-classes
  {:docker
-  {:small {:id "d1.small" :ga true :ui {:cpu 2.0 :ram 4096 :class :small} :outer {:cpu 2.0 :ram 4096}}
-   :medium {:id "d1.medium" :ga true :ui {:cpu 4.0 :ram 8192 :class :medium} :outer {:cpu 4.0 :ram 8192}}
-   :massive {:id "d1.massive" :ga true :ui {:cpu 7.0 :ram 28000 :class :massive} :outer {:cpu 7.0 :ram 28000}}}
+  {:small {:id "d1.small" :availability :general :ui {:cpu 2.0 :ram 4096 :class :small} :outer {:cpu 2.0 :ram 4096}}
+   :medium {:id "d1.medium" :availability :general :ui {:cpu 4.0 :ram 8192 :class :medium} :outer {:cpu 4.0 :ram 8192}}
+   :massive {:id "d1.massive" :availability :general :ui {:cpu 7.0 :ram 28000 :class :massive} :outer {:cpu 7.0 :ram 28000}}}
 
   :machine
-  {:medium {:id "l1.medium" :ga true :ui {:cpu 2.0 :ram 7680 :class :medium} :outer {:cpu 2.0 :ram 256}}
-   :large {:id "l1.large" :ga true :ui {:cpu 4.0 :ram 16000 :class :large} :outer {:cpu 2.0 :ram 256}}}}}
+  {:medium {:id "l1.medium" :availability :general :ui {:cpu 2.0 :ram 7680 :class :medium} :outer {:cpu 2.0 :ram 256}}
+   :large {:id "l1.large" :availability :general :ui {:cpu 4.0 :ram 16000 :class :large} :outer {:cpu 2.0 :ram 256}}}}}
 ```
 
 Let's take a look at one of the options in more detail


### PR DESCRIPTION
# Description
Correct the path to the custom resource definition (`/etc` is not directly bound) and fix outdated example custom resource definition.

# Reasons
https://circleci.atlassian.net/browse/CIRCLE-23983