### PR TITLE
Fix SEC-1344

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -58,8 +58,13 @@ brew install circleci
 **Note**: If you already have Docker for Mac installed, use `brew install --ignore-dependencies circleci`.
 
 ### Install with Chocolatey (Windows)
+{:.no_toc}
 
+For Windows users, we support [Chocolatey](https://chocolatey.org/):
+
+```sh
 choco install circleci-cli -y
+```
 
 ### Alternative Installation Method
 {:.no_toc}

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -34,7 +34,7 @@ There are multiple installation options for the CLI.
 
 For the majority of installations, we recommend one of the following package managers to install the CircleCI CLI:
 
-### Install with Snap
+### Install with Snap (Linux)
 {:.no_toc}
 
 The following commands will install the CircleCI CLI, Docker, and the security and auto-update features that come along with [Snap packages](https://snapcraft.io/).
@@ -46,7 +46,7 @@ sudo snap connect circleci:docker docker
 
 **Note:** With snap packages, the docker command will use the Docker snap, not any version of Docker you may have previously installed. For security purposes, snap packages can only read/write files from within $HOME.
 
-### Install With Homebrew
+### Install With Homebrew (macOS)
 {:.no_toc}
 
 If you’re using [Homebrew](https://brew.sh/) with macOS, you can install the CLI with the following command:
@@ -56,6 +56,10 @@ brew install circleci
 ```
 
 **Note**: If you already have Docker for Mac installed, use `brew install --ignore-dependencies circleci`.
+
+### Install with Chocolatey (Windows)
+
+choco install circleci-cli -y
 
 ### Alternative Installation Method
 {:.no_toc}

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -60,7 +60,7 @@ brew install circleci
 ### Install with Chocolatey (Windows)
 {:.no_toc}
 
-For Windows users, we support [Chocolatey](https://chocolatey.org/):
+For Windows users, we provide a [Chocolatey](https://chocolatey.org/) package:
 
 ```sh
 choco install circleci-cli -y

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -30,11 +30,35 @@ legacy CLI does work in Server and can be installed.
 
 There are multiple installation options for the CLI.
 
-### Quick Installation
-
 **Note**: If you have already installed the CLI prior to October 2018 you may need to do an extra one-time step to switch to the new CLI. See [upgrading instructions below](#updating-the-legacy-cli).
 
-For the majority of installations, the following commands will get you up and running with the CircleCI CLI:
+For the majority of installations, we recommend one of the following package managers to install the CircleCI CLI:
+
+### Install with Snap
+{:.no_toc}
+
+The following commands will install the CircleCI CLI, Docker, and the security and auto-update features that come along with [Snap packages](https://snapcraft.io/).
+
+```sh
+sudo snap install docker circleci
+sudo snap connect circleci:docker docker
+```
+
+**Note:** With snap packages, the docker command will use the Docker snap, not any version of Docker you may have previously installed. For security purposes, snap packages can only read/write files from within $HOME.
+
+### Install With Homebrew
+{:.no_toc}
+
+If you’re using [Homebrew](https://brew.sh/) with macOS, you can install the CLI with the following command:
+
+```sh
+brew install circleci
+```
+
+**Note**: If you already have Docker for Mac installed, use `brew install --ignore-dependencies circleci`.
+
+### Alternative Installation Method
+{:.no_toc}
 
 **Mac and Linux:**
 
@@ -47,33 +71,6 @@ By default, the CircleCI CLI tool will be installed to the `/usr/local/bin` dire
 ```sh
 curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | DESTDIR=/opt/bin bash
 ```
-
-### Alternative Installation Methods
-
-There are several alternative installation methods for the CircleCI CLI. Read on if you need to customize your installation, or are running into issues with the quick installation above.
-
-#### Install with Snap
-{:.no_toc}
-
-The following commands will install the CircleCI CLI, Docker, and the security and auto-update features that come along with [Snap packages](https://snapcraft.io/).
-
-```sh
-sudo snap install docker circleci
-sudo snap connect circleci:docker docker
-```
-
-**Note:** With snap packages, the docker command will use the Docker snap, not any version of Docker you may have previously installed. For security purposes, snap packages can only read/write files from within $HOME.
-
-#### Install With Homebrew
-{:.no_toc}
-
-If you’re using [Homebrew](https://brew.sh/) with macOS, you can install the CLI with the following command:
-
-```sh
-brew install circleci
-```
-
-**Note**: If you already have Docker for Mac installed, use `brew install --ignore-dependencies circleci`.
 
 ### Manual Download
 


### PR DESCRIPTION
# Description
Switch semantic priority of `curl|bash` and package managers for local CLI installation as piping curl to bash is generally considered bad.

# Reasons
https://circleci.atlassian.net/browse/SEC-1344