### PR TITLE
Added info about inability to trigger 2.1 jobs

### DIFF
--- a/jekyll/_cci2/triggers.md
+++ b/jekyll/_cci2/triggers.md
@@ -17,6 +17,8 @@ By default, CircleCI automatically builds a project whenever you push changes to
 
 ## Trigger a Job Using curl and Your API Token
 
+**Note:** You cannot currently trigger jobs that use 2.1 config from the API.
+
 ```
 curl -u ${CIRCLE_API_USER_TOKEN}: \
      -d build_parameters[CIRCLE_JOB]=deploy_docker \


### PR DESCRIPTION
# Description
Copied the note "You cannot currently trigger jobs that use 2.1 config from the API" that is included here https://circleci.com/docs/2.0/api-job-trigger/

# Reasons
I am having trouble manually triggering a job via the API and now I noticed the note saying this is incompatible with 2.1 configs. If this was included in this page I'd have seen it sooner.