### PR TITLE
Remove obsolete note about jobs that use 2.1 config

### DIFF
--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -284,8 +284,6 @@ tag | The tag to build. Default is null. Cannot be used with revision parameter.
 parallel | The number of containers to use to run the build. Default is null and the project default is used. This parameter is ignored for builds running on our 2.0 infrastructure.
 build_parameters | Additional environment variables to inject into the build environment. A map of names to values.
 
-**Note** Triggering a new job is not currently supported with configurations that specify `version: 2.1`.
-
 ## Trigger a new Job with a Branch
 
 ```sh
@@ -384,8 +382,6 @@ For more about build parameters, see 2.0 build parameters <a href="https://circl
 revision | The specific revision to build. Default is null and the head of the branch is used. Cannot be used with tag parameter.
 parallel | The number of containers to use to run the build. Default is null and the project default is used. This parameter is ignored for builds running on our 2.0 infrastructure.
 build_parameters | Additional environment variables to inject into the build environment. A map of names to values.
-
-**Note** Triggering a new job with a branch is not currently supported with configurations that specify `version: 2.1`.
 
 ## Trigger a new Build by Project (preview)
 

--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -295,7 +295,7 @@ curl -X POST --header "Content-Type: application/json" -H "Circle-Token: <circle
   "build_parameters": { // optional
     "RUN_EXTRA_TESTS": "true"
   }
-}
+}'
 
 https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/tree/:branch
 ```


### PR DESCRIPTION
# Description
Removing note "_Triggering a new job is not currently supported with configurations that specify version: 2.1_" in the API (v1) documentation:

- https://circleci.com/docs/api/v1/#trigger-a-new-job
- https://circleci.com/docs/api/v1/#trigger-a-new-job-with-a-branch

# Reasons
The note is no longer applicable (see [PR #4821](https://github.com/circleci/circleci-docs/pull/4821))