### PR TITLE
Typo fix: peak -> peek

### DIFF
--- a/jekyll/_cci2/examples-intro.md
+++ b/jekyll/_cci2/examples-intro.md
@@ -11,7 +11,7 @@ version:
 ---
 
 
-It is possible to build, test, and deploy applications that run on Linux, Android, iOS and Windows with CircleCI. See the following snippets for a peak into how you can customize the configuration of a job for any platform. You may also configure jobs to run on multiple platforms in a single [`.circleci/config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file. 
+It is possible to build, test, and deploy applications that run on Linux, Android, iOS and Windows with CircleCI. See the following snippets for a peek into how you can customize the configuration of a job for any platform. You may also configure jobs to run on multiple platforms in a single [`.circleci/config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file. 
 
 ## Linux with Docker
 


### PR DESCRIPTION
# Description
Incorrect use of _peak_ instead of **peek**.
> See the following snippets for a ~peak~ peek into how you can customize..."


# Reasons
Noticed the typo when following the docs, doesn't take away from content, just fixing a homophone issue.