### PR TITLE
Clean: remove out of date workflow image.

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -7,8 +7,6 @@ categories: [configuring-jobs]
 order: 30
 ---
 
-![header](  {{ site.baseurl }}/assets/img/docs/wf-header.png)
-
 To increase the speed of your software development through faster feedback, shorter reruns, and more efficient use of resources, configure Workflows. This document describes the Workflows feature and provides example configurations in the following sections:
 
 * TOC


### PR DESCRIPTION
Removes the (legacy ui) image header on the workflow document, at least until we find a suitable open source repo that we can use an example workflows screenshot from.