### PR TITLE
Fix link on Japanese index page

### DIFF
--- a/jekyll/_cci2_ja/index.md
+++ b/jekyll/_cci2_ja/index.md
@@ -14,22 +14,22 @@ CircleCI について理解を深めていただけるよう、チュートリ�
     <h2>はじめよう</h2>
     <p>CircleCI でビルドの自動化を始めましょう。</p>
     <ul>
-      <li><a href="/docs/2.0/first-steps/">ユーザー登録とトライアル</a></li>
-      <li><a href="/docs/2.0/getting-started/">初回ビルドの前提条件</a></li>
-      <li><a href="/docs/2.0/hello-world/">Hello World</a></li>
-      <li><a href="/docs/2.0/faq/">よくあるご質問</a></li>
-      <li><a href="/docs/2.0/orb-intro/">Orbs</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/first-steps/">ユーザー登録とトライアル</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/getting-started/">初回ビルドの前提条件</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/hello-world/">Hello World</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/faq/">よくあるご質問</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/orb-intro/">Orbs</a></li>
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">
     <h2>サンプル</h2>
     <p>人気のサンプルをチェックしましょう。</p>
     <ul>
-      <li><a href="/docs/2.0/example-configs/">CircleCI を使用したオープンソース プロジェクト</a></li>
-        <li><a href="/docs/2.0/postgres-config/">データベースの構成例</a></li>
-        <li><a href="/docs/2.0/sample-config/">config.yml のサンプル ファイル</a></li>
-        <li><a href="/docs/2.0/tutorials/">チュートリアルとサンプル アプリ</a></li>
-        <li><a href="/docs/2.0/using-orbs/">Orbs の使用</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/example-configs/">CircleCI を使用したオープンソース プロジェクト</a></li>
+        <li><a href="{{ site.baseurl }}/ja/2.0/postgres-config/">データベースの構成例</a></li>
+        <li><a href="{{ site.baseurl }}/ja/2.0/sample-config/">config.yml のサンプル ファイル</a></li>
+        <li><a href="{{ site.baseurl }}/ja/2.0/tutorials/">チュートリアルとサンプル アプリ</a></li>
+        <li><a href="{{ site.baseurl }}/ja/2.0/using-orbs/">Orbs の使用</a></li>
       </ul>
   </div>
   <div class="col-xs-12">
@@ -43,18 +43,18 @@ CircleCI について理解を深めていただけるよう、チュートリ�
       <li><a href="{{ site.baseurl }}/ja/2.0/writing-yaml/">YAML の記述</a></li>
       <li><a href="{{ site.baseurl }}/ja/2.0/env-vars/">環境変数の使用</a></li>
       <li><a href="{{ site.baseurl }}/ja/2.0/ssh-access-jobs/">SSH を使用したデバッグ</a></li>
-      <li><a href="/docs/2.0/reusing-config/">設定ファイルの再利用</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/reusing-config/">設定ファイルの再利用</a></li>
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">
     <h2>ワークフロー</h2>
     <p>CircleCI のワークフロー機能によってジョブのスケジュール実行と順次実行が構成できます。</p>
     <ul>
-      <li><a href="/docs/ja/2.0/workflows/">ワークフローを使用したジョブのスケジュール</a></li>
-      <li><a href="/docs/ja/2.0/workflows/#ワークフローの構成例">ワークフローの構成例</a></li>
-      <li><a href="/docs/ja/2.0/workflows/#ワークフローのスケジュール実行">ワークフローのスケジュール実行</a></li>
-      <li><a href="/docs/ja/2.0/workflows/#ワークフローにおけるコンテキストとフィルターの使用">ワークフローにおけるコンテキストとフィルターの使用</a></li>
-      <li><a href="/docs/ja/2.0/creating-orbs/">Orbs の作成</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/workflows/">ワークフローを使用したジョブのスケジュール</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/workflows/#ワークフローの構成例">ワークフローの構成例</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/workflows/#ワークフローのスケジュール実行">ワークフローのスケジュール実行</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/workflows/#ワークフローにおけるコンテキストとフィルターの使用">ワークフローにおけるコンテキストとフィルターの使用</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/creating-orbs/">Orbs の作成</a></li>
     </ul>
   </div>
 </div>

--- a/jekyll/_cci2_ja/index.md
+++ b/jekyll/_cci2_ja/index.md
@@ -26,11 +26,11 @@ CircleCI について理解を深めていただけるよう、チュートリ�
     <p>人気のサンプルをチェックしましょう。</p>
     <ul>
       <li><a href="{{ site.baseurl }}/ja/2.0/example-configs/">CircleCI を使用したオープンソース プロジェクト</a></li>
-        <li><a href="{{ site.baseurl }}/ja/2.0/postgres-config/">データベースの構成例</a></li>
-        <li><a href="{{ site.baseurl }}/ja/2.0/sample-config/">config.yml のサンプル ファイル</a></li>
-        <li><a href="{{ site.baseurl }}/ja/2.0/tutorials/">チュートリアルとサンプル アプリ</a></li>
-        <li><a href="{{ site.baseurl }}/ja/2.0/using-orbs/">Orbs の使用</a></li>
-      </ul>
+      <li><a href="{{ site.baseurl }}/ja/2.0/postgres-config/">データベースの構成例</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/sample-config/">config.yml のサンプル ファイル</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/tutorials/">チュートリアルとサンプル アプリ</a></li>
+      <li><a href="{{ site.baseurl }}/ja/2.0/using-orbs/">Orbs の使用</a></li>
+    </ul>
   </div>
   <div class="col-xs-12">
     <hr />


### PR DESCRIPTION
# Description
Links on the Japanese index page were pointing to the English version of the
docs.
I am fixing it to point to the Japanese version instead.

# Reasons
Links on the Japanese index page were pointing to the English version of the
docs.