### PR TITLE
Update `yarn install` argument name

### DIFF
--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -38,7 +38,7 @@ Here's an example:
             - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
-          command: yarn install --frozen-lockfile
+          command: yarn install --immutable
       - save_cache:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
# Description
The code snippet in the doc contains `--frozen-lockfile` as an argument to `yarn install`. That argument has been renamed to `--immutable`.

# Reasons
The compatibility alias `--frozen-lockfile` will be removed in later versions, according to the [yarn docs](https://yarnpkg.com/cli/install).