### PR TITLE
Minor English fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
             - crg
 
   # The Main "Build" job. It pulls in assets from previous jobs (the built api docs, pdfs and javascript)
-  # and puts everything in it's place for a Jekyll build.
+  # and puts everything in its place for a Jekyll build.
   build:
     executor:
       name: ruby/default

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -136,7 +136,7 @@ Our API is handled in two possible places currently:
 **What is Slate?**
 
 Slate is a tool for generating API documentation. Slate works by having a user
-clone or fork it's Github Repo, having the user fill in the API spec into a
+clone or fork its Github Repo, having the user fill in the API spec into a
 `index.html.md` file, and then generating the static documentation using Ruby
 (via `bundler`).
 

--- a/jekyll/_archive/build-image-precise.md
+++ b/jekyll/_archive/build-image-precise.md
@@ -8,7 +8,7 @@ sitemap: false
 ---
 
 <div class="alert alert-danger" markdown="1">
-  <strong>Warning: </strong>Ubuntu 12.04 has been End-of-Life'd (EOL) by it's maintainer Canonical. Neither Canonical nor CircleCI are maintaining this image. We strongly suggest switching to CircleCI 2.0, or at the very least the [Ubuntu 14.04 image](https://circleci.com/docs/1.0/build-image-trusty/) for CircleCI 1.0. Read our announcement [here](https://circleci.com/blog/ubuntu-12-04-precise-build-image-end-of-life-warning/).
+  <strong>Warning: </strong>Ubuntu 12.04 has been End-of-Life'd (EOL) by its maintainer Canonical. Neither Canonical nor CircleCI are maintaining this image. We strongly suggest switching to CircleCI 2.0, or at the very least the [Ubuntu 14.04 image](https://circleci.com/docs/1.0/build-image-trusty/) for CircleCI 1.0. Read our announcement [here](https://circleci.com/blog/ubuntu-12-04-precise-build-image-end-of-life-warning/).
 </div>
 
 Occasionally, bugs in tests arise because CircleCI's environment differs slightly from your local environment.

--- a/jekyll/_cci1/build-image-precise.md
+++ b/jekyll/_cci1/build-image-precise.md
@@ -8,7 +8,7 @@ sitemap: false
 ---
 
 <div class="alert alert-danger" markdown="1">
-  <strong>Warning: </strong>Ubuntu 12.04 has been End-of-Life'd (EOL) by it's maintainer Canonical. Neither Canonical nor CircleCI are maintaining this image. We strongly suggest switching to CircleCI 2.0, or at the very least the [Ubuntu 14.04 image](https://circleci.com/docs/1.0/build-image-trusty/) for CircleCI 1.0. Read our announcement [here](https://circleci.com/blog/ubuntu-12-04-precise-build-image-end-of-life-warning/).
+  <strong>Warning: </strong>Ubuntu 12.04 has been End-of-Life'd (EOL) by its maintainer Canonical. Neither Canonical nor CircleCI are maintaining this image. We strongly suggest switching to CircleCI 2.0, or at the very least the [Ubuntu 14.04 image](https://circleci.com/docs/1.0/build-image-trusty/) for CircleCI 1.0. Read our announcement [here](https://circleci.com/blog/ubuntu-12-04-precise-build-image-end-of-life-warning/).
 </div>
 
 Occasionally, bugs in tests arise because CircleCI's environment differs slightly from your local environment.

--- a/jekyll/_cci2/build-publish-snap-packages.md
+++ b/jekyll/_cci2/build-publish-snap-packages.md
@@ -46,7 +46,7 @@ The `docker` executor is used here with the [`cibuilds/snapcraft`](https://githu
 ...
 ```
 
-On CircleCI, this single command is needed to actually build your snap. This will run Snapcraft, which will then go through all of it's build steps and generate a `.snap` file for you. This file will typically be in the format of `<snap-name>-<snap-version>-<system-arch>.snap`.
+On CircleCI, this single command is needed to actually build your snap. This will run Snapcraft, which will then go through all of its build steps and generate a `.snap` file for you. This file will typically be in the format of `<snap-name>-<snap-version>-<system-arch>.snap`.
 
 ## Testing
 

--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -98,7 +98,7 @@ Because the second key is less specific than the first, it is more likely that t
 
 Let's walk through how the above cache keys are used in more detail:
 
-Each line in the `keys:` list all manage _one cache_ (each line does **not** correspond to it's own cache). The list of keys {% raw %}(`v1-npm-deps-{{ checksum "package-lock.json" }}`{% endraw %} and `v1-npm-deps-`), in this example, represent a **single** cache. When it comes time to restore the cache, CircleCI first validates the cache based on the first (and most specific) key, and then steps through the other keys looking for any other cache-key changes. 
+Each line in the `keys:` list all manage _one cache_ (each line does **not** correspond to its own cache). The list of keys {% raw %}(`v1-npm-deps-{{ checksum "package-lock.json" }}`{% endraw %} and `v1-npm-deps-`), in this example, represent a **single** cache. When it comes time to restore the cache, CircleCI first validates the cache based on the first (and most specific) key, and then steps through the other keys looking for any other cache-key changes.
 
 Here, the first key concatenates the checksum of `package-lock.json` file into the string `v1-npm-deps-`; if this file was to change in your commit, CircleCI would see a new cache-key. 
 

--- a/jekyll/_cci2/java-oom.md
+++ b/jekyll/_cci2/java-oom.md
@@ -37,7 +37,7 @@ e.g. `-XX:MaxRAMPercentage=90.0`.
 In CircleCI, containers are run using [Nomad](https://www.nomadproject.io).
 Nomad does set CGroup memory limits, but doesn't provide enough
 CGroup memory information to the container for the JVM to detect the container memory constraints.
-This means the JVM will set it's memory as a fraction of the total amount of RAM on the system.
+This means the JVM will set its memory as a fraction of the total amount of RAM on the system.
 Nomad currently has an [enhancement request](https://github.com/hashicorp/nomad/issues/5376)
 open to provide this information. Once that is added, container builds in CircleCI will
 automatically pick up their container memory limits.

--- a/jekyll/_cci2/jira-plugin.md
+++ b/jekyll/_cci2/jira-plugin.md
@@ -41,13 +41,13 @@ The example config below provides a bare `config.yml` illustrating the use of th
 ```yaml
 version: 2.1
 orbs: # adds orbs to your configuration
-  jira: circleci/jira@1.0.5 # invokes the Jira orb, making it's commands accessible
+  jira: circleci/jira@1.0.5 # invokes the Jira orb, making its commands accessible
 workflows:
   build:
     jobs:
       - build:
           post-steps:
-            - jira/notify # Runs the Jira's "notify" commands after a build has finished it's steps.
+            - jira/notify # Runs the Jira's "notify" commands after a build has finished its steps.
 jobs:
   build:
     docker:

--- a/jekyll/_cci2/packagecloud.md
+++ b/jekyll/_cci2/packagecloud.md
@@ -94,7 +94,7 @@ CircleCI users can deploy packages directly to npm registries hosted on packagec
 
 ### Configure the Test Job
 
-This job will retrieve the project code, install it's dependencies and run any tests in the NodeJS project:
+This job will retrieve the project code, install its dependencies and run any tests in the NodeJS project:
 
 ```yaml
 jobs:


### PR DESCRIPTION
Where correct, use possessive pronoun "its" instead of contraction for "it is"

# Description
Just grammar.

# Reasons
Grammatical correctness.