### PR TITLE
Update machine image examples to use Ubuntu 20.04 image

### DIFF
--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -121,10 +121,10 @@ jobs:
 #...
  build2:
    machine: # Specifies a machine image that uses
-   # an Ubuntu version 14.04 image with Docker 17.06.1-ce
-   # and docker-compose 1.14.0, follow CircleCI Discuss Announcements
+   # an Ubuntu version 20.04 image with Docker 19.03.13
+   # and docker-compose 1.27.4, follow CircleCI Discuss Announcements
    # for new image releases.
-     image: ubuntu-1604:201903-01
+     image: ubuntu-2004:202010-01
 #...       
  build3:
    macos: # Specifies a macOS virtual machine with Xcode version 11.3

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -35,7 +35,7 @@ Find out more about using the `docker` executor [here]({{ site.baseurl }}/2.0/ex
 jobs:
   build: # name of your job
     machine: # executor type
-      image: ubuntu-1604:201903-01 # # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+      image: ubuntu-2004:202010-01 # # recommended linux image - includes Ubuntu 20.04, docker 19.03.13, docker-compose 1.27.4
 
       steps:
         # Commands run in a Linux virtual machine environment


### PR DESCRIPTION
# Description
Reference new `ubuntu-2004:202010-01` image in examples

# Reasons
We have an Ubuntu 20.04 machine image available now