### PR TITLE
Fixed the link for Gemfile

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -20,7 +20,7 @@ _(If you already cloned the project and forgot `--recurse-submodules`, run `git 
 
 If you already have a stable Ruby environment (currently Ruby 2.3.3) and feel comfortable installing dependencies, install Jekyll by following [this guide](https://jekyllrb.com/docs/installation/).
 
-Check out the [Gemfile](Gemfile) for the Ruby version we're currently using. We recommend [RVM](https://rvm.io/) for managing multiple Ruby versions.
+Check out the [Gemfile](https://github.com/circleci/circleci-docs/blob/master/Gemfile) for the Ruby version we're currently using. We recommend [RVM](https://rvm.io/) for managing multiple Ruby versions.
 
 We also use a gem called [HTMLProofer](https://github.com/gjtorikian/html-proofer) to test links, images, and HTML. The docs site will need a passing build to be deployed, so use HTMLProofer to test everything before you push changes to GitHub.
 


### PR DESCRIPTION
# Description
Fixed the link provided for Gemfile to https://github.com/circleci/circleci-docs/blob/master/Gemfile.

# Reasons
The link was leading to a 404 Error page and needed a fix.
