### PR TITLE
support tickets no longer needed for DLC

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -225,7 +225,7 @@ All images have common language tools preinstalled. Refer to the [specification 
 
 **Note:** The `image` key is not required on self-hosted installations of CircleCI Server (see example above) but if it is used, it should be set to: `image: default`.
 
-The following example uses the default machine image and enables [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or Workflow. **Note:** You must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.
+The following example uses the default machine image and enables [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or Workflow.
 
 ```yaml
 version: 2


### PR DESCRIPTION
# Description
Support tickets are no longer needed to enable DLC. They can self-serve on performance plan

# Reasons
Improved accuracy