### PR TITLE
Android language guide update 

### DIFF
--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -38,58 +38,43 @@ Studio](https://developer.android.com/studio).
 
 ## Sample Configuration
 
+The below is a sample configuration for an [Android sample application](https://github.com/CircleCI-Public/MoodTracker/blob/master/.circleci/config.yml).
+
 {% raw %}
 
 ```yaml
 version: 2.1 # set the version of your config to enable use of orbs.
 
 orbs: # orbs provide lots of bundled functionality for your specific config.
- android: circleci/android@0.2.0
+ android: circleci/android@0.2.1
 
 jobs:
   build: # setup a "build job
     executor: android/android # set our executor using the `android` orb declared above
     steps:
       - checkout # download your code from your VCS
+      - android/restore-build-cache # restore dependency cache if it exists.
       - run:
-          command: ./gradlew lint test # run a test run.
+          name: Download Dependencies
+          command: ./gradlew androidDependencies
+      - android/save-build-cache # Cache our dependencies
+      - run:
+          command: ./gradlew lint test
+      - store_artifacts: # for display in Artifacts: https://circleci.com/docs/2.0/artifacts/ 
+          path: app/build/reports
+          destination: reports
+      - store_test_results: # for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: app/build/test-results
+      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
 
-workflows: 
+workflows:
   build:
     jobs:
       - build 
+
 ```
 
 {% endraw %}
-
-## Config Walkthrough
-
-We always start with the version.
-
-```yaml
-version: 2.1
-```
-
-In this sample application, we use the [Android
-orb](https://circleci.com/orbs/registry/orb/circleci/android). Next, we have a
-jobs key. Each job represents a phase in your Build-Test-Deploy process. Our
-sample app only needs a build job, so everything else is going to live under
-that key.
- 
-For the Android orb, you can pull in the recommended CircleCI `cimg` base docker
-image for [android](https://hub.docker.com/r/cimg/android) simply by calling
-`android/android` under the `executor` key.
-
-
-```yaml
-jobs:
-  build:
-    executor: android/android
-```
-
-
-Then `./gradlew lint test` runs the unit tests, and runs the built in linting
-tools to check your code for style issues.
 
 ## Docker Images
 

--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -7,37 +7,32 @@ categories: [language-guides]
 order: 9
 ---
 
-This document describes
-how to set up an Android project on CircleCI
-in the following sections.
+This document describes how to set up an Android project on CircleCI in the
+following sections.
 
-* TOC
-{:toc}
+* TOC {:toc}
 
 ## Overview
 {:.no_toc}
 
-This guide provides an introduction to Android development on CircleCI.
-If you are looking for a `.circleci/config.yml` template for Android,
-see the [Sample Configuration](#sample-configuration) section of this document.
+This guide provides an introduction to Android development on CircleCI. If you
+are looking for a `.circleci/config.yml` template for Android, see the [Sample
+Configuration](#sample-configuration) section of this document.
 
-**Note:**
-Running the Android emulator is not supported
-by the type of virtualization CircleCI uses on Linux.
-To run emulator tests from a job,
-consider using an external service like [Firebase Test Lab](https://firebase.google.com/docs/test-lab).
-For more details,
-see the [Testing With Firebase Test Lab](#testing-with-firebase-test-lab) section below.
+**Note:** Running the Android emulator is not supported by the type of
+virtualization CircleCI uses on Linux. To run emulator tests from a job,
+consider using an external service like [Firebase Test
+Lab](https://firebase.google.com/docs/test-lab). For more details, see the
+[Testing With Firebase Test Lab](#testing-with-firebase-test-lab) section below.
 
 ## Prerequisites
 {:.no_toc}
 
 This guide assumes the following:
 
-- You are using [Gradle](https://gradle.org/)
-to build your Android project.
-Gradle is the default build tool
-for projects created with [Android Studio](https://developer.android.com/studio).
+- You are using [Gradle](https://gradle.org/) to build your Android project.
+Gradle is the default build tool for projects created with [Android
+Studio](https://developer.android.com/studio).
 - Your project is located in the root of your VCS repository.
 - The project's application is located in a subfolder named `app`.
 
@@ -89,9 +84,14 @@ We always start with the version.
 version: 2
 ```
 
-Next, we have a `jobs` key. Each job represents a phase in your Build-Test-Deploy process. Our sample app only needs a `build` job, so everything else is going to live under that key.
+Next, we have a `jobs` key. Each job represents a phase in your
+Build-Test-Deploy process. Our sample app only needs a `build` job, so
+everything else is going to live under that key.
 
-In each job, we have the option of specifying a `working_directory`. This is the directory into which our code will be checked out, and this path will be used as the default working directory for the rest of the `job` unless otherwise specified.
+In each job, we have the option of specifying a `working_directory`. This is the
+directory into which our code will be checked out, and this path will be used as
+the default working directory for the rest of the `job` unless otherwise
+specified.
 
 ```yaml
 jobs:
@@ -99,47 +99,74 @@ jobs:
     working_directory: ~/code
 ```
 
-Directly beneath `working_directory`, we can specify container images under a `docker` key.
+Directly beneath `working_directory`, we can specify container images under a
+`docker` key.
 
 ```yaml
     docker:
       - image: circleci/android:api-25-alpha
 ```
 
-We use the CircleCI-provided Android image with the `api-25-alpha` tag. See [Docker Images](#docker-images) below for more information about what images are available.
+We use the CircleCI-provided Android image with the `api-25-alpha` tag. See
+[Docker Images](#docker-images) below for more information about what images are
+available.
 
 Now we’ll add several `steps` within the `build` job.
 
 We start with `checkout` so we can operate on the codebase.
 
-Next we pull down the cache, if present. If this is your first run, or if you've changed either of your `build.gradle` files, this won't do anything. We run `./gradlew androidDependencies` next to pull down the project's dependencies. Normally you never call this task directly since it's done automatically when it's needed, but calling it directly allows us to insert a `save_cache` step that will store the dependencies in order to speed things up for next time.
+Next we pull down the cache, if present. If this is your first run, or if you've
+changed either of your `build.gradle` files, this won't do anything. We run
+`./gradlew androidDependencies` next to pull down the project's dependencies.
+Normally you never call this task directly since it's done automatically when
+it's needed, but calling it directly allows us to insert a `save_cache` step
+that will store the dependencies in order to speed things up for next time.
 
-Then `./gradlew lint test` runs the unit tests, and runs the built in linting tools to check your code for style issues.
+Then `./gradlew lint test` runs the unit tests, and runs the built in linting
+tools to check your code for style issues.
 
-We then upload the build reports as job artifacts, and we upload the test metadata (XML) for CircleCI to process.
+We then upload the build reports as job artifacts, and we upload the test
+metadata (XML) for CircleCI to process.
 
 ## Docker Images
 
-For convenience, CircleCI provides a set of Docker images for building Android apps. These pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/r/circleci/android/). The source code and Dockerfiles for these images are available in [this GitHub repository](https://github.com/circleci/circleci-images/tree/master/android).
+For convenience, CircleCI provides a set of Docker images for building Android
+apps. These pre-built images are available in the [CircleCI org on Docker
+Hub](https://hub.docker.com/r/circleci/android/). The source code and
+Dockerfiles for these images are available in [this GitHub
+repository](https://github.com/circleci/circleci-images/tree/master/android).
 
-The CircleCI Android image is based on the [`openjdk:8-jdk`](https://hub.docker.com/_/openjdk/) official Docker image, which is based on [buildpack-deps](https://hub.docker.com/_/buildpack-deps/). The base OS is Debian Jessie, and builds run as the `circleci` user, which has full access to passwordless `sudo`.
+The CircleCI Android image is based on the
+[`openjdk:8-jdk`](https://hub.docker.com/_/openjdk/) official Docker image,
+which is based on [buildpack-deps](https://hub.docker.com/_/buildpack-deps/).
+The base OS is Debian Jessie, and builds run as the `circleci` user, which has
+full access to passwordless `sudo`.
 
 ### API Levels
 {:.no_toc}
 
-We have a different Docker image for each [Android API level](https://source.android.com/source/build-numbers). To use API level 24 (Nougat 7.0) in a job, you should select `circleci/android:api-24-alpha`.
+We have a different Docker image for each [Android API
+level](https://source.android.com/source/build-numbers). To use API level 24
+(Nougat 7.0) in a job, you should select `circleci/android:api-24-alpha`.
 
 ### Alpha Tag
 {:.no_toc}
 
-Our Android Docker images are currently tagged with the suffix `-alpha`. This is to indicate the images are currently under development and might change in backwards incompatible ways from week to week.
+Our Android Docker images are currently tagged with the suffix `-alpha`. This is
+to indicate the images are currently under development and might change in
+backwards incompatible ways from week to week.
 
 ### Customizing the Images
 {:.no_toc}
 
-We welcome contributions [on our GitHub repo for the Android image](https://github.com/circleci/circleci-images/tree/master/android). Our goal is provide a base image that has *most* of the tools you need; we do not plan to provide *every* tool that you might need.
+We welcome contributions [on our GitHub repo for the Android
+image](https://github.com/circleci/circleci-images/tree/master/android). Our
+goal is provide a base image that has *most* of the tools you need; we do not
+plan to provide *every* tool that you might need.
 
-To customize the image, create a Dockerfile that builds `FROM` the `circleci/android` image. See [Using Custom-Built Docker Images]({{ site.baseurl }}/2.0/custom-images/) for instructions.
+To customize the image, create a Dockerfile that builds `FROM` the
+`circleci/android` image. See [Using Custom-Built Docker Images]({{ site.baseurl
+}}/2.0/custom-images/) for instructions.
 
 You can also use the [CircleCI Android
 Orb](https://circleci.com/orbs/registry/orb/circleci/android) to select your
@@ -148,60 +175,51 @@ desired Android SDK and NDK.
 ### React Native Projects
 {:.no_toc}
 
-React Native projects can be built on CircleCI 2.0 using Linux, Android
-and macOS capabilities. Please check out [this example React Native
-application](https://github.com/CircleCI-Public/circleci-demo-react-native)
-on GitHub for a full example of a React Native project.
+React Native projects can be built on CircleCI 2.0 using Linux, Android and
+macOS capabilities. Please check out [this example React Native
+application](https://github.com/CircleCI-Public/circleci-demo-react-native) on
+GitHub for a full example of a React Native project.
 
 ## Testing With Firebase Test Lab
 
-To use Firebase Test Lab with CircleCI,
-first complete the following steps.
+To use Firebase Test Lab with CircleCI, first complete the following steps.
 
-1. **Create a Firebase project.**
-Follow the instructions in the [Firebase documentation](https://firebase.google.com/docs/test-lab/android/command-line#create_a_firebase_project).
+1. **Create a Firebase project.** Follow the instructions in the [Firebase
+documentation](https://firebase.google.com/docs/test-lab/android/command-line#create_a_firebase_project).
 
-2. **Install and authorize the Google Cloud SDK.**
-Follow the instructions in the [Authorizing the Google Cloud SDK]({{ site.baseurl }}/2.0/google-auth/) document.
+2. **Install and authorize the Google Cloud SDK.** Follow the instructions in
+the [Authorizing the Google Cloud SDK]({{ site.baseurl }}/2.0/google-auth/)
+document.
 
-    **Note:**
-    Instead of `google/cloud-sdk`,
-    consider using an [Android convenience image]({{ site.baseurl }}/2.0/circleci-images/#android),
-    which includes `gcloud` and Android-specific tools.
+    **Note:** Instead of `google/cloud-sdk`, consider using an [Android
+    convenience image]({{ site.baseurl }}/2.0/circleci-images/#android), which
+    includes `gcloud` and Android-specific tools.
 
-3. **Enable required APIs.**
-Using the service account you created,
-log into Google
-and go to the [Google Developers Console API Library page](https://console.developers.google.com/apis/library).
-Enable the **Google Cloud Testing API** and the **Cloud Tool Results API**
-by typing their names into the search box at the top of the console
-and clicking **Enable API**.
+3. **Enable required APIs.** Using the service account you created, log into
+Google and go to the [Google Developers Console API Library
+page](https://console.developers.google.com/apis/library). Enable the **Google
+Cloud Testing API** and the **Cloud Tool Results API** by typing their names
+into the search box at the top of the console and clicking **Enable API**.
 
-In your `.circleci/config.yml` file,
-add the following `run` steps.
+In your `.circleci/config.yml` file, add the following `run` steps.
 
-1. **Build the debug APK and test APK.**
-Use Gradle to build two APKs.
-To improve build performance,
-consider [disabling pre-dexing](#disabling-pre-dexing-to-improve-build-performance).
+1. **Build the debug APK and test APK.** Use Gradle to build two APKs. To
+improve build performance, consider [disabling
+pre-dexing](#disabling-pre-dexing-to-improve-build-performance).
 
-2. **Store the service account.**
-Store the service account you created in a local JSON file.
+2. **Store the service account.** Store the service account you created in a
+local JSON file.
 
-3. **Authorize `gcloud`**.
-Authorize the `gcloud` tool
-and set the default project.
+3. **Authorize `gcloud`**. Authorize the `gcloud` tool and set the default
+project.
 
-4. **Use `gcloud` to test with Firebase Test Lab.**
-Adjust the paths to the APK files
-to correspond to your project.
+4. **Use `gcloud` to test with Firebase Test Lab.** Adjust the paths to the APK
+files to correspond to your project.
 
-5. **Install `crcmod` and use `gsutil` to copy test results data.**
-`crcmod` is required
-to use `gsutil`.
-Use `gsutil`
-to download the newest files in the bucket to the CircleCI artifacts folder.
-Be sure to replace `BUCKET_NAME` and `OBJECT_NAME` with project-specific names.
+5. **Install `crcmod` and use `gsutil` to copy test results data.** `crcmod` is
+required to use `gsutil`. Use `gsutil` to download the newest files in the
+bucket to the CircleCI artifacts folder. Be sure to replace `BUCKET_NAME` and
+`OBJECT_NAME` with project-specific names.
 
 ```yaml
 version: 2
@@ -237,13 +255,14 @@ jobs:
             sudo gsutil -m cp -r -U `sudo gsutil ls gs://[BUCKET_NAME]/[OBJECT_NAME] | tail -1` ${CIRCLE_ARTIFACTS}/ | true
 ```
 
-For more details on using `gcloud` to run Firebase,
-see the [official documentation](https://firebase.google.com/docs/test-lab/android/command-line).
+For more details on using `gcloud` to run Firebase, see the [official
+documentation](https://firebase.google.com/docs/test-lab/android/command-line).
 
 
 ## Deployment
 
-See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for examples of deploy target configurations.
+See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for
+examples of deploy target configurations.
 
 ## Troubleshooting
 
@@ -251,12 +270,15 @@ See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for e
 
 You might run into out of memory (oom) errors with your build. To get acquainted
 with the basics of customizing the JVM's memory usage, consider reading the
-[Debugging Java OOM errors]({{ site.baseurl }}/2.0/java-oom/) document. 
+[Debugging Java OOM errors]({{ site.baseurl }}/2.0/java-oom/) document.
 
-If you are using [Robolectric](http://robolectric.org/) for testing you may need to make tweaks to gradle's
-use of memory. When the gradle vm is forked for tests it does not receive
-previously customized JVM memory parameters. You will need to supply Gradle with
-additional JVM heap for tests in your `build.gradle` file by adding `android.testOptions.unitTests.all { maxHeapSize = "1024m" }`. You can also add `all { maxHeapSize = "1024m" }` to your existing Android config block, which could look like so after the addition:
+If you are using [Robolectric](http://robolectric.org/) for testing you may need
+to make tweaks to gradle's use of memory. When the gradle vm is forked for tests
+it does not receive previously customized JVM memory parameters. You will need
+to supply Gradle with additional JVM heap for tests in your `build.gradle` file
+by adding `android.testOptions.unitTests.all { maxHeapSize = "1024m" }`. You can
+also add `all { maxHeapSize = "1024m" }` to your existing Android config block,
+which could look like so after the addition:
 
 ```groovy
 android {
@@ -277,19 +299,14 @@ gradle: `./gradlew test --max-workers 4`
 ### Disabling Pre-Dexing to Improve Build Performance
 {:.no_toc}
 
-Pre-dexing dependencies has no benefit on CircleCI.
-To disable pre-dexing,
-refer to [this blog post](http://www.littlerobots.nl/blog/disable-android-pre-dexing-on-ci-builds/).
+Pre-dexing dependencies has no benefit on CircleCI. To disable pre-dexing, refer
+to [this blog
+post](http://www.littlerobots.nl/blog/disable-android-pre-dexing-on-ci-builds/).
 
-By default,
-the Gradle Android plugin pre-dexes dependencies.
-Pre-dexing speeds up development
-by converting Java bytecode into Android bytecode,
-allowing incremental dexing
-as you change code.
-CircleCI runs clean builds,
-so pre-dexing actually increases compilation time
-and may also increase memory usage.
+By default, the Gradle Android plugin pre-dexes dependencies. Pre-dexing speeds
+up development by converting Java bytecode into Android bytecode, allowing
+incremental dexing as you change code. CircleCI runs clean builds, so pre-dexing
+actually increases compilation time and may also increase memory usage.
 
 ### Deploying to Google Play Store
 
@@ -297,5 +314,6 @@ There are a few third-party solutions for deploying to the Play Store from your
 CI build. [Gradle Play
 Publisher](https://github.com/Triple-T/gradle-play-publisher) enables you to
 upload an App Bundle/APK as well as app metadata. It's also possible to use
-[Fastlane](https://docs.fastlane.tools/getting-started/android/setup/) with Android.
+[Fastlane](https://docs.fastlane.tools/getting-started/android/setup/) with
+Android.
 


### PR DESCRIPTION
Updates to the Android language guide to use 2.1/orbs.

Related [sample app](https://github.com/CircleCI-Public/MoodTracker/blob/master/.circleci/config.yml).