### PR TITLE
Add 19.03.13 to list of supported remote docker versions

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -25,7 +25,7 @@ jobs:
       # ... steps for building/testing app ...
 
       - setup_remote_docker:
-        version: 19.03.12
+        version: 19.03.13
 ```
 
 When `setup_remote_docker` executes, a remote environment will be created, and your current [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) will be configured to use it. Then, any docker-related commands you use will be safely executed in this new environment.
@@ -83,7 +83,7 @@ jobs:
       # ... steps for building/testing app ...
 
       - setup_remote_docker:
-          version: 19.03.12
+          version: 19.03.13
           docker_layer_caching: true
 
       # build and push Docker image
@@ -116,11 +116,12 @@ To specify the Docker version, you can set it as a `version` attribute:
 
 ```
       - setup_remote_docker:
-          version: 19.03.12
+          version: 19.03.13
 ```
 
 CircleCI supports multiple versions of Docker. The following are the available versions:
 
+- `19.03.13`
 - `19.03.12`
 - `19.03.8`
 - `18.09.3`

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -341,7 +341,7 @@ jobs:
 ##### Available `machine` images
 CircleCI supports multiple machine images that can be specified in the `image` field:
 
-* `ubuntu-2004:202008-01` (beta) - Ubuntu 20.04, Docker v19.03.12, Docker Compose v1.26.2
+* `ubuntu-2004:202008-01` (beta) - Ubuntu 20.04, Docker v19.03.13, Docker Compose v1.27.4
 * `ubuntu-1604:202007-01` - Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
 * `ubuntu-1604:202004-01` - Ubuntu 16.04, Docker v19.03.8, Docker Compose v1.25.5
 * `ubuntu-1604:201903-01` - Ubuntu 16.04, Docker v18.09.3, Docker Compose v1.23.1


### PR DESCRIPTION
# Description
- Add 19.03.13 to list of supported remote docker versions
- Udate software version list for beta ubuntu 20.04 image

# Reasons
Docker 19.03.13 is now supported