### PR TITLE
pins the docker-ce-cli version to prevent api mismatch error

### DIFF
--- a/jekyll/_cci2/update-nomad-clients.adoc
+++ b/jekyll/_cci2/update-nomad-clients.adoc
@@ -149,7 +149,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get install -y "linux-image-$UNAME"
 apt-get update
-apt-get -y install docker-ce=5:18.09.9~3-0~ubuntu-xenial
+apt-get -y install docker-ce=5:18.09.9~3-0~ubuntu-xenial docker-ce-cli=5:18.09.9~3-0~ubuntu-xenial
 
 # force docker to use userns-remap to mitigate CVE 2019-5736
 apt-get -y install jq


### PR DESCRIPTION
# Description
Pins the docker-ce-cli version to prevent api mismatch errors

# Reasons

Without pinning the CLI version, the default install uses too new a version of the CLI. This pins the version to prevent an error

Below is the result of the script being executed as defined in the documentation
```
# docker ps
Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39
```

```
# dpkg -l |grep docker
ii  docker-ce                        5:18.09.9~3-0~ubuntu-xenial                amd64        Docker: the open-source application container engine
ii  docker-ce-cli                    5:19.03.9~3-0~ubuntu-xenial                amd64        Docker CLI: the open-source application container engine
```