### PR TITLE
docs: rm 2nd install sbt

### DIFF
--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -55,7 +55,7 @@ jobs:
                     dpkg -i sbt-$SBT_VERSION.deb
                     rm sbt-$SBT_VERSION.deb
                     apt-get update
-                    apt-get install -y sbt python-pip git
+                    apt-get install -y python-pip git
                     pip install awscli
                     apt-get clean && apt-get autoclean
       - checkout
@@ -125,7 +125,7 @@ jobs:
             dpkg -i sbt-$SBT_VERSION.deb
             rm sbt-$SBT_VERSION.deb
             apt-get update
-            apt-get install -y sbt python-pip git
+            apt-get install -y python-pip git
             pip install awscli
             apt-get clean && apt-get autoclean
 ```
@@ -148,7 +148,7 @@ The next run command executes multiple commands within the openjdk container. Si
             dpkg -i sbt-$SBT_VERSION.deb
             rm sbt-$SBT_VERSION.deb
             apt-get update
-            apt-get install -y sbt python-pip git
+            apt-get install -y python-pip git
             pip install awscli
             apt-get clean && apt-get autoclean
 ```

--- a/jekyll/_cci2_ja/language-scala.md
+++ b/jekyll/_cci2_ja/language-scala.md
@@ -56,7 +56,7 @@ jobs:
                     dpkg -i sbt-$SBT_VERSION.deb
                     rm sbt-$SBT_VERSION.deb
                     apt-get update
-                    apt-get install -y sbt python-pip git
+                    apt-get install -y python-pip git
                     pip install awscli
                     apt-get clean && apt-get autoclean
       - checkout
@@ -125,7 +125,7 @@ jobs:
             dpkg -i sbt-$SBT_VERSION.deb
             rm sbt-$SBT_VERSION.deb
             apt-get update
-            apt-get install -y sbt python-pip git
+            apt-get install -y python-pip git
             pip install awscli
             apt-get clean && apt-get autoclean
 ```
@@ -148,7 +148,7 @@ steps/run キーは、実行するアクションのタイプを指定します�
             dpkg -i sbt-$SBT_VERSION.deb
             rm sbt-$SBT_VERSION.deb
             apt-get update
-            apt-get install -y sbt python-pip git
+            apt-get install -y python-pip git
             pip install awscli
             apt-get clean && apt-get autoclean
 ```


### PR DESCRIPTION
# Description

This PR cleans docs. It removes 2nd install `sbt`.

# Reasons

In command, `sbt` is installed by `dpkg`, so `apt-get` do not have to install `sbt`.