### PR TITLE
doc: add clean option to bundle install

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -257,7 +257,7 @@ Then you can install these using bundler:
 steps:
   - restore_cache:
       key: 1-gems-{{ checksum "Gemfile.lock" }}
-  - run: bundle check || bundle install --path vendor/bundle
+  - run: bundle check || bundle install --path vendor/bundle --clean
   - save_cache:
       key: 1-gems-{{ checksum "Gemfile.lock" }}
       paths:

--- a/jekyll/_cci2_ja/testing-ios.md
+++ b/jekyll/_cci2_ja/testing-ios.md
@@ -389,7 +389,7 @@ run:
           - restore_cache:
               key: 1-gems-{{ checksum "Gemfile.lock" }}
 
-          - run: bundle check || bundle install --path vendor/bundle
+          - run: bundle check || bundle install --path vendor/bundle --clean
 
           - save_cache:
               key: 1-gems-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
# Description
I was setting out config for CircleCI for my new iOS project and noticed that `bundle clean` was missing in the document and this might lead cache to grow unnecessarily.

# Reasons
`bundle install` do not clean unused old gems by default and without cleaning them will lead cache to grow unnecessarily.

In addition, `bundle clean` is mentioned here https://github.com/circleci/circleci-docs/blob/master/jekyll/_cci2/caching.md#bundler-ruby and I suppose this is the best practice for cache setting for gems in CircleCI.

# Not in this scope but just want to share.
As you know, since bundler version 2.1 `bundle install --path` is deprecated. 
ref : https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#210pre1-august-28-2019

I am happy if this is fixed since warning message appears in most cases when setting following to the CircleCI guide