### PR TITLE
fix url

### DIFF
--- a/jekyll/_cci2/api-intro.md
+++ b/jekyll/_cci2/api-intro.md
@@ -86,7 +86,7 @@ The table below describes the new endpoints that have been added to the CircleCI
 Endpoint       | Description                       
 -----------|-------------------------------------------------------
 `GET /workflow/:id ` | This endpoint enables users to return an individual Workflow based on the `id` parameter being passed in the request
-`GET /workflow/:id/jobs` | This endoint enables users to retrieve all Jobs associated with a specific workflow, based on its unique `id`.
+`GET /workflow/:id/job` | This endoint enables users to retrieve all Jobs associated with a specific workflow, based on its unique `id`.
 `GET /project/:project_slug`  | This endpoint enables users to retrieve a specific Project by its unique slug.
 `POST /project/:project_slug/pipeline` | This endpoint enables users to retrieve an individual project by its unique slug.
 `GET /pipeline/:id` | This endpoint enables users to retrieve an individual pipeline, based on the `id` passed in the request.


### PR DESCRIPTION
retrieving jobs in a workflow is `GET /workflow/:id/job`, not `GET /workflow/:id/jobs`

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.