### PR TITLE
Fixed the link for Slate Docs

### DIFF
--- a/src-crg/README.md
+++ b/src-crg/README.md
@@ -29,7 +29,7 @@ Features
 
 * **RTL Support** Full right-to-left layout for RTL languages such as Arabic, Persian (Farsi), Hebrew etc.
 
-Getting started with Slate is super easy! Simply fork this repository and follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](http://lord.github.io/slate).
+Getting started with Slate is super easy! Simply fork this repository and follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](https://slatedocs.github.io/slate/).
 
 Getting Started with Slate
 ------------------------------


### PR DESCRIPTION
# Description
I have fixed the broken link for Slate Docs.

# Reasons
The link was leading to a 404 error page and needed a fix.