### PR TITLE
Remove condition key and add note about workflows

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1674,7 +1674,7 @@ Truthiness rules are as follows: `false`, `null`, `0`, the empty string, and `Na
 Logic statements always evaluate to a boolean value at the top level, and coerce as necessary. They can be nested in an arbitrary fashion, according to their argument specifications, and to a maximum depth of 100 levels.
 
 **Note:**
-When using logic statements at the workflow level, do not include the `condition:` key. That is only needed for job level logic statements.
+When using logic statements at the workflow level, do not include the `condition:` key (the `condition` key is only needed for `job` level logic statements).
 
 ### Logic Statement Examples
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1673,16 +1673,18 @@ Truthiness rules are as follows: `false`, `null`, `0`, the empty string, and `Na
 
 Logic statements always evaluate to a boolean value at the top level, and coerce as necessary. They can be nested in an arbitrary fashion, according to their argument specifications, and to a maximum depth of 100 levels.
 
+**Note:**
+When using logic statements at the workflow level, do not include the `condition:` key. That is only needed for job level logic statements.
+
 ### Logic Statement Examples
 
 ```yaml
 workflows:
   my-workflow:
       when:
-        condition:
-          or:
-            - equal: [ master, << pipeline.git.branch >> ]
-            - equal: [ staging, << pipeline.git.branch >> ]
+        or:
+          - equal: [ master, << pipeline.git.branch >> ]
+          - equal: [ staging, << pipeline.git.branch >> ]
 ```
 
 ```yaml


### PR DESCRIPTION
# Description
This PR will remove the `condition:` key from the workflow example as that isn't supported/doesn't work and it also adds a note specifically to not include it at the workflow level.

# Reasons
A customer raised this in a ticket and I tested and confirmed the current functionality. These changes will hopefully prevent future confusion. 