### PR TITLE
Fix docker orb usage

### DIFF
--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -57,7 +57,7 @@ Alternatively, you can utilize the `machine` executor to achieve the same result
 ``` yaml
 version: 2.1
 orbs:
-  docker: circleci/docker@1.4.0
+  docker: circleci/docker@1.5.0
 
 workflows:
   my-workflow:
@@ -73,7 +73,7 @@ jobs:
     steps:
       - docker/check:
           docker-username: mydockerhub-user  # DOCKER_LOGIN is the default value, if it exists, it automatically would be used.
-          docker-password: $DOCKERHUB_PASSWORD  # DOCKER_PASSWORD is the default value
+          docker-password: DOCKERHUB_PASSWORD  # DOCKER_PASSWORD is the default value
       - docker/pull:
           images: 'circleci/node:latest'
 ```

--- a/jekyll/_cci2_ja/private-images.md
+++ b/jekyll/_cci2_ja/private-images.md
@@ -54,7 +54,7 @@ jobs:
 ```yaml
 version: 2.1
 orbs:
-  docker: circleci/docker@1.4.0
+  docker: circleci/docker@1.5.0
 
 workflows:
   my-workflow:
@@ -70,7 +70,7 @@ jobs:
     steps:
       - docker/check:
           docker-username: mydockerhub-user  # DOCKER_LOGIN がデフォルト値となっており、この値が存在する場合自動で値がセットされます
-          docker-password: $DOCKERHUB_PASSWORD  # DOCKER_PASSWORD がデフォルト値になっております
+          docker-password: DOCKERHUB_PASSWORD  # DOCKER_PASSWORD がデフォルト値になっております
       - docker/pull:
           images: 'circleci/node:latest'
 ```


### PR DESCRIPTION
# Description
Update docker/check usage example

# Reasons
docker/checks takes **env_var_name** not **string**