### PR TITLE
Update to fix hyperlinks

### DIFF
--- a/jekyll/_cci2_ja/docker-hub-pull-through-mirror.adoc
+++ b/jekyll/_cci2_ja/docker-hub-pull-through-mirror.adoc
@@ -16,7 +16,7 @@ toc::[]
 
 == 概要
 
-[2020年11月1 日](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/)から、Docker Hub で匿名ユーザーに対する発信元 IP に基づいたプル回数制限が導入されます。運用中のサービスでの混乱を避けるために、Docker Hub から認証付きでプル操作を行うようにすることをお勧めします。認証は設定ファイルで行えます [Docker の認証付きプルの使用](https://circleci.com/ja/docs/2.0/private-images/)を参照。
+link:https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/[2020年11月1日]から、Docker Hub で匿名ユーザーに対する発信元 IP に基づいたプル回数制限が導入されます。運用中のサービスでの混乱を避けるために、Docker Hub から認証付きでプル操作を行うようにすることをお勧めします。認証は設定ファイルで行えます(link:https://circleci.com/ja/docs/2.0/private-images/[Docker の認証付きプルの使用]を参照)。
 
 あるいは、Docker Hub アカウントの資格情報をあらかじめ構成した Docker Hub のレジストリのミラーをセットアップするという方法もあります。レジストリのミラーを使用すると、場合によっては多数の設定ファイルを変更するよりも簡単に対応できます。また、Docker Hub への通信が減るため、パフォーマンスがさらに向上する可能性もあります。
 


### PR DESCRIPTION
# Description
Fixed wrong hyperlink format

# Reasons
Some hyperlinks have modified in *.md notation, not *.adoc notation by mistake.