### PR TITLE
Remove meaningless and unused environment variable from build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,6 @@ jobs:
     working_directory: ~/circleci-docs
     environment:
       JEKYLL_ENV: production
-      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       JOB_RESULTS_PATH: run-results
     steps:
       - checkout


### PR DESCRIPTION
# Description
Removes meaningless and unused environment variable from the `build` job.

# Reasons

This variable was originally introduced in 0fd59b4a in 2016-03: https://github.com/circleci/circleci-docs/commit/0fd59b4a0a298c9d95e9ecd

On migration from v1 to v2, this project did not remove the variable: https://github.com/circleci/circleci-docs/pull/1048

Ref. Jekyll is not using the variable any more with CircleCI 2.0: https://github.com/jekyll/jekyll/pull/8410

Also this variable has been set only for `build` job, but [`ruby-deps` step](https://github.com/circleci/circleci-docs/blob/7354b6c9582be79565aae799a2e3c7fac0c6939d/.circleci/config.yml#L35-L43) is used in other jobs, which is inconsistent with the job.