### PR TITLE
add matrix example to config cookbook

### DIFF
--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -21,7 +21,7 @@ This page, and its associated recipes, describes how you can perform specific co
 ### What Are CircleCI Orbs?
 {:.no_toc}
 
-CircleCI orbs are configuration packages that enable you to get started with the CircleCI platform. Orbs enable you to share, standardize, and simplify configurations across your projects. You may also want to use orbs as a refererence for configuration best practices.
+CircleCI orbs are configuration packages that enable you to get started with the CircleCI platform. Orbs enable you to share, standardize, and simplify configurations across your projects. You may also want to use orbs as a reference for configuration best practices.
 
 Refer to the [CircleCI Orbs Registry](https://circleci.com/orbs/registry/) for the complete list of available orbs.
 
@@ -42,6 +42,7 @@ workflows:
 For more detailed information about CircleCI orbs, refer to the [Orbs Introduction]({{ site.baseurl }}/2.0/orb-intro/) page.
 
 ## Configure Your Environment for CircleCI Pipelines and Orbs
+{:.no_toc}
 
 Most recipes in this cookbook call for version 2.1 configuration, pipelines and often, orbs. Before using the examples provided, you should check that you are set up for these features. The following notes and steps will get you where you need to be.
 
@@ -50,19 +51,6 @@ Most recipes in this cookbook call for version 2.1 configuration, pipelines and 
 * If you wish to remain using `version 2.0` config, or are using a self-hosted installation of CircleCI Server, these recipes are still relevant because you can view the expanded orb source within the [Orbs Registry](https://circleci.com/orbs/registry/) to see how the individual jobs and commands are built.
 * In the examples on this page that use orbs, you will notice that the orbs are versioned with tags, for example, `aws-s3: circleci/aws-s3@x.y.z`. If you copy paste any examples you will need to edit `x.y.z` to specify a version. You can find the available versions listed on the individual orb pages in the [CircleCI Orbs Registry](https://circleci.com/orbs/registry/).
 * Any items that appear within `< >` should be replaced with your own parameters.
-
-## Configuration Recipes
-
-The table below lists some recipes to help and inspire your projects.
-
-Configuration Recipe | Description
-------------|-----------
-[Deploy Changes to Amazon Elastic Container Service (ECS)](#deploy-changes-to-amazon-ecs) | This section describes how you can deploy changes to the Amazon Elastic Container Service (ECS) using a CircleCI-certified ECS orb.
-[Interact with Google Kubernetes Engine (GKE)](#interact-with-google-kubernetes-engine-gke) | This section describes how you can deploy changes to the Google Kubernetes Engine (GKE) using a CircleCI-certified GKE orb.
-[Using Amazon Elastic Container Service for Kubernetes (Amazon EKS)](#using-amazon-elastic-container-service-for-kubernetes-amazon-eks) | This section describes how you can use the Amazon ECS service for Kubernetes for Kubernetes-related tasks and operations.
-[Enabling Custom Slack Notifications in CircleCI Jobs](#enabling-custom-slack-notifications-in-circleci-jobs) | This section describes how you can enable customized Slack notifications in CircleCI jobs.
-[Using Logic in Configuration](#using-logic-in-configuration) | This section describes how you can use pipeline values & parameters to select the work to perform.
-{: class="table table-striped"}
 
 ## Deploy changes to Amazon ECS
 
@@ -464,11 +452,11 @@ Notice in the example that the job is run and a Slack status alert is sent to yo
 
 For more detailed information about this orb and its functionality, refer to the Slack orb in the [CircleCI Orb Registry](https://circleci.com/orbs/registry/orb/circleci/slack).
 
-## Using Logic in Configuration
+## Selecting a Workflow to Run Using Pipeline Parameters
 
-### Selecting a Workflow With a Pipeline Parameter
+You might find that you want to be able to trigger a specific workflow to run, manually, using the API, but still run a workflow on every push to your project. To achieve this, use [pipeline parameters]({{ site.baseurl }}/2.0/pipeline-variables/#pipeline-parameters-in-configuration) to decide which workflow(s) to run. 
 
-If you want to be able to trigger custom workflows manually via the API, but still run a workflow on every push, you can use pipeline parameters to decide which workflows to run. For more information see the [API Reference Documentation]({{ site.baseurl }}/2.0/configuration-cookbook/#selecting-a-workflow-with-a-pipeline-parameter) and the [API Developers Guide Example]({{ site.baseurl }}/2.0/api-developers-guide/#example-end-to-end-api-request)
+The following example defaults to running the `build` workflow, but allows control of which other workflow to run using the API:
 
 ```yaml
 version: 2.1
@@ -506,7 +494,7 @@ workflows:
       - report
 ```
 
-The `action` parameter will default to `build` on pushes. Below is an example of supplying a different value using the API v2 Trigger a New Pipeline endpoint and Pipeline Parameters to select a different workflow to run, in this case, `report`. Remember to substitute [`project-slug`({{ site.baseurl }}/2.0/api-developers-guide/#getting-started-with-the-api) for your values.
+The `action` parameter will default to `build` on pushes to the project. Below is an example of supplying a different value to `action` using the API v2 [Trigger a New Pipeline]({{ site.baseurl }}/api/v2/#trigger-a-new-pipeline) endpoint to select a different workflow to run, in this example, the workflow named `report` would run. Remember to substitute [`project-slug`]({{ site.baseurl }}/2.0/api-developers-guide/#getting-started-with-the-api) with your values.
 
 ```sh
 curl -X POST https://circleci.com/api/v2/project/{project-slug}/pipeline \
@@ -516,9 +504,13 @@ curl -X POST https://circleci.com/api/v2/project/{project-slug}/pipeline \
   -d '{ "parameters": { "action": report } }'
 ```
 
-### Branch-filtering for Job Steps
+For more information on using API v2 endpoints, see the [API Reference Documentation]({{ site.baseurl }}/api/v2/) and the [API Developers Guide Worked Example]({{ site.baseurl }}/2.0/api-developers-guide/#example-end-to-end-api-request).
 
-Branch filtering has previously only been available for workflows, but with compile-time logic statements, you can implement it for job steps as well.
+## Branch-filtering for Job Steps
+
+Branch filtering has previously only been available for workflows, but with compile-time logic statements, you can also implement branch filtering for job steps. 
+
+The following example shows using the [pipeline value]({{ site.baseurl }}/2.0/pipeline-variables/#pipeline-values) `pipeline.git.branch` to control `when` a step should run. In this case the step `run: echo "I am on master"` only runs when the commit is on the master branch:
 
 ```yaml
 version: 2.1
@@ -540,3 +532,63 @@ workflows:
     jobs:
       - my-job
 ```
+
+## Use Matrix Jobs to Run Multiple OS Tests
+
+Using matrix jobs is a good way to run a job multiple times with different arguments, using parameters. There are many uses for this, including testing on multiple operating systems and against different language/library versions.
+
+In the following example the `test` job is run in Linux, Windows and macOS environments, using two different versions of node. On each run of the `test` job different parameters are passed to set both the OS and the node version:
+
+```yaml
+version: 2.1
+
+orbs:
+  node: circleci/node@4.0.0
+  win: circleci/windows@2.2.0 
+
+executors:
+  linux: # linux executor using the node base image
+    docker:
+      - image: cimg/node
+  windows: win/default # windows executor - uses the default executor from the windows orb
+  macos: # macos executor using xcode 11.6
+    macos:
+      xcode: 11.6
+
+jobs:
+  test:
+    parameters:
+      os:
+        type: executor
+      node-version:
+        type: string
+    executor: << parameters.os >>
+    steps:
+      - checkout
+      - node/install:
+          node-version: << parameters.node-version >>
+          install-yarn: true
+      - run: yarn test
+
+workflows:
+  all-tests:
+    jobs:
+      - test:
+          matrix:
+            parameters:
+              os: [linux, windows, macos]
+              node-version: ["13.13.0", "14.0.0"]
+```
+
+The expanded version of this matrix runs the following list of jobs under the `all-tests` workflow:
+
+```yaml
+    - test-13.13.0-linux
+    - test-14.0.0-linux
+    - test-13.13.0-windows
+    - test-14.0.0-windows
+    - test-13.13.0-macos
+    - test-14.0.0-macos
+```
+
+For full details of the matrix jobs specification, see the [Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#matrix-requires-version-21).

--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -537,7 +537,7 @@ workflows:
 
 Using matrix jobs is a good way to run a job multiple times with different arguments, using parameters. There are many uses for this, including testing on multiple operating systems and against different language/library versions.
 
-In the following example the `test` job is run in Linux, Windows and macOS environments, using two different versions of node. On each run of the `test` job different parameters are passed to set both the OS and the node version:
+In the following example the `test` job is run across Linux, Windows and macOS environments, using two different versions of node. On each run of the `test` job different parameters are passed to set both the OS and the node version:
 
 ```yaml
 version: 2.1
@@ -582,7 +582,7 @@ workflows:
 
 The expanded version of this matrix runs the following list of jobs under the `all-tests` workflow:
 
-```yaml
+```
     - test-13.13.0-linux
     - test-14.0.0-linux
     - test-13.13.0-windows

--- a/jekyll/_cci2/orb-author-faq.md
+++ b/jekyll/_cci2/orb-author-faq.md
@@ -106,4 +106,4 @@ steps:
 - Refer to [Orb Publishing Process]({{site.baseurl}}/2.0/creating-orbs/) for information about orbs that you may use in your workflows and jobs.
 - Refer to [Orbs Reference]({{site.baseurl}}/2.0/reusing-config/) for examples of reusable orbs, commands, parameters, and executors.
 - Refer to [Orb Testing Methodologies]({{site.baseurl}}/2.0/testing-orbs/) for information on how to test orbs you have created.
-- Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/#configuration-recipes) for more detailed information about how you can use CircleCI orb recipes in your configurations.
+- Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/) for more detailed information about how you can use CircleCI orb recipes in your configurations.

--- a/jekyll/_cci2/orbs-faq.md
+++ b/jekyll/_cci2/orbs-faq.md
@@ -76,4 +76,4 @@ You attempted to run a local build with version 2.1 of configuration.
 - Refer to [Orbs Concepts]({{site.baseurl}}/2.0/using-orbs/) for high-level information about CircleCI orbs.
 - Refer to [Orb Publishing Process]({{site.baseurl}}/2.0/creating-orbs/) for information about orbs that you may use in your workflows and jobs.
 - Refer to [Orbs Reference]({{site.baseurl}}/2.0/reusing-config/) for examples of reusable orbs, commands, parameters, and executors.
-- Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/#configuration-recipes) for more detailed information about how you can use CircleCI orb recipes in your configurations.
+- Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/) for more detailed information about how you can use CircleCI orb recipes in your configurations.

--- a/jekyll/_cci2/testing-orbs.md
+++ b/jekyll/_cci2/testing-orbs.md
@@ -186,4 +186,4 @@ For advanced testing, you may also want to use a shell unit testing framework su
 - Refer to [Orbs Concepts]({{site.baseurl}}/2.0/using-orbs/) for high-level information about CircleCI orbs.
 - Refer to [Orb Publishing Process]({{site.baseurl}}/2.0/creating-orbs/) for information about orbs that you may use in your workflows and jobs.
 - Refer to [Orbs Reference]({{site.baseurl}}/2.0/reusing-config/) for examples of reusable orbs, commands, parameters, and executors.
-- Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/#configuration-recipes) for more detailed information about how you can use CircleCI orb recipes in your configurations.
+- Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/) for more detailed information about how you can use CircleCI orb recipes in your configurations.

--- a/jekyll/_cci2/using-orbs.md
+++ b/jekyll/_cci2/using-orbs.md
@@ -232,4 +232,4 @@ If the case arises where you need to delete an orb for emergency reasons, please
 
 - Refer to [Orb Introduction]({{site.baseurl}}/2.0/orb-intro/), for a high-level overview of using and authoring orbs.
 - Refer to [Orbs Reference]({{site.baseurl}}/2.0/reusing-config/) for more detailed examples of reusable orbs, commands, parameters, and executors.
-- Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/#configuration-recipes) for more detailed information about how you can use CircleCI orb recipes in your configurations.
+- Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/) for more detailed information about how you can use CircleCI orb recipes in your configurations.


### PR DESCRIPTION
fixes #4260 

This PR:
* adds an example of matrix jobs
* expands the current logic in config section to show multiple recipes rather than a couple of use cases under a category. I changed this for consistency and to make the recipes easier to find.