### PR TITLE
Clarify that build matrix requires version 2.1

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1391,7 +1391,7 @@ ignore | N | String, or List of Strings | Either a single tag specifier, or a li
 
 For more information, see the [Executing Workflows For a Git Tag]({{ site.baseurl }}/2.0/workflows/#executing-workflows-for-a-git-tag) section of the Workflows document.
 
-###### **`matrix`**
+###### **`matrix`** (requires version: 2.1)
 The `matrix` stanza allows you to run a parameterized job multiple times with different
 arguments.
 


### PR DESCRIPTION
# Description
We only support matrix jobs in version 2.1, so now the docs clarify that, in the same way that other sections of the docs do so.