### PR TITLE
Temporarily disable `build_config_ref`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,8 +250,6 @@ jobs:
             mkdir -p /tmp/workspace/api
             cp -r /tmp/workspace/api/**/* jekyll/_api/
 
-#            mkdir -p /tmp/workspace/crg
-#            cp -r /tmp/workspace/crg/**/* jekyll/_crg/
 
             mkdir -p /tmp/workspace/pdfs
             cp -r /tmp/workspace/api/* jekyll/_api/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,14 +52,14 @@ workflows:
             branches:
               only: /server\/.*/
       - build_api_docs
-      - build_config_ref
+#       - build_config_ref
 
       - build:
           requires:
             - js_build
             - build_server_pdfs
             - build_api_docs
-            - build_config_ref
+#             - build_config_ref
       - reindex-search:
           requires:
             - build
@@ -174,6 +174,7 @@ jobs:
             - api
 
 
+  # TODO: fix copying of build artifacts.
   build_config_ref: # a job to manage building our config-reference documentation and persisting it to the workspace
     executor:
       name: ruby/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,8 +250,8 @@ jobs:
             mkdir -p /tmp/workspace/api
             cp -r /tmp/workspace/api/**/* jekyll/_api/
 
-            mkdir -p /tmp/workspace/crg
-            cp -r /tmp/workspace/crg/**/* jekyll/_crg/
+#            mkdir -p /tmp/workspace/crg
+#            cp -r /tmp/workspace/crg/**/* jekyll/_crg/
 
             mkdir -p /tmp/workspace/pdfs
             cp -r /tmp/workspace/api/* jekyll/_api/


### PR DESCRIPTION
Our nightly build failed on the new build_config_ref. Disabling it until it's fixed on another branch. 