### PR TITLE
Clarify Ruby changes

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -225,7 +225,7 @@ If you want to run steps with a version of Ruby that is listed as "available to 
 
 ### Images using Xcode 11.7 and later
 
-As a result of the macOS system Ruby (2.6.3) becoming increasingly incompatible with various gems (especially those which require native extensions), Xcode 11.7 and later iamges default to Ruby 2.7 via `chruby`.
+As a result of the macOS system Ruby (2.6.3) becoming increasingly incompatible with various gems (especially those which require native extensions), Xcode 11.7 and later images default to Ruby 2.7 via `chruby`.
 
 Defaulting to Ruby 2.7 allows for greater compatibility and reliability with gems moving forward. Common gems, such as Fastlane, run without any issues in Ruby 2.7.
 

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -223,9 +223,9 @@ If you want to run steps with a version of Ruby that is listed as "available to 
 
 **Note:** Installing Gems with the system Ruby is not advised due to the restrictive permissions enforced on the system directories. As a general rule, we advise using one of the alternative Rubies provided by Chruby for all jobs.
 
-### Images using Xcode 12 and later
+### Images using Xcode 11.7 and later
 
-As a result of the macOS system Ruby (2.6.3) becoming increasingly incompatible with various gems (especially those which require native extensions), Xcode 12 and later iamges default to Ruby 2.7 via `chruby`. 
+As a result of the macOS system Ruby (2.6.3) becoming increasingly incompatible with various gems (especially those which require native extensions), Xcode 11.7 and later iamges default to Ruby 2.7 via `chruby`.
 
 Defaulting to Ruby 2.7 allows for greater compatibility and reliability with gems moving forward. Common gems, such as Fastlane, run without any issues in Ruby 2.7.
 


### PR DESCRIPTION
# Description
Clarify Ruby changes that apply to 11.7 and later

# Reasons
Originally these changes were only meant for Xcode 12 and later, but were back-ported to 11.7