### PR TITLE
Adding deploy keys and service hooks requires admin permission.

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -159,10 +159,12 @@ and the [Bitbucket permissions model](https://confluence.atlassian.com/bitbucket
 - Get a user's email address
 
 **Write Permissions**
-- Add deploy keys to a repo
-- Add service hooks to a repo
 - Get a list of a user's repos
 - Add an SSH key to a user's account
+
+**Admin Permissions**, needed for setting up a project
+- Add deploy keys to a repo
+- Add service hooks to a repo
 
 **Note:**
 CircleCI only asks for


### PR DESCRIPTION
Co-authored-by: Anna Calinawan <anna.calinawan@circleci.com>

# Description
State that some permissions actually require admin-level access.

# Reasons
The previous wording caused confusion, as it implied that write-level access to a repository was sufficient to set up a project in CircleCI. [A user must be a GitHub admin to add deploy keys or service hooks](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#repository-access-for-each-permission-level), and through experimentation, we found that a Bitbucket user must have admin access to add a [deploy key](https://confluence.atlassian.com/bitbucket/access-keys-294486051.html), which is required to set up a Bitbucket project.

Maybe there's a better place to clarify this? We think that this page of documentation exists to clarify why the level of access is requested in the auth flow:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/17014418/82249052-2444af00-9917-11ea-8be0-cd48293ef5b0.png">

(and the Bitbucket counterpart), and in this PR what we really want to do is clarify what access is needed to set up a project.