### PR TITLE
CIRCLE-27340 - Document two new audit log events for SSH key actions

### DIFF
--- a/jekyll/_cci2/security.md
+++ b/jekyll/_cci2/security.md
@@ -81,6 +81,8 @@ Following are the system events that are logged. See `action` in the Field secti
 - project.env_var.create
 - project.env_var.delete
 - project.settings.update
+- project.ssh_key.create
+- project.ssh_key.delete
 - user.create
 - user.logged_in
 - user.logged_out


### PR DESCRIPTION
# Description
Updating `jekyll/_cci2/security.md` to reflect two new audit log events for SSH key create/delete.

# Reasons
Audit log events for adding and deleting SSH keys were requested with https://circleci.atlassian.net/browse/CIRCLE-27340
PR with changes: https://github.com/circleci/circle/pull/11434