### PR TITLE
change to use maxMemory rather than totalMemory

### DIFF
--- a/jekyll/_cci2/jvm-heap-size-configuration.adoc
+++ b/jekyll/_cci2/jvm-heap-size-configuration.adoc
@@ -57,5 +57,5 @@ And following are the outputs you should see:
 (System/getenv "JVM_HEAP_SIZE") ;; should return what you have set above
 ```
 ```clojure
-(-> (java.lang.Runtime/getRuntime) (.totalMemory)) ;; return value should match with JVM_HEAP_SIZE
+(-> (java.lang.Runtime/getRuntime) (.maxMemory)) ;; return value should match with JVM_HEAP_SIZE
 ```

--- a/jekyll/_cci2_ja/jvm-heap-size-configuration.md
+++ b/jekyll/_cci2_ja/jvm-heap-size-configuration.md
@@ -58,5 +58,5 @@ JVM_HEAP_SIZE の値が変更されていることを確認します。
 ```
 
 ```clojure
-(-> (java.lang.Runtime/getRuntime) (.totalMemory)) ;; 戻り値は JVM_HEAP_SIZE の値と一致します
+(-> (java.lang.Runtime/getRuntime) (.maxMemory)) ;; 戻り値は JVM_HEAP_SIZE の値と一致します
 ```


### PR DESCRIPTION
# Description
Change to use maxMemory rather than totalMemory

# Reasons
`totalMemory` doesn't return the maximum heap size, it returns the total amount of memory in the Java virtual machine.
So, if the customer changes the JVM_HEAP_SIZE, `totalMemory` doesn't return the same value of it.

