### PR TITLE
[WIP] explore algolia search options

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -23,7 +23,7 @@ algolia:
     - html
     - md
     - adoc
-  nodes_to_index: 'p,li,td,pre,h1,h2,h3'
+  nodes_to_index: 'p,li,h1,h2,h3'
   settings:
     highlightPreTag: '<strong>'
     highlightPostTag: '</strong>'

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -23,8 +23,7 @@ algolia:
     - html
     - md
     - adoc
-  nodes_to_index:
-'p,li,td,pre,h1,h1,h3'
+  nodes_to_index: 'p,li,td,pre,h1,h1,h3'
   settings:
     highlightPreTag: '<strong>'
     highlightPostTag: '</strong>'

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -19,6 +19,12 @@ algolia:
   application_id: U0RXNGRK45
   api_key: dd49f5b81d238d474b49645a4daed322 # search-only API Key; safe for front-end code
   index_name: documentation
+  extensions_to_index:
+    - html
+    - md
+    - adoc
+  nodes_to_index:
+'p,li,td,pre,h1,h1,h3'
   settings:
     highlightPreTag: '<strong>'
     highlightPostTag: '</strong>'

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -23,7 +23,7 @@ algolia:
     - html
     - md
     - adoc
-  nodes_to_index: 'p,li,h1,h2,h3'
+  nodes_to_index: 'p,h1'
   settings:
     highlightPreTag: '<strong>'
     highlightPostTag: '</strong>'

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -23,7 +23,7 @@ algolia:
     - html
     - md
     - adoc
-  nodes_to_index: 'p,li,td,pre,h1,h1,h3'
+  nodes_to_index: 'p,li,td,pre,h1,h2,h3'
   settings:
     highlightPreTag: '<strong>'
     highlightPostTag: '</strong>'


### PR DESCRIPTION
Current search options only build md and html content, and only indexed content in <p> I think. Exploring more options here:

* add asciidoc content
* add heading and content in tables and code blocks (probably not a good idea to include code blocks but can dicuss)

Info from here: https://community.algolia.com/jekyll-algolia/options.html#extensions-to-index