### PR TITLE
Add display key documentation and update links

### DIFF
--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -164,7 +164,7 @@ workflows:
 
 ### Describing your Orb
 
-Before publishing your orb, it is recommended you add meta data to your orb to aid in the discoverability and documentation of your orb. We recommend adding a top-level `description` that informs users of the purpose of your orb and is indexed in search.
+Before publishing your orb, it is recommended you add metadata to your orb to aid in the discoverability and documentation of your orb. We recommend adding a top-level `description` that informs users of the purpose of your orb and is indexed in search.
 
 Under the `display` key,  add a link to the git repository via the `source_url`. If your orb relates to a specific product or service, you may optionally include a link to the homepage or documentation for said product or service via the `home_url` key.
 

--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -166,7 +166,7 @@ workflows:
 
 Before publishing your orb, it is recommended you add meta data to your orb to aid in the discoverability and documentation of your orb. We recommend adding a top-level `description` that informs users of the purpose of your orb and is indexed in search.
 
-Under the `display` key you should also add a link to the git repository via the `source_url`. If your orb relates to a specific product or service you may optionally include a link to the homepage or documentation for said product or service via the `home_url` key.
+Under the `display` key,  add a link to the git repository via the `source_url`. If your orb relates to a specific product or service, you may optionally include a link to the homepage or documentation for said product or service via the `home_url` key.
 
 ``` YAML
 version: 2.1

--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -162,6 +162,24 @@ workflows:
 ```
 {% endraw %}
 
+### Describing your Orb
+
+Before publishing your orb, it is recommended you add meta data to your orb to aid in the discoverability and documentation of your orb. We recommend adding a top-level `description` that informs users of the purpose of your orb and is indexed in search.
+
+Under the `display` key you should also add a link to the git repository via the `source_url`. If your orb relates to a specific product or service you may optionally include a link to the homepage or documentation for said product or service via the `home_url` key.
+
+``` YAML
+version: 2.1
+description: >
+  Integrate Amazon AWS S3 with your CircleCI CI/CD pipeline easily with the aws-s3 orb.
+display:
+  home_url: https://aws.amazon.com/s3/
+  source_url: https://github.com/CircleCI-Public/aws-s3-orb
+``` 
+
+The `description` and contents of the `display` key will be featured in the header of the orb's registry page.
+
+
 ## Providing Usage Examples of Orbs
 
 _The `examples` stanza is available in configuration version 2.1 and later_
@@ -259,6 +277,7 @@ The top level `examples` key is optional. Usage example maps nested below it can
 - **description:** (optional) A string that explains the example's purpose, making it easier for users to understand it.
 - **usage:** (required) A full, valid config map that includes an example of using the orb.
 - **result:** (optional) A full, valid config map demonstrating the result of expanding the orb with supplied parameters.
+
 
 ## Next Steps
 {:.no_toc}

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -14,7 +14,7 @@ A collection of best practices and strategies for authoring orbs. CircleCI orbs 
 ### Metadata
 
 - Ensure all commands, jobs, executors, and parameters have detailed descriptions.
-- Provide a `source_url` and if available, `home_url` [via the `display` key]({{ site.baseurl }}2.0/orb-author/#describing-your-orb).
+- Provide a `source_url` and if available, `home_url` [via the `display` key]({{ site.baseurl }}/2.0/orb-author/#describing-your-orb).
 - Define any prerequisites such as obtaining an API key in the description.
 - Be consistent and concise in naming your orb elements. For example, don't mix "kebab case" and "snake case."
 

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -14,7 +14,7 @@ A collection of best practices and strategies for authoring orbs. CircleCI orbs 
 ### Metadata
 
 - Ensure all commands, jobs, executors, and parameters have detailed descriptions.
-- Provide a `source_url` and if available, `home_url` [via the `display` key]({{ site.baseurl }}/2.0/orb-author/#describing-your-orb).
+- Provide a `source_url`, and if available, `home_url` [via the `display` key]({{ site.baseurl }}/2.0/orb-author/#describing-your-orb).
 - Define any prerequisites such as obtaining an API key in the description.
 - Be consistent and concise in naming your orb elements. For example, don't mix "kebab case" and "snake case."
 

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -14,18 +14,17 @@ A collection of best practices and strategies for authoring orbs. CircleCI orbs 
 ### Metadata
 
 - Ensure all commands, jobs, executors, and parameters have detailed descriptions.
-- Include the code repo link in the orb description.
-- Include link to website in description.
+- Provide a `source_url` and if available, `home_url` [via the `display` key]({{ site.baseurl }}2.0/orb-author/#describing-your-orb).
 - Define any prerequisites such as obtaining an API key in the description.
 - Be consistent and concise in naming your orb elements. For example, don't mix "kebab case" and "snake case."
 
 
 ### Examples
 
-- Must have at least 1 [usage example](https://circleci.com/docs/2.0/orb-author/#providing-usage-examples-of-orbs).
+- Must have at least 1 [usage example]({{ site.baseurl }}/2.0/orb-author/#providing-usage-examples-of-orbs).
 - Show orb version as `x.y` (patch version may not need to be included) in the example.
 - Example should include most common/simplest use case calling a top-level job or other base-case elements if no job is present.
-- If applicable, you may want to showcase the use of [pre and post steps](https://circleci.com/docs/2.0/reusing-config/#using-pre-and-post-steps) in conjunction with an orb’s job. 
+- If applicable, you may want to showcase the use of [pre and post steps]({{ site.baseurl }}/2.0/reusing-config/#using-pre-and-post-steps) in conjunction with an orb’s job. 
 
 ### Commands
 
@@ -35,7 +34,7 @@ A collection of best practices and strategies for authoring orbs. CircleCI orbs 
 - All commands available to the user should complete a full task. Do not create a command for the sole purpose of being a “partial” to another command unless it can be used on its own.
 - It is possible not all CLI commands need to be transformed into an orb command. Single line commands with no parameters do not necessarily need to have an orb command alias.
 - Command descriptions should call out any dependencies or assumptions, particularly if you intend for the command to run outside of a provided executor in your orb.
-- It is a good idea to check for the existance of required parameters, environment variables or other dependancies as a part of your command.
+- It is a good idea to check for the existence of required parameters, environment variables or other dependancies as a part of your command.
 
 example:
 ```
@@ -48,13 +47,13 @@ fi
 ### Parameters
 
 - When possible, use defaults for parameters unless a user input is essential. 
-- Utilize the [“env_var_name” parameter type](https://circleci.com/docs/2.0/reusing-config/#environment-variable-name) to secure API keys, webhook urls or other sensitive data. 
-- [Injecting steps as a parameter](https://circleci.com/docs/2.0/reusing-config/#steps) is a useful way to run user defined steps within a job between your orb-defined steps.Good for if you need to perform an action both before and after user-defined tasks - for instance, you could run user-provided steps between your caching logic inside the command.
+- Utilize the [“env_var_name” parameter type]({{ site.baseurl }}/2.0/reusing-config/#environment-variable-name) to secure API keys, webhook urls or other sensitive data. 
+- [Injecting steps as a parameter]({{ site.baseurl }}/2.0/reusing-config/#steps) is a useful way to run user defined steps within a job between your orb-defined steps.Good for if you need to perform an action both before and after user-defined tasks - for instance, you could run user-provided steps between your caching logic inside the command.
 
 **Installing binaries and tools**
-  - Set an `install-path` parameter, ideally with a default value of `/usr/local/bin`, and ensure to install the binary to this parameterized location. This may often avoid the issue of needing `root` privledges in environments where the user may not have root.
+  - Set an `install-path` parameter, ideally with a default value of `/usr/local/bin`, and ensure to install the binary to this parameterized location. This may often avoid the issue of needing `root` privileges in environments where the user may not have root.
   - If `root`is required for your use case, it is recommended to add pre-flight checks to determine if the user has root permissions and gracefully fail with a descriptive error message alerting the user they need proper permissions.
-  - Add the binary to the user's path via `$BASH_ENV` so the user may call the binary from a separate [run](https://circleci.com/docs/2.0/configuration-reference/#run) statement. This is required when installing to a non-default path.
+  - Add the binary to the user's path via `$BASH_ENV` so the user may call the binary from a separate [run]({{ site.baseurl }}/2.0/configuration-reference/#run) statement. This is required when installing to a non-default path.
   example:
 ```
 echo `export PATH="$PATH:<<parameters.install-path>>"` >> $BASH_ENV


### PR DESCRIPTION
# Description

-  Add display key information to orb-author page.
- Reference display key from orb-best-practices page.
- Correct links in orb-best-practices page to use proper `{{ site.baseurl }}` linking.
- Correct minor spelling mistakes found on page.

# Reasons
A new key has been added to orbs to allow users to prominently display the website for the service as well as the git repository.