### PR TITLE
Add: resource_class information for docker.

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -455,6 +455,7 @@ xlarge                | 8     | 16GB
 {: class="table table-striped"}
 
 ###### Example Usage
+
 ```yaml
 jobs:
   build:

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -184,7 +184,7 @@ jobs:
       - image: buildpack-deps:trusty
     resource_class: xlarge
     steps:
-      ... // other config
+    #  ...  other config
 ```
 
 ## Using Machine

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -158,6 +158,35 @@ Capability | `docker` | `machine`
 
 For more information on `machine`, see the next section below.
 
+
+### Available Docker Resource Classes
+
+The [`resource_class`]({{ site.baseurl }}/2.0/configuration-reference/#resource_class) key allows you to configure CPU and RAM resources for each
+job. In Docker, the following resources classes are available:
+
+Class                 | vCPUs | RAM
+----------------------|-------|-----
+small                 | 1     | 2GB
+medium (default)      | 2     | 4GB
+medium+               | 3     | 6GB
+large                 | 4     | 8GB
+xlarge                | 8     | 16GB
+2xlarge<sup>(2)</sup> | 16    | 32GB
+2xlarge+<sup>(2)</sup>| 20    | 40GB
+{: class="table table-striped"}
+
+Where example usage looks like the following:
+
+```yaml
+jobs:
+  build:
+    docker:
+      - image: buildpack-deps:trusty
+    resource_class: xlarge
+    steps:
+      ... // other config
+```
+
 ## Using Machine
 
 The `machine` option runs your jobs in a dedicated, ephemeral VM that has the following specifications:


### PR DESCRIPTION
Get to parity between configuration reference and executor types.