### PR TITLE
Be more explicit about npm command

### DIFF
--- a/README-local-development.md
+++ b/README-local-development.md
@@ -8,7 +8,7 @@ There are two ways to work on CircleCI docs locally: with Docker and with [Ruby]
 1. Install Docker for your platform: <https://docs.docker.com/engine/installation/>
 1. Clone the CircleCI docs repo: `git clone https://github.com/circleci/circleci-docs.git`
 1. Run `npm install` to fetch dependencies
-1. Run `webpack-dev` to create needed js assets
+1. Run `npm run webpack-dev` to create needed js assets
 1. Run `docker-compose up`
 1. The docs site will now be running on <http://localhost:4000/docs/>
 


### PR DESCRIPTION
# Description
Be more explicit about npm command in local development documentation.

# Reasons
`webpack-dev` is actually an npm package and can cause confusion(and potential security concerns) with developers that are not familiar with the webpack ecosystem.

https://www.npmjs.com/package/webpack-dev