### PR TITLE
Add disclaimer about docker support in MacOS

### DIFF
--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -73,9 +73,9 @@ Using `docker` combined with `setup_remote_docker` provides a remote engine simi
 
 This combination is required if you want to build docker images for deployment. 
 
-## Using Docker Compose with macOS Executor (not supported)
+## Limitations
 
-At the moment we [don't support utilizing docker](https://support.circleci.com/hc/en-us/articles/360045029591-Can-I-use-Docker-within-the-macOS-executor-) within the `macos` executor.
+Using `docker-compose` with the `macos` executor is not supported, see [the support article for more information](https://support.circleci.com/hc/en-us/articles/360045029591-Can-I-use-Docker-within-the-macOS-executor-).
 
 ## See Also
 {:.no_toc}

--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -73,6 +73,10 @@ Using `docker` combined with `setup_remote_docker` provides a remote engine simi
 
 This combination is required if you want to build docker images for deployment. 
 
+## Using Docker Compose with macOS Executor (not supported)
+
+At the moment we [don't support utilizing docker](https://support.circleci.com/hc/en-us/articles/360045029591-Can-I-use-Docker-within-the-macOS-executor-) within the `macos` executor.
+
 ## See Also
 {:.no_toc}
 


### PR DESCRIPTION
# Description
At the moment we don't support using docker with the `macos` executor. I wanted to ensure that was noted on this page to avoid any confusion.

# Reasons
These changes are from a suggestion from a customer that we did not note on this page that docker isn't supported for MacOS. Adding this to avoid future confusion amongst customers.  