### PR TITLE
Update oss.md

### DIFF
--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -56,6 +56,8 @@ Many open source projects accept PRs from forked repositories. Building these PR
 
 By default, CircleCI does not build PRs from forked repositories. To change this setting, go to the **Project Settings>Advanced** of your project and set the **Build forked pull requests** option to _On_.
 
+**Note**This feature is not currently supported for BitBucket users.
+
 **Note:** If a user submits a pull request to your repository from a fork, but no pipeline is triggered, then the user most likely is following a project fork on their personal account rather than the project itself of CircleCi, causing the jobs to trigger under the user's personal account and not the organization account. To resolve this issue, have the user unfollow their fork of the project on CircleCI and instead follow the source project. This will trigger their jobs to run under the organization when they submit pull requests.
 
 ### Pass Secrets to Builds From Forked Pull Requests


### PR DESCRIPTION
Added a note in the "Build Pull Requests From Forked Repositories" section to state that this feature is not currently supported for BitBucket users. This fixes #4554

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.