### PR TITLE
[CIRCLE-25351] Remove “Preview” from v2 Insights API doc heading

### DIFF
--- a/widdershins.apiv2.yml
+++ b/widdershins.apiv2.yml
@@ -20,7 +20,7 @@ tagGroups:
 - title: Job (Preview)
   tags:
   - Job
-- title: Insights (Preview)
+- title: Insights
   tags:
   - Insights
 search: true


### PR DESCRIPTION
# Description
Removes "(Preview)" from the heading for the v2 Insights API docs.

# Reasons
The insights API is going to be considered to be out of preview starting April 1st, 2020.