### PR TITLE
Add a note to mention CircleCI Server only supports x86_64 architecture

### DIFF
--- a/jekyll/_cci2/server-ports.adoc
+++ b/jekyll/_cci2/server-ports.adoc
@@ -68,7 +68,8 @@ Nomad client machines run CircleCI jobs that are scheduled by the Nomad Server. 
 - NIC speed: 1Gbps
 
 For an AWS install of CircleCI Server, the recommended instance type for Nomad clients is `m5.2xlarge` (8 vCPUs @ 2.4GHz, 32GB RAM). 
-Note: Currently Nomad Client only supports x86_64 architecture. 
+
+NOTE: Currently, Nomad Clients only support x86_64 architecture. 
 
 You can choose a larger instance type to fit more jobs per Client. To help in this choice, consider that when Nomad decides if a job will fit on a Client, the Job is allocated 1024MHz per CPU, and capacity is `number of cores` * `clock speed`. Using this method, the maximum capacity of a `m5.2xlarge` would be `19200MHz`, which would mean 9.6 jobs could run on that client (if there were no limiting factors). In practice, Nomad will researve some CPU for itself, and because of the CPU:RAM ratio, the available RAM is the limiting factor governing how many jobs can run. 
 

--- a/jekyll/_cci2/server-ports.adoc
+++ b/jekyll/_cci2/server-ports.adoc
@@ -13,6 +13,7 @@ toc::[]
 
 == Services Machine
 The Services machine hosts the core of our Server product, including the user-facing website, API engine, datastores, and Nomad job scheduler. It is best practice to use an isolated machine.
+Note: Currently CircleCI Server only supports x86_64 architecture.
 
 The following table defines the Services machine CPU, RAM, and disk space requirements:
 
@@ -66,8 +67,9 @@ Nomad client machines run CircleCI jobs that are scheduled by the Nomad Server. 
 - NIC speed: 1Gbps
 
 For an AWS install of CircleCI Server, the recommended instance type for Nomad clients is `m5.2xlarge` (8 vCPUs @ 2.4GHz, 32GB RAM). 
+Note: Currently Nomad Client only supports x86_64 architecture. 
 
-You can choose a larger instance type to fit more jobs per Client. To help in this choice, consider that when Nomad decides if a job will fit on a Client, the Job is allocated 1024MHz per CPU, and capacity is `number of cores` * `clock speed`. Using this method, the maximum capacity of a `m5.2xlarge` would be `19200MHz`, which would mean 9.6 jobs could run on that client (if there were no limiting factors). In practice, Nomad will researve some CPU for itself, and because of the CPU:RAM ratio, the available RAM is the limiting factor governing how many jobs can run.
+You can choose a larger instance type to fit more jobs per Client. To help in this choice, consider that when Nomad decides if a job will fit on a Client, the Job is allocated 1024MHz per CPU, and capacity is `number of cores` * `clock speed`. Using this method, the maximum capacity of a `m5.2xlarge` would be `19200MHz`, which would mean 9.6 jobs could run on that client (if there were no limiting factors). In practice, Nomad will researve some CPU for itself, and because of the CPU:RAM ratio, the available RAM is the limiting factor governing how many jobs can run. 
 
 === Recommendations for Heavy Usage
 

--- a/jekyll/_cci2/server-ports.adoc
+++ b/jekyll/_cci2/server-ports.adoc
@@ -13,7 +13,8 @@ toc::[]
 
 == Services Machine
 The Services machine hosts the core of our Server product, including the user-facing website, API engine, datastores, and Nomad job scheduler. It is best practice to use an isolated machine.
-Note: Currently CircleCI Server only supports x86_64 architecture.
+
+NOTE: Currently, CircleCI Server only supports x86_64 architecture.
 
 The following table defines the Services machine CPU, RAM, and disk space requirements:
 


### PR DESCRIPTION
# Description

Add a note to mention CircleCI Server only supports x86_64 architecture into the below page
> https://circleci.com/docs/2.0/server-ports/#nomad-clients

# Reasons
A customer asked us that the Server can uses `m6g` image type, but the instances type is arm-based architecture.
CircleCI Server doesn't support other than x86_64 architecture, so we should mention this.
