### PR TITLE
Fix typo in Installation on AWS for Server 2.x

### DIFF
--- a/jekyll/_cci2/aws.adoc
+++ b/jekyll/_cci2/aws.adoc
@@ -212,7 +212,7 @@ CAUTION: If Docker Layer Caching (DLC) is to be used, VM preallocation should be
 .Metrics
 image::metrics_setup.png[]
 
-. **Custom Metrics** are an alternative to Cloudwatch and Datadog metrics, you can also customize the metrics you recieve through Telegraf. For more on this see our https://circleci.com/docs/2.0/monitoring/#custom-metrics[Custom Metics] guide.
+. **Custom Metrics** are an alternative to Cloudwatch and Datadog metrics, you can also customize the metrics you receive through Telegraf. For more on this see our https://circleci.com/docs/2.0/monitoring/#custom-metrics[Custom Metics] guide.
 
 . **Distributed Tracing** is used in our support bundles, and settings should remain set to default unless a change is requested by CircleCI Support.
 


### PR DESCRIPTION
# Description
Fix a typo in [Installation on AWS for Server 2.x](https://circleci.com/docs/2.0/aws/#installation-setup).

# Reasons
Easier to read.