### PR TITLE
🔧 Fix some jobs indentation on sample-config.md

### DIFF
--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -461,9 +461,9 @@ jobs:
     prepare-dependencies:
         docker:
             - image: node:current-alpine
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+              auth:
+                username: mydockerhub-user
+                password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
         steps:
             - checkout
             - run:
@@ -490,9 +490,9 @@ jobs:
     build-production:
         docker:
             - image: node:current-alpine
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+              auth:
+                username: mydockerhub-user
+                password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
         steps:
             - attach_workspace:
                   at: .
@@ -532,9 +532,9 @@ jobs:
     test:
         docker:
             - image: node:current-alpine
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+              auth:
+                username: mydockerhub-user
+                password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
         parallelism: 2
         steps:
             - attach_workspace:


### PR DESCRIPTION
# Description
On [**Sample Configuration with Fan-in/Fan-out Workflow**](https://circleci.com/docs/2.0/sample-config/#sample-configuration-with-fan-infan-out-workflow) section, the `auth` key within `docker` element is improperly indented on some jobs like: prepare-dependencies, build-production and test, So I have fixed it 

# Reasons
it might mislead/confuse someone who read the guide if he wasn't vigilant enough that there's a typo in indentation