### PR TITLE
manual orb auth steps

### DIFF
--- a/jekyll/_cci2/orb-author-validate-publish.md
+++ b/jekyll/_cci2/orb-author-validate-publish.md
@@ -19,7 +19,7 @@ circleci namespace create <my-namespace> github <my-gh-org>
 circleci orb create <my-namespace>/<my-orb-name>
 ```
 
-1. Create the content of your orb in a YAML file. For example:
+1. Create the content of your orb in a YAML file. Here is a simple example to get you started:
 ```yaml
 version: 2.1
 description: A greeting command orb
@@ -32,6 +32,7 @@ commands:
                 default: World
         steps:
             - run: echo "Hello, << parameters.to >>"
+```
 
 1. Validate your orb code using the CLI:
 ```

--- a/jekyll/_cci2/orb-author-validate-publish.md
+++ b/jekyll/_cci2/orb-author-validate-publish.md
@@ -32,9 +32,6 @@ commands:
                 default: World
         steps:
             - run: echo "Hello, << parameters.to >>"
-```sh
-echo 'version: "2.1"\ndescription: "a sample orb"' > /tmp/orb.yml
-```
 
 1. Validate your orb code using the CLI:
 ```

--- a/jekyll/_cci2/orb-author-validate-publish.md
+++ b/jekyll/_cci2/orb-author-validate-publish.md
@@ -6,7 +6,7 @@ version:
 - Cloud
 ---
 
-This guide covers the steps required to create a simple orb manually, without using the orb development kit. We recommend the orb development kit for most orb projects, to find out more, see the [Orb Authoring Guide]({{site.baseurl}}/2.0/orb-author).
+This guide covers the steps required to create a simple orb, manually, without using the orb development kit. We recommend the orb development kit for most orb projects, to find out more, see the [Orb Authoring Guide]({{site.baseurl}}/2.0/orb-author).
 
 1. If you have not already done so, claim a namespace for your user/organization using the following command, substituting your namespace choice and GitHub org name:
 ```sh

--- a/jekyll/_cci2/orb-author-validate-publish.md
+++ b/jekyll/_cci2/orb-author-validate-publish.md
@@ -19,7 +19,19 @@ circleci namespace create <my-namespace> github <my-gh-org>
 circleci orb create <my-namespace>/<my-orb-name>
 ```
 
-1. Create the content of your orb in a YAML file. Generally, you would do this in your code editor, in a git repo made for your orb, but, For this simple example, let's assume a file in `/tmp/orb.yml` could be made with a bare-bones orb like:
+1. Create the content of your orb in a YAML file. For example:
+```yaml
+version: 2.1
+description: A greeting command orb
+commands:
+    greet:
+        description: Greet someone with a "hello".
+        parameters:
+            to:
+                type: string
+                default: World
+        steps:
+            - run: echo "Hello, << parameters.to >>"
 ```sh
 echo 'version: "2.1"\ndescription: "a sample orb"' > /tmp/orb.yml
 ```

--- a/jekyll/_cci2/orb-author-validate-publish.md
+++ b/jekyll/_cci2/orb-author-validate-publish.md
@@ -1,107 +1,45 @@
 ---
 layout: classic-docs
-title: "Orb Author - Validate and Publish Orbs"
-short-title: "Testing and Publishing Orbs"
-description: "Starting point for testing and publishing orbs"
-categories: [getting-started]
-order: 1
-sitemap: false
+title: "Manual Orb Authoring Process"
+description: "Authoring simple orbs manually without the orb development kit."
 version:
 - Cloud
 ---
 
-## Introduction
+This guide covers the steps required to create a simple orb manually, without using the orb development kit.
 
-When you have finished authoring your orb, you may then test your orb to ensure it will work in your configuration. After testing has been completed, you may then publish the orb to the [CircleCI Orb Registry](https://circleci.com/orbs/registry/). CircleCI recommends you use the CircleCI CLI to validate and publish your orb since the the CLI provides the `orb-tools` orb, with its associated commands, that simplify the validation and publication process.
+1. If you have not already done so, claim a namespace for your user/organization using the following command, substituting your namespace choice and GitHub org name:
+```sh
+circleci namespace create <my-namespace> github <my-GH-Org>
+```
+**Note:** When creating a namespace via the CircleCI CLI, be sure to specify the VCS provider.
 
-## orb-tools
-
-The `orb-tools` orb provides a simple and easy way for you to structure and validate your orb before you choose to publish by enabling you to run the following jobs and commands:
-
-Command/Job | Description
-------------|-----------
-orb-tools/pack | This command enables you to use the CircleCI CLI to pack an orb file structure into a single orb yml.
-orb-tools/validate | This command enables you to use the CircleCI CLI to validate a given orb yml.
-orb-tools/increment | This command enables you to use the CircleCI CLI to increment the version of an orb in the registry. If the orb does not have a version yet, it starts at 0.0.0.
-orb-tools/publish | This command uses the CLI to publish an orb to the registry.
-{: class="table table-striped"}
-
-### orb-tools/pack
-
-This CLI command enables you to pack the content of an orb prior to publishing. When using this command, you may pass the following parameters with this command:
-
-Parameter | Description
-------------|-----------
-source-dir | Path to the root of the orb source directory to be packed. (for example, my-orb/src/)
-destination-orb-path | Path including filename of where the packed orb will be written.
-attach-workspace | Boolean for whether or not to attach to an existing workspace. Default is false.
-workspace-root | Workspace root path that is either an absolute path or a path relative to the working directory. Defaults to ‘.’ (the working directory)
-workspace-path | Path of the workspace to persist to relative to workspace-root. Typically this is the same as the destination-orb-path. If the default value of blank is provided, then this job will not persist to a workspace.
-artifact-path | Path to the directory that should be saved as a job artifact. If the default value of blank is provided, then this job will not save any artifacts.
-{: class="table table-striped"}
-
-### orb-tools/validate
-
-This CLI command enables you to validate a given orb to ensure that the orb can be published to the CircleCI Orb Registry. When using this command, you may pass the following parameters with this command:
-
-Parameter | Description
-------------|-----------
-validate | Boolean for whether or not to do validation on the orb. Default is false.
-checkout | Boolean for whether or not to checkout as a first step. Default is true.
-attach-workspace | Boolean for whether or not to attach to an existing workspace. Default is false.
-workspace-root | Workspace root path that is either an absolute path or a path relative to the working directory. Defaults to ‘.’ (the working directory)
-workspace-path | Path of the workspace to persist to relative to workspace-root. Typically this is the same as the destination-orb-path. If the default value of blank is provided, then this job will not persist to a workspace.
-artifact-path | Path to the directory that should be saved as a job artifact. If the default value of blank is provided, then this job will not save any artifacts.
-{: class="table table-striped"}
-
-### orb-tools/increment
-
-This command uses the CLI to increment the version of an orb in the registry. If the orb does not have a version yet it starts at 0.0.0. The following parameters may be passed with this command:
-
-Parameter | Description
-------------|-----------
-orb-path | Path to an orb file.
-orb-ref | A version-less orb-ref in the form /
-segment | The semantic version segment to increment ‘major’ or ‘minor’ or ‘patch’
-publish-token-variable | The env var containing your token. Pass this as a literal string such as $ORB_PUBLISHING_TOKEN. Do not paste the actual token into your configuration. If omitted it’s assumed the CLI has already been setup with a valid token.
-validate | Boolean for whether or not to do validation on the orb. Default is false.
-checkout | Boolean for whether or not to checkout as a first step. Default is true.
-attach-workspace | Boolean for whether or not to attach to an existing workspace. Default is false.
-workspace-root | Workspace root path that is either an absolute path or a path relative to the working directory. Defaults to ‘.’ (the working directory)
-{: class="table table-striped"}
-
-### orb-tools/publish
-
-This command is used to publish an orb. The following parameters may be passed with this command:
-
-Parameter | Description
-------------|-----------
-orb-path | Path of the orb file to publish.
-orb-ref | A full orb-ref in the form of /@
-publish-token-variable | The env var containing your publish token. Pass this as a literal string such as $ORB_PUBLISHING_TOKEN. DO NOT paste the actual token into your configuration. If omitted it’s assumed the CLI has already been setup with a valid token.
-validate | Boolean for whether or not to do validation on the orb. Default is false.
-checkout | Boolean for whether or not to checkout as a first step. Default is true.
-attach-workspace | Boolean for whether or not to attach to an existing workspace. Default is false.
-workspace-root | Workspace root path that is either an absolute path or a path relative to the working directory. Defaults to ‘.’ (the working directory)
-{: class="table table-striped"}
-
-### Validate and Publish Example
-
-Below is an example of how to use the `orb-tools` orb to validate and publish an orb.
-
-```yaml
-version: 2.1
-orbs:
-  orb-tools: circleci/orb-tools@2.0.0
-
-workflows:
-  btd:
-    jobs:
-      - orb-tools/publish:
-          orb-path: src/orb.yml
-          orb-ref: circleci/hello-build@dev:${CIRCLE_BRANCH}
-          publish-token-variable: "$CIRCLECI_DEV_API_TOKEN"
-          validate: true
+1. Create your orb inside your namespace. At this stage no orb content is being generated, but the naming is reserved for when the orb is published:
+```sh
+circleci orb create <my-namespace>/<my-orb-name>
 ```
 
-In the above example, the Build-Test-Deploy (BTD) workflow runs the `orb-tools/validate` job first. If the orb is deemed valid, the next step will execute, and `orb-tools/publish` will execute. When `orb-tools/publish` succeeds, the job input will contain a success message that the new orb has been published to the [CircleCI Orbs Registry](https://circleci.com/orbs/registry/).
+1. Create the content of your orb in a YAML file. Generally, you would do this in your code editor, in a git repo made for your orb, but, For this simple example, let's assume a file in `/tmp/orb.yml` could be made with a bare-bones orb like:
+```sh
+echo 'version: "2.1"\ndescription: "a sample orb"' > /tmp/orb.yml
+```
+
+1. Validate that your code is a valid orb using the CLI. For example, using the path above you could use:
+```
+circleci orb validate /tmp/orb.yml
+```
+
+1. Publish a dev version of your orb:
+```sh
+circleci orb publish /tmp/orb.yml <my-namespace>/<my-orb-name>@dev:first
+```
+
+1. Once you are ready to push your orb to production, you can publish it manually using `circleci orb publish` or promote it directly from the dev version. In the case where you want to publish the orb, assuming you wanted to increment the new dev version to become 0.0.1, you can use:
+```sh
+circleci orb publish promote sandbox/hello-world@dev:first patch
+```
+
+1. Your orb is now published in an immutable form as a production version and can be used safely in builds. You can then pull the source of your orb using:
+```sh
+circleci orb source sandbox/hello-world@0.0.1
+```

--- a/jekyll/_cci2/orb-author-validate-publish.md
+++ b/jekyll/_cci2/orb-author-validate-publish.md
@@ -6,11 +6,11 @@ version:
 - Cloud
 ---
 
-This guide covers the steps required to create a simple orb manually, without using the orb development kit.
+This guide covers the steps required to create a simple orb manually, without using the orb development kit. We recommend the orb development kit for most orb projects, to find out more, see the [Orb Authoring Guide]({{site.baseurl}}/2.0/orb-author).
 
 1. If you have not already done so, claim a namespace for your user/organization using the following command, substituting your namespace choice and GitHub org name:
 ```sh
-circleci namespace create <my-namespace> github <my-GH-Org>
+circleci namespace create <my-namespace> github <my-gh-org>
 ```
 **Note:** When creating a namespace via the CircleCI CLI, be sure to specify the VCS provider.
 
@@ -24,7 +24,7 @@ circleci orb create <my-namespace>/<my-orb-name>
 echo 'version: "2.1"\ndescription: "a sample orb"' > /tmp/orb.yml
 ```
 
-1. Validate that your code is a valid orb using the CLI. For example, using the path above you could use:
+1. Validate your orb code using the CLI:
 ```
 circleci orb validate /tmp/orb.yml
 ```
@@ -34,12 +34,12 @@ circleci orb validate /tmp/orb.yml
 circleci orb publish /tmp/orb.yml <my-namespace>/<my-orb-name>@dev:first
 ```
 
-1. Once you are ready to push your orb to production, you can publish it manually using `circleci orb publish` or promote it directly from the dev version. In the case where you want to publish the orb, assuming you wanted to increment the new dev version to become 0.0.1, you can use:
+1. Once you are ready to push your orb to production, you can publish it manually using `circleci orb publish` or promote it directly from the dev version. Using the following command will increment the dev version to become `0.0.1`:
 ```sh
-circleci orb publish promote sandbox/hello-world@dev:first patch
+circleci orb publish promote <my-namespace>/<my-orb-name>@dev:first patch
 ```
 
-1. Your orb is now published in an immutable form as a production version and can be used safely in builds. You can then pull the source of your orb using:
+1. Your orb is now published, in an immutable form, as a production version and can be used safely in CircleCI projects. You can pull the source of your orb using:
 ```sh
-circleci orb source sandbox/hello-world@0.0.1
+circleci orb source <my-namespace>/<my-orb-name>@0.0.1
 ```


### PR DESCRIPTION
* retain manual orb creation steps to link to as an alternative to the orb dev kit