### PR TITLE
Add outer quotes and alternative syntaxes (cURL request example)

### DIFF
--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -33,6 +33,10 @@ curl -u ${CIRCLE_API_USER_TOKEN}: \
      https://circleci.com/api/v1.1/project/<vcs-type>/<org>/<repo>/tree/<branch>
 ```
 
+Alternative syntaxes for the above example:
+- Replace single quotes with double quotes (`-d "build_parameters[CIRCLE_JOB]=deploy_docker"`)
+- Escape the square brackets (`-d build_parameters\[CIRCLE_JOB\]=deploy_docker`)
+
 Some notes on the variables used in this example:
 - `CIRCLE_API_USER_TOKEN` is a [personal API token]({{ site.baseurl }}/2.0/managing-api-tokens/#creating-a-personal-api-token).
 - `<vcs-type>` is a placeholder variable and refers to your chosen VCS (either `github` or `bitbucket`).

--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -29,7 +29,7 @@ The following example shows how to trigger the `deploy_docker` job by using `cur
 
 ```bash
 curl -u ${CIRCLE_API_USER_TOKEN}: \
-     -d build_parameters[CIRCLE_JOB]=deploy_docker \
+     -d 'build_parameters[CIRCLE_JOB]=deploy_docker' \
      https://circleci.com/api/v1.1/project/<vcs-type>/<org>/<repo>/tree/<branch>
 ```
 
@@ -79,7 +79,7 @@ jobs:
             # replace this with your build/deploy check (i.e. current branch is "release")
             if [[ true ]]; then
               curl --user ${CIRCLE_API_USER_TOKEN}: \
-                --data build_parameters[CIRCLE_JOB]=deploy_docker \
+                --data 'build_parameters[CIRCLE_JOB]=deploy_docker' \
                 --data revision=$CIRCLE_SHA1 \
                 https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
             fi


### PR DESCRIPTION
# Description

1. Add necessary outer quotes to cURL requests

1. Add note with alternative syntaxes (use double quotes, escape square brackets)

# Reasons
In the [current example](https://circleci.com/docs/2.0/api-job-trigger/#overview):

```
curl -u ${CIRCLE_API_USER_TOKEN}: \
     -d build_parameters[CIRCLE_JOB]=deploy_docker \
     https://circleci.com/api/v1.1/project/<vcs-type>/<org>/<repo>/tree/<branch>
```
The absence of outer quotes around the data "name=value" pair will cause the command to fail with:

`no matches found: build_parameters[CIRCLE_JOB]=deploy_docker`
(See [PR #4818](https://github.com/circleci/circleci-docs/pull/4818))
&nbsp;
Alternative syntaxes can't hurt ¯\\\_(ツ)\_/¯