### PR TITLE
Add a requirement to trigger builds with a restricted context

### DIFF
--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -91,7 +91,7 @@ The default security group is `All members` and enables any member of the organi
 
 ### Running Workflows with a Restricted Context
 
-To invoke a job that uses a restricted context, a user must be a member of one of the security groups for the context. If the user running the workflow does not have access to the context, the workflow will fail with the `Unauthorized` status.
+To invoke a job that uses a restricted context, a user must be a member of one of the security groups for the context and must sign up for CircleCI. If the user running the workflow does not have access to the context, the workflow will fail with the `Unauthorized` status.
 
 ### Restrict a Context to a Security Group or Groups
 


### PR DESCRIPTION
# Description
Add the requirement to trigger builds with a restricted context

# Reasons
Users need to sign up for CircleCI to trigger builds with a restricted context. Even if they don't sign up for CircleCI, they can trigger builds, but to trigger a build with a restricted context, CircleCI needs to check the accounts permission, so users must sign up for CircleCI.