### PR TITLE
Fix Broken Link in Docs/2.0/ local-cli

### DIFF
--- a/jekyll/_cci2/local-cli-getting-started.md
+++ b/jekyll/_cci2/local-cli-getting-started.md
@@ -152,7 +152,7 @@ Success!
 	
 ## Connect Your Repo to CircleCI
 
-We will need to leave the terminal behind for this step. Head over to [the "Add Projects page"](https://circleci.com/add-projects). It's time to set up your project to run CI whenever you push code.
+We will need to leave the terminal behind for this step. Head over to [the "Add Projects page"](https://circleci.com/docs/2.0/project-build/#adding-projects). It's time to set up your project to run CI whenever you push code.
 
 Find your project ("foo_ci", or whatever you named it on GitHub) in the list of projects and click "Set Up Project". Next, return to your terminal and push your latest changes to GitHub (the addition of our `config.yml` file.)
 

--- a/jekyll/_cci2/local-cli-getting-started.md
+++ b/jekyll/_cci2/local-cli-getting-started.md
@@ -152,7 +152,7 @@ Success!
 	
 ## Connect Your Repo to CircleCI
 
-We will need to leave the terminal behind for this step. Head over to [the "Add Projects page"](https://circleci.com/docs/2.0/project-build/#adding-projects). It's time to set up your project to run CI whenever you push code.
+We will need to leave the terminal behind for this step. Head over to [the "Add Projects page"](https://app.circleci.com/projects/project-dashboard/github/circleci/). It's time to set up your project to run CI whenever you push code.
 
 Find your project ("foo_ci", or whatever you named it on GitHub) in the list of projects and click "Set Up Project". Next, return to your terminal and push your latest changes to GitHub (the addition of our `config.yml` file.)
 

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -106,7 +106,7 @@ This command may prompt you for `sudo` if your user doesn't have write permissio
 
 ## Configuring The CLI
 
-Before using the CLI you need to generate a CircleCI API Token from the [Personal API Token tab](https://circleci.com/account/api). After you get your token, configure the CLI by running:
+Before using the CLI you need to generate a CircleCI API Token from the [Personal API Token tab](https://app.circleci.com/settings/user/tokens). After you get your token, configure the CLI by running:
 
 ```sh
 circleci setup


### PR DESCRIPTION
# Description
The link in the docs is leading to 404 page,  so I replaced it with the correct one.


# Reasons
Easy navigation and easy reading.