### PR TITLE
Fix broken link to Database Examples

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -976,4 +976,4 @@ steps |	Y |	Sequence |	A list of steps to execute when the condition is falsy.
 
 - Refer to [Sample Configurations]({{site.baseurl}}/2.0/sample-config/) for some sample configurations that you can use in your own CircleCI configuration.
 - Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/) for more detailed information about how you can use CircleCI orb recipes in your configurations.
-- Refer to [Database Examples]({{site.baseurl}}/2.0//postgres-config/) for database examples you can use in your CircleCI configuration.
+- Refer to [Database Examples]({{site.baseurl}}/2.0/postgres-config/) for database examples you can use in your CircleCI configuration.


### PR DESCRIPTION
# Description
Fix the "Database Examples" link at https://circleci.com/docs/2.0/reusing-config/#see-also.

# Reasons
The "Database Examples" link is broken.