### PR TITLE
Adding missing closing quote in API doc example

### DIFF
--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -295,7 +295,7 @@ curl -X POST --header "Content-Type: application/json" -H "Circle-Token: <circle
   "build_parameters": { // optional
     "RUN_EXTRA_TESTS": "true"
   }
-}
+}'
 
 https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/tree/:branch
 ```


### PR DESCRIPTION
# Description
Adding missing closing quote in the "**Trigger a new Job with a Branch**" cURL example ([API v1 documentation](https://circleci.com/docs/api/v1/#trigger-a-new-job-with-a-branch))

# Reasons
The current syntax is incorrect (closing single quote missing).

```
curl -X POST --header "Content-Type: application/json" -H "Circle-Token: <circle-token>" -d '{
  "parallel": 2, //optional, default null
  "revision": "f1baeb913288519dd9a942499cef2873f5b1c2bf" // optional
  "build_parameters": { // optional
    "RUN_EXTRA_TESTS": "true"
  }
}

https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/tree/:branch
```

The above cURL request will not be executed, and won't trigger any job. (Similar to [PR #4817](https://github.com/circleci/circleci-docs/pull/4817))