### PR TITLE
Include what broke when docs building breaks (and fail the job)

### DIFF
--- a/scripts/build_api_docs.sh
+++ b/scripts/build_api_docs.sh
@@ -1,5 +1,6 @@
-
 #!/bin/bash
+
+set -e
 
 # commands to build the widdershins/slate api documentation.
 #
@@ -7,7 +8,7 @@
 build_api_v1() {
     echo "Building API v1 documentation with Slate"
     cd src-api
-    bundle exec middleman build --clean
+    bundle exec middleman build --clean --verbose
     echo "Output bundled."
     cp -R build/* /tmp/workspace/api
     echo "Output build moved to /tmp/workspace/api"
@@ -19,7 +20,7 @@ build_api_v2() {
     cd src-api; rm -r build; rm source/index.html.md
     curl https://circleci.com/api/v2/openapi.json > openapi.json
     node node_modules/widdershins/widdershins.js --environment widdershins.apiv2.yml --summary openapi.json -o source/index.html.md
-    bundle exec middleman build --clean
+    bundle exec middleman build --clean --verbose
     cp -R build/* /tmp/workspace/api/v2
     echo "Output build moved to /tmp/workspace/api/v2"
 }
@@ -28,7 +29,7 @@ build_api_v2() {
 build_crg() {
     echo "Building Configuration Reference with Slate "
     cd src-crg;
-    bundle exec middleman build --clean
+    bundle exec middleman build --clean --verbose
     echo "CRG bundle built."
     cp -R build/* /tmp/workspace/crg
     echo "CRG Output build moved to /tmp/workspace/crg"


### PR DESCRIPTION
# Description
This should help avoid us shipping any broken assets in future.

# Reasons
https://app.circleci.com/pipelines/github/circleci/circleci-docs/24561/workflows/c42fbe58-8b04-483e-b104-03c3ad3d30a0/jobs/61314/parallel-runs/0/steps/0-108