### PR TITLE
[CIRCLE-28743] Add DevHub link and url filter to global-nav

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -8,6 +8,7 @@ description: > # this means to ignore newlines until "baseurl:"
 url: "http://localhost:4040" # the base hostname & protocol for your site
 baseurl: "/docs" # the subpath of your site, e.g. /blog
 gh_url: "https://github.com/circleci/circleci-docs"
+devhub_base_url: "https://circleci.com/developer"
 
 plugins:
   - jekyll-assets

--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -27,8 +27,8 @@
             <li class="nav-item"><a href="{{ '/pricing/' | outer_url }}">Pricing</a></li>
             <li class="nav-item"><a href="{{ '/enterprise/' | outer_url }}">Enterprise</a></li>
             <li class="nav-item">
-              <a href="#">
-                Developers
+              <a href="{{ '' | devhub_url }}">
+                Developer
               </a>
               <div class="submenu">
                 <ul class="subnav">
@@ -120,9 +120,10 @@
             <li class="arrow collapsed border-bottom">
               <span class="heading">
                 <i class="fa fa-angle-right" aria-hidden="true"></i>
-                Developers
+                Developer
               </span>
               <ul class="subnav">
+                <li class="subnav-item"><a href="{{ '' | devhub_url }}">Developer Hub</a></li>
                 <li class="subnav-item"><a href="{{ '/2.0/hello-world/' | language_relative_url }}">Getting Started</a></li>
                 <li class="subnav-item"><a href="{{ '/' | language_relative_url }}">Documentation</a></li>
                 <li class="subnav-item"><a href="https://discuss.circleci.com/" target="_blank">Community Forum</a></li>

--- a/jekyll/_plugins/devhub_url_filter.rb
+++ b/jekyll/_plugins/devhub_url_filter.rb
@@ -1,0 +1,18 @@
+require_relative 'language_url_prefix.rb'
+
+module DevHubUrlFilter
+  include Liquid::StandardFilters
+  include LanguageUrlPrefix
+
+  def devhub_url(input)
+    "#{config['devhub_base_url']}#{language_url_prefix(@context)}#{input}"
+  end
+
+  private
+
+  def config
+    @context.registers[:site].config
+  end
+end
+
+Liquid::Template.register_filter(DevHubUrlFilter)


### PR DESCRIPTION
**Ticket:** [CIRCLE-28743](https://circleci.atlassian.net/browse/CIRCLE-28743)

## Changes
* Create `devhub_url` filter so Japanese link are formed correctly (is different structure from outer_url)
  - use full `https://circleci.com/developer` url in config so that links still work locally
  - pass empty string `''` rather than `'/'` to prevent trailing slash, not used in the DevHub project
* Add link to `Developer` in main nav
* Add link titled `Developer Hub` as new link under `Developer` in mobile nav
* Remove `s` from `Developers` in navigation.

## Rationale
Supporting the launch of Developer Hub on August 25th, 2020

## Considerations
* This does not add the `data-analytics` data attributes that were included on the [PR for outer](https://github.com/circleci/circleci.com/pull/3761) as none of the other link here had these attributes.

## How to test
- Run docs locally
  - Hover over/click the `Developer` link, see that there is a link there to `https://circleci.com/developer` 
- View on mobile.
  - Open the mobile nav 
  - Click `Developer` in the mobile nav
  - See there is a new link `Developer Hub` in the sub nav
  - See that this link goes to https://circleci.com/developer
- View Japanese page on desktop
  - Hover over/click the `Developer` link, see that there is a link there to `https://circleci.com/developer/ja` 
- View Japanese page on mobile.
  - Open the mobile nav 
  - Click `Developer` in the mobile nav
  - See there is a new link `Developer Hub` in the sub nav
  - See that this link goes to https://circleci.com/developer/ja

