### PR TITLE
Add an alternative save/restore cache approach

### DIFF
--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -181,6 +181,32 @@ jobs:
 Use the `chown` command
 to grant CircleCI access to dependency locations.
 
+Alternatively, the following example avoids using `pipenv` and installs all dependencies
+into the user's home directory, negating the need for a set of `sudo chown` commands.
+
+{% raw %}
+
+```yaml
+version: 2
+jobs:
+  build:
+    # ...
+    steps:
+      - checkout
+      - restore_cache:  # ensure this step occurs *before* installing dependencies
+          key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - run:
+          command: pip install --user -r requirements.txt
+      - save_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          paths:
+            - "~/.cache/pip"
+            - "~/.local"
+```
+
+{% endraw %}
+
+
 ### Run Tests
 
 Use the `run` step


### PR DESCRIPTION
I wasn't a big fan of the approach to save/restore cache that requires two `sudo chown` commands so I have suggested an alternative approach.

# Description
Add a second paragraph suggesting a different approach to dependency caching.

# Reasons
Fixes #4458 
