### PR TITLE
Add further clarification of invoking the same job multiple times with parameters

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -715,7 +715,21 @@ workflows:
 ```
 {% endraw %}
 
-**Note:** The ability to invoke jobs multiple times in a single workflow and parameters in jobs is available in configuration version 2.1. When invoking the same job multiple times with parameters passed in the job, the build name will be changed (i.e. `build-1` , `build-2`, etc.). To ensure build numbers are not appended, utilize the `name` key.
+**Note:** The ability to invoke jobs multiple times in a single workflow with parameters is available in configuration version 2.1. When invoking the same job multiple times with parameters across any number of workflows, the build name will be changed (i.e. `sayhello-1` , `sayhello-2`, etc.). To ensure build numbers are not appended, utilize the `name` key. As an example:
+
+```yaml
+workflows:
+  build:
+    jobs:
+      - sayhello:
+          name: build-sayhello
+          saywhat: Everyone
+  deploy:
+    jobs:
+      - sayhello:
+          name: deploy-sayhello
+          saywhat: All
+```
 
 ### Jobs Defined in an Orb
 


### PR DESCRIPTION
# Description
This PR will update the "Authoring Parameterized Jobs" section to have additional details around what happens when you invoke the same job multiple times with different parameters. It gives an example of how to utilize the `name` option in workflows.

I swapped to `sayhello-1` as the example since the section above this section has an example utilizing that job name, so wanted to keep it consistent. 

# Reasons
Making these changes to ensure its clear that without the `name` key jobs will be appended with a number if invoked multiple times with parameters. 