### PR TITLE
Anchor to rack < 2.1.0

### DIFF
--- a/src-crg/Gemfile.lock
+++ b/src-crg/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.10.0)
     public_suffix (2.0.5)
-    rack (2.2.3)
+    rack (2.0.9)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)


### PR DESCRIPTION
# Description
Downgrading `rack` to 2.0.9 to fix Config Reference Guide.

# Reasons
I don't know the reason but it worked. :P