### PR TITLE
Update api-job-trigger.md

### DIFF
--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -9,8 +9,6 @@ order: 80
 
 This document describes how to trigger jobs using the CircleCI API.
 
-**Note:** You cannot currently trigger jobs that use 2.1 config from the API.
-
 * TOC
 {:toc}
 


### PR DESCRIPTION
Removed outdated note from page mentioning that you cannot trigger jobs using a 2.1 configuration.

This fixes #4347

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.