### PR TITLE
Add minProximity setting to search index

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -32,6 +32,7 @@ algolia:
       'headings',
       'title'
     ]
+    minProximity: 3
 
 sass:
   sass_dir: _sass


### PR DESCRIPTION
# Description
This change adds the [minProximity](https://www.algolia.com/doc/api-reference/api-parameters/minProximity/) setting to the search index, with a value of 3.

This change loosens the precision of the engine in matching words that are close together. Due to how Algolia's ranking formula works, if we search "parallel tests", a page will rank higher if it includes "parallel tests" _even if it's buried far down the page_. What we'd likely prefer is that if a page _title_ includes "tests in parallel", the fact that the word "in" separates the two isn't a strong indicator the result is not relevant - the fact this match is in the _title_ is what we care about.

With this new setting, the ranking will only differentiate if there are 3 or more words separating the search terms.

Increasing this value was an established best practice when working on documentation/blog type use cases (compared with more structured indexes like e-commerce etc).

# Reasons
See extended discussion on search relevancy in #4515 regarding the parallel tests query.

Note, there is no hard and fast rule as to what we should set this value to. I've gone with 3 as a guesstimate as documentation is by its very nature long-form unstructured text. Happy to consider alternative values.