### PR TITLE
docs: fix the coveralls link

### DIFF
--- a/jekyll/_cci2/code-coverage.md
+++ b/jekyll/_cci2/code-coverage.md
@@ -381,7 +381,7 @@ Read more about Codecov's orb in their [guest blog post](https://circleci.com/bl
 ## Coveralls
 
 If you're a Coveralls customer, follow
-[their guide to set up your coverage stats.](https://coveralls.io/docs)
+[their guide to set up your coverage stats.](https://docs.coveralls.io/)
 You'll need to add `COVERALLS_REPO_TOKEN` to your CircleCI
 [environment variables]( {{ site.baseurl }}/1.0/environment-variables/).
 


### PR DESCRIPTION
# Description
The link https://coveralls.io/docs is an old link and is not maintained anymore.

This PR replaces the link with the updated link to the coveralls doc.

# Reasons
Should fix https://github.com/circleci/circleci-docs/issues/4782