### PR TITLE
Add Chroma Feedback to Notifications

### DIFF
--- a/jekyll/_cci2/notifications.md
+++ b/jekyll/_cci2/notifications.md
@@ -149,6 +149,8 @@ workflows:
       - build
 ```
 
-## Notification with RGB hardware
+## Third Party Tools
+
+### Chroma Feedback
 
 [Chroma Feedback](https://github.com/redaxmedia/chroma-feedback) is a command line tool in Python to turn your RGB powered hardware into an build indicator. The idea of such extreme visibility is to encourage developers to instantly repair their builds.

--- a/jekyll/_cci2/notifications.md
+++ b/jekyll/_cci2/notifications.md
@@ -152,5 +152,3 @@ workflows:
 ## Notification with RGB hardware
 
 [Chroma Feedback](https://github.com/redaxmedia/chroma-feedback) is a command line tool in Python to turn your RGB powered hardware into an build indicator. The idea of such extreme visibility is to encourage developers to instantly repair their builds.
-
-![Terminal Session](https://cdn.rawgit.com/redaxmedia/media/master/chroma-feedback/terminal-session.svg)

--- a/jekyll/_cci2/notifications.md
+++ b/jekyll/_cci2/notifications.md
@@ -149,4 +149,8 @@ workflows:
       - build
 ```
 
+## Notification with RGB hardware
 
+[Chroma Feedback](https://github.com/redaxmedia/chroma-feedback) is a command line tool in Python to turn your RGB powered hardware into an build indicator. The idea of such extreme visibility is to encourage developers to instantly repair their builds.
+
+![Terminal Session](https://cdn.rawgit.com/redaxmedia/media/master/chroma-feedback/terminal-session.svg)


### PR DESCRIPTION
# Description
Added Chroma Feedback to the notifications page... I would prefer a third party tooling page but this is a temporary solution suggested by Tyler in https://github.com/circleci/circleci-docs/issues/4209

# Reasons
Because it is awesome:
![chroma-feedback](https://user-images.githubusercontent.com/1835397/76713222-6ab33d00-671f-11ea-9162-914d3e5a4341.gif)