### PR TITLE
Fix a broken link in Docs/2.0/ orb-author-intro

### DIFF
--- a/jekyll/_cci2/orb-author-intro.md
+++ b/jekyll/_cci2/orb-author-intro.md
@@ -66,5 +66,5 @@ Continue on to the  [Orb Authoring Process]({{site.baseurl}}/2.0/orb-author/) gu
 {:.no_toc}
 
 - [Orb Authoring]({{site.baseurl}}/2.0/orb-author/)
-- [Orb Concepts]({{site.baseurl}}/2.0//orb-concepts/)
+- [Orb Concepts]({{site.baseurl}}/2.0/orb-concepts/)
 - [Orb Author FAQ]({{site.baseurl}}/2.0/orb-author-faq/)


### PR DESCRIPTION
# Description
Fix a broken link in the Docs/2.0/ orb-author-intro

# Reasons
Easy navigation and easy reading.