### PR TITLE
[WIP] Further explain `env_var_name` parameter type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     asciidoctor (2.0.10)
-    asciidoctor-pdf (1.5.0.rc.3)
+    asciidoctor-pdf (1.5.3)
       asciidoctor (>= 1.5.3, < 3.0.0)
       concurrent-ruby (~> 1.1.0)
       prawn (~> 2.2.0)
@@ -184,7 +184,7 @@ PLATFORMS
 
 DEPENDENCIES
   asciidoctor
-  asciidoctor-pdf (~> 1.5.0.rc.3)
+  asciidoctor-pdf (~> 1.5.3)
   html-proofer
   jekyll (= 3.8.6)
   jekyll-algolia (~> 1.0)

--- a/jekyll/_cci2/orbs-faq.md
+++ b/jekyll/_cci2/orbs-faq.md
@@ -21,7 +21,7 @@ This document describes various questions and technical issues that you may find
 
 * **Question:** What is the difference between commands and jobs?
 
-* **Answer:** Both [commands]({{site.baseurl}}/2.0/reusing-config/#the-commands-key) and [jobs]({{site.baseurl}}/2.0/reusing-config/#authoring-parameterized-jobs) are elements that can be used within orbs. _Commands_ contain one or many [steps]({{site.baseurl}}/2.0/configuration-reference/#steps), which contain the logic of the orb. Commands generally execute some shell code (bash). _Jobs_ are a definition of what steps/commands to run _and_ the [executor]({{site.baseurl}}/2.0/reusing-config/#executors) to run them in. _Commands_ are invoked within jobs. _Jobs_ are orchestrated using _[Workflows]({{site.baseurl}}/2.0/workflows/#workflows-configuration-examples)_.
+* **Answer:** Both [commands]({{site.baseurl}}/2.0/reusing-config/#the-commands-key) and [jobs]({{site.baseurl}}/2.0/reusing-config/#authoring-parameterized-jobs) are elements that can be used within orbs. _Commands_ contain one or many [steps]({{site.baseurl}}/2.0/configuration-reference/#steps), which contain the logic of the orb. Commands generally execute some shell code (bash). _Jobs_ are a definition of what steps/commands to run _and_ the [executor]({{site.baseurl}}/2.0/reusing-config/#the-executors-key) to run them in. _Commands_ are invoked within jobs. _Jobs_ are orchestrated using _[Workflows]({{site.baseurl}}/2.0/workflows/#workflows-configuration-examples)_.
 
 ## Using Orbs on CircleCI Server
 

--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -393,7 +393,7 @@ jobs:
     docker:
       - image: "cimg/base:stable"
     steps:
-      - sayhello: // invoke command "sayhello"
+      - sayhello: # invoke command "sayhello"
           to: "Lev"
 ```
 

--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -17,7 +17,7 @@ This guide describes how to get started with reusable commands, jobs, executors 
 
 * Install the CircleCI CLI so that you have access to the `circleci config process` command (optional). This command lets you see the expanded configuration with all reusable keys processed. Follow the [Using the CircleCI CLI]({{ site.baseurl }}/2.0/local-cli/) documentation for installation instructions and tips.
 
-* CircleCI reusable configuration elements require a `version: 2.1` `.circleci/config.yml` file.
+* CircleCI reusable configuration elements require a **`version: 2.1`** `.circleci/config.yml` file.
 
 * Command, job, executor, and parameter names must start with a letter and can only contain lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`) and hyphens (`-`).
 

--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -158,6 +158,7 @@ The `enum` parameter may be a list of any values. Use the `enum` parameter type 
 
 ```yaml
 version: 2.1
+
 commands:
   list-files:
     parameters:
@@ -173,6 +174,7 @@ The following `enum` type declaration is invalid because the default is not decl
 {% raw %}
 ```yaml
 version: 2.1
+
 commands:
   list-files:
     parameters:
@@ -191,6 +193,7 @@ Use an `executor` parameter type to allow the invoker of a job to decide what ex
 {% raw %}
 ```yaml
 version: 2.1
+
 executors:
   xenial:
     parameters:
@@ -234,6 +237,7 @@ Steps are used when you have a job or command that needs to mix predefined and u
 {% raw %}
 ```yaml
 version: 2.1
+
 commands:
   run-tests:
     parameters:
@@ -242,9 +246,9 @@ commands:
         type: steps
         default: []
     steps:
-    - run: make deps
-    - steps: << parameters.after-deps >>
-    - run: make test
+      - run: make deps
+      - steps: << parameters.after-deps >>
+      - run: make test
 ```
 {% endraw %}
 
@@ -253,14 +257,27 @@ The following example demonstrates that steps passed as parameters are given as 
 {% raw %}
 ```yaml
 version: 2.1
+
+commands:
+  run-tests:
+    parameters:
+      after-deps:
+        description: "Steps that will be executed after dependencies are installed, but before tests are run"
+        type: steps
+        default: []
+    steps:
+      - run: make deps
+      - steps: << parameters.after-deps >>
+      - run: make test
+
 jobs:
   build:
     machine: true
     steps:
-    - run-tests:
-        after-deps:
-          - run: echo "The dependencies are installed"
-          - run: echo "And now I'm going to run the tests"
+      - run-tests:
+          after-deps:
+            - run: echo "The dependencies are installed"
+            - run: echo "And now I'm going to run the tests"
 ```
 {% endraw %}
 


### PR DESCRIPTION
- clear up what's going on with env_var_name param type -  original request: https://circleci.slack.com/archives/C0KBNJGRH/p1595872682016600
- move parameters section to the start of the doc as this needs to be understood for all other sections
- update a couple of examples 