### PR TITLE
Fix broken link to Personal API Tokens page

### DIFF
--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -142,7 +142,7 @@ The following section details the steps you would need, from start to finish, to
         - welcome/run
     ```
 
-3. Add an API token from the [Personal API Tokens page](https://account.circleci.com/tokens). Be sure to write down and store your API token in a secure place once you generate it.
+3. Add an API token from the [Personal API Tokens page](https://circleci.com/account/api). Be sure to write down and store your API token in a secure place once you generate it.
 
 4. It's time to test out your API token using `curl` to make sure everything works. The following code snippets demonstrate querying all pipelines on a project. Please note that in the example below, the values within curly braces (`{}`) need to be replaced with values specific to your username/orgname.
 


### PR DESCRIPTION
# Description
Fix the "Personal API Tokens page" link at https://circleci.com/docs/2.0/api-developers-guide/#add-an-api-token.

# Reasons
The "Personal API Tokens page" link is broken.