### PR TITLE
Updated note about DLC on optimizations page

### DIFF
--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -145,7 +145,7 @@ jobs:
 
 ## Docker Layer Caching
 
-**Note**: [The Performance Plan](https://circleci.com/pricing/) is required to use Docker Layer Caching. If you are on the container-based plan you will need to upgrate to [the Performance Plan](https://circleci.com/pricing/) to enable DLC for your account.
+**Note**: [The Performance Plan](https://circleci.com/pricing/) is required to use Docker Layer Caching. If you are on the container-based plan you will need to upgrate to [the Performance Plan](https://circleci.com/pricing/) to enable DLC for your organization.
 
 DLC is a feature that can help to reduce the _build time_ of a Docker image in your build. Docker Layer Caching is useful if you find yourself frequently building Docker images as a regular part of your CI/CD process.
 

--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -145,7 +145,7 @@ jobs:
 
 ## Docker Layer Caching
 
-**Note**: An eligible plan is required to use Docker Layer Caching. If you are on the container-based plan you will need to open a [support ticket](https://support.circleci.com/hc/en-us/requests/new) to enable DLC for your account.
+**Note**: [The Performance Plan](https://circleci.com/pricing/) is required to use Docker Layer Caching. If you are on the container-based plan you will need to upgrate to [the Performance Plan](https://circleci.com/pricing/) to enable DLC for your account.
 
 DLC is a feature that can help to reduce the _build time_ of a Docker image in your build. Docker Layer Caching is useful if you find yourself frequently building Docker images as a regular part of your CI/CD process.
 


### PR DESCRIPTION
# Description

At the moment, Docker Layer Caching (DLC) is only available for Performance Plan users.
This documentation was outdated and asking users to create a support ticket, which does not help.
Updated the note to clarify that DLC is only available on Performance Plan.

# Reasons

At the moment, DLC is only available for Performance Plan users.
