### PR TITLE
⚠️ [NO MERGE BEFORE FEB 13 EOD] [CIRCLE-23956] Add "Training" links to top nav and footer

### DIFF
--- a/jekyll/_includes/global-footer.html
+++ b/jekyll/_includes/global-footer.html
@@ -17,6 +17,7 @@
           <h6>Support</h6>
           <ul class="list-unstyled">
             <li><a href="https://circleci.com/docs/" data-analytics-child='{ "menu": "documentation" }'>Documentation</a></li>
+            <li><a href="https://academy.circleci.com/?access_code=public-2020" data-analytics-child='{ "menu": "training" }' target="_blank">Training</a></li>
             <li><a href="https://support.circleci.com/hc/en-us" data-analytics-child='{ "menu": "get-support" }' target="_blank">Get Support</a></li>
             <li><a href="https://discuss.circleci.com/" data-analytics-child='{ "menu": "community-forum" }' target="_blank">Community Forum</a></li>
             <li><a href="https://status.circleci.com/" data-analytics-child='{ "menu": "system-status" }' target="_blank">System Status</a></li>

--- a/jekyll/_includes/global-footer.html
+++ b/jekyll/_includes/global-footer.html
@@ -16,7 +16,6 @@
         <div class="col-md-2 col-sm-3 col-xs-6">
           <h6>Support</h6>
           <ul class="list-unstyled">
-            <li><a href="https://circleci.com/docs/" data-analytics-child='{ "menu": "documentation" }'>Documentation</a></li>
             <li><a href="https://academy.circleci.com/?access_code=public-2020" data-analytics-child='{ "menu": "training" }' target="_blank">Training</a></li>
             <li><a href="https://support.circleci.com/hc/en-us" data-analytics-child='{ "menu": "get-support" }' target="_blank">Get Support</a></li>
             <li><a href="https://discuss.circleci.com/" data-analytics-child='{ "menu": "community-forum" }' target="_blank">Community Forum</a></li>

--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -58,6 +58,7 @@
             <li class="default-item nav-item">Support
               <div class="submenu">
                 <ul class="subnav">
+                  <li class="subnav-item"><a href="https://academy.circleci.com/?access_code=public-2020" target="_blank">Training</a></li>
                   <li class="subnav-item"><a href="https://support.circleci.com/hc/en-us" target="_blank">Get Support</a></li>
                   <li class="subnav-item"><a href="https://status.circleci.com/" target="_blank">System Status</a></li>
                   <li class="subnav-item"><a href="https://ideas.circleci.com/">Feature Requests</a></li>
@@ -139,6 +140,7 @@
               <i class="fa fa-angle-right" aria-hidden="true"></i>
               Support
               <ul class="subnav">
+                <li class="subnav-item"><a href="https://academy.circleci.com/?access_code=public-2020" target="_blank">Training</a></li>
                 <li class="subnav-item"><a href="https://support.circleci.com/hc/en-us" target="_blank">Get Support</a></li>
                 <li class="subnav-item"><a href="https://status.circleci.com/" target="_blank">System Status</a></li>
                 <li class="subnav-item"><a href="https://ideas.circleci.com/">Feature Requests</a></li>


### PR DESCRIPTION
**Ticket:** [CIRCLE-23956](https://circleci.atlassian.net/browse/CIRCLE-23956)

⚠️ [NO MERGE BEFORE FEB 13 EOD] ⚠️

## Changes

- Add links to CCI Academy to top nav and footer
- Remove footer docs link. This is probably a copy-paste error from the footer on outer. For the top nav, we exclude the "Docs" link on this site, since we're already on docs. We should do the same for this link in the footer.