### PR TITLE
Fix a mislabled image.

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -373,7 +373,7 @@ workflows:
 jobs:
   build:
     machine:
-      image: ubuntu-1604:202007-01
+      image: windows-server-2019-nvidia:stable
       docker_layer_caching: true    # default - false
 ```
 


### PR DESCRIPTION
I think, based on the context of this section, that the example image was suppose to be a Windows image not a Linux one.