### PR TITLE
fix typo in oss.md

### DIFF
--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -16,7 +16,7 @@ for building your open source project on CircleCI in the following sections:
 ## Overview
 {:.no_toc}
 
-To support the open source community, organizations on Github or Bitbucket will be given 100,000 free credits per week that can be spent on on open source projects. These credits can be spent on Linux-medium resources. Each organization can have a maximum of four concurrent jobs running.
+To support the open source community, organizations on Github or Bitbucket will be given 100,000 free credits per week that can be spent on open source projects. These credits can be spent on Linux-medium resources. Each organization can have a maximum of four concurrent jobs running.
 
 **Note:**
 If you are building an open source project on macOS,


### PR DESCRIPTION
fix typo.
`on on` -> `on`