### PR TITLE
update button title to add GitHub projects to CircleCI

### DIFF
--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -32,7 +32,7 @@ Database images for use as a secondary 'service' container are also available.
 A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
 
 1. Fork the project on GitHub to your own account
-2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to the project you just forked
+2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Set Up Project button next to the project you just forked
 3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 


### PR DESCRIPTION
# Description
Update the title of the button for Adding GitHub projects to CircleCI... Docs did have it as "Build Project" but it's actually "Set Up Project"

![image](https://user-images.githubusercontent.com/296864/74788824-73c40200-5278-11ea-9d8d-60897338d224.png)


# Reasons
Documentation is important and needs to reflect the actual steps and what the developer is seeing