### PR TITLE
Clarify description of deploy key with write access

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -233,7 +233,10 @@ and the CircleCI project is [https://circleci.com/gh/you/test-repo](https://circ
 When prompted to enter a passphrase,
 do **not** enter one.
 
-**Caution:** Recent updates in `ssh-keygen` don't generate the key in PEM format by default. If your private key does not start with `-----BEGIN RSA PRIVATE KEY-----`, enforce PEM format by generating the key with `ssh-keygen -m PEM -t rsa -C "your_email@example.com"`
+    **Caution:** Recent updates in `ssh-keygen` don't generate the key in PEM
+    format by default. If your private key does not start with `-----BEGIN RSA
+    PRIVATE KEY-----`, enforce PEM format by generating the key with `ssh-keygen
+    -m PEM -t rsa -C "your_email@example.com"`
 
 2. Go to `https://github.com/you/test-repo/settings/keys`,
 and click "Add deploy key".

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -216,7 +216,7 @@ key. If you are using GitHub as your VCS then GitHub has the public key, and
 CircleCI  stores the private key. The deployment key gives CircleCI access to a single repository.
 To prevent CircleCI from pushing to your repository, this deployment key is read-only.
 
-If you want to push to the repository from your builds, you will need a deployment key with write access (user key). The steps to create a user key depend on your VCS.
+If you want to push to the repository from your builds, you will need a deployment key with write access. The steps to create a deployment key with write access depend on your VCS. See below for GitHub-specific instructions.
 
 **What is a user key?**
 


### PR DESCRIPTION
# Description

I removed the reference to "user key" in the [description](https://circleci.com/docs/2.0/gh-bb-integration/#deployment-keys-and-user-keys) of a deploy key with write access.

# Reasons

In this one place in the documentation, it implies that a deploy key with write access is a "user key". This really confused me. This PR updates this section to be consistent with the rest of the documentation of deploy vs user keys.

Also, I indented the paragraph from PR #2958 to fix the numbering of the markdown list. Currently it is 1-1-2-3 when it should be 1-2-3-4.

cc: @pat-s