### PR TITLE
Fix typo at heading

### DIFF
--- a/jekyll/_cci2/optimization-cookbook.md
+++ b/jekyll/_cci2/optimization-cookbook.md
@@ -158,7 +158,7 @@ When running tests on the CircleCI platform, one of the primary considerations y
 
 There are many different test suites and approaches you can use when testing on the CircleCI platform. Although CircleCI is test suite agnostic, the example below (adapted with permission from the developer who wrote about this test optimization use case in his [blog post](https://www.brautaset.org/articles/2019/speed-up-circleci.html)) describes how you can optimize testing using Django and the CircleCI platform.
 
-### Testing Optmization on the CircleCI Platform For a Python Django Project
+### Testing Optimization on the CircleCI Platform For a Python Django Project
 
 Some organizations use CircleCI to run tests for each change before merging to the main branch. Faster tests means faster feedback cycles, which in turn means you can confidently ship code more often. Let's take a look at a case study for a Python Django application's workflow, that took more than 13 minutes to complete testing on the CircleCI platform.
 


### PR DESCRIPTION
# Description
Testing Optmization becomes Testing Optimization

# Reasons
Found this typo while I was reading the docs.