### PR TITLE
fix: typo /_cci2_ja/code-coverage.md

### DIFF
--- a/jekyll/_cci2/code-coverage.md
+++ b/jekyll/_cci2/code-coverage.md
@@ -56,7 +56,7 @@ class ActiveSupport::TestCase
 end
 ```
 
-Now configure your `.circleci/config.yaml` for uploading your coverage report.
+Now configure your `.circleci/config.yml` for uploading your coverage report.
 
 ```yaml
 version: 2

--- a/jekyll/_cci2_ja/code-coverage.md
+++ b/jekyll/_cci2_ja/code-coverage.md
@@ -46,7 +46,7 @@ class ActiveSupport::TestCase
 end
 ```
 
-次に、カバレッジレポートをアップロードするために `.circleci/config.yaml` を設定します。
+次に、カバレッジレポートをアップロードするために `.circleci/config.yml` を設定します。
 
 ```yaml
 version: 2


### PR DESCRIPTION
# Description
Changed 2 occurrences of config.yaml into config.yml

# Reasons
Because .yaml is not recognized.