### PR TITLE
size up h6 so they aren't smaller than main text

### DIFF
--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -419,3 +419,7 @@ pre {
   border: 1px solid grey;
   border-radius: 3px;
 }
+
+h6{
+	font-size: 16px;
+}


### PR DESCRIPTION
This is probably a very clunky way of getting the desired result but.....

h6 now same size at h5, but h6 is generally in italics.

Original report here: https://circleci.slack.com/archives/C0KBNJGRH/p1587401595092400

before:
<img width="779" alt="Screenshot 2020-04-24 at 08 55 34" src="https://user-images.githubusercontent.com/24589403/80188677-6bd26680-8609-11ea-909b-305414628fb2.png">

after:
<img width="783" alt="Screenshot 2020-04-24 at 08 55 47" src="https://user-images.githubusercontent.com/24589403/80188710-77259200-8609-11ea-96c3-3f7a18c1614f.png">

