### PR TITLE
Synchronize launch configuration for Nomad clients with enterprise-setup

### DIFF
--- a/jekyll/_cci2/nomad-metrics.adoc
+++ b/jekyll/_cci2/nomad-metrics.adoc
@@ -68,6 +68,8 @@ export http_proxy=""
 export https_proxy=""
 export no_proxy=""
 export aws_instance_metadata_url="http://169.254.169.254"
+export PUBLIC_IP="$(curl $aws_instance_metadata_url/latest/meta-data/public-ipv4)"
+export PRIVATE_IP="$(curl $aws_instance_metadata_url/latest/meta-data/local-ipv4)"
 export DEBIAN_FRONTEND=noninteractive
 UNAME="$(uname -r)"
 export CONTAINER_NAME="nomad_metrics"
@@ -90,9 +92,11 @@ if [ -f /sys/hypervisor/uuid ] && [ `head -c 3 /sys/hypervisor/uuid` == ec2 ]; t
 cat <<EOT > /etc/ntp.conf
 driftfile /var/lib/ntp/ntp.drift
 disable monitor
+
 restrict default ignore
 restrict 127.0.0.1 mask 255.0.0.0
 restrict 169.254.169.123 nomodify notrap
+
 server 169.254.169.123 prefer iburst
 EOT
 else
@@ -109,7 +113,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get install -y "linux-image-$UNAME"
 apt-get update
-apt-get -y install docker-ce=5:18.09.9~3-0~ubuntu-xenial --allow-downgrades
+apt-get -y install docker-ce=5:18.09.9~3-0~ubuntu-xenial
 
 # force docker to use userns-remap to mitigate CVE 2019-5736
 apt-get -y install jq
@@ -126,6 +130,17 @@ sudo service docker restart
 sleep 5
 
 echo "--------------------------------------"
+echo " Populating /etc/circleci/public-ipv4"
+echo "--------------------------------------"
+if ! (echo $PUBLIC_IP | grep -qP "^[\d.]+$")
+then
+  echo "Setting the IPv4 address below in /etc/circleci/public-ipv4."
+  echo "This address will be used in builds with \"Rebuild with SSH\"."
+  mkdir -p /etc/circleci
+  echo $PRIVATE_IP | tee /etc/circleci/public-ipv4
+fi
+
+echo "--------------------------------------"
 echo "         Installing nomad"
 echo "--------------------------------------"
 apt-get install -y zip
@@ -136,7 +151,6 @@ mv nomad /usr/bin
 echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
-export PRIVATE_IP="$(/sbin/ifconfig ens3 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
 export INSTANCE_ID="$(curl $aws_instance_metadata_url/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl

--- a/jekyll/_cci2/update-nomad-clients.adoc
+++ b/jekyll/_cci2/update-nomad-clients.adoc
@@ -112,6 +112,8 @@ export http_proxy=""
 export https_proxy=""
 export no_proxy=""
 export aws_instance_metadata_url="http://169.254.169.254"
+export PUBLIC_IP="$(curl $aws_instance_metadata_url/latest/meta-data/public-ipv4)"
+export PRIVATE_IP="$(curl $aws_instance_metadata_url/latest/meta-data/local-ipv4)"
 export DEBIAN_FRONTEND=noninteractive
 UNAME="$(uname -r)"
 
@@ -130,9 +132,11 @@ if [ -f /sys/hypervisor/uuid ] && [ `head -c 3 /sys/hypervisor/uuid` == ec2 ]; t
 cat <<EOT > /etc/ntp.conf
 driftfile /var/lib/ntp/ntp.drift
 disable monitor
+
 restrict default ignore
 restrict 127.0.0.1 mask 255.0.0.0
 restrict 169.254.169.123 nomodify notrap
+
 server 169.254.169.123 prefer iburst
 EOT
 else
@@ -149,7 +153,7 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get install -y "linux-image-$UNAME"
 apt-get update
-apt-get -y install docker-ce=5:18.09.9~3-0~ubuntu-xenial docker-ce-cli=5:18.09.9~3-0~ubuntu-xenial
+apt-get -y install docker-ce=5:18.09.9~3-0~ubuntu-xenial
 
 # force docker to use userns-remap to mitigate CVE 2019-5736
 apt-get -y install jq
@@ -159,11 +163,22 @@ tmp=$(mktemp)
 cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
 jq '.["userns-remap"]="default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
 
-sudo echo 'export http_proxy=""' >> /etc/default/docker
-sudo echo 'export https_proxy=""' >> /etc/default/docker
-sudo echo 'export no_proxy=""' >> /etc/default/docker
+sudo echo 'export http_proxy="${http_proxy}"' >> /etc/default/docker
+sudo echo 'export https_proxy="${https_proxy}"' >> /etc/default/docker
+sudo echo 'export no_proxy="${no_proxy}"' >> /etc/default/docker
 sudo service docker restart
 sleep 5
+
+echo "--------------------------------------"
+echo " Populating /etc/circleci/public-ipv4"
+echo "--------------------------------------"
+if ! (echo $PUBLIC_IP | grep -qP "^[\d.]+$")
+then
+  echo "Setting the IPv4 address below in /etc/circleci/public-ipv4."
+  echo "This address will be used in builds with \"Rebuild with SSH\"."
+  mkdir -p /etc/circleci
+  echo $PRIVATE_IP | tee /etc/circleci/public-ipv4
+fi
 
 echo "--------------------------------------"
 echo "         Installing nomad"
@@ -176,7 +191,6 @@ mv nomad /usr/bin
 echo "--------------------------------------"
 echo "      Creating config.hcl"
 echo "--------------------------------------"
-export PRIVATE_IP="$(/sbin/ifconfig ens3 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')"
 export INSTANCE_ID="$(curl $aws_instance_metadata_url/latest/meta-data/instance-id)"
 mkdir -p /etc/nomad
 cat <<EOT > /etc/nomad/config.hcl

--- a/jekyll/_cci2/update-nomad-clients.adoc
+++ b/jekyll/_cci2/update-nomad-clients.adoc
@@ -101,7 +101,7 @@ ec2ccc9d  us-east-1  i-0895ee505ec7e692c  linux-64bit  false  eligible     down
 
 
 
-## Updated Nomad Client Launch Configuration Script
+## Updated Nomad Client Launch Configuration Script (Last Update: July 10, 2020)
 
 ```bash
 #!/bin/bash


### PR DESCRIPTION
# Description & Reasons
Due to CIRCLE-27149, we updated [a reference launch configuration for Nomad clients](https://github.com/circleci/enterprise-setup/commit/f0fe945e23b4ec601960f034bb95c47cda321589) in [`enterprise-setup`](https://github.com/circleci/enterprise-setup). This PR reflects that update to documentations as well so that customers using CircleCI Server in private subnets on AWS can mitigate the issue that the `Rebuild With SSH` feature is broken.

# Considerations
I've confirmed that both updated launch configuration passed [`realitycheck`](https://github.com/circleci/realitycheck) and another tests for SSH rebuilds.