### PR TITLE
update references to ECS and ECR orbs

### DIFF
--- a/jekyll/_cci2/deployment-examples.md
+++ b/jekyll/_cci2/deployment-examples.md
@@ -19,9 +19,10 @@ This document presents example config for a variately of popular deployment targ
 
 ## AWS
 
-This section covers deployment to S3, ECR/ECS (Elastic Container Registry/Elastic Container Service), as well as application deployment using AWS Code Deploy. For an in-depth look at deploying to AWS ECS from ECR, see the [Deploying to AWS ECS/ECR document]({{ site.baseurl }}/2.0/ecs-ecr/).
+This section covers deployment to S3, ECR/ECS (Elastic Container Registry/Elastic Container Service), as well as application deployment using AWS Code Deploy.
 
-For more detailed information about the AWS ECS, AWS ECR, & AWS CodeDeploy orbs, refer to the following Orb registry pages:
+For more detailed information about the AWS S3, ECS, ECR, and CodeDeploy orbs, refer to the following Orb registry pages:
+- [AWS S3](https://circleci.com/orbs/registry/orb/circleci/aws-s3)
 - [AWS ECR](https://circleci.com/orbs/registry/orb/circleci/aws-ecr)
 - [AWS ECS](https://circleci.com/orbs/registry/orb/circleci/aws-ecs)
 - [AWS CodeDeploy](https://circleci.com/orbs/registry/orb/circleci/aws-code-deploy)

--- a/jekyll/_cci2/ecs-ecr.md
+++ b/jekyll/_cci2/ecs-ecr.md
@@ -67,6 +67,8 @@ Every CircleCI project requires a configuration file called [`.circleci/config.y
  - [AWS-ECR](https://circleci.com/orbs/registry/orb/circleci/aws-ecr)
  - [AWS-ECS](https://circleci.com/orbs/registry/orb/circleci/aws-ecs)
 
+Notice the orbs are versioned with tags, for example, `aws-ecr: circleci/aws-ecr@x.y.z`. If you copy paste any examples you will need to edit `x.y.z` to specify a version. You can find the available versions listed on the individual orb pages in the [CircleCI Orbs Registry](https://circleci.com/orbs/registry/).
+
 ### Build and Push the Docker image to AWS ECR
 
 The `build_and_push_image` job builds a Docker image from a Dockerfile in the default location (i.e. root of the checkout directory) and pushes it to the specified ECR repository.
@@ -75,8 +77,8 @@ The `build_and_push_image` job builds a Docker image from a Dockerfile in the de
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@6.7.0
-  aws-ecs: circleci/aws-ecs@01.1.0
+  aws-ecr: circleci/aws-ecr@x.y.z
+  aws-ecs: circleci/aws-ecs@0x.y.z
 
 workflows:
   build-and-deploy:
@@ -95,8 +97,8 @@ The `deploy-service-update` job of the aws-ecs orb creates a new task definition
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@6.7.0
-  aws-ecs: circleci/aws-ecs@01.1.0
+  aws-ecr: circleci/aws-ecr@x.y.z
+  aws-ecs: circleci/aws-ecs@0x.y.z
 
 workflows:
   build-and-deploy:

--- a/jekyll/_cci2/ecs-ecr.md
+++ b/jekyll/_cci2/ecs-ecr.md
@@ -82,6 +82,7 @@ workflows:
   build-and-deploy:
     jobs:
       - aws-ecr/build_and_push_image:
+          aws-region: ${AWS_DEFAULT_REGION}
           repo: "${AWS_RESOURCE_NAME_PREFIX}"
           tag: "${CIRCLE_SHA1}"
 ```

--- a/jekyll/_cci2/ecs-ecr.md
+++ b/jekyll/_cci2/ecs-ecr.md
@@ -53,7 +53,7 @@ Variable                 | Description
 -------------------------|------------
 AWS_ACCESS_KEY_ID        | Security credentials for AWS.
 AWS_SECRET_ACCESS_KEY    | Security credentials for AWS.
-AWS_DEFAULT_REGION       | Used by the AWS CLI.
+AWS_REGION               | Used by the AWS CLI.
 AWS_ACCOUNT_ID           | Required for deployment. [Find your AWS Account ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#FindingYourAWSId).
 AWS_RESOURCE_NAME_PREFIX | Prefix for some required AWS resources. Should correspond to the value of `aws_resource_prefix` in `terraform_setup/terraform.tfvars`.
 AWS_ECR_ACCOUNT_URL      | Amazon ECR account URL that maps to an AWS account, e.g. {awsAccountNum}.dkr.ecr.us-west-2.amazonaws.com
@@ -82,7 +82,6 @@ workflows:
   build-and-deploy:
     jobs:
       - aws-ecr/build_and_push_image:
-          aws-region: ${AWS_DEFAULT_REGION}
           repo: "${AWS_RESOURCE_NAME_PREFIX}"
           tag: "${CIRCLE_SHA1}"
 ```
@@ -108,7 +107,6 @@ workflows:
       - aws-ecs/deploy-service-update:
           requires:
             - aws-ecr/build_and_push_image # only run this job once aws-ecr/build_and_push_image has completed
-          aws-region: ${AWS_DEFAULT_REGION}
           family: "${AWS_RESOURCE_NAME_PREFIX}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX}-cluster"
           container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX}-service,tag=${CIRCLE_SHA1}"

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -261,8 +261,6 @@ en:
           link: 2.0/deployment-integrations/
         - name: Deployment Examples
           link: 2.0/deployment-examples/
-        - name: Deploying to AWS ECR/ECS
-          link: 2.0/ecs-ecr/
         - name: Publishing Snap Packages
           link: 2.0/build-publish-snap-packages/
         - name: Using Artifactory


### PR DESCRIPTION
fixes #4144 

Also: 
* remove unnecessary parameter definitions from config where env vars can be used
* it seemed to me there were too many sections, the last one about introducing workflows didn't actually add to the config, and the full example was just repeated at the end so I removed that. Happy to reintroduce though if others don't agree!
* change to use env var `AWS_REGION` so default is used for all orb commands without having to declare in config. This needs checking though in case I am over-simplifying :-)
* remove this page from the sidenav because it's covered in the main deployment examples page.