### PR TITLE
Revert "Clean: remove settings page."

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -416,7 +416,7 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 }' https://circleci.com/api/v2/project/:project_slug/pipeline
 ```
 
-**IMPORTANT** Pipeline parameters are not treated as sensitive data and must not be used by customers for sensitive values (secrets). You can find this sensitive information in your Project Settings page and [Contexts]({{site.baseurl}}/2.0/glossary/#context).
+**IMPORTANT** Pipeline parameters are not treated as sensitive data and must not be used by customers for sensitive values (secrets). You can find this sensitive information in [Project Settings]({{site.baseurl}}/2.0/settings/) and [Contexts]({{site.baseurl}}/2.0/glossary/#context).
 
 Read more in the [Pipeline Variables]({{site.baseurl}}/2.0/pipeline-variables/) guide.
 
@@ -430,7 +430,7 @@ Build parameters are environment variables, therefore their names have to meet t
 
 Aside from the usual constraints for environment variables there are no restrictions on the values themselves and are treated as simple strings. The order that build parameters are loaded in is **not** guaranteed so avoid interpolating one build parameter into another. It is best practice to set build parameters as an unordered list of independent environment variables.
 
-**IMPORTANT** Build parameters are not treated as sensitive data and must not be used by customers for sensitive values (secrets). You can find this sensitive information in your Project Settings page and [Contexts]({{site.baseurl}}/2.0/glossary/#context).
+**IMPORTANT** Build parameters are not treated as sensitive data and must not be used by customers for sensitive values (secrets). You can find this sensitive information in [Project Settings]({{site.baseurl}}/2.0/settings/) and [Contexts]({{site.baseurl}}/2.0/glossary/#context).
 
 For example, when you pass the parameters:
 

--- a/jekyll/_cci2/project-build.md
+++ b/jekyll/_cci2/project-build.md
@@ -58,3 +58,6 @@ of the page to navigate back to a job's respective workflow or pipeline.
 
 ![Pipelines Breadcrumbs]({{ site.baseurl }}/assets/img/docs/pipeline-breadcrumbs.png)
 
+## See Also
+
+[Settings]({{ site.baseurl }}/2.0/settings)

--- a/jekyll/_cci2/settings.md
+++ b/jekyll/_cci2/settings.md
@@ -1,0 +1,27 @@
+---
+layout: classic-docs
+title: "Settings"
+short-title: "Settings"
+description: "Summary of project and org settings"
+categories: [settings]
+order: 2
+---
+
+CircleCI provides Project and Org settings with encrypted storage in the CircleCI app.
+
+## Project Settings Page
+
+![settings]( {{ site.baseurl }}/assets/img/docs/settings.png)
+
+
+## Organization Settings Page
+For your [Org Plan or Billing settings]({{ site.baseurl }}/2.0/faq/#billing), see the Settings tab of the CircleCI app for summary data about your usage.
+<hr>
+
+![settings]( {{ site.baseurl }}/assets/img/docs/plan-settings.png)
+
+## See Also
+
+- Plans and Billing -- For your [Org Plan or Billing settings]({{ site.baseurl }}/2.0/faq/#billing), see the Settings tab of the CircleCI app for summary data about your usage. 
+- Contexts --  Share environment variables across projects with a Workflow key, on the [contexts page]({{ site.baseurl }}/2.0/contexts/).
+

--- a/jekyll/_cci2_ja/project-build.md
+++ b/jekyll/_cci2_ja/project-build.md
@@ -36,3 +36,6 @@ CircleCI プロジェクトは、関連付けられているコード リポジ�
 
 ![ワークフロー]({{ site.baseurl }}/assets/img/docs/approval_job.png)
 
+## 関連項目
+
+[設定]({{ site.baseurl }}/ja/2.0/settings)

--- a/jekyll/_cci2_ja/settings.md
+++ b/jekyll/_cci2_ja/settings.md
@@ -1,0 +1,28 @@
+---
+layout: classic-docs
+title: "設定"
+short-title: "設定"
+description: "プロジェクト設定および組織設定の概要"
+categories:
+  - settings
+order: 2
+---
+
+CircleCI は、CircleCI アプリケーション内でプロジェクト設定と組織設定のための暗号化ストレージを提供しています。
+
+## プロジェクト設定ページ
+
+![設定ページ]({{ site.baseurl }}/assets/img/docs/settings.png)
+
+## 組織設定ページ
+
+[組織のプランまたは課金設定]({{ site.baseurl }}/ja/2.0/faq/#料金支払い)については、CircleCI アプリケーションの [Settings (設定)] タブで、使用状況に関するサマリー データを参照してください。
+
+<hr />
+
+![設定ページ]({{ site.baseurl }}/assets/img/docs/plan-settings.png)
+
+## 関連項目
+
+- プランと課金 -- [組織のプランまたは課金設定]({{ site.baseurl }}/ja/2.0/faq/#料金支払い)については、CircleCI アプリケーションの [Settings (設定)] タブで、使用状況に関するサマリー データを参照してください。
+- コンテキスト -- ワークフロー キーを使用してプロジェクト間で環境変数を共有できます。「[コンテキストの使用]({{ site.baseurl }}/ja/2.0/contexts/)」を参照してください。


### PR DESCRIPTION
Reverts circleci/circleci-docs#4690

@teesloane I propose reverting this change and instead I'll update the page to be an actual intro section to this docs section?

<img width="272" alt="Screenshot 2020-09-18 at 09 43 57" src="https://user-images.githubusercontent.com/24589403/93577064-811ea780-f993-11ea-898c-8d29a56555ad.png">

What do you think?