### PR TITLE
Remove instructions for accessing the old UI

### DIFF
--- a/jekyll/_cci2/pipelines.md
+++ b/jekyll/_cci2/pipelines.md
@@ -23,9 +23,6 @@ Where you once saw the term `Jobs` in the sidebar, you will now see `Pipelines`.
 
 ![]({{ site.baseurl }}/assets/img/docs/pipelines-jobs-to-pipelines.png)
 
-**Note:** If you would like to continue to use the old UI while it is still available, you can temporarily opt out while the new UI is continually improved.
-
-![]({{ site.baseurl }}/assets/img/docs/pipelines-opt-out-1.png)
 
 ## Jobs, Tests, Artifacts
 


### PR DESCRIPTION
This page contained a note and screenshots for access the old UI with the "Old Experience" button. However, access to the old UI was sunset as of Aug 14.

# Description
This proposed change removes those instructions, to prevent readers from looking for a button they no longer have access to.

# Reasons
Remove outdated reference to old UI for clarity