### PR TITLE
add SSH key troubleshooting feedback

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -59,7 +59,7 @@ CircleCI also will not accept OpenSSH's default file format - use `ssh-keygen -m
 Even though all CircleCI jobs use `ssh-agent`
 to automatically sign all added SSH keys,
 you **must** use the `add_ssh_keys` key
-to actually add keys to a container.
+to actually add keys to a container. Note that `~/.ssh/config` file is what the `add_ssh_keys` step creates or appends to along with adding the key to ~/.ssh/.
 
 To add a set of SSH keys to a container,
 use the `add_ssh_keys` [special step]({{ site.baseurl }}/2.0/configuration-reference/#add_ssh_keys)


### PR DESCRIPTION
# Description
A brief description of the changes.
Add the sentence or something similar to - Note that `~/.ssh/config` file is what the `add_ssh_keys` step creates or appends to along with adding the key to ~/.ssh/.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.zendesk.com/agent/tickets/74412

Feedback from a customer having issues from trying to use the key before a custom git push bash script - 

"Thank you for letting me know that what the add keys step does is to modify ~/.ssh/config - that's extremely useful information, and I really wish it had been stated explicitly in the documentation I linked above."