### PR TITLE
Add: note insights is only available on server.

### DIFF
--- a/jekyll/_cci2/insights.md
+++ b/jekyll/_cci2/insights.md
@@ -7,7 +7,11 @@ categories: [configuring-jobs]
 order: 41
 ---
 
-This document describes creating and using insights in CircleCI in the following sections:
+<div class="alert alert-warning" role="alert">
+  <p><span style="font-size: 115%; font-weight: bold;">⚠️ Heads up!</span></p>
+  <span> This document refers to using the Insights page on the CircleCI <i>Server</i> product. If you are interested in accessing insights and analytics for your usage, please consider exploring the <a href="https://circleci.com/docs/api/v2/#circleci-api-insights">Insights endpoints</a> of the CircleCI V2 API.</span>
+</div>
+
 
 ## Overview
 


### PR DESCRIPTION
Insights are only available on our server product now; this warning directs users to check out the api-v2. 

screenshot:
![image](https://user-images.githubusercontent.com/12987958/81423539-93a1ee00-9122-11ea-90ef-d8dc15b95864.png)
