### PR TITLE
Remove extra bracket in ruby versions link

### DIFF
--- a/jekyll/_cci2/deploying-ios.md
+++ b/jekyll/_cci2/deploying-ios.md
@@ -216,7 +216,7 @@ workflows:
       - adhoc
 ```
 
-**Note:** The Firebase plugin may cause errors when run with the macOS system Ruby. It is therefore advisable to [switch to a different ruby version][({{ site.baseurl }}/2.0/testing-ios/#using-custom-ruby-versions)
+**Note:** The Firebase plugin may cause errors when run with the macOS system Ruby. It is therefore advisable to [switch to a different ruby version]({{ site.baseurl }}/2.0/testing-ios/#using-custom-ruby-versions)
 
 ## Deploying to Visual Studio App Center
 

--- a/jekyll/_cci2/deploying-ios.md
+++ b/jekyll/_cci2/deploying-ios.md
@@ -216,7 +216,7 @@ workflows:
       - adhoc
 ```
 
-**Note:** The Firebase plugin may cause errors when run with the macOS system Ruby. It is therefore advisable to [switch to a different ruby version]({{ site.baseurl }}/2.0/testing-ios/#using-custom-ruby-versions)
+**Note:** The Firebase plugin may cause errors when run with the macOS system Ruby. It is therefore advisable to [switch to a different ruby version]({{ site.baseurl }}/2.0/testing-ios/#using-ruby)
 
 ## Deploying to Visual Studio App Center
 


### PR DESCRIPTION
# Description
This PR removes an extra bracket `[` that we had in a link within the docs. It was not allowing the markdown to work and causing this to be displayed in the docs:

![Screen Shot 2020-08-21 at 2 20 39 PM](https://user-images.githubusercontent.com/19393321/90926966-c1513100-e3b9-11ea-8125-ef0cb2d8ea65.png)

# Reasons
The extra bracket was making the content display as text and not a link, the update will ensure its rendered as a link and references the proper documentation section. 