### PR TITLE
Remove note about jobs that use 2.1 config 

### DIFF
--- a/jekyll/_cci2/triggers.md
+++ b/jekyll/_cci2/triggers.md
@@ -20,8 +20,6 @@ By default, CircleCI automatically builds a project whenever you push changes to
 
 ## Trigger a Job Using curl and Your API Token
 
-**Note:** You cannot currently trigger jobs that use 2.1 config from the API.
-
 ```
 curl -u ${CIRCLE_API_USER_TOKEN}: \
      -d 'build_parameters[CIRCLE_JOB]=deploy_docker' \


### PR DESCRIPTION
# Description
Removing note "_You cannot currently trigger jobs that use 2.1 config from the API_." in the ["Trigger a Job Using curl and Your API Token" example](https://circleci.com/docs/2.0/triggers/#trigger-a-job-using-curl-and-your-api-token).

# Reasons
I ran tests with a `config.yml` that uses `version: 2.1`. The job I successfully triggered includes [conditional steps](https://circleci.com/docs/2.0/reusing-config/#defining-conditional-steps), and is part of a workflow that contains [`post-steps`](https://circleci.com/docs/2.0/configuration-reference/#pre-steps-and-post-steps-requires-version-21).