### PR TITLE
[CIRCLE-24660] Fix search box close button

### DIFF
--- a/src-js/instantsearch.js
+++ b/src-js/instantsearch.js
@@ -121,8 +121,7 @@ export function init () {
 
   window.addEventListener('load', renderResults);
   searchResetButton.addEventListener('click', function () {
-    setTimeout(function () {
-      renderResults();
-    }, 100);
+    searchBox.value = ''
+    renderResults();
   });
 };


### PR DESCRIPTION
This appears to be broken on Algolia's side in the widget, as the close button is their native element that they create when the widget is created. I assume this originally had the timeout to allow Algolia to do its reset, which hopefully is completed by 100ms later when we trigger a re-render with the now-empty search field.

However this isn't working for whatever reason. Instead we can do what blog search does and clear the query string ourselves and immediately re-render. It's nice to be able to remove that timeout/asynchronous behavior too.