### PR TITLE
Update local-cli-getting-started.md

### DIFF
--- a/jekyll/_cci2/local-cli-getting-started.md
+++ b/jekyll/_cci2/local-cli-getting-started.md
@@ -10,6 +10,7 @@ order: 50
 # Overview
 
 For those who prefer to spend most of their development time in the terminal, consider installing the [CircleCI CLI](https://github.com/CircleCI-Public/circleci-cli) to interact with your projects on CircleCI. This document provides a step-by-step guide on intializing and working with a CircleCI project primarily from within the terminal. 
+Please note that our server offering only supports a legacy version of the CLI. You can find more information on how to install that here: https://circleci.com/docs/2.0/local-cli/#using-the-cli-on-circleci-server.
 
 # Prerequisites
 


### PR DESCRIPTION
This is a suggested added note to this documentation to clarify to customers that the newer versions of the CLI are not available on server.

# Description
Added disclaimer that server only supports the legacy CLI

# Reasons
Some customers have tried to use the current CLI for their server installations and it has not been apparent why it didn't work
