### PR TITLE
Fix incorrect aws-ecr-orb command name

### DIFF
--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -90,14 +90,14 @@ orbs:
 workflows:
   build-and-deploy:
     jobs:
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           account-url: '${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com'
           repo: '${MY_APP_PREFIX}'
           region: '${AWS_REGION}'
           tag: '${CIRCLE_SHA1}'
       - aws-ecs/deploy-service-update:
           requires:
-            - aws-ecr/build_and_push_image
+            - aws-ecr/build-and-push-image
           family: '${MY_APP_PREFIX}-service'
           cluster-name: '${MY_APP_PREFIX}-cluster'
           container-image-name-updates: 'container=${MY_APP_PREFIX}-service,tag=${CIRCLE_SHA1}'

--- a/jekyll/_cci2/deployment-examples.md
+++ b/jekyll/_cci2/deployment-examples.md
@@ -132,7 +132,7 @@ For a complete list of AWS CLI commands and options, see the [AWS CLI Command Re
 {:.no_toc}
 The AWS ECR orb enables you to log into AWS, build, and then push a Docker image to AWS Elastic Container Registry with minimal config. See the [orb registry page](https://circleci.com/orbs/registry/orb/circleci/aws-ecr) for a full list of parameters, jobs, commands and options.
 
-Using the `build_and_push_image` job, as shown below requires the following env vars to be set: `AWS_ECR_ACCOUNT_URL`, `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `AWS_REGION`. {% include snippets/env-var-or-context.md %}
+Using the `build-and-push-image` job, as shown below requires the following env vars to be set: `AWS_ECR_ACCOUNT_URL`, `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `AWS_REGION`. {% include snippets/env-var-or-context.md %}
 
 {% raw %}
 
@@ -145,7 +145,7 @@ orbs:
 workflows:
   build_and_push_image: 
     jobs:
-      - aws-ecr/build_and_push_image: # Use the pre-defined `build_and_push_image` job
+      - aws-ecr/build-and-push-image: # Use the pre-defined `build-and-push-image` job
           dockerfile: <my-Docker-file>
           path: <path-to-my-Docker-file>
           profile-name: <my-profile-name>
@@ -160,7 +160,7 @@ workflows:
 
 Use the [AWS ECR](https://circleci.com/orbs/registry/orb/circleci/aws-ecr) and [ECS](https://circleci.com/orbs/registry/orb/circleci/aws-ecs) orbs to easily update an existing AWS ECS instance.
 
-Using the `build_and_push_image` job, as shown below requires the following env vars to be set: `AWS_ECR_ACCOUNT_URL`, `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `AWS_REGION`. {% include snippets/env-var-or-context.md %}
+Using the `build-and-push-image` job, as shown below requires the following env vars to be set: `AWS_ECR_ACCOUNT_URL`, `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `AWS_REGION`. {% include snippets/env-var-or-context.md %}
 
 {% raw %}
 
@@ -174,7 +174,7 @@ orbs:
 workflows:
   build-and-deploy:
     jobs:
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           dockerfile: <my-Docker-file>
           path: <path-to-my-Docker-file>
           profile-name: <my-profile-name>
@@ -182,7 +182,7 @@ workflows:
           tag: '${CIRCLE_SHA1}' 
       - aws-ecs/deploy-service-update:
           requires:
-            - aws-ecr/build_and_push_image # only run the deployment job once the build and push image job has completed
+            - aws-ecr/build-and-push-image # only run the deployment job once the build and push image job has completed
           family: '${MY_APP_PREFIX}-service'
           cluster-name: '${MY_APP_PREFIX}-cluster'
           container-image-name-updates: 'container=${MY_APP_PREFIX}-service,tag=${CIRCLE_SHA1}'

--- a/jekyll/_cci2/ecs-ecr.md
+++ b/jekyll/_cci2/ecs-ecr.md
@@ -71,7 +71,7 @@ Notice the orbs are versioned with tags, for example, `aws-ecr: circleci/aws-ecr
 
 ### Build and Push the Docker image to AWS ECR
 
-The `build_and_push_image` job builds a Docker image from a Dockerfile in the default location (i.e. root of the checkout directory) and pushes it to the specified ECR repository.
+The `build-and-push-image` job builds a Docker image from a Dockerfile in the default location (i.e. root of the checkout directory) and pushes it to the specified ECR repository.
 
 ```yaml
 version: 2.1
@@ -83,7 +83,7 @@ orbs:
 workflows:
   build-and-deploy:
     jobs:
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           repo: "${AWS_RESOURCE_NAME_PREFIX}"
           tag: "${CIRCLE_SHA1}"
 ```
@@ -91,7 +91,7 @@ workflows:
 ### Deploy the new Docker image to an existing AWS ECS service
 The `deploy-service-update` job of the aws-ecs orb creates a new task definition that is based on the current task definition, but with the new Docker image specified in the task definition's container definitions, and deploys the new task definition to the specified ECS service. If you would like more information about the CircleCI AWS-ECS orb, go to: https://circleci.com/orbs/registry/orb/circleci/aws-ecs
 
-**Note** The `deploy-service-update` job depends on `build_and_push_image` because of the `requires` key.
+**Note** The `deploy-service-update` job depends on `build-and-push-image` because of the `requires` key.
 
 ```yaml
 version: 2.1
@@ -103,12 +103,12 @@ orbs:
 workflows:
   build-and-deploy:
     jobs:
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           repo: "${AWS_RESOURCE_NAME_PREFIX}"
           tag: "${CIRCLE_SHA1}"
       - aws-ecs/deploy-service-update:
           requires:
-            - aws-ecr/build_and_push_image # only run this job once aws-ecr/build_and_push_image has completed
+            - aws-ecr/build-and-push-image # only run this job once aws-ecr/build-and-push-image has completed
           family: "${AWS_RESOURCE_NAME_PREFIX}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX}-cluster"
           container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX}-service,tag=${CIRCLE_SHA1}"

--- a/jekyll/_cci2_ja/deployment-integrations.md
+++ b/jekyll/_cci2_ja/deployment-integrations.md
@@ -153,7 +153,7 @@ AWS S3 Orb の詳細については、[CircleCI AWS S3 Orb リファレンス](h
     workflows:
       build_and_push_image:
         jobs:
-          - aws-ecr/build_and_push_image:
+          - aws-ecr/build-and-push-image:
               account-url: AWS_ECR_ACCOUNT_URL_ENV_VAR_NAME
               aws-access-key-id: ACCESS_KEY_ID_ENV_VAR_NAME
               aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
@@ -178,7 +178,7 @@ AWS S3 Orb の詳細については、[CircleCI AWS S3 Orb リファレンス](h
     workflows:
       build-and-deploy:
         jobs:
-          - aws-ecr/build_and_push_image:
+          - aws-ecr/build-and-push-image:
               account-url: '${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com'
               repo: '${MY_APP_PREFIX}'
               region: '${AWS_REGION}'
@@ -186,7 +186,7 @@ AWS S3 Orb の詳細については、[CircleCI AWS S3 Orb リファレンス](h
       '
           - aws-ecs/deploy-service-update:
               requires:
-                - aws-ecr/build_and_push_image
+                - aws-ecr/build-and-push-image
               family: '${MY_APP_PREFIX}-service'
               cluster-name: '${MY_APP_PREFIX}-cluster'
               container-image-name-updates: 'container=${MY_APP_PREFIX}-service,tag=${CIRCLE_SHA1}'

--- a/jekyll/_cci2_ja/ecs-ecr.md
+++ b/jekyll/_cci2_ja/ecs-ecr.md
@@ -66,7 +66,7 @@ AWS_RESOURCE_NAME_PREFIX | 必須の AWS リソースのプレフィックスで
 
 ### Docker イメージをビルドして AWS ECR にプッシュする
 
-`build_and_push_image` ジョブは、デフォルトの場所 (チェックアウトディレクトリのルート) に Dockerfile から Docker イメージをビルドし、それを指定された ECR リポジトリにプッシュします。
+`build-and-push-image` ジョブは、デフォルトの場所 (チェックアウトディレクトリのルート) に Dockerfile から Docker イメージをビルドし、それを指定された ECR リポジトリにプッシュします。
 
 ```yaml
 version: 2.1
@@ -76,7 +76,7 @@ orbs:
 workflows:
   build-and-deploy:
     jobs:
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           account-url: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}
           .amazonaws.com"
           repo: "${AWS_RESOURCE_NAME_PREFIX}"
@@ -89,7 +89,7 @@ workflows:
 
 aws-ecs Orb の `deploy-service-update` ジョブは、現在のタスク定義に基づきつつ、タスク定義のコンテナ定義で指定された新しい Docker イメージを使用して新しいタスク定義を作成し、この新しいタスク定義を指定された ECS サービスにデプロイします。 CircleCI AWS-ECS Orb の詳細については、https://circleci.com/orbs/registry/orb/circleci/aws-ecs を参照してください。
 
-**メモ：**`deploy-service-update` ジョブは、`requires` キーがあるため、`build_and_push_image` に依存します。
+**メモ：**`deploy-service-update` ジョブは、`requires` キーがあるため、`build-and-push-image` に依存します。
 
 ```yaml
 version: 2.1
@@ -102,7 +102,7 @@ workflows:
       - ...
       - aws-ecs/deploy-service-update:
           requires:
-            - aws-ecr/build_and_push_image
+            - aws-ecr/build-and-push-image
           aws-region: ${AWS_DEFAULT_REGION}
           family: "${AWS_RESOURCE_NAME_PREFIX}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX}-cluster"
@@ -111,7 +111,7 @@ workflows:
 
 ### ワークフローを準備する
 
-ワークフローを使用して、`build_and_push_image` ジョブと `deploy-service-update` ジョブをリンクします。
+ワークフローを使用して、`build-and-push-image` ジョブと `deploy-service-update` ジョブをリンクします。
 
 ```yaml
 version: 2.1
@@ -121,7 +121,7 @@ orbs:
 workflows:
   build-and-deploy:
     jobs:
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           account-url: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}
           .amazonaws.com"
           repo: "${AWS_RESOURCE_NAME_PREFIX}"
@@ -129,7 +129,7 @@ workflows:
           tag: "${CIRCLE_SHA1}"
       - aws-ecs/deploy-service-update:
           requires:
-            - aws-ecr/build_and_push_image
+            - aws-ecr/build-and-push-image
           aws-region: ${AWS_DEFAULT_REGION}
           family: "${AWS_RESOURCE_NAME_PREFIX}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX}-cluster"
@@ -148,14 +148,14 @@ orbs:
 workflows:
   build-and-deploy:
     jobs:
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           account-url: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           repo: "${AWS_RESOURCE_NAME_PREFIX}"
           region: ${AWS_DEFAULT_REGION}
           tag: "${CIRCLE_SHA1}"
       - aws-ecs/deploy-service-update:
           requires:
-            - aws-ecr/build_and_push_image
+            - aws-ecr/build-and-push-image
           aws-region: ${AWS_DEFAULT_REGION}
           family: "${AWS_RESOURCE_NAME_PREFIX}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX}-cluster"


### PR DESCRIPTION
# Description

The orb command names are incorrect.

Sources:
- https://github.com/CircleCI-Public/aws-ecr-orb/blob/master/src/commands/build-and-push-image.yml
- https://circleci.com/orbs/registry/orb/circleci/aws-ecr#jobs-build-and-push-image

# Reasons

When I tried to use aws-ecr-orb with `build_and_push_image` command (same as the document), it returned an error: `Cannot find a definition for job named aws-ecr/build_and_push_image` 
