### PR TITLE
[CIRCLE-24237] Add artifacts redirect docs

### DIFF
--- a/jekyll/_api/index.html
+++ b/jekyll/_api/index.html
@@ -953,9 +953,15 @@ This is also the payload for the notification webhooks, in which case this objec
 <li>the value of path is relative to the project root (the working_directory)</li>
 <li>pretty_path returns the same value as path. It is included in the response for backwards compatibility</li>
 </ul>
-<h2 id='download-an-artifact-file'>Download an artifact file</h2><pre class="highlight plaintext"><code>https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt?circle-token=:token
-</code></pre>
-<p>You can download an individual artifact file via the API by appending a query string to its URL. Note that <code>:token</code> is an API token with &#39;view-builds&#39; scope.</p>
+<h2 id='download-an-artifact-file'>Download an artifact file</h2>
+<p>You can download an individual artifact file via the API with an API-token authenticated HTTP request.</p>
+</code></pre><h3 id='notes'>Notes</h3>
+<ul>
+  <li>Make sure your HTTP client is configured to follow follow redirects as the artifact URLs can respond with
+      an HTTP <code>3xx</code> status code (the <code>-L</code> switch in <code>curl</code> will achieve this).</li>
+  <li><code>:token</code> is an API token with &#39;view-builds&#39; scope.</li>
+</ul>
+<pre class="highlight plaintext"><code>curl -L -H'Circle-Token: :token' 'https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt'</code></pre>
 <h2 id='artifacts-of-the-latest-build'>Artifacts of the latest Build</h2>
 <p>Returns an array of artifacts produced by the latest build on a given branch.</p>
 

--- a/jekyll/_api/v1-reference.md
+++ b/jekyll/_api/v1-reference.md
@@ -171,13 +171,16 @@ The branch name should be url-encoded.
 
 <h2 id="download-artifact">Download an artifact file</h2>
 
-You can download an individual artifact file via the API by appending a query string to its URL:
+You can download an individual artifact file via the API with an API-token authenticated HTTP request.
 
-```
-https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt?circle-token=:token
+```sh
+curl -L -H'Circle-Token: :token' https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt
 ```
 
-':token' is an API token with 'view-builds' scope.
+**Notes:**
+- Make sure your HTTP client is configured to follow follow redirects as the artifact URLs can respond with
+an HTTP `3xx` status code (the `-L` switch in `curl` will achieve this).
+- `:token` is an API token with 'view-builds' scope.
 
 <h2 id="build-artifacts-latest">Artifacts of the latest Build</h2>
 

--- a/src-api/source/includes/_artifacts.md
+++ b/src-api/source/includes/_artifacts.md
@@ -3,7 +3,7 @@
 ## Artifacts Of A Build
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts?circle-token=:token
+curl -H'Circle-Token: :token' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts
 ```
 
 ```json
@@ -32,17 +32,21 @@ Request Type: `GET`
 
 ## Download an artifact file
 
-```
-https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt?circle-token=:token
+You can download an individual artifact file via the API with an API-token authenticated HTTP request.
+
+```sh
+curl -L -H'Circle-Token: :token' https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt
 ```
 
-You can download an individual artifact file via the API by appending a query string to its URL. Note that `:token` is an API token with 'view-builds' scope.
+### Notes
+* Make sure your HTTP client is configured to follow redirects as the artifact URLs can respond with
+an HTTP `3xx` status code (the `-L` switch in `curl` will achieve this).
+* `:token` is an API token with 'view-builds' scope.
 
 ## Artifacts of the latest Build
 
-
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts?circle-token=:token&branch=:branch&filter=:filter
+curl -H'Circle-Token: :token' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts?branch=:branch&filter=:filter
 ```
 
 ```json
@@ -73,4 +77,3 @@ filter | Restricts which builds are returned. Set to "completed", "successful", 
 
 * the value of path is relative to the project root (the working_directory)
 * pretty_path returns the same value as path. It is included in the response for backwards compatibility
-


### PR DESCRIPTION
# Description
- Mention `3xx` redirects for artifacts downloading.
- Make the description of the the downloading uniform across the two APIs.
- Use header based authentication in examples, so the credentials aren't leaked into proxy logs, etc.

# Reasons
https://circleci.atlassian.net/browse/CIRCLE-24237