### PR TITLE
fix typo in instruction

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -784,7 +784,7 @@ A value of `on_fail` means that the step will run only if one of the preceding s
 
 ###### Ending a Job from within a `step`
 
-A job can exit without failing by using using `run: circleci-agent step halt`. This can be useful in situations where jobs need to conditionally execute.
+A job can exit without failing by using `run: circleci-agent step halt`. This can be useful in situations where jobs need to conditionally execute.
 
 Here is an example where `halt` is used to avoid running a job on the `develop` branch:
 


### PR DESCRIPTION
# Description
Fixing typo in the [Ending a job from within a step](https://circleci.com/docs/2.0/configuration-reference/#ending-a-job-from-within-a-step) section.

# Reasons
I think `by using using` is a typo.