### PR TITLE
[CIRCLE-28511] Update v1 reference link to point to v1 API docs

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -280,7 +280,7 @@ en:
         - name: API v2 Developer's Guide
           link: 2.0/api-developers-guide
         - name: API v1.1 Reference
-          link: api/
+          link: api/v1
         - name: Prebuilt Images
           link: 2.0/circleci-images/
         - name: Glossary


### PR DESCRIPTION
# Description
It looks like we are now forwarding `https://circleci.com/docs/api/` to our v2 API documentation. This means the existing link we have in the documentation for the "API v1.1 Reference" was pointing to the v2 documentation instead of the v1 documentation.

This PR takes care of that by adding `v1` to the link so it points to the proper API docs. So as of right now it directs to:

```
https://circleci.com/docs/api/#section=reference
```

After this change it will direct to:

```
https://circleci.com/docs/api/v1#section=reference
```

# Reasons
This PR takes care of CIRCLE-28511