### PR TITLE
[CIRCLE-24917] Navigation updates 20200305

### DIFF
--- a/jekyll/_includes/global-footer.html
+++ b/jekyll/_includes/global-footer.html
@@ -20,7 +20,7 @@
             <li><a href="https://support.circleci.com/hc/en-us" data-analytics-child='{ "menu": "get-support" }' target="_blank">Get Support</a></li>
             <li><a href="https://discuss.circleci.com/" data-analytics-child='{ "menu": "community-forum" }' target="_blank">Community Forum</a></li>
             <li><a href="https://status.circleci.com/" data-analytics-child='{ "menu": "system-status" }' target="_blank">System Status</a></li>
-            <li><a href="https://ideas.circleci.com/" data-analytics-child='{ "menu": "feature-requests" }'>Feature Requests</a></li>
+            <li><a href="https://ideas.circleci.com/" data-analytics-child='{ "menu": "feature-requests" }' target="_blank">Feature Requests</a></li>
             <li><a href="https://circleci.com/support/premium-support/" data-analytics-child='{ "menu": "premium-support" }'>Premium Support</a></li>
           </ul>
         </div>

--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -70,7 +70,7 @@
                   <li class="subnav-item"><a href="https://academy.circleci.com/?access_code=public-2020" target="_blank">Training</a></li>
                   <li class="subnav-item"><a href="https://support.circleci.com/hc/en-us" target="_blank">Get Support</a></li>
                   <li class="subnav-item"><a href="https://status.circleci.com/" target="_blank">System Status</a></li>
-                  <li class="subnav-item"><a href="https://ideas.circleci.com/">Feature Requests</a></li>
+                  <li class="subnav-item"><a href="https://ideas.circleci.com/" target="_blank">Feature Requests</a></li>
                   <li class="subnav-item"><a href="{{ '/support/premium-support/' | outer_url }}">Premium Support</a></li>
                 </ul>
               </div>
@@ -152,7 +152,7 @@
                 <li class="subnav-item"><a href="https://academy.circleci.com/?access_code=public-2020" target="_blank">Training</a></li>
                 <li class="subnav-item"><a href="https://support.circleci.com/hc/en-us" target="_blank">Get Support</a></li>
                 <li class="subnav-item"><a href="https://status.circleci.com/" target="_blank">System Status</a></li>
-                <li class="subnav-item"><a href="https://ideas.circleci.com/">Feature Requests</a></li>
+                <li class="subnav-item"><a href="https://ideas.circleci.com/" target="_blank">Feature Requests</a></li>
                 <li class="subnav-item"><a href="{{ '/support/premium-support/' | outer_url }}">Premium Support</a></li>
               </ul>
             </li>

--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -36,7 +36,7 @@
                   <li class="subnav-item"><a href="{{ '/' | language_relative_url }}">Documentation</a></li>
                   <li class="subnav-item"><a href="https://discuss.circleci.com/" target="_blank">Community Forum</a></li>
                   <li class="subnav-item" ><a href="https://circleci.com/orbs/">Orbs</a></li>
-                  <li class="subnav-item"><a href="https://circleci.com/docs/api/">API</a></li>
+                  <li class="subnav-item"><a href="https://circleci.com/docs/api/v2/#circleci-api">API</a></li>
                   <li class="subnav-item"><a href="{{ '/open-source/' | outer_url }}">Open Source</a></li>
                 </ul>
               </div>
@@ -127,7 +127,7 @@
                 <li class="subnav-item"><a href="{{ '/' | language_relative_url }}">Documentation</a></li>
                 <li class="subnav-item"><a href="https://discuss.circleci.com/" target="_blank">Community Forum</a></li>
                 <li class="subnav-item"><a href="https://circleci.com/orbs/">Orbs</a></li>
-                <li class="subnav-item"><a href="https://circleci.com/docs/api/v1-reference/">API</a></li>
+                <li class="subnav-item"><a href="https://circleci.com/docs/api/v2/#circleci-api">API</a></li>
                 <li class="subnav-item"><a href="{{ '/open-source/' | outer_url }}">Open Source</a></li>
               </ul>
             </li>


### PR DESCRIPTION
# Description
- Update "API" link in main nav to `https://circleci.com/docs/api/v2/#circleci-api`, per the tickets below, for consistency with this change on circleci.com.
- Add `target="_blank"` to "Feature Requests" links to open in a new tab, for consistency with this same update to circleci.com.

# Reasons
[CIRCLE-24917](https://circleci.atlassian.net/browse/CIRCLE-24917)
[CIRCLE-23675](https://circleci.atlassian.net/browse/CIRCLE-23675)
