### PR TITLE
Clarify docker installation in 3rd party images

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -94,7 +94,7 @@ jobs:
           docker push CircleCI-Public/circleci-demo-docker:$TAG
 {% endhighlight %}
 
-If the primary container you are using doesn't already have the docker CLI installed, then [you will need to install it](https://docs.docker.com/install/#supported-platforms).
+**Note:** The [CircleCI convenience images](https://circleci.com/docs/2.0/circleci-images/) for the Docker executor come with the Docker CLI pre-installed. If you are using a third-party image for your primary container that doesn't already have the Docker CLI installed, then [you will need to install it](https://docs.docker.com/install/#supported-platforms) as part of your job before calling any `docker` commands.
 
 ```
       # Install via apk on alpine based images


### PR DESCRIPTION
# Description
Clarify docker installation in 3rd party images

# Reasons
Acting on recent feedback with regards to running docker commands in a container using a 3rd party image that doesn't already have docker installed.