### PR TITLE
Node language guide update

### DIFF
--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -14,18 +14,12 @@ This document provides a walkthrough of the [`.circleci/config.yml`]({{ site.bas
 
 ## Quickstart: Demo JavaScript Node.js Reference Project
 
-We maintain a reference JavaScript Node.js project to show how to build an Express.js app on CircleCI with `version: 2.1` configuration:
+We maintain a reference JavaScript project to show how to build a React.js app on CircleCI with `version: 2.1` configuration:
 
-- <a href="https://github.com/CircleCI-Public/circleci-demo-javascript-express" target="_blank">Demo JavaScript Node Project on GitHub</a>
+- [Demo JavaScript Node Project on GitHub](https://github.com/CircleCI-Public/circleci-demo-javascript-express)
 - [Demo JavaScript Node Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express){:rel="nofollow"}
 
-In the project you will find a CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-javascript-express/blob/master/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using version 2.1 config with Node projects.
-
-## Pre-Built CircleCI Docker Images
-
-We recommend using a CircleCI pre-built image that comes pre-installed with tools that are useful in a CI environment. You can select the Node version you need from Docker Hub: <https://hub.docker.com/r/circleci/node/>. The demo project uses an official CircleCI image.
-
-Database images for use as a secondary 'service' container are also available.
+In the project you will find a CircleCI configuration file [`.circleci/config.yml`](https://github.com/CircleCI-Public/circleci-demo-javascript-react-app/blob/2.1-orb-example/.circleci/config.yml). This file shows best practice for using version 2.1 config with Node projects.
 
 ## Build the Demo JavaScript Node Project Yourself
 
@@ -38,140 +32,38 @@ A good way to start using CircleCI is to build a project yourself. Here's how to
 
 ## Sample Configuration
 
-Following is the `.circleci/config.yml` file in the demo project with comments.
+Below is the `.circleci/config.yml` file in the demo project.
 
 {% raw %}
+
 ```yaml
-version: 2.1 # use CircleCI 2.1
-jobs: # a collection of steps
-  build: # runs not using Workflows must have a `build` job as entry point
-    working_directory: ~/mern-starter # directory where steps will run
-    docker: # run the steps with Docker
-      - image: circleci/node:10.16.3 # ...with this image as the primary container; this is where all `steps` will run
-      - image: mongo:4.2.0 # and this image as the secondary service container
-    steps: # a collection of executable commands
-      - checkout # special step to check out source code to working directory
-      - run:
-          name: update-npm
-          command: 'sudo npm install -g npm@latest'
-      - restore_cache: # special step to restore the dependency cache
-          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: install-npm-wee
-          command: npm install
-      - save_cache: # special step to save the dependency cache
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
-      - run: # run tests
-          name: test
-          command: npm test
-      - run: # run coverage report
-          name: code-coverage
-          command: './node_modules/.bin/nyc report --reporter=text-lcov'
-      - store_artifacts: # special step to save test results as as artifact
-          # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/ 
-          path: test-results.xml
-          prefix: tests
-      - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/ 
-          path: coverage
-          prefix: coverage
-      - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
-          path: test-results.xml
-      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
+orbs: # declare what orbs we are going to use
+  node: circleci/node@2.0.2 # the node orb provdies common node-related configuration 
+
+version: 2.1 # using 2.1 provides access to orbs and other features
+
+workflows:
+  matrix-tests:
+    jobs:
+      - node/test:
+          version: 13.11.0
+      - node/test:
+          version: 12.16.0
+      - node/test:
+          version: 10.19.0
 ```
 {% endraw %}
----
 
 ## Config Walkthrough
 
+By using the  [2.1 Node orb](https://circleci.com/orbs/registry/orb/circleci/node#jobs-test), it sets an executor from CircleCI's highly cached convenience images built for CI and allows you to set the version of NodeJS to use. Any available tag in the [docker image list](https://hub.docker.com/r/cimg/node/tags) can be used.
+ 
+The Node Orb `test` command will test your code with a one-line command, with optional parameters.
 
-Every `config.yml` starts with the [`version`]({{ site.baseurl }}/2.0/configuration-reference/#version) key.
-This key is used
-to issue warnings about breaking changes.
+Matrix jobs are a simple way to test your Node app on various node environments. For a more in depth example of how the Node orb utilizes matrix jobs, see our blog on [matrix jobs](https://circleci.com/blog/circleci-matrix-jobs/). See [documentation on pipeline parameters](https://circleci.com/docs/2.0/pipeline-variables/#pipeline-parameters-in-configuration) to learn how to set a node version via Pipeline parameters.
 
-```yaml
-version: 2.1
-```
+Success! You just set up a Node.js app to build on CircleCI with version: 2.1 configuration. Check out our project’s Job page to see how this looks when building on CircleCI.
 
-A run is comprised of one or more [jobs]({{ site.baseurl }}/2.0/configuration-reference/#jobs).
-Because this run does not use [workflows]({{ site.baseurl }}/2.0/configuration-reference/#workflows),
-it must have a `build` job.
-
-Use the [`working_directory`]({{ site.baseurl }}/2.0/configuration-reference/#job_name) key
-to specify where a job's [`steps`]({{ site.baseurl }}/2.0/configuration-reference/#steps) run. By default, the value of `working_directory` is `~/project`, where `project` is a literal string.
-
-The steps of a job occur in a virtual environment called an [executor]({{ site.baseurl }}/2.0/executor-types/).
-
-In this example, the [`docker`]({{ site.baseurl }}/2.0/configuration-reference/#docker) executor is used
-to specify a custom Docker image. The first image listed becomes the job's [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container). All commands for a job execute in this container.
-
-```yaml
-jobs:
-  build:
-    working_directory: ~/mern-starter
-    docker:
-      - image: circleci/node:4.8.2
-      - image: mongo:3.4.4
-```
-
-After choosing containers for a job,
-create [`steps`]({{ site.baseurl }}/2.0/configuration-reference/#steps) to run specific commands.
-
-Use the [`checkout`]({{ site.baseurl }}/2.0/configuration-reference/#checkout) step
-to check out source code. By default, source code is checked out to the path specified by `working_directory`.
-
-To save time between runs, consider [caching dependencies or source code]({{ site.baseurl }}/2.0/caching/).
-
-Use the [`save_cache`]({{ site.baseurl
-}}/2.0/configuration-reference/#save_cache) step to cache certain files or
-directories. In this example, we cache `node_modules` using a checksum of the
-`package-lock.json` as the cache-key.
-
-Use the [`restore_cache`]({{ site.baseurl }}/2.0/configuration-reference/#restore_cache) step
-to restore cached files or directories.
-
-{% raw %}
-```yaml
-    steps:
-      - checkout
-      - run:
-          name: update-npm
-          command: 'sudo npm install -g npm@latest'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: install-npm-wee
-          command: npm install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
-```
-{% endraw %}
-
-Now that dependencies are installed we can run the test suite
-and upload the test results as an artifact (made available on the CircleCI web app).
-
-```yaml
-      - run:
-          name: test
-          command: npm test
-      - run:
-          name: code-coverage
-          command: './node_modules/.bin/nyc report --reporter=text-lcov'
-      - store_artifacts:
-          path: test-results.xml
-          prefix: tests
-      - store_artifacts:
-          path: coverage
-          prefix: coverage
-      - store_test_results:
-          path: test-results.xml
-```
-
-Success! You just set up a Node.js app to build on CircleCI with `version: 2.1` configuration. Check out our project’s [Job page](https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express){:rel="nofollow"} to see how this looks when building on CircleCI.
 
 ## See Also
 {:.no_toc}

--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -16,8 +16,8 @@ This document provides a walkthrough of the [`.circleci/config.yml`]({{ site.bas
 
 We maintain a reference JavaScript project to show how to build a React.js app on CircleCI with `version: 2.1` configuration:
 
-- [Demo JavaScript Node Project on GitHub](https://github.com/CircleCI-Public/circleci-demo-javascript-express)
-- [Demo JavaScript Node Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express){:rel="nofollow"}
+- [Demo JavaScript Node Project on GitHub](https://github.com/CircleCI-Public/circleci-demo-javascript-react-app)
+- [Demo JavaScript Node Project building on CircleCI](https://app.circleci.com/pipelines/github/CircleCI-Public/circleci-demo-javascript-react-app){:rel="nofollow"}
 
 In the project you will find a CircleCI configuration file [`.circleci/config.yml`](https://github.com/CircleCI-Public/circleci-demo-javascript-react-app/blob/master/.circleci/config.yml). This file shows best practice for using version 2.1 config with Node projects.
 
@@ -54,17 +54,16 @@ workflows:
 ```
 {% endraw %}
 
-
+  
 ## Config Walkthrough
 
-By using the [2.1 Node orb](https://circleci.com/orbs/registry/orb/circleci/node#jobs-test), it sets an executor from CircleCI's highly cached convenience images built for CI and allows you to set the version of NodeJS to use. Any available tag in the [docker image list](https://hub.docker.com/r/cimg/node/tags) can be used.
+Using the [2.1 Node orb](https://circleci.com/orbs/registry/orb/circleci/node#jobs-test) sets an executor from CircleCI's highly cached convenience images built for CI and allows you to set the version of NodeJS to use. Any available tag in the [docker image list](https://hub.docker.com/r/cimg/node/tags) can be used.
  
 The Node Orb `test` command will test your code with a one-line command, with optional parameters.
 
 Matrix jobs are a simple way to test your Node app on various node environments. For a more in depth example of how the Node orb utilizes matrix jobs, see our blog on [matrix jobs](https://circleci.com/blog/circleci-matrix-jobs/). See [documentation on pipeline parameters](https://circleci.com/docs/2.0/pipeline-variables/#pipeline-parameters-in-configuration) to learn how to set a node version via Pipeline parameters.
 
-Success! You just set up a Node.js app to build on CircleCI with version: 2.1 configuration. Check out our project’s Job page to see how this looks when building on CircleCI.
-
+Success! You just set up a Node.js app to build on CircleCI with version: 2.1 configuration. Check out [our project’s pipeline page](https://app.circleci.com/pipelines/github/CircleCI-Public/circleci-demo-javascript-react-app) to see how this looks when building on CircleCI.
 
 ## See Also
 {:.no_toc}

--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -19,7 +19,7 @@ We maintain a reference JavaScript project to show how to build a React.js app o
 - [Demo JavaScript Node Project on GitHub](https://github.com/CircleCI-Public/circleci-demo-javascript-express)
 - [Demo JavaScript Node Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-javascript-express){:rel="nofollow"}
 
-In the project you will find a CircleCI configuration file [`.circleci/config.yml`](https://github.com/CircleCI-Public/circleci-demo-javascript-react-app/blob/2.1-orb-example/.circleci/config.yml). This file shows best practice for using version 2.1 config with Node projects.
+In the project you will find a CircleCI configuration file [`.circleci/config.yml`](https://github.com/CircleCI-Public/circleci-demo-javascript-react-app/blob/master/.circleci/config.yml). This file shows best practice for using version 2.1 config with Node projects.
 
 ## Build the Demo JavaScript Node Project Yourself
 
@@ -38,7 +38,7 @@ Below is the `.circleci/config.yml` file in the demo project.
 
 ```yaml
 orbs: # declare what orbs we are going to use
-  node: circleci/node@2.0.2 # the node orb provdies common node-related configuration 
+  node: circleci/node@2.0.2 # the node orb provides common node-related configuration 
 
 version: 2.1 # using 2.1 provides access to orbs and other features
 
@@ -54,9 +54,10 @@ workflows:
 ```
 {% endraw %}
 
+
 ## Config Walkthrough
 
-By using the  [2.1 Node orb](https://circleci.com/orbs/registry/orb/circleci/node#jobs-test), it sets an executor from CircleCI's highly cached convenience images built for CI and allows you to set the version of NodeJS to use. Any available tag in the [docker image list](https://hub.docker.com/r/cimg/node/tags) can be used.
+By using the [2.1 Node orb](https://circleci.com/orbs/registry/orb/circleci/node#jobs-test), it sets an executor from CircleCI's highly cached convenience images built for CI and allows you to set the version of NodeJS to use. Any available tag in the [docker image list](https://hub.docker.com/r/cimg/node/tags) can be used.
  
 The Node Orb `test` command will test your code with a one-line command, with optional parameters.
 


### PR DESCRIPTION
Updates to the language guide to use 2.1/orbs. 

_Do not merge_ until 2.1 config changes are merged into master in the [sample repo](https://github.com/CircleCI-Public/circleci-demo-javascript-react-app/pull/17/files). I think this guide will get more content, so it will be revisited. For example, the sample app only demonstrates testing - it might be useful to demonstrate _building_ the react app. 