### PR TITLE
Docker to Machine migration doc

### DIFF
--- a/jekyll/_cci2/docker-to-machine.md
+++ b/jekyll/_cci2/docker-to-machine.md
@@ -1,0 +1,96 @@
+---
+layout: classic-docs
+title: "Migrating from Docker to Machine executor"
+short-title: "Migrate from Docker to Machine"
+description: "Migrate from Docker to Machine executors"
+categories: [containerization, configuration]
+order: 20
+---
+
+This document contains some general guidelines and considerations to make when
+moving from the Docker executor to machine, or vice versa.
+
+* TOC
+{:toc}
+
+## Overview
+{:.no_toc}
+
+Occiasonally, the Docker executor isn't quite the right fit for your builds - 
+this can include a lack of memory or requiring more dedicated CPU  power. Moving
+to a dedicated virtual machine can help alleviate some of these  issues, but 
+changing out the executor isn't as easy as replacing a few lines of  
+configuration. There are some other considerations to make, such as the tools 
+and libraries required to be installed for the application and tests. 
+
+## Pre-installed software
+
+By default, the machine executor images come installed with useful utilities,
+but application specific requirements will need to be installed - if the
+dependency is not installed within Ubuntu 16.04 by default or is not found on
+this list, it will need to be manually installed (note the most up to date
+list can be found here: https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh):
+
+* mysql_57 
+* mongo 
+* postgres
+* java 
+* oraclejdk8
+* java
+* openjdk8
+* sysadmin
+* devtools
+* jq
+* redis
+* memcached
+* rabbitmq
+* firefox
+* chrome
+* phantomjs
+* awscli
+* gcloud
+* heroku
+* python 2.7.12*
+* python 3.5.2
+* nodejs 6.1.0*
+* nvm
+* golang 1.7.3
+* ruby 2.3.1*
+* rvm
+* clojure
+* scala
+* docker
+* socat
+* nsenter
+
+\* global default
+
+Additional packages can be installed with `sudo apt-get install <package>`. IF
+the package in question is not found, `sudo apt-get update` may be required 
+before installing it.
+
+## Can I run Docker containers on machine?
+
+Yes! Machine executors come installed with Docker, which could be utilized to
+run your applications within the container rather than installing additional
+dependencies. Note it's recommended this is done with a customer Docker image
+rather than one of the convenience images, as the convenience images are built
+under the assumption they will be used with the Docker executor and may be 
+tricky to work around. Since it's a dedicated virtual machine, commands to run
+background containers can be used normally as well. 
+
+Note that if you have Docker Layer Caching enabled for your account, machine
+executors can utilize this to cache your image layers for subsequent runs as
+well.
+
+### Why use Docker executors at all?
+
+While machine executors do offer twice the memory and a more isolated 
+enviornment, there is some additional overhead regarding spin up time, and,
+depending on the approach taken for running the application, more time is taken
+to install the required dependencies or pull your Docker image. The Docker
+executor will also cache as many layers as possible from your image during
+spin-up, as opposed to the machine executor, where DLC will need to be enabled.
+
+With that in mind, there are tradeoffs to using either executor. Which one fits
+your use case is something only you can determine.

--- a/jekyll/_cci2/docker-to-machine.md
+++ b/jekyll/_cci2/docker-to-machine.md
@@ -1,96 +1,102 @@
----
-layout: classic-docs
-title: "Migrating from Docker to Machine executor"
-short-title: "Migrate from Docker to Machine"
-description: "Migrate from Docker to Machine executors"
-categories: [containerization, configuration]
-order: 20
----
+This document contains some general guidelines and considerations to
+make when moving from the Docker executor to machine, or vice versa.
 
-This document contains some general guidelines and considerations to make when
-moving from the Docker executor to machine, or vice versa.
+-   TOC {:toc}
 
-* TOC
-{:toc}
+Overview
+--------
 
-## Overview
-{:.no_toc}
+{:.no\_toc}
 
-Occiasonally, the Docker executor isn't quite the right fit for your builds - 
-this can include a lack of memory or requiring more dedicated CPU  power. Moving
-to a dedicated virtual machine can help alleviate some of these  issues, but 
-changing out the executor isn't as easy as replacing a few lines of  
-configuration. There are some other considerations to make, such as the tools 
-and libraries required to be installed for the application and tests. 
+Occiasonally, the Docker executor isn't quite the right fit for your
+builds - this can include a lack of memory or requiring more dedicated
+CPU power. Moving to a dedicated virtual machine can help alleviate some
+of these issues, but changing out an executor is not as easy as
+replacing a few lines of configuration. There are some other
+considerations to make, such as the tools and libraries required to be
+installed for your application and tests.
 
-## Pre-installed software
+Pre-installed software
+----------------------
 
-By default, the machine executor images come installed with useful utilities,
-but application specific requirements will need to be installed - if the
-dependency is not installed within Ubuntu 16.04 by default or is not found on
-this list, it will need to be manually installed (note the most up to date
-list can be found here: https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh):
+By default, the machine executor images come installed with useful
+utilities, but application specific requirements will need to be
+installed - if the dependency is not installed within Ubuntu 16.04 by
+default or is not found on this list, it will need to be manually
+installed (note the most up to date list can be found
+[here](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh)):
 
-* mysql_57 
-* mongo 
-* postgres
-* java 
-* oraclejdk8
-* java
-* openjdk8
-* sysadmin
-* devtools
-* jq
-* redis
-* memcached
-* rabbitmq
-* firefox
-* chrome
-* phantomjs
-* awscli
-* gcloud
-* heroku
-* python 2.7.12*
-* python 3.5.2
-* nodejs 6.1.0*
-* nvm
-* golang 1.7.3
-* ruby 2.3.1*
-* rvm
-* clojure
-* scala
-* docker
-* socat
-* nsenter
+-   mysql\_57
+-   mongo
+-   postgres
+-   java
+-   oraclejdk8
+-   java
+-   openjdk8
+-   sysadmin
+-   devtools
+-   jq
+-   redis
+-   memcached
+-   rabbitmq
+-   firefox
+-   chrome
+-   phantomjs
+-   awscli
+-   gcloud
+-   heroku
+-   python 2.7.12\*
+-   python 3.5.2
+-   nodejs 6.1.0\*
+-   nvm
+-   golang 1.7.3
+-   ruby 2.3.1\*
+-   rvm
+-   clojure
+-   scala
+-   docker
+-   socat
+-   nsenter
 
 \* global default
 
-Additional packages can be installed with `sudo apt-get install <package>`. IF
-the package in question is not found, `sudo apt-get update` may be required 
-before installing it.
+Additional packages can be installed with
+`sudo apt-get install <package>`. If the package in question is not
+found, `sudo apt-get update` may be required before installing it.
 
-## Can I run Docker containers on machine?
+Can I run Docker containers on machine?
+---------------------------------------
 
-Yes! Machine executors come installed with Docker, which could be utilized to
-run your applications within the container rather than installing additional
-dependencies. Note it's recommended this is done with a customer Docker image
-rather than one of the convenience images, as the convenience images are built
-under the assumption they will be used with the Docker executor and may be 
-tricky to work around. Since it's a dedicated virtual machine, commands to run
-background containers can be used normally as well. 
+Yes! Machine executors come installed with Docker, which can be utilized
+to run your application within a container rather than installing
+additional dependencies. Note, it is recommended this is done with a
+customer Docker image rather than a CircleCI convenience image, which
+are built under the assumption they will be used with the Docker
+executor and may be tricky to work around. Since each machine executor
+enviornment is a dedicated virtual machine, commands to run background
+containers can be used is normal as well.
 
-Note that if you have Docker Layer Caching enabled for your account, machine
-executors can utilize this to cache your image layers for subsequent runs as
-well.
+**Note:** that if you have Docker Layer Caching (DLC) enabled for your
+account, machine executors can utilize this to cache your image layers
+for subsequent runs.
 
 ### Why use Docker executors at all?
 
-While machine executors do offer twice the memory and a more isolated 
-enviornment, there is some additional overhead regarding spin up time, and,
-depending on the approach taken for running the application, more time is taken
-to install the required dependencies or pull your Docker image. The Docker
-executor will also cache as many layers as possible from your image during
-spin-up, as opposed to the machine executor, where DLC will need to be enabled.
+While machine executors do offer twice the memory and a more isolated
+enviornment, there is some additional overhead regarding spin up time,
+and, depending on the approach taken for running the application, more
+time is taken to install the required dependencies or pull your Docker
+image. The Docker executor will also cache as many layers as possible
+from your image during spin-up, as opposed to the machine executor,
+where DLC will need to be enabled.
 
-With that in mind, there are tradeoffs to using either executor. Which one fits
-your use case is something only you can determine.
+All executors have their pros and cons, which have been laid out here to
+help decide which is right for your pipelines.
+
+Further Reading
+---------------
+
+We have more details on each specific executor
+[here](https://circleci.com/docs/2.0/executor-types/), which includes
+specific memory and vCPU allocation details, as well as how to implement
+each one in your own configuration.

--- a/jekyll/_cci2/docker-to-machine.md
+++ b/jekyll/_cci2/docker-to-machine.md
@@ -18,7 +18,7 @@ Overview
 
 {:.no_toc}
 
-Occiasonally, the Docker executor isn't quite the right fit for your
+Occasionally, the Docker executor isn't quite the right fit for your
 builds. This can include a lack of memory or requiring more dedicated
 CPU power. Moving to a dedicated virtual machine can help alleviate some
 of these issues, but changing out an executor is not as easy as

--- a/jekyll/_cci2/docker-to-machine.md
+++ b/jekyll/_cci2/docker-to-machine.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: "Migrating Executor from Docker to machine"
+title: "Executor Migration from Docker to Machine"
 short-title: "Migrating Executor from Docker to `machine`"
 description: "Best practices and considerations when migrating executor"
 categories: [migration]

--- a/jekyll/_cci2/docker-to-machine.md
+++ b/jekyll/_cci2/docker-to-machine.md
@@ -1,15 +1,25 @@
+---
+layout: classic-docs
+title: "Migrating Executor from Docker to machine"
+short-title: "Migrating Executor from Docker to `machine`"
+description: "Best practices and considerations when migrating executor"
+categories: [migration]
+order:  1
+---
+
 This document contains some general guidelines and considerations to
 make when moving from the Docker executor to machine, or vice versa.
 
--   TOC {:toc}
+* TOC 
+{:toc}
 
 Overview
 --------
 
-{:.no\_toc}
+{:.no_toc}
 
 Occiasonally, the Docker executor isn't quite the right fit for your
-builds - this can include a lack of memory or requiring more dedicated
+builds. This can include a lack of memory or requiring more dedicated
 CPU power. Moving to a dedicated virtual machine can help alleviate some
 of these issues, but changing out an executor is not as easy as
 replacing a few lines of configuration. There are some other
@@ -21,8 +31,8 @@ Pre-installed software
 
 By default, the machine executor images come installed with useful
 utilities, but application specific requirements will need to be
-installed - if the dependency is not installed within Ubuntu 16.04 by
-default or is not found on this list, it will need to be manually
+installed. If a dependency is not installed within Ubuntu 16.04 by
+default, or is not found on this list, it will need to be manually
 installed (note the most up to date list can be found
 [here](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh)):
 
@@ -64,19 +74,19 @@ Additional packages can be installed with
 `sudo apt-get install <package>`. If the package in question is not
 found, `sudo apt-get update` may be required before installing it.
 
-Can I run Docker containers on machine?
+Running Docker containers on machine
 ---------------------------------------
 
-Yes! Machine executors come installed with Docker, which can be utilized
+Machine executors come installed with Docker, which can be used
 to run your application within a container rather than installing
 additional dependencies. Note, it is recommended this is done with a
 customer Docker image rather than a CircleCI convenience image, which
 are built under the assumption they will be used with the Docker
 executor and may be tricky to work around. Since each machine executor
 enviornment is a dedicated virtual machine, commands to run background
-containers can be used is normal as well.
+containers can be used is normal.
 
-**Note:** that if you have Docker Layer Caching (DLC) enabled for your
+**Note:** if you have Docker Layer Caching (DLC) enabled for your
 account, machine executors can utilize this to cache your image layers
 for subsequent runs.
 

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -88,7 +88,7 @@ medium (default) | 2     | 7.5GB
 large            | 4     | 15GB
 {: class="table table-striped"}
 
-Using the `machine` executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack, for example to listen on a network interface, or to modify the system with `sysctl` commands.
+Using the `machine` executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack, for example to listen on a network interface, or to modify the system with `sysctl` commands. To find out about migrating a project from using the Docker executor to using `machine`, see the [Executor Migration from Docker to Machine]({{ site.baseurl }}/2.0/docker-to-machine) document.
 
 Using the `machine` executor also means that you get full access to the Docker process. This allows you to run privileged Docker containers and build new Docker images.
 


### PR DESCRIPTION
# Description

Adds some documentation around the steps required to move from a Docker executor to machine, and vice versa.

# Reasons

Occasionally, the machine executor is recommended to customers who require more memory for their project, but there is no clear documentation regarding the differences between the two executors, which can make the move difficult. This also lays out a list of manually installed software within the machine images.