### PR TITLE
Fix 'contributing guide' link in docs footer.

### DIFF
--- a/jekyll/_includes/edit-on-github.html
+++ b/jekyll/_includes/edit-on-github.html
@@ -4,7 +4,7 @@
 <p>This guide, as well as the rest of our docs, are open-source and available on <a href="{{ site.gh_url }}">GitHub</a>. We welcome your contributions.
 </p>
 <ul>
-	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}" target="_blank">Suggest an edit to this page</a> (please read the <a href="{{ site.gh_url }}/blob/master/CONTRIBUTING.md&#35;contributing-to-circleci-docs" target="_blank">contributing guide</a> first).</li>
+	<li><a href="{{ site.gh_url }}/blob/master/jekyll/{{ page.path }}" target="_blank">Suggest an edit to this page</a> (please read the <a href="{{ site.gh_url }}/blob/master/docs/CONTRIBUTING.md&#35;contributing-to-circleci-docs" target="_blank">contributing guide</a> first).</li>
 	<li>
         To report a problem in the documentation, or to submit feedback and comments, please
         <a href="{{ site.gh_url }}/issues/new/choose">open an issue on GitHub.</a>


### PR DESCRIPTION
# Description
Added `/docs` segment in the URI so the link to "contributing guide" workds.

# Reasons
The link to 'contributing guide' on Github is pointing to a 404 error due to a missing a `/docs` segment in the link URI.