### PR TITLE
Update/gpu

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -137,7 +137,7 @@ Docker also has built-in image caching and enables you to build, run, and publis
 
 Choosing Docker limits your runs to what is possible from within a Docker container (including our [Remote Docker][building-docker-images] feature). For instance, if you require low-level access to the network or need to mount external volumes consider using `machine`.
 
-## Using Machine (Linux VM)
+## Using Machine
 
 The `machine` option runs your jobs in a dedicated, ephemeral VM that has the following specifications:
 
@@ -210,7 +210,7 @@ jobs:
       - run: xcodebuild -version
 ```
 
-## Using Windows
+## Using the Windows Executor
 
 Using the `windows` executor allows you to run your job in a Windows environment. The following is an example configuration that will run a simple Windows job. The syntax for using the Windows executor in your config differs depending on whether you are using: 
 * CircleCI Cloud – config version 2.1 – you will also need to [enable Pipelines]({{ site.baseurl }}/2.0/build-processing).

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -31,33 +31,6 @@ It is possible to specify a different executor type for every job in your ['.cir
 - Jobs that require a complete Linux virtual machine (VM) image (`machine`) may use an Ubuntu version such as 16.04.
 - Jobs that require a macOS VM image (`macos`) may use an Xcode version such as 10.0.0.
 
-For building software on Linux,
-there are tradeoffs to using a `docker` image versus an Ubuntu-based `machine` image as the environment for the container, as follows:
-
-Capability | `docker` | `machine`
-----------|----------|----------
- Start time | Instant | 30-60 sec
- Clean environment | Yes | Yes
- Custom images | Yes <sup>(1)</sup> | No
- Build Docker images | Yes <sup>(2)</sup> | Yes
- Full control over job environment | No | Yes
- Full root access | No | Yes
- Run multiple databases | Yes <sup>(3)</sup> | Yes
- Run multiple versions of the same software | No | Yes
- [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching/) | Yes | Yes
- Run privileged containers | No | Yes
- Use docker compose with volumes | No | Yes
- [Configurable resources (CPU/RAM)]({{ site.baseurl }}/2.0/configuration-reference/#resource_class) | Yes | Yes
-{: class="table table-striped"}
-
-<sup>(1)</sup> See [Using Custom Docker Images][custom-images].
-
-<sup>(2)</sup> Requires using [Remote Docker][building-docker-images].
-
-<sup>(3)</sup> While you can run multiple databases with Docker, all images (primary and secondary) share the underlying resource limits. Performance in this regard will be dictated by the compute capacities of your container plan.
-
-It is also possible to use the `macos` executor type with `xcode`, see the [iOS Project Tutorial]({{ site.baseurl }}/2.0/ios-tutorial/) to get started.
-
 ## Using Docker
 
 The `docker` key defines Docker as the underlying technology to run your jobs using Docker Containers. Containers are an instance of the Docker Image you specify and the first image listed in your configuration is the primary container image in which all steps run. If you are new to Docker, see the [Docker Overview documentation](https://docs.docker.com/engine/docker-overview/) for concepts.
@@ -136,6 +109,32 @@ Docker also has built-in image caching and enables you to build, run, and publis
 - You want to use `docker-compose` (requires using [Remote Docker][building-docker-images])
 
 Choosing Docker limits your runs to what is possible from within a Docker container (including our [Remote Docker][building-docker-images] feature). For instance, if you require low-level access to the network or need to mount external volumes consider using `machine`.
+
+There are tradeoffs to using a `docker` image versus an Ubuntu-based `machine` image as the environment for the container, as follows:
+
+Capability | `docker` | `machine`
+----------|----------|----------
+ Start time | Instant | 30-60 sec
+ Clean environment | Yes | Yes
+ Custom images | Yes <sup>(1)</sup> | No
+ Build Docker images | Yes <sup>(2)</sup> | Yes
+ Full control over job environment | No | Yes
+ Full root access | No | Yes
+ Run multiple databases | Yes <sup>(3)</sup> | Yes
+ Run multiple versions of the same software | No | Yes
+ [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching/) | Yes | Yes
+ Run privileged containers | No | Yes
+ Use docker compose with volumes | No | Yes
+ [Configurable resources (CPU/RAM)]({{ site.baseurl }}/2.0/configuration-reference/#resource_class) | Yes | Yes
+{: class="table table-striped"}
+
+<sup>(1)</sup> See [Using Custom Docker Images][custom-images].
+
+<sup>(2)</sup> Requires using [Remote Docker][building-docker-images].
+
+<sup>(3)</sup> While you can run multiple databases with Docker, all images (primary and secondary) share the underlying resource limits. Performance in this regard will be dictated by the compute capacities of your container plan.
+
+For more information on `machine`, see the next section below.
 
 ## Using Machine
 


### PR DESCRIPTION
# Description
-  Added section about GPUs in Choosing Executor doc.
- Moved Docker-related sections and nested them under `Using Docker`.

# Reasons
Thought it'd be good to mention that we have GPU executors, and having all of the Docker-related information under main Docker heading made more sense. Came from a customer's feedback