### PR TITLE
Add missing closing quote

### DIFF
--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -194,7 +194,7 @@ curl -X POST --header "Content-Type: application/json" -H "Circle-Token: <circle
   "build_parameters": { // optional
     "RUN_EXTRA_TESTS": "true"
   }
-}
+}'
 
 https://circleci.com/api/v1.1/project/:vcs-type/:username/:project
 ```


### PR DESCRIPTION
# Description
Add missing closing quote in the "**Trigger a new Job**" shell example ([API v1 documentation](https://circleci.com/docs/api/v1/#trigger-a-new-job))

# Reasons
The current syntax is incorrect.
```
curl -X POST --header "Content-Type: application/json" -H "Circle-Token: <circle-token>" -d '{
  "tag": "v0.1", // optional
  "parallel": 2, //optional, default null
  "build_parameters": { // optional
    "RUN_EXTRA_TESTS": "true"
  }
}

https://circleci.com/api/v1.1/project/:vcs-type/:username/:project
```

The above cURL request will not be executed, and won't trigger any job.