### PR TITLE
Adding necessary outer single quotes around the parameter

### DIFF
--- a/jekyll/_cci2/triggers.md
+++ b/jekyll/_cci2/triggers.md
@@ -24,7 +24,7 @@ By default, CircleCI automatically builds a project whenever you push changes to
 
 ```
 curl -u ${CIRCLE_API_USER_TOKEN}: \
-     -d build_parameters[CIRCLE_JOB]=deploy_docker \
+     -d 'build_parameters[CIRCLE_JOB]=deploy_docker' \
      https://circleci.com/api/v1.1/project/<vcs-type>/<org>/<repo>/tree/<branch>
 ```
 


### PR DESCRIPTION
# Description
Adding outer single quotes  the ["Trigger a Job Using curl and Your API Token" example](https://circleci.com/docs/2.0/triggers/#trigger-a-job-using-curl-and-your-api-token).

# Reasons
In the current example:
```
curl -u ${CIRCLE_API_USER_TOKEN}: \
     -d build_parameters[CIRCLE_JOB]=deploy_docker \
     https://circleci.com/api/v1.1/project/<vcs-type>/<org>/<repo>/tree/<branch>
```
The absence of outer quotes around the data "name=value" pair will cause the command to fail with:
```
no matches found: build_parameters[CIRCLE_JOB]=deploy_docker
```

A note could be added to mention that double quotes can also be used, instead of single quotes.