### PR TITLE
Clarify where to copy public/private key for GitHub and Bitbucket Integration

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -254,12 +254,12 @@ do **not** enter one.
 2. Go to `https://github.com/you/test-repo/settings/keys`,
 and click "Add deploy key".
 Enter a title in the "Title" field,
-then copy and paste the key you created in step 1.
+then copy and paste the public key you created in step 1.
 Check "Allow write access",
 then click "Add key".
 
 3. Go to your project settings, click on SSH Keys, and "Add SSH key",
-and add the key you created in step 1.
+and add the private key you created in step 1.
 In the "Hostname" field,
 enter "github.com",
 and press the submit button.


### PR DESCRIPTION
# Description
Add `public` and `private` prefixes when referring to an SSH deploy key

# Reasons
Noticed this could be noted explicitly to increase clarity in the steps. It is mentioned in the paragraph before, but that might be skimmed and missed when going for a quick copy paste 