### PR TITLE
fix sidenav to one line per item

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -19,7 +19,7 @@ en:
     - name: Introduction
       link: 2.0/getting-started/
       children:
-        - name: Getting Started Introduction
+        - name: Getting Started
           link: 2.0/getting-started/
         - name: What is CircleCI?
           link: 2.0/about-circleci/
@@ -31,7 +31,7 @@ en:
           link: 2.0/hello-world-macos/
         - name: Hello World Windows
           link: 2.0/hello-world-windows/
-        - name: Getting Started with the CircleCI CLI
+        - name: Get Started with the CLI
           link: 2.0/local-cli-getting-started/
         - name: FAQ
           link: 2.0/faq/
@@ -82,7 +82,7 @@ en:
           link: 2.0/config-intro/
         - name: Configuration Reference
           link: 2.0/configuration-reference/
-        - name: Configuration Reference 2.1
+        - name: Config Reference 2.1
           link: reference-2-1/
         - name: Reusable Config Reference
           link: 2.0/reusing-config/
@@ -108,7 +108,7 @@ en:
     - name: Authoring Orbs
       link: 2.0/orb-author-intro/
       children:
-        - name: Introduction to Authoring an Orb
+        - name: Intro to Authoring an Orb
           link: 2.0/orb-author-intro/
         - name: Set up the CircleCI CLI
           link: 2.0/orb-author-cli/
@@ -123,7 +123,7 @@ en:
     - name: Using Orbs
       link: 2.0/orbs-user-config/
       children:
-        - name: Set Your Version to Work With Orbs
+        - name: Get Set Up For Orbs
           link: 2.0/orbs-user-config/
         - name: Selecting and Using an Orb
           link: 2.0/orbs-user-select-orb/
@@ -147,7 +147,7 @@ en:
     - name: EXECUTORS & IMAGES
       link: 2.0/executor-intro/
       children:
-        - name: Executor & Image Introduction
+        - name: Executor & Image Intro
           link: 2.0/executor-intro/
         - name: Choosing an Executor Type
           link: 2.0/executor-types/
@@ -160,7 +160,7 @@ en:
     - name: ADVANCED CONFIG
       link: 2.0/adv-config/
       children:
-        - name: Advanced Config Introduction
+        - name: Advanced Config Intro
           link: 2.0/adv-config/
         - name: Pipeline Variables
           link: 2.0/pipeline-variables
@@ -170,7 +170,7 @@ en:
           link: 2.0/browser-testing/
         - name: Configuring Databases
           link: 2.0/databases/
-        - name: Running Docker Commands
+        - name: Run Docker Commands
           link: 2.0/building-docker-images/
         - name: Using Docker Compose
           link: 2.0/docker-compose/
@@ -187,21 +187,21 @@ en:
           link: 2.0/gh-bb-integration/
         - name: Enabling GitHub Checks
           link: 2.0/enable-checks/
-        - name: Building Open Source Projects
+        - name: Open Source Projects
           link: 2.0/oss/
         - name: Using Notifications
           link: 2.0/notifications/
-        - name: Connecting JIRA with CircleCI
+        - name: Connect with JIRA
           link: 2.0/jira-plugin/
         - name: Managing API tokens
           link: 2.0/managing-api-tokens/
-        - name: Using Environment Variables
+        - name: Environment Variables
           link: 2.0/env-vars/
         - name: Using Contexts
           link: 2.0/contexts/
         - name: Enabling Pipelines
           link: 2.0/build-processing/
-        - name: Setting Up iOS Code Signing
+        - name: iOS Code Signing
           link: 2.0/ios-codesigning/
     - name: Optimizations
       link: 2.0/optimizations/
@@ -212,7 +212,7 @@ en:
           link: 2.0/caching/
         - name: Running Tests in Parallel
           link: 2.0/parallelism-faster-jobs/
-        - name: Using Docker Layer Caching
+        - name: Docker Layer Caching
           link: 2.0/docker-layer-caching/
         - name: Optimizations Cookbook
           link: 2.0/optimization-cookbook/
@@ -237,7 +237,7 @@ en:
           link: 2.0/artifacts/
         - name: Debugging with SSH
           link: 2.0/ssh-access-jobs/
-        - name: Debugging Java Memory Errors
+        - name: Debug Java Memory Errors
           link: 2.0/java-oom/
         - name: Collecting Test Metadata
           link: 2.0/collect-test-data/
@@ -252,9 +252,9 @@ en:
           link: 2.0/triggers/
         - name: Skip and Cancel Builds
           link: 2.0/skip-build/
-        - name: Using the API to Trigger Jobs
+        - name: Trigger Jobs with the API
           link: 2.0/api-job-trigger/
-        - name: Using Workflows to Schedule Jobs
+        - name: Schedule Jobs with Workflows
           link: 2.0/workflows/
 
 - name: Deployment
@@ -271,16 +271,16 @@ en:
           link: 2.0/build-publish-snap-packages/
         - name: Using Artifactory
           link: 2.0/artifactory/
-        - name: Publishing Packages to packagecloud
+        - name: Publishing to packagecloud
           link: 2.0/packagecloud/
 
 - name: Reference
   icon: docs/reference.svg
   children:
     - children:
-        - name: Configuration Reference
+        - name: Config Reference Full
           link: 2.0/configuration-reference/
-        - name: Configuration Reference 2.1
+        - name: Config Reference 2.1
           link: reference-2-1/
         - name: API v1.1 Reference
           link: api/

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -57,7 +57,7 @@ en:
           link: 2.0/migration-intro/
         - name: Migrating from AWS
           link: 2.0/migrating-from-aws/
-        - name: Migrating from Azure DevOps
+        - name: Migrating from Azure
           link: 2.0/migrating-from-azuredevops/
         - name: Migrating from Buildkite
           link: 2.0/migrating-from-buildkite/
@@ -80,12 +80,14 @@ en:
       children:
         - name: Configuration Introduction
           link: 2.0/config-intro/
-        - name: Configuration Reference
+        - name: Config Reference Full
           link: 2.0/configuration-reference/
         - name: Config Reference 2.1
           link: reference-2-1/
         - name: Reusable Config Reference
           link: 2.0/reusing-config/
+        - name: Config Builder
+          link: config-builder
         - name: Writing YAML
           link: 2.0/writing-yaml/
         - name: Using the CircleCI CLI
@@ -241,7 +243,7 @@ en:
           link: 2.0/java-oom/
         - name: Collecting Test Metadata
           link: 2.0/collect-test-data/
-        - name: Generating Code Coverage Metrics
+        - name: Code Coverage Metrics
           link: 2.0/code-coverage/
         - name: Using Insights
           link: 2.0/insights/
@@ -254,7 +256,7 @@ en:
           link: 2.0/skip-build/
         - name: Trigger Jobs with the API
           link: 2.0/api-job-trigger/
-        - name: Schedule Jobs with Workflows
+        - name: Workflows
           link: 2.0/workflows/
 
 - name: Deployment
@@ -282,14 +284,14 @@ en:
           link: 2.0/configuration-reference/
         - name: Config Reference 2.1
           link: reference-2-1/
-        - name: API v1.1 Reference
-          link: api/
         - name: API v2 Reference
           link: api/v2
         - name: API v2 Introduction
           link: 2.0/api-intro/
         - name: API v2 Developer's Guide
           link: 2.0/api-developers-guide
+        - name: API v1.1 Reference
+          link: api/
         - name: Prebuilt Images
           link: 2.0/circleci-images/
         - name: Glossary


### PR DESCRIPTION
Some items in the sidenav have ended up with names that exceed one line, it's not immediately clear when this happens that it is a two line item rather than two items. This PR proposes a fix for these items.