### PR TITLE
Update the note for the only build pull requests option

### DIFF
--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -47,7 +47,7 @@ By default, CircleCI builds every commit from every branch. This behavior may be
 
 To change this setting, go to the **Project Settings>Advanced** of your project and set the **Only build pull requests** option to _On_.
 
-**Note:** Even if this option is enabled, CircleCI will still build all commits from your project's default branch.
+**Note:** Even if this option is enabled, CircleCI will still build all commits from your project's default branch and tags
 
 ### Build Pull Requests From Forked Repositories
 {:.no_toc}


### PR DESCRIPTION
# Description
Even if the only build pull requests option is enabled, tag pushing triggers builds. 

# Reasons
A customer asked this question through the ticket, and we didn't mention about this behavior on the doc.