### PR TITLE
Update test collection docs for Jest

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -490,7 +490,7 @@ steps:
       path: ./reports/junit
 ```
 
-For a full walkthrough, refer to this article by Viget: [Using JUnit on CircleCI 2.0 with Jest and ESLint](https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint).
+For a full walkthrough, refer to this article by Viget: [Using JUnit on CircleCI 2.0 with Jest and ESLint](https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint). Note that usage of the jest cli argument `--testResultsProcessor` in the article has been superseded by the `--reporters` syntax, and JEST_JUNIT_OUTPUT has been replaced with `JEST_JUNIT_OUTPUT_DIR` and `JEST_JUNIT_OUTPUT_NAME`, as demonstrated above.
 
 **Note:** When running Jest tests, please use the `--runInBand` flag. Without this flag, Jest will try to allocate the CPU resources of the entire virtual machine in which your job is running. Using `--runInBand` will force Jest to use only the virtualized build environment within the virtual machine.
 

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -470,17 +470,9 @@ A working `.circleci/config.yml` section might look like this:
 #### Jest
 {:.no_toc}
 
-To collect Jest data, first create a Jest config file called `jest.config.js` with the following:
+To output JUnit compatible test data with Jest you can use [jest-junit](https://www.npmjs.com/package/jest-junit).
 
-```javascript
-// jest.config.js
-{
-  reporters: ["default", "jest-junit"],
-}
-```
-
-In your `.circleci/config.yml`,
-add the following `run` steps:
+A working `.circleci/config.yml` section might look like this:
 
 ```yaml
 steps:

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -483,7 +483,11 @@ steps:
       name: Run tests with JUnit as reporter
       command: jest --ci --runInBand --reporters=default --reporters=jest-junit
       environment:
-        JEST_JUNIT_OUTPUT_DIR: "reports/junit/js-test-results.xml"
+        JEST_JUNIT_OUTPUT_DIR: ./reports/junit/
+  - store_test_results:
+      path: ./reports/junit/
+  - store_artifacts:
+      path: ./reports/junit
 ```
 
 For a full walkthrough, refer to this article by Viget: [Using JUnit on CircleCI 2.0 with Jest and ESLint](https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint).


### PR DESCRIPTION
# Description
* Remove reference to jest.config.js. This Jest config file is not required, as the example includes the parameters in the CLI arguments.
* Updated example CircleCI config for Jest test data. JEST_JUNIT_OUTPUT_DIR should be a folder, not a file, `store_test_results` was not present as a step, and should be for this config to work (and to be similar to other examples in this document)
* Added caveats for referenced article, as it's now out of date
