### PR TITLE
Revert "Bump ffi from 1.9.17 to 1.13.1 in /src-crg"

### DIFF
--- a/src-crg/Gemfile.lock
+++ b/src-crg/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.0.1)
       addressable (~> 2)
-    ffi (1.13.1)
+    ffi (1.9.17)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt


### PR DESCRIPTION
Reverts circleci/circleci-docs#4493