### PR TITLE
Migration from TeamCity: Template -> Meta-Runners

### DIFF
--- a/jekyll/_cci2/migrating-from-teamcity.adoc
+++ b/jekyll/_cci2/migrating-from-teamcity.adoc
@@ -433,9 +433,9 @@ jobs:
 ----
 |===
 
-=== Meta-Runners
+=== Build Templates/Meta-Runners
 
-CircleCI's equivalent of Meta-Runners is orbs, which are templatizable, shareable configuration. Read more about them in our https://circleci.com/docs/2.0/orb-intro/#section=configuration[orbs documentation].
+CircleCI's equivalent of Meta-Runners and Build Templates is orbs, which are templatizable, shareable configuration. Read more about them in our https://circleci.com/docs/2.0/orb-intro/#section=configuration[orbs documentation].
 
 === Complex Builds
 

--- a/jekyll/_cci2/migrating-from-teamcity.adoc
+++ b/jekyll/_cci2/migrating-from-teamcity.adoc
@@ -433,9 +433,9 @@ jobs:
 ----
 |===
 
-=== Build Templates
+=== Meta-Runners
 
-CircleCI's equivalent of Build Templates is orbs, which are templatizable, shareable configuration. Read more about them in our https://circleci.com/docs/2.0/orb-intro/#section=configuration[orbs documentation].
+CircleCI's equivalent of Meta-Runners is orbs, which are templatizable, shareable configuration. Read more about them in our https://circleci.com/docs/2.0/orb-intro/#section=configuration[orbs documentation].
 
 === Complex Builds
 


### PR DESCRIPTION
I think that Orbs are similar to TeamCity meta-runners, but not templates: https://www.jetbrains.com/help/teamcity/working-with-meta-runner.html

Meta-runners are basically XML files that can be shared between different TeamCity servers and used as build steps.
