### PR TITLE
Add warning for rename script

### DIFF
--- a/jekyll/_cci2/updating-server.adoc
+++ b/jekyll/_cci2/updating-server.adoc
@@ -21,6 +21,8 @@ WARNING: For AWS installs, *before upgrading* to v2.19, follow <<update-nomad-cl
 WARNING: Before upgrading please read and follow the steps below if you have **ever had issues with renaming an organization within CircleCI**
 or you suspect that an **organization rename might have happened at any point**.
 
+WARNING: This is necessary when you upgrade from 2.17 or previous version. If you're using 2.18 already, please skip this step.
+
 . SSH into your Services machine
 . REPL into `workflows-conductor` by running the following: `sudo docker exec -it workflows-conductor lein repl :connect 6005`
 . Go to this link for the https://gist.githubusercontent.com/BoVice/49a5a98e93508e7913b7d62d6e5de68b/raw/e354eb42a97ca509809eaafe7b28052481702b9e/org-rename.cjl[org rename script]. Copy/paste this script into the REPL session. It will run migration and output current progress.

--- a/jekyll/_cci2/updating-server.adoc
+++ b/jekyll/_cci2/updating-server.adoc
@@ -8,20 +8,17 @@
 
 [.serveronly]_This document is intended for system administrators of self-hosted installations of CircleCI Server._
 
-This section describes the process for upgrading your CircleCI Server installation from v2.17.x to v{serverversion}. If you have already upgraded to v2.18 and would like steps to upgrade to patch release v2.18.3, first take a <<1-snapshot-for-rollback,snapshot>> and then follow the <<3-upgrade-circleci-server,application upgrade steps>>.
+This document describes the process for upgrading your CircleCI Server installation to v{serverversion}. 
 
 toc::[]
 
 == Nomad Launch Configuration
 
-WARNING: For AWS installs, *before upgrading* to v2.19, follow <<update-nomad-clients#,this guide>> to update your nomad launch configuration.
+WARNING: *Before upgrading* to v2.19, follow <<update-nomad-clients#,this guide>> to update your nomad launch configuration.
 
 == Org Rename Script
 
-WARNING: Before upgrading please read and follow the steps below if you have **ever had issues with renaming an organization within CircleCI**
-or you suspect that an **organization rename might have happened at any point**.
-
-WARNING: This is necessary when you upgrade from 2.17 or previous version. If you're using 2.18 already, please skip this step.
+CAUTION: If upgrading directly from v2.17 (or below) and you have **ever had issues with renaming an organization within CircleCI** or you suspect that an **organization rename might have happened at any point** follow the steps below. If you are running Server v2.18.x already you can skip these steps.
 
 . SSH into your Services machine
 . REPL into `workflows-conductor` by running the following: `sudo docker exec -it workflows-conductor lein repl :connect 6005`


### PR DESCRIPTION
# Description
Add a warning for user who's using 2.18 already (done for org rename script previously when they update 2.17 > 2.18) to skip the script step

# Reasons
It's not necessary for users who is already 2.18 - they will see this error when they're already done.

```
user=> (migrate)
===== Syncing orgs =====
==== Syncing contexts =====
Execution error (IllegalStateException) at user/migrate (REPL:6).
Attempting to call unbound fn: #'user/migrate-contexts
```