### PR TITLE
Replaced the broken link for the cli installation guide here with the…

### DIFF
--- a/jekyll/_cci2/creating-orbs.md
+++ b/jekyll/_cci2/creating-orbs.md
@@ -17,9 +17,9 @@ Before working with orbs, you may find it helpful to gain a high-level understan
 
 Although it is possible to CI/CD orb publishing using the [`orbs-tool`](https://circleci.com/docs/2.0/creating-orbs/#orb-toolspublish) orb, the most direct and iterable way to build, publish, and test orbs is by using our CLI. Follow the steps below to install and then configure the CircleCI CLI.
 
-* [Install the CircleCI CLI](https://circleci.com/docs/2.0/orb-author-cli/#install-the-cli-for-the-first-time).
-* [Update the CLI](https://circleci.com/docs/2.0/orb-author-cli/#update-the-cli).
-* [Configure the CLI](https://circleci.com/docs/2.0/orb-author-cli/#configure-the-circleci-cli).
+* [Install the CircleCI CLI](https://circleci.com/docs/2.0/local-cli/#installation).
+* [Update the CLI](https://circleci.com/docs/2.0/local-cli/#updating-the-cli).
+* [Configure the CLI](https://circleci.com/docs/2.0/local-cli/#configuring-the-cli).
 
 ### Step 2 - Verify You Installed the CLI Correctly
 


### PR DESCRIPTION
… correct guide link

# Description
In this docs, there happens to be a broken link about circleci installation guide, so I removed the dead links and added the correct links.

# Reasons
Fixed broken link in the guide.