### PR TITLE
Improve descriptions of some environment variables

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -511,10 +511,10 @@ Variable                    | Type    | Value
 `CIRCLE_REPOSITORY_URL`     | String  | The URL of your GitHub or Bitbucket repository.
 `CIRCLE_SHA1`               | String  | The SHA1 hash of the last commit of the current build.
 `CIRCLE_TAG`                | String  | The name of the git tag, if the current build is tagged. For more information, see the [Git Tag Job Execution]({{ site.baseurl }}/2.0/workflows/#executing-workflows-for-a-git-tag).
-`CIRCLE_USERNAME`           | String  | The GitHub or Bitbucket username of the user who committed the build.
+`CIRCLE_USERNAME`           | String  | The GitHub or Bitbucket username of the user who triggered the pipeline.
 `CIRCLE_WORKFLOW_ID`        | String  | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
 `CIRCLE_WORKING_DIRECTORY`  | String  | The value of the `working_directory` key of the current job.
-`CIRCLE_INTERNAL_TASK_DATA` | String  | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of contents of this directory; the data schema is subject to change.
+`CIRCLE_INTERNAL_TASK_DATA` | String  | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.
 `CIRCLE_COMPARE_URL`        | String  | **Deprecated**. The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{ site.baseurl }}/2.0/pipeline-variables/) as an alternative.
 `CI_PULL_REQUEST`           | String  | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUEST` instead.
 `CI_PULL_REQUESTS`          | List    | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUESTS` instead.

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -493,16 +493,13 @@ For more details, see [Setting an Environment Variable in a Shell Command](#sett
 Variable                    | Type    | Value
 ----------------------------|---------|-----------------------------------------------
 `CI`                        | Boolean | `true` (represents whether the current environment is a CI environment)
-`CI_PULL_REQUEST`           | String  | Deprecated version of `CIRCLE_PULL_REQUEST`. Kept for backward compatibility with CircleCI 1.0.
-`CI_PULL_REQUESTS`          | List    | Deprecated version of `CIRCLE_PULL_REQUESTS`. Kept for backward compatibility with CircleCI 1.0.
+`CIRCLECI`                  | Boolean | `true` (represents whether the current environment is a CircleCI environment)
 `CIRCLE_BRANCH`             | String  | The name of the Git branch currently being built.
-`CIRCLE_BUILD_NUM`          | Integer | The number of the CircleCI build.
-`CIRCLE_BUILD_URL`          | String  | The URL for the current build.
-`CIRCLE_COMPARE_URL`        | String  | The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{ site.baseurl }}/2.0/pipeline-variables/) as an alternative.
-`CIRCLE_INTERNAL_TASK_DATA` | String  | The directory where test timing data is saved.
+`CIRCLE_BUILD_NUM`          | Integer | The number of the current job. Job numbers are unique for each job.
+`CIRCLE_BUILD_URL`          | String  | The URL for the current job on CircleCI.
 `CIRCLE_JOB`                | String  | The name of the current job.
-`CIRCLE_NODE_INDEX`         | Integer | The index of the specific build instance. A value between 0 and (`CIRCLE_NODE_TOTAL` - 1)
-`CIRCLE_NODE_TOTAL`         | Integer | The number of total build instances.
+`CIRCLE_NODE_INDEX`         | Integer | For jobs that run with parallelism enabled, this is the index of the current parallel run. The value ranges from 0 to (`CIRCLE_NODE_TOTAL` - 1)
+`CIRCLE_NODE_TOTAL`         | Integer | For jobs that run with parallelism enabled, this is the number of parallel runs. This is equivielnt to the value of `parallelism` in your config file.
 `CIRCLE_PR_NUMBER`          | Integer | The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
 `CIRCLE_PR_REPONAME`        | String  | The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
 `CIRCLE_PR_USERNAME`        | String  | The GitHub or Bitbucket username of the user who created the pull request. Only available on forked PRs.
@@ -517,8 +514,11 @@ Variable                    | Type    | Value
 `CIRCLE_USERNAME`           | String  | The GitHub or Bitbucket username of the user who committed the build.
 `CIRCLE_WORKFLOW_ID`        | String  | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
 `CIRCLE_WORKING_DIRECTORY`  | String  | The value of the `working_directory` key of the current job.
-`CIRCLECI`                  | Boolean | `true` (represents whether the current environment is a CircleCI environment)
-`HOME`                      | String  | Your home directory.
+`CIRCLE_INTERNAL_TASK_DATA` | String  | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of contents of this directory; the data schema is subject to change.
+`CIRCLE_COMPARE_URL`        | String  | **Deprecated**. The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{ site.baseurl }}/2.0/pipeline-variables/) as an alternative.
+`CI_PULL_REQUEST`           | String  | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUEST` instead.
+`CI_PULL_REQUESTS`          | List    | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUESTS` instead.
+
 {:class="table table-striped"}
 
 ## See Also


### PR DESCRIPTION
- Move deprecated and internal variables to the bottom of the list.
- Bring `CIRCLECI` to the top of the list.
- Make clear that `CIRCLE_INTERNAL_TASK_DATA` is internal.
- Improve the accuracy of other descriptions.