### PR TITLE
Add rate limits as motivation to use authenticated docker pulls

### DIFF
--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs
-title: "Using Private Images"
-short-title: "Using Private Images"
-description: "How to use private images"
+title: "Using Docker Authenticated Pulls"
+short-title: "Using Docker Authenticated Pulls"
+description: "Use Docker authenticated pulls to access private images and avoid rate limits."
 categories: [containerization]
 order: 50
 version:
@@ -10,7 +10,14 @@ version:
 - Server v2.x
 ---
 
-To use private Docker images, specify the username and password in the `auth` field of your [config.yml]({{ site.baseurl }}/2.0/configuration-reference/) file.  To protect the password, create an Environment Variable in the CircleCI Project Settings page, and then reference it:
+
+This document describes how to authenticate with your Docker registry provider to pull images.
+
+Authenticated pulls allow access to private Docker images.  It may also grant higher rate limits depending on your registry provider.
+
+Starting [November 1, 2020](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/), Docker Hub will impose rate limits based on the originating IP.  Since CirlceCI runs jobs from a shared pool of IPs, it is highly recommended to use authenticated Docker pulls with Docker Hub to avoid rate limit problems.
+
+For the [Docker]({{ site.baseurl }}/2.0/executor-types/#using-docker) executor, specify username and password in the `auth` field of your [config.yml]({{ site.baseurl }}/2.0/configuration-reference/) file.  To protect the password, create a [context]({{ site.baseurl }}/2.0/contexts) or Environment Variable in the CircleCI Project Settings page, and then reference it:
 
 ```yaml
 jobs:
@@ -31,7 +38,29 @@ You can also use images from a private repository like [gcr.io](https://cloud.go
     password: $QUAY_PASSWORD
 ```
 
-Alternatively, you can utilize the `machine` executor to achieve the same result:
+Alternatively, you can utilize the `machine` executor to achieve the same result using the Docker orb:
+
+``` yaml
+version: 2.1
+orbs:
+  docker: circleci/docker@1.4.0
+
+workflows:
+  my-workflow:
+    jobs:
+      - machine-job:
+          context:
+            - docker-hub-context
+
+jobs:
+  machine-job:
+    machine: true
+    steps:
+      - docker/pull:
+          images: 'circleci/node:latest'
+```
+
+or with cli:
 
 ```yaml
 version: 2
@@ -47,7 +76,7 @@ jobs:
       - run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker run -d --name db company/proprietary-db:1.2.3
-```          
+```
 
 CircleCI now supports pulling private images from Amazon's ECR service. You can start using private images from ECR in one of two ways:
 
@@ -87,8 +116,8 @@ jobs:
     docker:
       - image: account-id.dkr.ecr.us-east-1.amazonaws.com/org/repo:0.1
         aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID_STAGING
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY_STAGING
+          aws_access_key_id: $AWS_ACCESS_KEY_ID_PRODUCTION
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY_PRODUCTION
     steps:
       - run:
           name: "Full Test Suite"

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -146,7 +146,7 @@ en:
           link: 2.0/circleci-images/
         - name: Using Custom Images
           link: 2.0/custom-images/
-        - name: Using Private Images
+        - name: Using Docker Authenticated Pulls
           link: 2.0/private-images/
     - name: ADVANCED CONFIG
       link: 2.0/adv-config/
@@ -532,7 +532,7 @@ ja:
         - name: Using Custom Images
           i18n_name: カスタムイメージを使う
           link: ja/2.0/custom-images/
-        - name: Using Private Images
+        - name: Using Docker Authenticated Pulls
           i18n_name: プライベートイメージを使う
           link: ja/2.0/private-images/
     - name: ADVANCED CONFIG


### PR DESCRIPTION
# Description
Originally we were going to add a new document just for rate limits.  The contents of that document ended up being similar to the existing `private-images`, so I decided to merge the two.


# Reasons
We are specifically mentioning this because Docker Hub intend to enforce rate limits starting November 1, 2020.

https://circleci.atlassian.net/browse/CIRCLE-29510
