### PR TITLE
Update caching instructions for yarn users

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -505,7 +505,6 @@ steps:
   - save_cache:
       paths:
         - ~/.cache/yarn
-        - node_modules
       key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
 ```
 

--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -508,11 +508,11 @@ steps:
       key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
 ```
 
-We recommend using `yarn --frozen-lockfile --cache-folder=.cache/yarn` for two reasons.
+We recommend using `yarn --frozen-lockfile --cache-folder ~/.cache/yarn` for two reasons.
 
 1) `--frozen-lockfile` ensures that a whole new lockfile is created and it also ensures your lockfile isn't altered. This allows for the checksum to stay relevant and your dependencies should identically match what you use in development.
 
-2) The default cache location depends on OS: https://github.com/yarnpkg/yarn/blob/25d5526c8995443b03c113c44f9c8e9a79c2c074/src/util/user-dirs.js#L26 `--cache-folder=.cache/yarn` ensures we're explitly matching our cache save location.
+2) The default cache location depends on OS: https://github.com/yarnpkg/yarn/blob/25d5526c8995443b03c113c44f9c8e9a79c2c074/src/util/user-dirs.js#L26 `--cache-folder ~.cache/yarn` ensures we're explitly matching our cache save location.
 
 {% endraw %}
 

--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -512,7 +512,7 @@ We recommend using `yarn --frozen-lockfile --cache-folder ~/.cache/yarn` for two
 
 1) `--frozen-lockfile` ensures that a whole new lockfile is created and it also ensures your lockfile isn't altered. This allows for the checksum to stay relevant and your dependencies should identically match what you use in development.
 
-2) The default cache location depends on OS: https://github.com/yarnpkg/yarn/blob/25d5526c8995443b03c113c44f9c8e9a79c2c074/src/util/user-dirs.js#L26 `--cache-folder ~.cache/yarn` ensures we're explitly matching our cache save location.
+2) The default cache location depends on OS. `--cache-folder ~.cache/yarn` ensures we're explitly matching our cache save location.
 
 {% endraw %}
 

--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -505,8 +505,15 @@ steps:
   - save_cache:
       paths:
         - ~/.cache/yarn
+        - node_modules
       key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
 ```
+
+We recommend using `yarn --frozen-lockfile --cache-folder=.cache/yarn` for two reasons.
+
+1) `--frozen-lockfile` ensures that a whole new lockfile is created and it also ensures your lockfile isn't altered. This allows for the checksum to stay relevant and your dependencies should identically match what you use in development.
+
+2) The default cache location depends on OS: https://github.com/yarnpkg/yarn/blob/25d5526c8995443b03c113c44f9c8e9a79c2c074/src/util/user-dirs.js#L26 `--cache-folder=.cache/yarn` ensures we're explitly matching our cache save location.
 
 {% endraw %}
 


### PR DESCRIPTION
# Description
Advise on install command

# Reasons
I've noticed that the out-of-box instructions on caching dependencies using yarn doesn't work.

Example:
https://discuss.circleci.com/t/circle-ci-2-0-yarn-dependencies/30912/3