### PR TITLE
Add note about job name needing to be unique

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -713,7 +713,7 @@ workflows:
 ```
 {% endraw %}
 
-**Note:** The ability to invoke jobs multiple times in a single workflow with parameters is available in configuration version 2.1. When invoking the same job multiple times with parameters across any number of workflows, the build name will be changed (i.e. `sayhello-1` , `sayhello-2`, etc.). To ensure build numbers are not appended, utilize the `name` key. As an example:
+**Note:** The ability to invoke jobs multiple times in a single workflow with parameters is available in configuration version 2.1. When invoking the same job multiple times with parameters across any number of workflows, the build name will be changed (i.e. `sayhello-1` , `sayhello-2`, etc.). To ensure build numbers are not appended, utilize the `name` key. The name you assign needs to be unique, otherwise the numbers will still be appended to the job name. As an example:
 
 ```yaml
 workflows:


### PR DESCRIPTION
# Description
This update adds a note that the name assigned to the `name` key needs to be unique.

# Reasons
I previously added (https://github.com/circleci/circleci-docs/pull/4536) this disclaimer about job names appending numbers when calling multiple times with parameters. However, I didn't note that the name assigned via `name` needs to be unique, otherwise the numbers will still be appended.