### PR TITLE
More explicit name suggestion for default executor

### DIFF
--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -72,7 +72,7 @@ echo `export PATH="$PATH:<<parameters.install-path>>"` >> $BASH_ENV
 ### Executors
 
 - At least one executor per supported OS (MacOs, Windows, Docker, VM).
-- Must include a “default” executor.
+- Must include one executor, named `default`.
 - Executor should be parameterized to allow the user to overwrite the version/tag in the event an issue arises with the included image.
 
 ### Imported Orbs

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -72,7 +72,7 @@ echo `export PATH="$PATH:<<parameters.install-path>>"` >> $BASH_ENV
 ### Executors
 
 - At least one executor per supported OS (MacOs, Windows, Docker, VM).
-- Must include one executor, named `default`.
+- Must include one executor named `default`.
 - Executor should be parameterized to allow the user to overwrite the version/tag in the event an issue arises with the included image.
 
 ### Imported Orbs


### PR DESCRIPTION
# Description
This PR changes the language, suggesting explicitly that one executor is named `default`.

# Reasons
When reading this page it's not clear what one has to do to include one "default" executor.