### PR TITLE
List bash as a required tool

### DIFF
--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -107,6 +107,7 @@ RUN go get github.com/jstemmer/go-junit-report
 In order to be used as a primary container on CircleCI,
 a custom Docker image must have the following tools installed:
 
+- bash (most likely already installed or available via your package manager)
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [ssh](https://help.ubuntu.com/lts/serverguide/openssh-server.html.en#openssh-installation)
 - [tar](https://www.howtoforge.com/tutorial/linux-tar-command/#installing-tar)


### PR DESCRIPTION
# Description
Add bash to the list of required tools for primary images.

# Reasons
I was surprised to see a build using a custom image built on Alpine Linux fail because `bash` wasn't installed. Alpine apparently doesn't include `bash` by default, so I'm hoping to save the next person a few minutes by implying they should check to ensure that `bash` is present in their image.