### PR TITLE
[CIRCLE-27357] Deprecate putting token in query parameters

### DIFF
--- a/jekyll/_api/v1-reference.md
+++ b/jekyll/_api/v1-reference.md
@@ -50,7 +50,7 @@ All CircleCI API endpoints begin with `"https://circleci.com/api/v1.1/"`.
     or call the API using `curl`:
 
     ```
-$ curl https://circleci.com/api/v1.1/me?circle-token=:token
+$ curl -H "Circle-Token: <circle-token>" https://circleci.com/api/v1.1/me
 ```
 
 3.  You should see a response like the following:
@@ -74,11 +74,12 @@ All CircleCI API endpoints begin with `"https://circleci.com/api/v1.1/"`.
 
 ## Authentication
 
-To authenticate, add an API token using your [account dashboard](https://circleci.com/account/api). To use the API token, add it to the
-`circle-token` query param, like so:
+To authenticate, add an API token using your [account dashboard](https://circleci.com/account/api).
+
+To be authenticated by the API server, use this as the value of the Circle-Token header:
 
 ```
-curl https://circleci.com/api/v1.1/me?circle-token=:token
+curl -H "Circle-Token: <circle-token>" "https://circleci.com/api/..."
 ```
 Alternatively, you can use the API token as the username for HTTP Basic Authentication, by passing the `-u` flag to the `curl` command, like so:
 
@@ -87,6 +88,11 @@ curl -u <circle-token>: https://circleci.com/api/...
 ```
 
 (Note the colon `:`, which tells `curl` that there's no password.)
+
+DEPRECATED (this option will be removed in the future): The API token can be added to the `circle-token` query param:
+```
+curl https://circleci.com/api/v1.1/me
+```
 
 ## Version Control System (:vcs-type)
 
@@ -124,7 +130,7 @@ If you prefer to receive compact JSON with no whitespace or comments, add the `"
 Using `curl`:
 
 ```
-curl https://circleci.com/api/v1.1/me?circle-token=:token -H "Accept: application/json"
+curl -H "Accept: application/json" -H "Circle-Token: <circle-token>" https://circleci.com/api/v1.1/me
 ```
 
 ## User
@@ -174,7 +180,7 @@ The branch name should be url-encoded.
 You can download an individual artifact file via the API with an API-token authenticated HTTP request.
 
 ```sh
-curl -L -H'Circle-Token: :token' https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt
+curl -L -H "Circle-Token: <circle-token>" https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt
 ```
 
 **Notes:**

--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -159,16 +159,15 @@ for all variables that start with `:`.
 ```bash
 export CIRCLE_TOKEN=':your_token'
 
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/$build_number/artifacts?circle-token=$CIRCLE_TOKEN \
+curl -H "Circle-Token: $CIRCLE_TOKEN" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/$build_number/artifacts \
    | grep -o 'https://[^"]*' \
-   | sed -e "s/$/?circle-token=$CIRCLE_TOKEN/" \
-   | wget -v -i -
+   | wget --verbose --header "Circle-Token: $CIRCLE_TOKEN" --input-file -
 ```
 
 Similarly, if you want to download the _latest_ artifacts of a build, replace the curl call with a URL that follows this scheme:
 
 ```bash
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts?circle-token=:your_token
+curl -H "Circle-Token: <circle-token>" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts
 ```
 
 You can read more about using CircleCI's API to interact with artifacts in our [API reference guide](https://circleci.com/docs/api/#artifacts).

--- a/jekyll/_cci2/config-translation.md
+++ b/jekyll/_cci2/config-translation.md
@@ -42,7 +42,7 @@ The `config-translator` endpoint does **not** currently support translation of t
 3. To use the `config-translation` from your browser when you are **not** authenticated in circleci.com for a repository called `foo` in a GitHub org named `bar`, request the following URL and pass your `circle-token` directly in the query string. The following example calls this with `curl`, passes the `branch` to translate, and assumes your [CircleCI API token]({{ site.baseurl }}/2.0/managing-api-tokens/#creating-a-personal-api-token) is in an environment variable called `CIRCLE_TOKEN`.
 
      ``` Shell
-     curl "https://circleci.com/api/v1.1/project/github/bar/foo/config-translation?circle-token=$CIRCLE_TOKEN&branch=develop"
+     curl -H "Circle-Token: $CIRCLE_TOKEN" "https://circleci.com/api/v1.1/project/github/bar/foo/config-translation?branch=develop"
      ```
       The default is to use the default branch that is set in your VCS, typically `master`.
       

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -463,9 +463,10 @@ For example using `curl`
 ```sh
 curl \
   --header "Content-Type: application/json" \
+  --header "Circle-Token: $CIRCLE_TOKEN" \
   --data '{"build_parameters": {"param1": "value1", "param2": 500}}' \
   --request POST \
-  https://circleci.com/api/v1.1/project/github/circleci/mongofinil/tree/master?circle-token=$CIRCLE_TOKEN
+  https://circleci.com/api/v1.1/project/github/circleci/mongofinil/tree/master
 ```
 
 In the above example,

--- a/jekyll/_cci2_ja/artifacts.md
+++ b/jekyll/_cci2_ja/artifacts.md
@@ -131,11 +131,9 @@ CircleCI がジョブを実行すると、**[Job (ジョブ)] ページ**の [Ar
 ```bash
 export CIRCLE_TOKEN=':your_token'
 
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/$build_number/artifacts?circle-token=$CIRCLE_TOKEN \
+curl -H "Circle-Token: $CIRCLE_TOKEN" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/$build_number/artifacts \
    | grep -o 'https://[^"]*' \
-   | tr -d \" \
-   | sed -e "s/$/?circle-token=$CIRCLE_TOKEN/" \
-   | wget -v -i -
+   | wget --verbose --header "Circle-Token: $CIRCLE_TOKEN" --input-file -
 ```
 
 プレースホルダ | 意味 |

--- a/jekyll/_cci2_ja/config-translation.md
+++ b/jekyll/_cci2_ja/config-translation.md
@@ -38,7 +38,7 @@ order: 60
 3. `bar` という GitHub 組織の `foo` というリポジトリに対して、`circleci.com` で認証されて**いない**場合、ブラウザーから `config-translation` を使用するには、以下の URL をリクエストし、クエリ文字列に `circle-token` を直接渡します。 以下の例では、`curl` を使用してこれを呼び出し、変換する `branch` を渡しています。また、[CircleCI API トークン]({{ site.baseurl }}/ja/2.0/managing-api-tokens/#パーソナル-api-トークンの作成)は `CIRCLE_TOKEN` という環境変数にあると仮定しています。
 
         Shell
-         curl "https://circleci.com/api/v1.1/project/github/bar/foo/config-translation?circle-token=$CIRCLE_TOKEN&branch=develop" デフォルトでは、VCS で設定されているデフォルトのブランチ (通常は
+         curl -H "Circle-Token: $CIRCLE_TOKEN" "https://circleci.com/api/v1.1/project/github/bar/foo/config-translation?branch=develop" デフォルトでは、VCS で設定されているデフォルトのブランチ (通常は
 
     `master`) を使用します。
 

--- a/jekyll/_cci2_ja/env-vars.md
+++ b/jekyll/_cci2_ja/env-vars.md
@@ -256,9 +256,10 @@ export list="[\"a\", \"list\", \"of\", \"strings\"]"
 ```
 curl \
   --header "Content-Type: application/json" \
+  --header "Circle-Token: $CIRCLE_TOKEN" \
   --data '{"build_parameters": {"param1": "value1", "param2": 500}}' \
   --request POST \
-  https://circleci.com/api/v1.1/project/github/circleci/mongofinil/tree/master?circle-token=$CIRCLE_TOKEN
+  https://circleci.com/api/v1.1/project/github/circleci/mongofinil/tree/master
 ```
 
 ここで使われている `$CIRCLE_TOKEN` は [パーソナル API トークン]({{ site.baseurl }}/ja/2.0/managing-api-tokens/#パーソナル-api-トークンの作成)です。

--- a/jekyll/_ccie/faq.md
+++ b/jekyll/_ccie/faq.md
@@ -52,5 +52,5 @@ New builder boxes joining the fleet will use the new passphrase. Existing builde
 2. Run the following command, replacing *builder IP* with the IP address of the builder you want to shutdown and using the token from Step 1:
 
 ```
-curl -k -X POST "https://<builder ip>/api/v1/admin/system/shutdown?circle-token=$TOKEN&unstoppable=true"
+curl -k -X POST -H "Circle-Token: $TOKEN" "https://<builder ip>/api/v1/admin/system/shutdown?unstoppable=true"
 ```

--- a/jekyll/_plugins/api_endpoint.rb
+++ b/jekyll/_plugins/api_endpoint.rb
@@ -45,12 +45,12 @@ module Jekyll
     def curl_params(endpoint)
       params = endpoint['params']
       if params and (endpoint['method'] == 'GET')
-        '&' + params.map {|param| "#{param['name']}=#{param['example']}"}.join('&')
+        '?' + params.map {|param| "#{param['name']}=#{param['example']}"}.join('&')
       end
     end
 
     def api_curl(endpoint)
-      "curl #{curl_args_padded(endpoint)}https://circleci.com#{endpoint['url']}?circle-token=:token#{curl_params(endpoint)}"
+      "curl -u <circle-token>: #{curl_args_padded(endpoint)}https://circleci.com#{endpoint['url']}#{curl_params(endpoint)}"
     end
 
     def params(params)

--- a/jekyll/_plugins/api_endpoint.rb
+++ b/jekyll/_plugins/api_endpoint.rb
@@ -28,7 +28,7 @@ module Jekyll
     end
 
     def curl_args_padded(endpoint)
-      args = ['--header "Circle-Token: <circle-token>"']
+      args = ['--header "Circle-Token: &lt;circle-token&gt;"']
       args << "-X #{endpoint['method']}" if not endpoint['method'] == 'GET'
       args << '--header "Content-Type: application/json"' if endpoint['body']
       if endpoint['body']

--- a/jekyll/_plugins/api_endpoint.rb
+++ b/jekyll/_plugins/api_endpoint.rb
@@ -28,7 +28,7 @@ module Jekyll
     end
 
     def curl_args_padded(endpoint)
-      args = []
+      args = ['--header "Circle-Token: <circle-token>"']
       args << "-X #{endpoint['method']}" if not endpoint['method'] == 'GET'
       args << '--header "Content-Type: application/json"' if endpoint['body']
       if endpoint['body']
@@ -50,7 +50,7 @@ module Jekyll
     end
 
     def api_curl(endpoint)
-      "curl -u <circle-token>: #{curl_args_padded(endpoint)}https://circleci.com#{endpoint['url']}#{curl_params(endpoint)}"
+      "curl #{curl_args_padded(endpoint)}https://circleci.com#{endpoint['url']}#{curl_params(endpoint)}"
     end
 
     def params(params)

--- a/src-api/source/includes/_artifacts.md
+++ b/src-api/source/includes/_artifacts.md
@@ -3,7 +3,7 @@
 ## Artifacts Of A Build
 
 ```sh
-curl -H'Circle-Token: :token' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -35,7 +35,7 @@ Request Type: `GET`
 You can download an individual artifact file via the API with an API-token authenticated HTTP request.
 
 ```sh
-curl -L -H'Circle-Token: :token' https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt
+curl -L https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt -H 'Circle-Token: <circle-token>' 
 ```
 
 ### Notes
@@ -46,7 +46,7 @@ an HTTP `3xx` status code (the `-L` switch in `curl` will achieve this).
 ## Artifacts of the latest Build
 
 ```sh
-curl -H'Circle-Token: :token' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts?branch=:branch&filter=:filter
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts?branch=:branch&filter=:filter -H 'Circle-Token: <circle-token>'
 ```
 
 ```json

--- a/src-api/source/includes/_artifacts.md
+++ b/src-api/source/includes/_artifacts.md
@@ -3,7 +3,7 @@
 ## Artifacts Of A Build
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -35,7 +35,7 @@ Request Type: `GET`
 You can download an individual artifact file via the API with an API-token authenticated HTTP request.
 
 ```sh
-curl -L https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt -H 'Circle-Token: <circle-token>' 
+curl -L https://132-55688803-gh.circle-artifacts.com/0//tmp/circle-artifacts.7wgAaIU/file.txt -H "Circle-Token: <circle-token>"
 ```
 
 ### Notes
@@ -46,7 +46,7 @@ an HTTP `3xx` status code (the `-L` switch in `curl` will achieve this).
 ## Artifacts of the latest Build
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts?branch=:branch&filter=:filter -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/latest/artifacts?branch=:branch&filter=:filter -H "Circle-Token: <circle-token>"
 ```
 
 ```json

--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -3,7 +3,7 @@
 ## Single Job
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -94,7 +94,7 @@ This is also the payload for the notification webhooks, in which case this objec
 ## Retry a Build
 
 ```sh
-curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/retry
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/retry -H 'Circle-Token: <circle-token>'
 
 ```
 
@@ -136,7 +136,7 @@ curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/
 
 
 ```sh
-curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/ssh-users
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/ssh-users -H 'Circle-Token: <circle-token>'
 ```
 
 ```text
@@ -149,7 +149,7 @@ curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/
 ## Cancel a Build
 
 ```sh
-curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/cancel
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/cancel -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -188,7 +188,7 @@ curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/
 
 ## Trigger a new Job
 ```sh
-curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{
+curl -X POST --header "Content-Type: application/json" -H 'Circle-Token: <circle-token>' -d '{
   "tag": "v0.1", // optional
   "parallel": 2, //optional, default null
   "build_parameters": { // optional
@@ -289,7 +289,7 @@ build_parameters | Additional environment variables to inject into the build env
 ## Trigger a new Job with a Branch
 
 ```sh
-curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{
+curl -X POST --header "Content-Type: application/json" -H 'Circle-Token: <circle-token>' -d '{
   "parallel": 2, //optional, default null
   "revision": "f1baeb913288519dd9a942499cef2873f5b1c2bf" // optional
   "build_parameters": { // optional
@@ -390,7 +390,7 @@ build_parameters | Additional environment variables to inject into the build env
 ## Trigger a new Build by Project (preview)
 
 ```sh
-curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -418,7 +418,7 @@ tag | The git tag to build. Cannot be used with branch and revision parameters.
 ## Get Build Test Metadata
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/tests
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/tests -H 'Circle-Token: <circle-token>'
 ```
 
 ```json

--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -3,7 +3,7 @@
 ## Single Job
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num
 ```
 
 ```json
@@ -94,7 +94,7 @@ This is also the payload for the notification webhooks, in which case this objec
 ## Retry a Build
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/retry?circle-token=:token
+curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/retry
 
 ```
 
@@ -136,7 +136,7 @@ curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/
 
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/ssh-users?circle-token=:token
+curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/ssh-users
 ```
 
 ```text
@@ -149,7 +149,7 @@ curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/
 ## Cancel a Build
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/cancel?circle-token=:token
+curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/cancel
 ```
 
 ```json
@@ -188,7 +188,7 @@ curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/
 
 ## Trigger a new Job
 ```sh
-curl -X POST --header "Content-Type: application/json" -d '{
+curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{
   "tag": "v0.1", // optional
   "parallel": 2, //optional, default null
   "build_parameters": { // optional
@@ -196,7 +196,7 @@ curl -X POST --header "Content-Type: application/json" -d '{
   }
 }
 
-https://circleci.com/api/v1.1/project/:vcs-type/:username/:project?circle-token=:token
+https://circleci.com/api/v1.1/project/:vcs-type/:username/:project
 ```
 
 ```json
@@ -289,7 +289,7 @@ build_parameters | Additional environment variables to inject into the build env
 ## Trigger a new Job with a Branch
 
 ```sh
-curl -X POST --header "Content-Type: application/json" -d '{
+curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{
   "parallel": 2, //optional, default null
   "revision": "f1baeb913288519dd9a942499cef2873f5b1c2bf" // optional
   "build_parameters": { // optional
@@ -297,7 +297,7 @@ curl -X POST --header "Content-Type: application/json" -d '{
   }
 }
 
-https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/tree/:branch?circle-token=:token
+https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/tree/:branch
 ```
 
 ```json
@@ -390,7 +390,7 @@ build_parameters | Additional environment variables to inject into the build env
 ## Trigger a new Build by Project (preview)
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build?circle-token=:token
+curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build
 ```
 
 ```json
@@ -418,7 +418,7 @@ tag | The git tag to build. Cannot be used with branch and revision parameters.
 ## Get Build Test Metadata
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/tests?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/tests
 ```
 
 ```json

--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -3,7 +3,7 @@
 ## Single Job
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -94,7 +94,7 @@ This is also the payload for the notification webhooks, in which case this objec
 ## Retry a Build
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/retry -H 'Circle-Token: <circle-token>'
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/retry -H "Circle-Token: <circle-token>"
 
 ```
 
@@ -136,7 +136,7 @@ curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/
 
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/ssh-users -H 'Circle-Token: <circle-token>'
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/ssh-users -H "Circle-Token: <circle-token>"
 ```
 
 ```text
@@ -149,7 +149,7 @@ curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/
 ## Cancel a Build
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/cancel -H 'Circle-Token: <circle-token>'
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/cancel -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -188,7 +188,7 @@ curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/
 
 ## Trigger a new Job
 ```sh
-curl -X POST --header "Content-Type: application/json" -H 'Circle-Token: <circle-token>' -d '{
+curl -X POST --header "Content-Type: application/json" -H "Circle-Token: <circle-token>" -d '{
   "tag": "v0.1", // optional
   "parallel": 2, //optional, default null
   "build_parameters": { // optional
@@ -289,7 +289,7 @@ build_parameters | Additional environment variables to inject into the build env
 ## Trigger a new Job with a Branch
 
 ```sh
-curl -X POST --header "Content-Type: application/json" -H 'Circle-Token: <circle-token>' -d '{
+curl -X POST --header "Content-Type: application/json" -H "Circle-Token: <circle-token>" -d '{
   "parallel": 2, //optional, default null
   "revision": "f1baeb913288519dd9a942499cef2873f5b1c2bf" // optional
   "build_parameters": { // optional
@@ -390,7 +390,7 @@ build_parameters | Additional environment variables to inject into the build env
 ## Trigger a new Build by Project (preview)
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build -H 'Circle-Token: <circle-token>'
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -418,7 +418,7 @@ tag | The git tag to build. Cannot be used with branch and revision parameters.
 ## Get Build Test Metadata
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/tests -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/tests -H "Circle-Token: <circle-token>"
 ```
 
 ```json

--- a/src-api/source/includes/_environment_vars.md
+++ b/src-api/source/includes/_environment_vars.md
@@ -3,7 +3,7 @@
 ## List Environment Variables
 
 ```sh 
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
 ```
 
 ```json 
@@ -15,7 +15,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar?c
 ## Add Environment Variables
 
 ```sh 
-curl -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar?circle-token=:token
+curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
 ```
 
 ```json
@@ -27,7 +27,7 @@ curl -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value
 ## Get Single Environment Variable
 
 ```sh 
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
 ```
 
 ```json
@@ -39,7 +39,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:
 ## Delete Environment Variables
 
 ```sh
-curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name?circle-token=:token
+curl -u <circle-token>: -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
 ```
 
 ```json

--- a/src-api/source/includes/_environment_vars.md
+++ b/src-api/source/includes/_environment_vars.md
@@ -3,7 +3,7 @@
 ## List Environment Variables
 
 ```sh 
-curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar -H 'Circle-Token: <circle-token>'
 ```
 
 ```json 
@@ -15,7 +15,7 @@ curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:usernam
 ## Add Environment Variables
 
 ```sh 
-curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
+curl -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -27,7 +27,7 @@ curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"
 ## Get Single Environment Variable
 
 ```sh 
-curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -39,7 +39,7 @@ curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:usernam
 ## Delete Environment Variables
 
 ```sh
-curl -u <circle-token>: -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
+curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name -H 'Circle-Token: <circle-token>'
 ```
 
 ```json

--- a/src-api/source/includes/_environment_vars.md
+++ b/src-api/source/includes/_environment_vars.md
@@ -3,7 +3,7 @@
 ## List Environment Variables
 
 ```sh 
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar -H "Circle-Token: <circle-token>"
 ```
 
 ```json 
@@ -15,7 +15,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar -
 ## Add Environment Variables
 
 ```sh 
-curl -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar -H 'Circle-Token: <circle-token>'
+curl -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -27,7 +27,7 @@ curl -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value
 ## Get Single Environment Variable
 
 ```sh 
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -39,7 +39,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:
 ## Delete Environment Variables
 
 ```sh
-curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name -H 'Circle-Token: <circle-token>'
+curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name -H "Circle-Token: <circle-token>"
 ```
 
 ```json

--- a/src-api/source/includes/_keys.md
+++ b/src-api/source/includes/_keys.md
@@ -3,7 +3,7 @@
 ## List Checkout Keys
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key
 ```
 
 ```json
@@ -20,7 +20,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout
 ## New Checkout Key
 
 ```sh
-curl -X POST --header "Content-Type: application/json" -d '{"type":"github-user-key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key?circle-token=:token
+curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"type":"github-user-key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key
 ```
 
 ```json
@@ -42,7 +42,7 @@ type | The type of key to create. Can be 'deploy-key' or 'github-user-key'.
 ## Get Checkout Key
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint
 ```
 
 ```json
@@ -61,7 +61,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout
 **`DELETE` Request:** Deletes the checkout key.
 
 ```sh
-curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint?circle-token=:token
+curl -u <circle-token>: -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint
 ```
 
 ```json
@@ -73,7 +73,7 @@ curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:projec
 **`POST` Request:** Creates an SSH key that will be used to access the external system identified by the hostname parameter for SSH key-based authentication.
 
 ```sh
-curl -X POST --header "Content-Type: application/json" -d '{"hostname":"hostname","private_key":"RSA private key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key?circle-token=:token
+curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"hostname":"hostname","private_key":"RSA private key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key
 ```
 
 ```
@@ -83,7 +83,7 @@ curl -X POST --header "Content-Type: application/json" -d '{"hostname":"hostname
 ## Delete SSH Key
 
 ```sh
-curl -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fingerprint", "hostname":"Hostname"} https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key?circle-token=:token
+curl -u <circle-token>: -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fingerprint", "hostname":"Hostname"} https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key
 ```
 
 ```
@@ -98,7 +98,7 @@ curl -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fing
 **`POST` Request:** Adds your Heroku API key to CircleCI and then takes `apikey` as form param name.
 
 ```sh
-curl -X POST --header "Content-Type: application/json" -d '{"apikey":"Heroku key"}' https://circleci.com/user/heroku-key?circle-token=:token
+curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"apikey":"Heroku key"}' https://circleci.com/user/heroku-key
 ```
 
 ```

--- a/src-api/source/includes/_keys.md
+++ b/src-api/source/includes/_keys.md
@@ -3,7 +3,7 @@
 ## List Checkout Keys
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -20,7 +20,7 @@ curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:usernam
 ## New Checkout Key
 
 ```sh
-curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"type":"github-user-key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key
+curl -X POST --header "Content-Type: application/json" -d '{"type":"github-user-key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -42,7 +42,7 @@ type | The type of key to create. Can be 'deploy-key' or 'github-user-key'.
 ## Get Checkout Key
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -61,7 +61,7 @@ curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:usernam
 **`DELETE` Request:** Deletes the checkout key.
 
 ```sh
-curl -u <circle-token>: -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint
+curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -73,7 +73,7 @@ curl -u <circle-token>: -X DELETE https://circleci.com/api/v1.1/project/:vcs-typ
 **`POST` Request:** Creates an SSH key that will be used to access the external system identified by the hostname parameter for SSH key-based authentication.
 
 ```sh
-curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"hostname":"hostname","private_key":"RSA private key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key
+curl -X POST --header "Content-Type: application/json" -d '{"hostname":"hostname","private_key":"RSA private key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key -H 'Circle-Token: <circle-token>'
 ```
 
 ```
@@ -83,7 +83,7 @@ curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"
 ## Delete SSH Key
 
 ```sh
-curl -u <circle-token>: -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fingerprint", "hostname":"Hostname"} https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key
+curl -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fingerprint", "hostname":"Hostname"} https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key -H 'Circle-Token: <circle-token>'
 ```
 
 ```
@@ -98,7 +98,7 @@ curl -u <circle-token>: -X DELETE --header "Content-Type: application/json" -d {
 **`POST` Request:** Adds your Heroku API key to CircleCI and then takes `apikey` as form param name.
 
 ```sh
-curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"apikey":"Heroku key"}' https://circleci.com/user/heroku-key
+curl -X POST --header "Content-Type: application/json" -d '{"apikey":"Heroku key"}' https://circleci.com/user/heroku-key -H 'Circle-Token: <circle-token>'
 ```
 
 ```

--- a/src-api/source/includes/_keys.md
+++ b/src-api/source/includes/_keys.md
@@ -3,7 +3,7 @@
 ## List Checkout Keys
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -20,7 +20,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout
 ## New Checkout Key
 
 ```sh
-curl -X POST --header "Content-Type: application/json" -d '{"type":"github-user-key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key -H 'Circle-Token: <circle-token>'
+curl -X POST --header "Content-Type: application/json" -d '{"type":"github-user-key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -42,7 +42,7 @@ type | The type of key to create. Can be 'deploy-key' or 'github-user-key'.
 ## Get Checkout Key
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -61,7 +61,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout
 **`DELETE` Request:** Deletes the checkout key.
 
 ```sh
-curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint -H 'Circle-Token: <circle-token>'
+curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -73,7 +73,7 @@ curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:projec
 **`POST` Request:** Creates an SSH key that will be used to access the external system identified by the hostname parameter for SSH key-based authentication.
 
 ```sh
-curl -X POST --header "Content-Type: application/json" -d '{"hostname":"hostname","private_key":"RSA private key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key -H 'Circle-Token: <circle-token>'
+curl -X POST --header "Content-Type: application/json" -d '{"hostname":"hostname","private_key":"RSA private key"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key -H "Circle-Token: <circle-token>"
 ```
 
 ```
@@ -83,7 +83,7 @@ curl -X POST --header "Content-Type: application/json" -d '{"hostname":"hostname
 ## Delete SSH Key
 
 ```sh
-curl -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fingerprint", "hostname":"Hostname"} https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key -H 'Circle-Token: <circle-token>'
+curl -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fingerprint", "hostname":"Hostname"} https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/ssh-key -H "Circle-Token: <circle-token>"
 ```
 
 ```
@@ -98,7 +98,7 @@ curl -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fing
 **`POST` Request:** Adds your Heroku API key to CircleCI and then takes `apikey` as form param name.
 
 ```sh
-curl -X POST --header "Content-Type: application/json" -d '{"apikey":"Heroku key"}' https://circleci.com/user/heroku-key -H 'Circle-Token: <circle-token>'
+curl -X POST --header "Content-Type: application/json" -d '{"apikey":"Heroku key"}' https://circleci.com/user/heroku-key -H "Circle-Token: <circle-token>"
 ```
 
 ```

--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -48,7 +48,7 @@ The CircleCI API utilizes token-based authentication to manage access to the API
 ## Add an API Token
 
 ```sh
-$ curl -u <circle-token>: https://circleci.com/api/v1.1/me
+$ curl -H 'Circle-Token: <circle-token>' https://circleci.com/api/v1.1/me
 ```
 
 
@@ -76,22 +76,29 @@ All API calls are made in the same way, by making standard HTTP calls, using JSO
 
 ## Get Authenticated
 
+
+```sh 
+curl -H 'Circle-Token: <circle-token>' "https://circleci.com/api/..."
+```
+
 ```sh 
 curl -u <circle-token>: "https://circleci.com/api/..."
 ```
 
 ```sh
-curl -u <circle-token>: "https://circleci.com/api/v1.1/me
+curl "https://circleci.com/api/v1.1/me?circle-token=<circle-token>"
 ```
 You can add the API token using your [account dashboard](https://circleci.com/account/api).
 
-To be authenticated by the API server, use the API token as the username for HTTP Basic Authentication, by passing the `-u` flag to the `curl` command:
+To be authenticated by the API server, use this as the value of the Circle-Token header:
+
+Or you can use the API token as the username for HTTP Basic Authentication, by passing the `-u` flag to the `curl` command:
 
 <aside class="notice">
 the colon ":" tells curl that there's no password.
 </aside>
 
-DEPRECATED (this option will be removed in the future): The API token can be added to the `circle-token` query param instead:
+DEPRECATED (this option will be removed in the future): The API token can be added to the `circle-token` query param:
 
 ## Version Control Systems (:vcs-type)
 
@@ -123,7 +130,7 @@ In both cases, builds are returned in the order that they were created. For all 
 ## Accept Header
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/me -H "Accept: application/json"
+curl https://circleci.com/api/v1.1/me -H "Accept: application/json" -H 'Circle-Token: <circle-token>'
 ```
 
 If no accept header is specified (or it is empty), CircleCI will return the data in a Clojure EDN format. To recieve the data as nicely formatted JSON, include any value for the `Accept` header (e.g `text/plain`). If you prefer to receive compact JSON with no whitespace or comments, use `application/json` as the `Accept` header.

--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -48,7 +48,7 @@ The CircleCI API utilizes token-based authentication to manage access to the API
 ## Add an API Token
 
 ```sh
-$ curl https://circleci.com/api/v1.1/me?circle-token=:token
+$ curl -u <circle-token>: https://circleci.com/api/v1.1/me
 ```
 
 
@@ -76,21 +76,22 @@ All API calls are made in the same way, by making standard HTTP calls, using JSO
 
 ## Get Authenticated
 
-```sh
-curl "https://circleci.com/api/v1.1/me?circle-token=:token"
-```
-
 ```sh 
 curl -u <circle-token>: "https://circleci.com/api/..."
 ```
 
-To be authenticated by the API server, add an API token using your [account dashboard](https://circleci.com/account/api). To use the API token, add it to the `circle-token` query param:
+```sh
+curl -u <circle-token>: "https://circleci.com/api/v1.1/me
+```
+You can add the API token using your [account dashboard](https://circleci.com/account/api).
 
-Alternatively, you can use the API token as the username for HTTP Basic Authentication, by passing the `-u` flag to the `curl` command:
+To be authenticated by the API server, use the API token as the username for HTTP Basic Authentication, by passing the `-u` flag to the `curl` command:
 
 <aside class="notice">
 the colon ":" tells curl that there's no password.
 </aside>
+
+DEPRECATED (this option will be removed in the future): The API token can be added to the `circle-token` query param instead:
 
 ## Version Control Systems (:vcs-type)
 
@@ -122,7 +123,7 @@ In both cases, builds are returned in the order that they were created. For all 
 ## Accept Header
 
 ```sh
-curl https://circleci.com/api/v1.1/me?circle-token=:token -H "Accept: application/json"
+curl -u <circle-token>: https://circleci.com/api/v1.1/me -H "Accept: application/json"
 ```
 
 If no accept header is specified (or it is empty), CircleCI will return the data in a Clojure EDN format. To recieve the data as nicely formatted JSON, include any value for the `Accept` header (e.g `text/plain`). If you prefer to receive compact JSON with no whitespace or comments, use `application/json` as the `Accept` header.

--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -48,7 +48,7 @@ The CircleCI API utilizes token-based authentication to manage access to the API
 ## Add an API Token
 
 ```sh
-$ curl -H 'Circle-Token: <circle-token>' https://circleci.com/api/v1.1/me
+$ curl -H "Circle-Token: <circle-token>" https://circleci.com/api/v1.1/me
 ```
 
 
@@ -78,7 +78,7 @@ All API calls are made in the same way, by making standard HTTP calls, using JSO
 
 
 ```sh 
-curl -H 'Circle-Token: <circle-token>' "https://circleci.com/api/..."
+curl -H "Circle-Token: <circle-token>" "https://circleci.com/api/..."
 ```
 
 ```sh 
@@ -130,7 +130,7 @@ In both cases, builds are returned in the order that they were created. For all 
 ## Accept Header
 
 ```sh
-curl https://circleci.com/api/v1.1/me -H "Accept: application/json" -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/me -H "Accept: application/json" -H "Circle-Token: <circle-token>"
 ```
 
 If no accept header is specified (or it is empty), CircleCI will return the data in a Clojure EDN format. To recieve the data as nicely formatted JSON, include any value for the `Accept` header (e.g `text/plain`). If you prefer to receive compact JSON with no whitespace or comments, use `application/json` as the `Accept` header.

--- a/src-api/source/includes/_projects.md
+++ b/src-api/source/includes/_projects.md
@@ -7,7 +7,7 @@ The sections below describe the endpoints you may call to return Project informa
 ## Get All Followed Projects
 
 ```sh
-curl https://circleci.com/api/v1.1/projects?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/projects
 ```
 
 ```json
@@ -56,7 +56,7 @@ Returns an array of all projects you are currently following on CircleCI, with b
 ## Follow a New Project on CircleCI
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/follow?circle-token=:token
+curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/follow
 ```
 
 ```json
@@ -177,7 +177,7 @@ shallow | An optional boolean parameter that may be sent to improve performance 
 ## Recent Builds For A Single Project
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project?circle-token=:token&limit=20&offset=5&filter=completed
+curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project?limit=20&offset=5&filter=completed
 ```
 
 >**Note:** You can narrow the builds to a single branch by appending /tree/:branch to the url. Note that the branch name should be url-encoded.
@@ -294,7 +294,7 @@ The example to the right shows a user request for recent build information. Noti
 **`DELETE` Request:** Clears the cache for a project.
 
 ```sh
-curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build-cache?circle-token=:token
+curl -u <circle-token>: -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build-cache
 ```
 
 ```json

--- a/src-api/source/includes/_projects.md
+++ b/src-api/source/includes/_projects.md
@@ -7,7 +7,7 @@ The sections below describe the endpoints you may call to return Project informa
 ## Get All Followed Projects
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/projects
+curl https://circleci.com/api/v1.1/projects -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -56,7 +56,7 @@ Returns an array of all projects you are currently following on CircleCI, with b
 ## Follow a New Project on CircleCI
 
 ```sh
-curl -u <circle-token>: -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/follow
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/follow -H 'Circle-Token: <circle-token>'
 ```
 
 ```json
@@ -177,7 +177,7 @@ shallow | An optional boolean parameter that may be sent to improve performance 
 ## Recent Builds For A Single Project
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project?limit=20&offset=5&filter=completed
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project?limit=20&offset=5&filter=completed -H 'Circle-Token: <circle-token>'
 ```
 
 >**Note:** You can narrow the builds to a single branch by appending /tree/:branch to the url. Note that the branch name should be url-encoded.
@@ -294,7 +294,7 @@ The example to the right shows a user request for recent build information. Noti
 **`DELETE` Request:** Clears the cache for a project.
 
 ```sh
-curl -u <circle-token>: -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build-cache
+curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build-cache -H 'Circle-Token: <circle-token>'
 ```
 
 ```json

--- a/src-api/source/includes/_projects.md
+++ b/src-api/source/includes/_projects.md
@@ -7,7 +7,7 @@ The sections below describe the endpoints you may call to return Project informa
 ## Get All Followed Projects
 
 ```sh
-curl https://circleci.com/api/v1.1/projects -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/projects -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -56,7 +56,7 @@ Returns an array of all projects you are currently following on CircleCI, with b
 ## Follow a New Project on CircleCI
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/follow -H 'Circle-Token: <circle-token>'
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/follow -H "Circle-Token: <circle-token>"
 ```
 
 ```json
@@ -177,7 +177,7 @@ shallow | An optional boolean parameter that may be sent to improve performance 
 ## Recent Builds For A Single Project
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project?limit=20&offset=5&filter=completed -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project?limit=20&offset=5&filter=completed -H "Circle-Token: <circle-token>"
 ```
 
 >**Note:** You can narrow the builds to a single branch by appending /tree/:branch to the url. Note that the branch name should be url-encoded.
@@ -294,7 +294,7 @@ The example to the right shows a user request for recent build information. Noti
 **`DELETE` Request:** Clears the cache for a project.
 
 ```sh
-curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build-cache -H 'Circle-Token: <circle-token>'
+curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build-cache -H "Circle-Token: <circle-token>"
 ```
 
 ```json

--- a/src-api/source/includes/_user.md
+++ b/src-api/source/includes/_user.md
@@ -2,7 +2,7 @@
 
 
 ```sh
-curl https://circleci.com/api/v1.1/me?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/me
 ```
 
 ```json

--- a/src-api/source/includes/_user.md
+++ b/src-api/source/includes/_user.md
@@ -2,7 +2,7 @@
 
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/me
+curl https://circleci.com/api/v1.1/me -H 'Circle-Token: <circle-token>'
 ```
 
 ```json

--- a/src-api/source/includes/_user.md
+++ b/src-api/source/includes/_user.md
@@ -2,7 +2,7 @@
 
 
 ```sh
-curl https://circleci.com/api/v1.1/me -H 'Circle-Token: <circle-token>'
+curl https://circleci.com/api/v1.1/me -H "Circle-Token: <circle-token>"
 ```
 
 ```json

--- a/src-api/source/includes/environment_variables.md
+++ b/src-api/source/includes/environment_variables.md
@@ -5,7 +5,7 @@
 Returns a list of all environment variables.
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
 ``
 
 ```json
@@ -22,7 +22,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar?c
 Creates a new environment variable.
 
 ```sh
-curl -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar?circle-token=:token
+curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
 ```
 
 ```json
@@ -38,7 +38,7 @@ curl -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value
 Gets the hidden value of environment variable :name
 
 ```sh
-curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name?circle-token=:token
+curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
 ```
 
 ```json
@@ -53,7 +53,7 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:
 ## Delete Environment Variables
 
 ```sh
-curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name?circle-token=:token
+curl -u <circle-token>: -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
 ```
 
 ```json

--- a/src-api/source/includes/environment_variables.md
+++ b/src-api/source/includes/environment_variables.md
@@ -5,7 +5,7 @@
 Returns a list of all environment variables.
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
+curl -H "Circle-Token: <circle-token>" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
 ``
 
 ```json
@@ -22,7 +22,7 @@ curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:usernam
 Creates a new environment variable.
 
 ```sh
-curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
+curl -H "Circle-Token: <circle-token>" -X POST --header "Content-Type: application/json" -d '{"name":"foo", "value":"bar"}' https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar
 ```
 
 ```json
@@ -38,7 +38,7 @@ curl -u <circle-token>: -X POST --header "Content-Type: application/json" -d '{"
 Gets the hidden value of environment variable :name
 
 ```sh
-curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
+curl -H "Circle-Token: <circle-token>" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
 ```
 
 ```json
@@ -53,7 +53,7 @@ curl -u <circle-token>: https://circleci.com/api/v1.1/project/:vcs-type/:usernam
 ## Delete Environment Variables
 
 ```sh
-curl -u <circle-token>: -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
+curl -H "Circle-Token: <circle-token>" -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/envvar/:name
 ```
 
 ```json


### PR DESCRIPTION
# Description
Document that we are deprecating putting the token in query parameters and use basic auth in examples

# Reasons
https://circleci.atlassian.net/browse/CIRCLE-27357