### PR TITLE
Change Environment Variable name for AWS Region

### DIFF
--- a/jekyll/_cci2/ecs-ecr.md
+++ b/jekyll/_cci2/ecs-ecr.md
@@ -53,7 +53,7 @@ Variable                 | Description
 -------------------------|------------
 AWS_ACCESS_KEY_ID        | Security credentials for AWS.
 AWS_SECRET_ACCESS_KEY    | Security credentials for AWS.
-AWS_REGION               | Used by the AWS CLI.
+AWS_DEFAULT_REGION       | Used by the AWS CLI.
 AWS_ACCOUNT_ID           | Required for deployment. [Find your AWS Account ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#FindingYourAWSId).
 AWS_RESOURCE_NAME_PREFIX | Prefix for some required AWS resources. Should correspond to the value of `aws_resource_prefix` in `terraform_setup/terraform.tfvars`.
 AWS_ECR_ACCOUNT_URL      | Amazon ECR account URL that maps to an AWS account, e.g. {awsAccountNum}.dkr.ecr.us-west-2.amazonaws.com


### PR DESCRIPTION
The AWS-CLI library has changed its default environment variable, previously AWS_REGION to AWS_DEFAULT_REGION. A change can be reflected in the docs for deploying codebase to ECR and ECS. Fixes issue #4585.

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.