### PR TITLE
Fixed links and grammar

### DIFF
--- a/jekyll/_cci2/using-orbs.md
+++ b/jekyll/_cci2/using-orbs.md
@@ -149,7 +149,7 @@ A development version should be referenced by its complete, fully-qualified name
 
 Orb versions may be added to the registry either as development versions or production versions. Production versions are always a semantic version like 1.5.3; whereas development versions can be tagged with a string and are always prefixed with dev: for example `dev:myfirstorb`.
 
-**Note:** Dev versions are mutable and expire: their contents can change, and they are subject to deletion after 90 days; therefore, it is strongly recommended you do not rely on a development versions in any production software, and use them only while actively developing your orb. It is possible for org members of a team to publish a semantic version of an orb based off of a dev orb instead of copy-pasting some config from another teammate.
+**Note:** Dev versions are mutable and expire: their contents can change, and they are subject to deletion after 90 days; therefore, it is strongly recommended you do not rely on development versions in any production software, and use them only while actively developing your orb. It is possible for org members of a team to publish a semantic version of an orb based off of a dev orb instead of copy-pasting some config from another teammate.
 
 ### Development and Production Orb Security Profiles
 
@@ -234,8 +234,6 @@ In general, CircleCI prefers to never delete production orbs that were published
 If the case arises where you need to delete an orb for emergency reasons, please contact CircleCI (Note: If you are deleting because of a security concern, you must practice responsible disclosure using the CircleCI Security web page.
 
 ## See Also
-{:.no_toc}
-
-- Refer to [Orb Introduction]({{site.baseurl}}/2.0/orb-intro/), for a high-level overview of using and authoring orbs.
-- Refer to [Orbs Reference]({{site.baseurl}}/2.0/reusing-config/) for more detailed examples of reusable orbs, commands, parameters, and executors.
-- Refer to [Configuration Cookbook]({{site.baseurl}}/2.0/configuration-cookbook/) for more detailed information about how you can use CircleCI orb recipes in your configurations.
+- Refer to [Orb Introduction](https://circleci.com/docs/2.0/orb-intro/), for a high-level overview of using and authoring orbs.
+- Refer to [Orbs Reference](https://circleci.com/docs}/2.0/reusing-config/) for more detailed examples of reusable orbs, commands, parameters, and executors.
+- Refer to [Configuration Cookbook](https://circleci.com/docs/2.0/configuration-cookbook/) for more detailed information about how you can use CircleCI orb recipes in your configurations.


### PR DESCRIPTION
Fixed minor grammar.
Fixed links using {{site.baseurl}} that were dead.
Removed {{:no.toc}} that wasn't being displayed.

#orbtoberfest