### PR TITLE
All external links should open in new tabs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :jekyll_plugins do
   gem 'jekyll-algolia', '~> 1.0'
   gem 'jekyll-sitemap'
   gem 'jekyll-assets'
+  gem 'jekyll-target-blank'
   # jekyll-assets depends on sprockets, which depends on rack, which has two
   # security vulnerabilities prior to 2.0.6.
   # https://nvd.nist.gov/vuln/detail/CVE-2018-16471

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
       sass (~> 3.4)
     jekyll-sitemap (1.3.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-target-blank (2.0.0)
+      jekyll (>= 3.0, < 5.0)
+      nokogiri (~> 1.10)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.2.0)
@@ -188,6 +191,7 @@ DEPENDENCIES
   jekyll-asciidoc
   jekyll-assets
   jekyll-sitemap
+  jekyll-target-blank
   pygments.rb (~> 1.1.2)
   rack (>= 2.0.6)
 

--- a/jekyll/_cci2/admin-faq.adoc
+++ b/jekyll/_cci2/admin-faq.adoc
@@ -104,14 +104,16 @@ sudo systemctl restart replicated
 sudo systemctl restart replicated-operator
 ```
 
-Then try restarting the CircleCi app: go to your services box admin (for example, `https://<your-circleci-hostname>.com:8800`) and try restarting with "Stop Now" and "Start Now".
+Then try restarting the CircleCi app: go to your services box admin (for example, `<your-circleci-hostname>.com:8800`) and try restarting with "Stop Now" and "Start Now".
 
 // add screenshot showing StopNow and StartNow -->
 
 [discrete]
 ==== 3. Try to log into Replicated
 
-Try logging in to Replicated. You can do this by running the following command on the service box. You will be asked to enter your password - the same one used to unlock the Management Console (i.e. `https://<your-circleci-hostname>.com:8800`).
+Try logging in to Replicated. You can do this by running the following command
+on the service box. You will be asked to enter your password - the same one used
+to unlock the Management Console (i.e.  `<your-circleci-hostname>.com:8800` ).
 
 ```shell
 replicated login

--- a/jekyll/_cci2/build-artifacts.adoc
+++ b/jekyll/_cci2/build-artifacts.adoc
@@ -100,7 +100,7 @@ Also, by default, the following types will be rendered as plain text:
 == Allow Unsafe Content types
 If you would like to allow content types that are not included in the whitelist above, follow these steps:
 
-1. Navigate to the CircleCI Management Console (for example, `https://<your-circleci-hostname>:8800/settings`) and select Settings from the menu bar.
+1. Navigate to the CircleCI Management Console (for example, `<your-circleci-hostname>:8800/settings`) and select Settings from the menu bar.
 2. Scroll down to find the Artifacts section.
 3. Select Serve Artifacts with Unsafe Content-Types.
 +

--- a/jekyll/_cci2/certificates.adoc
+++ b/jekyll/_cci2/certificates.adoc
@@ -153,7 +153,7 @@ You may use various solutions to generate valid SSL certificate and key file. Tw
 
 This section describes setting up TLS/HTTPS on your Server install using Certbot by manually adding a DNS record set to the Services machine. Certbot generally relies on verifying the DNS record via either port 80 or 443, however this is not supported on CircleCI Server installations as of 2.2.0 because of port conflicts.
 
-. Stop the Service CircleCI Server Management Console (`http://<circleci-hostname>.com:8800`).
+. Stop the Service CircleCI Server Management Console (`<circleci-hostname>.com:8800`).
 
 . SSH into the Services machine.
 
@@ -190,6 +190,6 @@ Once you have a valid certificate and key file in `.pem` format, you must upload
 
 More information is available https://letsencrypt.readthedocs.io/en/latest/using.html#manual[here].
 
-Ensure the hostname is properly configured from the Management Console (`http://<circleci-hostname>.com:8800`) **and** that the hostname used matches the DNS records associated with the TLS certificates.
+Ensure the hostname is properly configured from the Management Console (`<circleci-hostname>.com:8800`) **and** that the hostname used matches the DNS records associated with the TLS certificates.
 
 Make sure the Auth Callback URL in GitHub/GHE matches the domain name pointing to the Services machine, including the protocol used, for example `**https**://info-tech.io/`.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -317,7 +317,7 @@ Once created, environment variables are hidden and uneditable in the application
 
 ## Setting an Environment Variable in a Container
 
-Environment variables can also be set for a Docker container. To do this, use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#docker--machine--macos--windows-executor). 
+Environment variables can also be set for a Docker container. To do this, use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#docker). 
 
 **Note**: Environment variables set in this way are not available to _steps_ run within the container, they are only available to the entrypoint/command run _by_ the container. By default, CircleCI will ignore the entrypoint for a job's primary container. For the primary container's environment variables to be useful, you will need to preserve the entrypoint. For more information, see the [_adding an entrypoint_ section of the Custom Images guide]({{ site.baseurl }}/2.0/custom-images/#adding-an-entrypoint).
 

--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -79,7 +79,7 @@ provide a more in-depth overview of how a `config.yml` works.
 
 Since this is a general introduction to building on MacOs, the `config.yml` above example covers the following:
 
-- Picking an [`executor`]({{ site.baseurl }}/2.0/configuration-reference/#docker--machine--macos--windows-executor) to use 
+- Picking an [`executor`]({{ site.baseurl }}/2.0/configuration-reference/#docker) to use 
 - Pulling code via the [`checkout`]({{ site.baseurl }}/2.0/configuration-reference/#checkout) key
 - Running tests with Xcode
 - Building our application

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -100,7 +100,7 @@ See the table in the next section to compare configuration.
 | Github Config | CircleCI Config
 
 2+| Specifying execution environment. While container execution is specified separately in Github, +
-`docker` is its https://circleci.com/docs/2.0/configuration-reference/#docker--machine--macos--windows-executor[own class of executor] in CircleCI.
+`docker` is its https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor[own class of executor] in CircleCI.
 
 a|
 [source, yaml]

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -235,7 +235,7 @@ For larger and more complex build files, we recommend moving over the build step
 . https://circleci.com/docs/2.0/configuration-reference/#checkout[Checkout code]
 . https://circleci.com/docs/2.0/env-vars/[Environment variables] and https://circleci.com/docs/2.0/contexts/[Contexts]
 . Install dependencies, also see https://circleci.com/docs/2.0/caching/[Cache dependencies]
-. https://circleci.com/docs/2.0/configuration-reference/#docker--machine--macosexecutor[Service containers]
+. https://circleci.com/docs/2.0/configuration-reference/#docker[Service containers]
 . Run testing commands
 . https://circleci.com/docs/2.0/custom-images/[Custom convenience images]
 . https://circleci.com/docs/2.0/configuration-reference/#resource_class[Resource classes]

--- a/jekyll/_cci2/monitoring.adoc
+++ b/jekyll/_cci2/monitoring.adoc
@@ -25,7 +25,7 @@ Following are the enabled metrics:
 * https://github.com/influxdata/telegraf/blob/master/plugins/inputs/cpu/README.md#cpu-time-measurements[CPU]
 * https://github.com/influxdata/telegraf/blob/master/plugins/inputs/disk/README.md#metrics[Disk]
 * https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mem/README.md#metrics[Memory]
-* https://github.com/influxdata/telegraf/blob/master/plugins/inputs/net/NET_README.md#measurements--fields[Networking]
+* https://github.com/influxdata/telegraf/blob/master/plugins/inputs/net/NET_README.md[Networking]
 * https://github.com/influxdata/telegraf/tree/master/plugins/inputs/docker#metrics[Docker]
 
 === Nomad Job Metrics

--- a/jekyll/_cci2/ops.adoc
+++ b/jekyll/_cci2/ops.adoc
@@ -366,7 +366,7 @@ https://www.replicated.com/docs/kb/supporting-your-customers/resetting-console-p
 
 . SSH into the services box
 . Use the following command: `replicated auth reset` to remove the password
-. Visit `https://<server>:8800/create-password` to create a new password or connect LDAP.
+. Visit `<server>:8800/create-password` to create a new password or connect LDAP.
 
 === How do I resolve the case of VM spin-up / spin-down issues?
 

--- a/jekyll/_cci2/v.2.17-overview.md
+++ b/jekyll/_cci2/v.2.17-overview.md
@@ -93,13 +93,13 @@ Steps to update to CircleCI Server v2.17 are as follows:
 1. Take a snapshot of your installation so you can rollback later if necessary (optional but recommended)
 2. Check you are running Docker v17.12.1 and update if necessary
 3. Update Replicated to v2.34.1 (steps in section below)
-4. Navigate to your Management Console dashboard (e.g. `https://<your-circleci-hostname>.com:8800`) and select the v2.17 upgrade
+4. Navigate to your Management Console dashboard (e.g. `<your-circleci-hostname>.com:8800`) and select the v2.17 upgrade
 
 ### Snapshot for Rollback
 
 To take a snapshot of your installation:
 
-1. Go to the Management Console (`http://<circleci-hostname>.com:8800`) and click Stop Now to stop the CircleCI Services machine from running
+1. Go to the Management Console (`<circleci-hostname>.com:8800`) and click Stop Now to stop the CircleCI Services machine from running
 2. Ensure no jobs are running on the nomad clients – check by running `nomad status`
 3. Navigate to the AWS EC2 management console and select your Services machine instance
 4. Select Actions > Image > Create Image – Select the No Reboot option if you want to avoid downtime at this point. This image creation step creates an AMI that can be readily launched as a new EC2 instance to restore your installation.

--- a/jekyll/_cci2_ja/creating-orbs.md
+++ b/jekyll/_cci2_ja/creating-orbs.md
@@ -49,7 +49,7 @@ Orbs を使用する前に、Orbs パブリッシュプロセス全体につい�
 
 - [CircleCI CLI のダウンロードとインストール](https://circleci.com/docs/ja/2.0/creating-orbs/#installing-the-cli-for-the-first-time)
 - [CLI の更新](https://circleci.com/docs/ja/2.0/creating-orbs/#updating-the-circleci-cli-after-installation)
-- [CLI の設定](https://circleci.com/docs/ja/2.0/creating-orbs/#circleci-cli-の設定)
+- [CLI の設定](https://circleci.com/docs/ja/2.0/creating-orbs)
 
 #### ステップ 2 - CLI が正しくインストールされていることを検証する
 

--- a/jekyll/_cci2_ja/deployment-integrations.md
+++ b/jekyll/_cci2_ja/deployment-integrations.md
@@ -68,7 +68,10 @@ ECR から AWS ECS にデプロイする方法については、「[AWS ECR/ECS 
 
 1. セキュリティ上のベストプラクティスとして、CircleCI 専用の新しい [IAM ユーザー](https://aws.amazon.com/jp/iam/details/manage-users/)を作成します。
 
-2. [AWS アクセスキー](https://docs.aws.amazon.com/ja_jp/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)を[プロジェクト環境変数](https://circleci.com/docs/ja/2.0/env-vars/#プロジェクト内で環境変数を設定する)または[コンテキスト環境変数](https://circleci.com/docs/ja/2.0/env-vars/#context内で環境変数を設定する)として CircleCI に追加します。 アクセスキー ID を `AWS_ACCESS_KEY_ID` という変数に、またシークレットアクセスキーを `AWS_SECRET_ACCESS_KEY` という変数に格納します。
+2. [AWS アクセス
+   キー
+   ](https://docs.aws.amazon.com/ja_jp/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
+   を[プロジェクト環境変数](https://circleci.com/docs/ja/2.0/env-vars/#) または [コンテキスト環境変 数](https://circleci.com/docs/ja/2.0/env-vars/) として CircleCI に追加します。 アクセスキー ID を `AWS_ACCESS_KEY_ID` という変数に、またシークレットアクセスキーを `AWS_SECRET_ACCESS_KEY` という変数に格納します。
 
 3. `.circleci/config.yml` ファイルで、新しい `deploy` ジョブを作成します。 `deploy` ジョブで、プライマリコンテナに `awscli` をインストールするステップを追加します。
 

--- a/jekyll/_cci2_ja/env-vars.md
+++ b/jekyll/_cci2_ja/env-vars.md
@@ -131,7 +131,7 @@ jobs:
 <a name="setting-an-environment-variable-in-a-container"></a>
 ## コンテナ内で環境変数を設定する
 
-コンテナの中で環境変数を設定するには [`environment` キー]({{ site.baseurl }}/ja/2.0/configuration-reference/#docker--machine--macosexecutor)を使います。
+コンテナの中で環境変数を設定するには [`environment` キー]({{ site.baseurl }}/ja/2.0/configuration-reference/#docker)を使います。
 
 ```yaml
 version: 2

--- a/jekyll/_cci2_ja/hello-world-macos.md
+++ b/jekyll/_cci2_ja/hello-world-macos.md
@@ -67,7 +67,7 @@ jobs: # 1回の実行の基本作業単位
 
 macOS でのビルドの基礎について説明しているため、上記のサンプルの `config.yml` には以下の内容が含まれています。
 
-- 使用する [`executor`]({{ site.baseurl }}/ja/2.0/configuration-reference/#docker--machine--macosexecutor) の選択
+- 使用する [`executor`]({{ site.baseurl }}/ja/2.0/configuration-reference/#docker) の選択
 - [`checkout`]({{ site.baseurl }}/ja/2.0/configuration-reference/#checkout) キーによるコードのプル
 - Xcode でのテストの実行
 - アプリケーションのビルド

--- a/jekyll/_cci2_ja/monitoring.md
+++ b/jekyll/_cci2_ja/monitoring.md
@@ -23,7 +23,7 @@ Services VM ホストと Docker のメトリクスは、メトリクスを収集
 * [CPU](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/cpu/README.md#cpu-time-measurements)
 * [ディスク](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/disk/README.md#metrics)
 * [メモリ](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/mem/README.md#metrics)
-* [ネットワーク通信](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/net/NET_README.md#measurements--fields)
+* [ネットワーク通信](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/net/NET_README.md)
 * [Docker](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/docker#metrics)
 
 #### Nomad ジョブのメトリクス

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -13,6 +13,7 @@ plugins:
   - jekyll-assets
   - jekyll-sitemap
   - jekyll-asciidoc
+  - jekyll-target-blank
 
 algolia:
   application_id: U0RXNGRK45

--- a/jekyll/_plugins/target_links.rb
+++ b/jekyll/_plugins/target_links.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+## this patches the jekyll-target-blank gem: https://github.com/keithmifsud/jekyll-target-blank/
+## see here: https://github.com/keithmifsud/jekyll-target-blank/pull/46 for more details.
+## to allow uri escaping, enabling non-asci urls.
+require 'jekyll-target-blank'
+
+module Jekyll
+  class TargetBlank
+    class << self
+      def external?(link)
+        if link&.match?(URI.regexp(%w(http https)))
+          URI.parse(URI.escape(link)).host != URI.parse(URI.escape(@site_url)).host
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes https://github.com/circleci/circleci-docs/issues/4293.

Adds a new [jekyll plugin](https://github.com/keithmifsud/jekyll-target-blank/)  as well as patches it to make urls work with non-ascii characters.

Note: the `jekyll-target-blank` plugin also pointed out several invalid links that we had in our url. Many of these urls are in our server documentation serve as example urls. For example:

> Visit `https://<server>:8800/create-password` to create a new password or connect LDAP.

Where this will actually render a link, at least in ascidoc, which means we have weird dead links sprinkled throughout our documentation. I have removed all instances of `http|https` in these urls, so they remain plain text. If this behaviour is intention let me know cc @rosieyohannan .