### PR TITLE
Added references to VC++ sample projects

### DIFF
--- a/jekyll/_includes/snippets/language-guides.md
+++ b/jekyll/_includes/snippets/language-guides.md
@@ -22,6 +22,7 @@
 | [Ruby and Rails]{:target="_blank"}      | Rails        | [circleci-demo-ruby-rails]{:target="_blank"}             |
 | [Scala]{:target="_blank"}               | sbt          | [sample-scala]{:target="_blank"}                         |
 | [Windows]{:target="_blank"}             | .NET         | [circleci-demo-windows]{:target="_blank"}                |
+| [Windows]{:target="_blank"}             | Visual C++   | [HelloVCSuite-Cloud]{:target="_blank"} for circleci.com<br>[HelloVCSuite-Server]{:target="_blank"} for on-premises |
 {: class="table table-striped"}
 
 [Android]: {{ site.baseurl }}/2.0/language-android/
@@ -66,3 +67,5 @@
 [circleci-demo-windows]: https://github.com/CircleCI-Public/circleci-demo-windows/
 [parallel-compile-circleci]: https://github.com/eddiewebb/parallel-compile-circleci/blob/master/.circleci/config.yml
 [circleci-demo-javascript-react-app]: https://github.com/CircleCI-Public/circleci-demo-javascript-react-app
+[HelloVCSuite-Cloud]: https://github.com/CircleCI-Public/HelloVCSuite-Cloud
+[HelloVCSuite-Server]: https://github.com/CircleCI-Public/HelloVCSuite-Server


### PR DESCRIPTION
# Description
Added references to sample projects for Visual C++ (i.e. Windows)

# Reasons
(Background0 It was developed as a show case for a specific customer onboarding Windows builds on CircleCI. It is encouraged by the team in charge of sample projects to retune it for broader audience. The project showcases how unit tests in VC++ should be implemented - actually it needs special architectural design; I believe this is a good demonstration of best CI/CD practices for VC++-based apps.