### PR TITLE
contexts.md: add an example of non-bash interpolation

### DIFF
--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -68,11 +68,15 @@ If you find you need to rename an org or repo that you have previously hooked up
       run-tests:
         docker:
           - image: cimg/base:2020.01
+          - image: ${ECR_ENDPOINT}/company/image:2020.01
         steps:
           - checkout
           - run: 
               name: "echo environment variables from org-global context"
               command: echo $MY_ENV_VAR  
+          - run: 
+              name: "variables from org-global context can be also interpolated"
+              command: echo ${ECR_ENDPOINT}  
     ```
 
 ### Moving a Repository that Uses a Context


### PR DESCRIPTION
# Description

Add an example of context variable interpolation in non-bash places.

# Reasons

This works for us but I haven't found it in documentation. This may also require changes to https://circleci.com/docs/2.0/env-vars/#using-parameters-and-bash-environment section, which says interpolation is not supported.