### PR TITLE
Add missing docker login step

### DIFF
--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -71,6 +71,9 @@ jobs:
   machine-job:
     machine: true
     steps:
+      - docker/check:
+          docker-username: mydockerhub-user  # DOCKER_LOGIN is the default value, if it exists, it automatically would be used.
+          docker-password: $DOCKERHUB_PASSWORD  # DOCKER_PASSWORD is the default value
       - docker/pull:
           images: 'circleci/node:latest'
 ```

--- a/jekyll/_cci2_ja/private-images.md
+++ b/jekyll/_cci2_ja/private-images.md
@@ -68,7 +68,9 @@ jobs:
   machine-job:
     machine: true
     steps:
-
+      - docker/check:
+          docker-username: mydockerhub-user  # DOCKER_LOGIN がデフォルト値となっており、この値が存在する場合自動で値がセットされます
+          docker-password: $DOCKERHUB_PASSWORD  # DOCKER_PASSWORD がデフォルト値になっております
       - docker/pull:
           images: 'circleci/node:latest'
 ```


### PR DESCRIPTION
# Description

This example explains how to authenticate to docker hub to avoid Docker hub rate limiting. However, this example doesn't include the docker login step, so I add it. 

```
jobs:
  machine-job:
    machine: true
    steps:
      - docker/pull:
          images: 'circleci/node:latest'
```
↓
```
jobs:
  machine-job:
    machine: true
    steps:
      - docker/check:
          docker-username: mydockerhub-user  # DOCKER_LOGIN is the default value, if it exists, it automatically would be used.
          docker-password: $DOCKERHUB_PASSWORD  # DOCKER_PASSWORD is the default value
      - docker/pull:
          images: 'circleci/node:latest'
```