### PR TITLE
fix step formatting and improve side nav naming

### DIFF
--- a/jekyll/_cci2/nomad.adoc
+++ b/jekyll/_cci2/nomad.adoc
@@ -91,6 +91,7 @@ Complete the following steps to get logs from the allocation of the specified jo
 === Scaling the Cluster
 
 By default, your Nomad Client is set up within an Auto Scaling Group (ASG) within AWS. To view settings:
+
 . Go to your EC2 Dashboard and select Auto Scaling Groups from the left hand menu
 . Select your Nomad Client
 . Select Actions > Edit to set Desired/Minimum/Maximum counts. This defines the number of Nomad Clients to spin up and keep available. Use the Scaling Policy tab to scale up your group automatically at your busiest times, see below for best practices for defining scaling policies. Use <<monitoring#nomad-job-metrics,nomad job metrics>> to assist in defining your scaling policies.

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -325,7 +325,7 @@ en:
       children:
         - name: Overview
           link: 2.0/overview/
-        - name: Nomad
+        - name: Intro to Nomad
           link: 2.0/nomad/
         - name: Metrics & Monitoring
           link: 2.0/monitoring/


### PR DESCRIPTION
* Formatting failed for some steps due to lack of line space. This fixes it.
* Also update "Nomad" in navigation to "Intro to Nomad" - just for clarity