### PR TITLE
Explicitly exclude macOS executors from Docker

### DIFF
--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -12,7 +12,7 @@ This document describes how to install and use `docker-compose`.
 * TOC 
 {:toc}
 
-The `docker-compose` utility is [pre-installed in the CircleCI convenience images][pre-installed] and machine executors. If you're using another image, you can install it into your [primary container][primary-container] during the job execution with the Remote Docker Environment activated by adding the following to your [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file:
+The `docker-compose` utility is [pre-installed in the CircleCI convenience images][pre-installed] and machine executors excluding macOS executors. If you're using another image, excluding macOS executors, you can install it into your [primary container][primary-container] during the job execution with the Remote Docker Environment activated by adding the following to your [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file:
 
 ``` 
       - run:


### PR DESCRIPTION
# Description
Specify that Docker is not included on macOS executors.
Specify that `setup_remote_docker` is not available on macOS executors.

# Reasons
macOS does not have Docker pre-installed, nor is Remote Docker available for macOS