### PR TITLE
Replace wrong JavaScript repo link

### DIFF
--- a/jekyll/_includes/snippets/language-guides.md
+++ b/jekyll/_includes/snippets/language-guides.md
@@ -65,3 +65,4 @@
 [sample-scala]: https://github.com/ariv3ra/samplescala
 [circleci-demo-windows]: https://github.com/CircleCI-Public/circleci-demo-windows/
 [parallel-compile-circleci]: https://github.com/eddiewebb/parallel-compile-circleci/blob/master/.circleci/config.yml
+[circleci-demo-javascript-react-app]: https://github.com/CircleCI-Public/circleci-demo-javascript-react-app

--- a/jekyll/_includes/snippets/language-guides.md
+++ b/jekyll/_includes/snippets/language-guides.md
@@ -13,7 +13,7 @@
 | [macOS]{:target="_blank"}               | MacOS        | [circleci-demo-macos]{:target="_blank"}                  |
 | [Java]{:target="_blank"}                | Spring       | [circleci-demo-java-spring]{:target="_blank"}            |
 | [Java - Maven]{:target="_blank"}        | Maven        | [circleci-demo-java-spring-tree-maven]{:target="_blank"} |
-| [JavaScript]{:target="_blank"}          | React Native | [circleci-demo-react-native]{:target="_blank"}           |
+| [JavaScript]{:target="_blank"}          | React        | [circleci-demo-javascript-react-app]{:target="_blank"}   |
 | [NodeJS - JavaScript]{:target="_blank"} | React        | [circleci-demo-javascript-express]{:target="_blank"}     |
 | [PHP]{:target="_blank"}                 | Laravel      | [circleci-demo-php-laravel]{:target="_blank"}            |
 | [Python]{:target="_blank"}              | Django       | [circleci-demo-python-django]{:target="_blank"}          |


### PR DESCRIPTION
# Reasons
Right now the JavaScript example points to the React Native example. In my opinion this is wrong and I've a found a React demo made by CircleCI so I guess that should be used instead.