### PR TITLE
Add Parallelism - Splitting by Timings section to Elixir doc

### DIFF
--- a/jekyll/_cci2/language-elixir.md
+++ b/jekyll/_cci2/language-elixir.md
@@ -186,6 +186,22 @@ available in the CircleCI web app.
           path: _build/test/lib/REPLACE_WITH_YOUR_APP_NAME
 ```
 
+## Parallelism
+
+**Splitting by Timings**
+
+As of version 2.0, CircleCI requires users to upload their own JUnit XML [test output](https://circleci.com/docs/2.0/collect-test-data/#enabling-formatters). Currently the main/only Elixir library that produces that output is [JUnitFormatter](https://github.com/victorolinasc/junit-formatter). 
+
+In order to allow CircleCI's parallelization to use the `--split-by=timings` strategy with the XML output, you need to configure JUnitFOrmatter with the `include_filename?: true` option which will add the filename to the XML. 
+
+By default, JUnitFormatter saves the output to the `_build/test/lib/<application name>` directory, so in your `.circleci/config.yml` you will want to configure the `store_test_results` step to point to that same directory:
+  
+```
+  - store_test_results:
+      path: _build/test/lib/<application name>
+```
+
+However, JUnitFormatter also allows you to configure the directory where the results are saved via the `report_dir` setting, in which case, the `path` value in your CircleCI config should match the relative path of wherever you're storing the output. 
 
 ## See Also
 

--- a/jekyll/_cci2/language-elixir.md
+++ b/jekyll/_cci2/language-elixir.md
@@ -192,7 +192,7 @@ available in the CircleCI web app.
 
 As of version 2.0, CircleCI requires users to upload their own JUnit XML [test output](https://circleci.com/docs/2.0/collect-test-data/#enabling-formatters). Currently the main/only Elixir library that produces that output is [JUnitFormatter](https://github.com/victorolinasc/junit-formatter). 
 
-In order to allow CircleCI's parallelization to use the `--split-by=timings` strategy with the XML output, you need to configure JUnitFOrmatter with the `include_filename?: true` option which will add the filename to the XML. 
+In order to allow CircleCI's parallelization to use the `--split-by=timings` strategy with the XML output, you need to configure JUnitFormatter with the `include_filename?: true` option which will add the filename to the XML. 
 
 By default, JUnitFormatter saves the output to the `_build/test/lib/<application name>` directory, so in your `.circleci/config.yml` you will want to configure the `store_test_results` step to point to that same directory:
   


### PR DESCRIPTION
- Explain that CircleCI 2.0 parallelism requires JUnit XML output via the JUnitFormatter library
- Explain that JUnitFormatter has an optional `include_filename` configuration that must be set for `--split-by=timings` to work
- Explain where the output file is stored by default and how to configure CircleCI to match that default

# Description
I raised [an issue in the CircleCI discussion forums](https://discuss.circleci.com/t/split-by-timings-on-elixir-project-fails-to-find-stored-timings-possibly-missing-file-names-in-junit-xml/34813) that my parallelization configuration suddenly stopped working last December. The solution turned out to be that 1) we had not been manually uploading our own JUnit XML test metadata and needed to add that and 2) there was actually an issue between JUnitFormatter and CircleCI where Circle is expecting to find a `file` attribute in the XML, and JUnitFormatter was not including that. I created a [PR that has now been merged]( https://github.com/victorolinasc/junit-formatter/pull/37 ) on that library that includes the necessary changes, however, Elixir users need to know that filenames are not included by default and that they need to add the `include_filename?: true` JUnitFormatter configuration. 

Please note that I have tested this with an without the added filename and test splitting only works with the `file` attribute included in the XML.


# Reasons
I [outlined the issue](https://github.com/CircleCI-Public/circleci-demo-elixir-phoenix/issues/9) on the CircleCI hosted Elixir demo app and @zzak replied and invited me to add this information to the docs.
