### PR TITLE
fix markdown syntax managing-api-tokens.md

### DIFF
--- a/jekyll/_cci2_ja/managing-api-tokens.md
+++ b/jekyll/_cci2_ja/managing-api-tokens.md
@@ -23,7 +23,7 @@ CircleCI では 2種類の API トークンを作成できます。
 ### パーソナル API トークンの作成
 
 1. CircleCI アプリケーションで、[ユーザー設定](https://circleci.com/account){:rel="nofollow"}に移動します。
-2. [[Personal API Tokens (パーソナル API トークン)](https://circleci.com/account/api)]{:rel="nofollow"} をクリックします。
+2. [Personal API Tokens (パーソナル API トークン)](https://circleci.com/account/api)]{:rel="nofollow"} をクリックします。
 3. **[Create New Token (新しいトークンを作成する)]** ボタンをクリックします。
 4. **[Token name (トークン名)]** フィールドに、覚えやすいトークン名を入力します。
 5. **[Add API Token (API トークンを追加する)]** ボタンをクリックします。


### PR DESCRIPTION
# Description

remove duplicate `[`

# Reasons


https://circleci.com/docs/ja/2.0/managing-api-tokens/

![image](https://user-images.githubusercontent.com/389787/82785358-6a60bc00-9e9d-11ea-84cc-229b9a3e6ed2.png)
