### PR TITLE
Add instructions to initialize and update the src-shared submodule

### DIFF
--- a/README-local-development.md
+++ b/README-local-development.md
@@ -6,9 +6,10 @@ There are two ways to work on CircleCI docs locally: with Docker and with [Ruby]
 ## 1. Local Development with Docker (recommended)
 
 1. Install Docker for your platform: <https://docs.docker.com/engine/installation/>
-1. Clone the CircleCI docs repo: `git clone https://github.com/circleci/circleci-docs.git`
+1. Clone the CircleCI docs repo: `git clone --recurse-submodules https://github.com/circleci/circleci-docs.git`   
+_(If you already cloned the project and forgot `--recurse-submodules`, run `git submodule update --init`)_
 1. Run `npm install` to fetch dependencies
-1. Run `webpack-dev` to create needed js assets
+1. Run `npm run webpack-dev` to create needed js assets
 1. Run `docker-compose up`
 1. The docs site will now be running on <http://localhost:4000/docs/>
 


### PR DESCRIPTION
# Description
Add instructions to include the _src-shared @ 75ac85b_ submodule when cloning the forked repository.

# Reasons
Failing to pass `--recurse-submodules` when running the `git clone` command will result in an empty local _src-shared_ folder.
This will prevent the Docker container from starting and will produce the below error when running the `docker-compose up` command:

```
jekyll_1  | jekyll 3.8.6 | Error:  No such file or directory @ rb_sysopen - /srv/jekyll/jekyll/assets/js/shared
````