### PR TITLE
Fix example in Logic Statements

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1625,12 +1625,13 @@ Logic statements always evaluate to a boolean value at the top level, and coerce
 
 ```yaml
 when:
-  and:
-    - not:
-        equal: [ master, << pipeline.git.branch >> ]
-    - or:
-        - equal: [ canary, << pipeline.git.tag >> ]
-        - << pipeline.parameter.deploy-canary >>
+  condition:
+    and:
+      - not:
+          equal: [ master, << pipeline.git.branch >> ]
+      - or:
+          - equal: [ canary, << pipeline.git.tag >> ]
+          - << pipeline.parameter.deploy-canary >>
 ```
 
 ## Example Full Configuration


### PR DESCRIPTION
# Description

Add `condition` key to the logic statement example

# Reasons

Validation passes, but it does not seem to be processed correctly without `condition` key.