### PR TITLE
Minor change in section heading in Config Reference

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -9,7 +9,7 @@ order: 20
 
 This document is a reference for the CircleCI 2.x configuration keys that are used in the `config.yml` file. The presence of a `.circleci/config.yml` file in your CircleCI-authorized repository branch indicates that you want to use the 2.x infrastructure.
 
-You can see a complete `config.yml` in our [full example](#full-example).
+You can see a complete `config.yml` in our [full example](#example-full-configuration).
 
 **Note:** If you already have a CircleCI 1.0 configuration, the `config.yml` file allows you to test 2.x builds on a separate branch, leaving any existing configuration in the old `circle.yml` style unaffected and running on the CircleCI 1.0 infrastructure in branches that do not contain `.circleci/config.yml`.
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1615,7 +1615,7 @@ when:
         - << pipeline.parameter.deploy-canary >>
 ```
 
-## Full Example
+## Example Full Configuration
 {:.no_toc}
 
 {% raw %}


### PR DESCRIPTION
# Description
Modified the heading for the final section in the configuration reference.

# Reasons
There was odd continuity between the previous section and the final section - reader potentially confused into thinking the "Full Example" is a full example of logic statements.

![Screen Shot 2020-05-20 at 9 25 39 AM](https://user-images.githubusercontent.com/2441695/82466842-1eb5a900-9a7e-11ea-8ac1-c691f8ceb118.png)
