### PR TITLE
change url for adding ssh key to circleci project

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -258,7 +258,7 @@ then copy and paste the key you created in step 1.
 Check "Allow write access",
 then click "Add key".
 
-3. Go to [https://app.circleci.com/settings/project/github/you/test-repo/ssh](https://app.circleci.com/settings/project/github/you/test-repo/ssh){:rel="nofollow"},
+3. Go to [https://app.circleci.com/settings/project/github/you/test-repo/edit#ssh](https://app.circleci.com/settings/project/github/you/test-repo/edit#ssh){:rel="nofollow"},
 and add the key you created in step 1.
 In the "Hostname" field,
 enter "github.com",


### PR DESCRIPTION
I think the url in the guide is outdated. The actual location for adding ssh keys to a circleci project seems to be:
https://app.circleci.com/settings/project/github/you/test-repo/edit#ssh
instead of
https://app.circleci.com/settings/project/github/you/test-repo/ssh

# Description
Update outdated url for manually adding ssh keys to cireclci project.

# Reasons
The current url seems to be wrong.