### PR TITLE
Correct the when-step docs to include logic

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -958,7 +958,7 @@ Under the `when` key are the subkeys `condition` and `steps`. The subkey `steps`
 
 Key | Required | Type | Description
 ----|-----------|------|------------
-condition | Y | String | A parameter value.
+condition | Y | Logic | [A logic statement](https://circleci.com/docs/2.0/configuration-reference/#logic-statements)
 steps |	Y |	Sequence |	A list of steps to execute when the condition is truthy.
 {: class="table table-striped"}
 
@@ -968,7 +968,7 @@ Under the `unless` key are the subkeys `condition` and `steps`. The subkey `step
 
 Key | Required | Type | Description
 ----|-----------|------|------------
-condition | Y | String | A parameter value.
+condition | Y | Logic | [A logic statement](https://circleci.com/docs/2.0/configuration-reference/#logic-statements)
 steps |	Y |	Sequence |	A list of steps to execute when the condition is falsy.
 {: class="table table-striped"}
 


### PR DESCRIPTION
# Description
Update the `when`-step docs to include logic statements under the `condition` key.

# Reasons
I had changed the configuration reference but forgot about this bit here.