### PR TITLE
fix include path

### DIFF
--- a/jekyll/_cci2/admin-faq.adoc
+++ b/jekyll/_cci2/admin-faq.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This chapter answers frequently asked questions and provides installation troubleshooting tips.
 

--- a/jekyll/_cci2/admin-faq.adoc
+++ b/jekyll/_cci2/admin-faq.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This chapter answers frequently asked questions and provides installation troubleshooting tips.
 

--- a/jekyll/_cci2/architecture.adoc
+++ b/jekyll/_cci2/architecture.adoc
@@ -8,7 +8,7 @@
 //:circle-warning: image:circle-warning.png[]
 //:circle-failure: image:circle-failure.png[]
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document outlines the containerized services that run on the Services machine within a CircleCI Server installation. This is provided both to give an overview of service operation, and to help with troubleshooting in the event of service outages. Supplementary notes and a key are provided below the following table.
 

--- a/jekyll/_cci2/architecture.adoc
+++ b/jekyll/_cci2/architecture.adoc
@@ -8,7 +8,7 @@
 //:circle-warning: image:circle-warning.png[]
 //:circle-failure: image:circle-failure.png[]
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document outlines the containerized services that run on the Services machine within a CircleCI Server installation. This is provided both to give an overview of service operation, and to help with troubleshooting in the event of service outages. Supplementary notes and a key are provided below the following table.
 

--- a/jekyll/_cci2/authentication.adoc
+++ b/jekyll/_cci2/authentication.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document describes the various ways users of your CircleCI Server installation can get access and authenticate their accounts. Currently OAuth and LDAP are supported as authentication methods.
 

--- a/jekyll/_cci2/authentication.adoc
+++ b/jekyll/_cci2/authentication.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document describes the various ways users of your CircleCI Server installation can get access and authenticate their accounts. Currently OAuth and LDAP are supported as authentication methods.
 

--- a/jekyll/_cci2/aws-prereq.adoc
+++ b/jekyll/_cci2/aws-prereq.adoc
@@ -7,7 +7,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 CircleCI uses Terraform to automate parts of the infrastructure for your CircleCI Server install, so you will need to install this first:
 

--- a/jekyll/_cci2/aws-prereq.adoc
+++ b/jekyll/_cci2/aws-prereq.adoc
@@ -7,7 +7,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 CircleCI uses Terraform to automate parts of the infrastructure for your CircleCI Server install, so you will need to install this first:
 

--- a/jekyll/_cci2/aws-teardown.adoc
+++ b/jekyll/_cci2/aws-teardown.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 If you wish to delete your installation of CircleCI Server, please let us know first in case there are any specific, supplementary steps required for your installation. Below is our basic step by step guide to tearing down an installation of CircleCI Server that was made with Terraform:
 

--- a/jekyll/_cci2/aws-teardown.adoc
+++ b/jekyll/_cci2/aws-teardown.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 If you wish to delete your installation of CircleCI Server, please let us know first in case there are any specific, supplementary steps required for your installation. Below is our basic step by step guide to tearing down an installation of CircleCI Server that was made with Terraform:
 

--- a/jekyll/_cci2/aws.adoc
+++ b/jekyll/_cci2/aws.adoc
@@ -6,7 +6,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 Following is a step by step guide to installing CircleCI Server v{serverversion} with Terraform.
 

--- a/jekyll/_cci2/aws.adoc
+++ b/jekyll/_cci2/aws.adoc
@@ -6,7 +6,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 Following is a step by step guide to installing CircleCI Server v{serverversion} with Terraform.
 

--- a/jekyll/_cci2/backup.adoc
+++ b/jekyll/_cci2/backup.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This chapter describes failover or replacement of the services machine. Refer to the Backup section below for information about possible backup strategies and procedures for implementing a regular backup image or snapshot of the services machine.
 

--- a/jekyll/_cci2/backup.adoc
+++ b/jekyll/_cci2/backup.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This chapter describes failover or replacement of the services machine. Refer to the Backup section below for information about possible backup strategies and procedures for implementing a regular backup image or snapshot of the services machine.
 

--- a/jekyll/_cci2/build-artifacts.adoc
+++ b/jekyll/_cci2/build-artifacts.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 Build artifacts persist data after a job is completed. They can be used for longer-term storage of your build process outputs. For example, when a Java build/test process finishes, the output of the process is saved as a `.jar` file. CircleCI can store this file as an artifact, keeping it available long after the process has finished.
 

--- a/jekyll/_cci2/build-artifacts.adoc
+++ b/jekyll/_cci2/build-artifacts.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 Build artifacts persist data after a job is completed. They can be used for longer-term storage of your build process outputs. For example, when a Java build/test process finishes, the output of the process is saved as a `.jar` file. CircleCI can store this file as an artifact, keeping it available long after the process has finished.
 

--- a/jekyll/_cci2/certificates.adoc
+++ b/jekyll/_cci2/certificates.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document provides a script for using a custom Root Certificate Authority and the process for using an Elastic Load Balancing certificate.
 

--- a/jekyll/_cci2/certificates.adoc
+++ b/jekyll/_cci2/certificates.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document provides a script for using a custom Root Certificate Authority and the process for using an Elastic Load Balancing certificate.
 

--- a/jekyll/_cci2/customizations.adoc
+++ b/jekyll/_cci2/customizations.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 The following sections summarize the key files and variables that impact CircleCI Server behavior, and configuration options for your Server installation.
 

--- a/jekyll/_cci2/customizations.adoc
+++ b/jekyll/_cci2/customizations.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 The following sections summarize the key files and variables that impact CircleCI Server behavior, and configuration options for your Server installation.
 

--- a/jekyll/_cci2/deployment-integrations.adoc
+++ b/jekyll/_cci2/deployment-integrations.adoc
@@ -57,7 +57,7 @@ Under the hood, this orb creates, bundles and deploys your application using you
 
 In this section we will look at a simple example of deploying a Rails application to Heroku. 
 
-==== Using the Heroku Orb
+=== Using the Heroku Orb
 
 Below is a Heroku Deployment example using the https://circleci.com/orbs/registry/orb/circleci/heroku[Heroku orb] to simplify the configuration. The configuration uses https://circleci.com/docs/2.0/workflows/[workflows] to deploy only if the `sequential-branch-filter` branch is checked out and the `build` job has run.
 
@@ -96,7 +96,7 @@ jobs:
           command: rake
 ```
 
-==== 2.0 config
+=== 2.0 config
 
 This version shows the same pipeline, but without using the orb. The full application can be found in the https://github.com/CircleCI-Public/circleci-demo-workflows/tree/sequential-branch-filter[Sequential Job branch of the CircleCI Demo Workflows repository]
 

--- a/jekyll/_cci2/gpu.adoc
+++ b/jekyll/_cci2/gpu.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document outlines how to run GPU (graphics processing unit) machine executors using CircleCI Server.
 

--- a/jekyll/_cci2/gpu.adoc
+++ b/jekyll/_cci2/gpu.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document outlines how to run GPU (graphics processing unit) machine executors using CircleCI Server.
 

--- a/jekyll/_cci2/install-overview.adoc
+++ b/jekyll/_cci2/install-overview.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 The following sections provide planning information, system requirements and step-by-step instructions for installing CircleCI Server on Amazon Web Services (AWS) with Terraform.
 

--- a/jekyll/_cci2/install-overview.adoc
+++ b/jekyll/_cci2/install-overview.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 The following sections provide planning information, system requirements and step-by-step instructions for installing CircleCI Server on Amazon Web Services (AWS) with Terraform.
 

--- a/jekyll/_cci2/jvm-heap-size-configuration.adoc
+++ b/jekyll/_cci2/jvm-heap-size-configuration.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 The JVM heap size is configurable for the following containers: `frontend`, `test-results`, `output-processing` and `contexts-service`. You might want to consider increasing the heap size if you see "out of memory" errors, such as: `Terminating due to java.lang.OutOfMemoryError: Java heap space`.
 

--- a/jekyll/_cci2/jvm-heap-size-configuration.adoc
+++ b/jekyll/_cci2/jvm-heap-size-configuration.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 The JVM heap size is configurable for the following containers: `frontend`, `test-results`, `output-processing` and `contexts-service`. You might want to consider increasing the heap size if you see "out of memory" errors, such as: `Terminating due to java.lang.OutOfMemoryError: Java heap space`.
 

--- a/jekyll/_cci2/monitoring.adoc
+++ b/jekyll/_cci2/monitoring.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section includes information on metrics for monitoring your CircleCI Server installation.
 

--- a/jekyll/_cci2/monitoring.adoc
+++ b/jekyll/_cci2/monitoring.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section includes information on metrics for monitoring your CircleCI Server installation.
 

--- a/jekyll/_cci2/nomad-metrics.adoc
+++ b/jekyll/_cci2/nomad-metrics.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 Nomad Metrics is a helper service used to collect metrics data from the <<nomad#basic-terminology-and-architecture,Nomad server and clients>> running on the Services and Nomad instances respectively.  Metrics are collected and sent using the https://docs.datadoghq.com/developers/dogstatsd/[DogStatsD] protocol and sent to the Services machine.
 

--- a/jekyll/_cci2/nomad-metrics.adoc
+++ b/jekyll/_cci2/nomad-metrics.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 Nomad Metrics is a helper service used to collect metrics data from the <<nomad#basic-terminology-and-architecture,Nomad server and clients>> running on the Services and Nomad instances respectively.  Metrics are collected and sent using the https://docs.datadoghq.com/developers/dogstatsd/[DogStatsD] protocol and sent to the Services machine.
 

--- a/jekyll/_cci2/nomad.adoc
+++ b/jekyll/_cci2/nomad.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 CircleCI 2.0 uses https://www.hashicorp.com/blog/nomad-announcement/[Nomad] as the primary job scheduler. This chapter provides a basic introduction to Nomad for understanding how to operate the Nomad Cluster in your CircleCI 2.0 installation.
 

--- a/jekyll/_cci2/nomad.adoc
+++ b/jekyll/_cci2/nomad.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 CircleCI 2.0 uses https://www.hashicorp.com/blog/nomad-announcement/[Nomad] as the primary job scheduler. This chapter provides a basic introduction to Nomad for understanding how to operate the Nomad Cluster in your CircleCI 2.0 installation.
 

--- a/jekyll/_cci2/ops.adoc
+++ b/jekyll/_cci2/ops.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This chapter describes system checks and the basics of user management.
 

--- a/jekyll/_cci2/ops.adoc
+++ b/jekyll/_cci2/ops.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This chapter describes system checks and the basics of user management.
 

--- a/jekyll/_cci2/overview.adoc
+++ b/jekyll/_cci2/overview.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../_includes/snippets/server-unsupported.adoc[]
+include::../jekyll/_includes/snippets/server-unsupported.adoc[]
 
 CircleCI Server is a modern continuous integration and continuous delivery (CI/CD) platform installable inside your private cloud or data center. Refer to the https://circleci.com/server/changelog[Changelog] for what's new in this CircleCI Server release.
 

--- a/jekyll/_cci2/overview.adoc
+++ b/jekyll/_cci2/overview.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../jekyll/_includes/snippets/server-unsupported.adoc[]
+//include::../jekyll/_includes/snippets/server-unsupported.adoc[]
 
 CircleCI Server is a modern continuous integration and continuous delivery (CI/CD) platform installable inside your private cloud or data center. Refer to the https://circleci.com/server/changelog[Changelog] for what's new in this CircleCI Server release.
 

--- a/jekyll/_cci2/proxy.adoc
+++ b/jekyll/_cci2/proxy.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section describes how to configure CircleCI to use an HTTP proxy.
 

--- a/jekyll/_cci2/proxy.adoc
+++ b/jekyll/_cci2/proxy.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section describes how to configure CircleCI to use an HTTP proxy.
 

--- a/jekyll/_cci2/security.adoc
+++ b/jekyll/_cci2/security.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document outlines security features built into CircleCI and related integrations.
 

--- a/jekyll/_cci2/security.adoc
+++ b/jekyll/_cci2/security.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document outlines security features built into CircleCI and related integrations.
 

--- a/jekyll/_cci2/server-ports.adoc
+++ b/jekyll/_cci2/server-ports.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section defines the system and port access requirements for installing CircleCI v{serverversion}.
 

--- a/jekyll/_cci2/server-ports.adoc
+++ b/jekyll/_cci2/server-ports.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section defines the system and port access requirements for installing CircleCI v{serverversion}.
 

--- a/jekyll/_cci2/troubleshooting.adoc
+++ b/jekyll/_cci2/troubleshooting.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document describes an initial set of troubleshooting steps to take if you are having problems with your CircleCI installation on your private server. If your issue is not addressed below, please https://help.replicated.com/docs/native/packaging-an-application/support-bundle/[generate a support bundle] and contact our Support Engineers by https://support.circleci.com/hc/en-us/requests/new[opening a support ticket].
 

--- a/jekyll/_cci2/troubleshooting.adoc
+++ b/jekyll/_cci2/troubleshooting.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This document describes an initial set of troubleshooting steps to take if you are having problems with your CircleCI installation on your private server. If your issue is not addressed below, please https://help.replicated.com/docs/native/packaging-an-application/support-bundle/[generate a support bundle] and contact our Support Engineers by https://support.circleci.com/hc/en-us/requests/new[opening a support ticket].
 

--- a/jekyll/_cci2/updating-server-replicated-version.adoc
+++ b/jekyll/_cci2/updating-server-replicated-version.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 To update your CircleCI Server installation, see our https://circleci.com/docs/2.0/updating-server/#section=server-administration[Upgrade Guide]. This guide only runs through the steps required to update Replicated, not the CircleCI application.
 

--- a/jekyll/_cci2/updating-server-replicated-version.adoc
+++ b/jekyll/_cci2/updating-server-replicated-version.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 To update your CircleCI Server installation, see our https://circleci.com/docs/2.0/updating-server/#section=server-administration[Upgrade Guide]. This guide only runs through the steps required to update Replicated, not the CircleCI application.
 

--- a/jekyll/_cci2/updating-server.adoc
+++ b/jekyll/_cci2/updating-server.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section describes the process for upgrading your CircleCI Server installation from v2.17.x to v{serverversion}. If you have already upgraded to v2.18 and would like steps to upgrade to patch release v2.18.3, first take a <<1-snapshot-for-rollback,snapshot>> and then follow the <<3-upgrade-circleci-server,application upgrade steps>>.
 

--- a/jekyll/_cci2/updating-server.adoc
+++ b/jekyll/_cci2/updating-server.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section describes the process for upgrading your CircleCI Server installation from v2.17.x to v{serverversion}. If you have already upgraded to v2.18 and would like steps to upgrade to patch release v2.18.3, first take a <<1-snapshot-for-rollback,snapshot>> and then follow the <<3-upgrade-circleci-server,application upgrade steps>>.
 

--- a/jekyll/_cci2/usage-stats.adoc
+++ b/jekyll/_cci2/usage-stats.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This chapter is for System Administrators who want to automatically send some aggregate usage statistics to CircleCI. Usage statistics data enhances visibility into CircleCI installations and is used to better support you and ensure a smooth transition from CircleCI 1.0 to CircleCI 2.0.
 

--- a/jekyll/_cci2/usage-stats.adoc
+++ b/jekyll/_cci2/usage-stats.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This chapter is for System Administrators who want to automatically send some aggregate usage statistics to CircleCI. Usage statistics data enhances visibility into CircleCI installations and is used to better support you and ensure a smooth transition from CircleCI 1.0 to CircleCI 2.0.
 

--- a/jekyll/_cci2/user-accounts.adoc
+++ b/jekyll/_cci2/user-accounts.adoc
@@ -6,7 +6,7 @@
 :toc: macro
 :toc-title:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section provides information to help system administrators of self-hosted CircleCI Server installations manage accounts for their users. For an overview of user accounts, view the Admin settings overview from the CircleCI app by clicking on your profile in the top right corner and selecting Admin. This overview provides the active user count and the total number of licensed users.
 

--- a/jekyll/_cci2/user-accounts.adoc
+++ b/jekyll/_cci2/user-accounts.adoc
@@ -6,7 +6,7 @@
 :toc: macro
 :toc-title:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section provides information to help system administrators of self-hosted CircleCI Server installations manage accounts for their users. For an overview of user accounts, view the Admin settings overview from the CircleCI app by clicking on your profile in the top right corner and selecting Admin. This overview provides the active user count and the total number of licensed users.
 

--- a/jekyll/_cci2/vm-service.adoc
+++ b/jekyll/_cci2/vm-service.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../jekyll/_includes/snippets/server-only.adoc[]
+//include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section outlines how to set up and customize VM service for your CircleCI installation, to be used for `machine` executor (Linux and Winows images) and remote Docker jobs.
 

--- a/jekyll/_cci2/vm-service.adoc
+++ b/jekyll/_cci2/vm-service.adoc
@@ -6,7 +6,7 @@
 :toc-title:
 :sectanchors:
 
-include::../_includes/snippets/server-only.adoc[]
+include::../jekyll/_includes/snippets/server-only.adoc[]
 
 This section outlines how to set up and customize VM service for your CircleCI installation, to be used for `machine` executor (Linux and Winows images) and remote Docker jobs.
 

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -48,6 +48,7 @@ asciidoc:
       serverversion: 2.18.3
 
 asciidoctor:
+  safe: 0
   attributes:
     imagesdir: /docs/assets/img/docs/
     relfileprefix: ../


### PR DESCRIPTION
Include path was incorrect for snippets in asciidoc files, I hadn't noticed due to asciidoctor safe mode being turned on so local staging version is displaying correctly. 

This PR removes the content (non-essential) until I work out a fix.