### PR TITLE
Resolve cases for framework and filesystem references in documentation

### DIFF
--- a/jekyll/_archive/docker-btrfs-error.md
+++ b/jekyll/_archive/docker-btrfs-error.md
@@ -1,8 +1,8 @@
 ---
 layout: classic-docs
-title: Docker Btrfs volume error
+title: Docker BTRFS volume error
 last_updated: Mar 29, 2016
-description: Docker Btrfs issue
+description: Docker BTRFS issue
 sitemap: false
 ---
 
@@ -12,10 +12,10 @@ When you build a Docker image on CircleCI, you will see the following strange er
 Error removing intermediate container 9988070f8621: Cannot destroy container 9988070f8621135d7af41973b9e20a9kdk9178795c0fa1371b0ff111238a4e76a: Driver btrfs failed to remove root filesystem 9988070f8621135d7af41973b9e20a9kdk9178795c0fa1371b0ff111238a4e76a: Failed to destroy btrfs snapshot: operation not permitted
 ```
 
-When Docker creates a container, the container is created on Btrfs, the 
+When Docker creates a container, the container is created on BTRFS, the 
 filesystem that we use to store all build containers, and removing a container 
-is equivalent to removing a Btrfs subvolume. However, the Docker process doesn't 
-have permission to remove btrfs subvolumes, resulting in the error. 
+is equivalent to removing a BTRFS subvolume. However, the Docker process doesn't 
+have permission to remove BTRFS subvolumes, resulting in the error. 
 Please see [this](https://github.com/docker/docker/issues/9939) issue 
 for more details.
 

--- a/jekyll/_archive/docker.md
+++ b/jekyll/_archive/docker.md
@@ -294,7 +294,7 @@ sudo lxc-attach -n "$(docker inspect --format "{{.Id}}" $MY_CONTAINER_NAME)" -- 
 ```
 {% endraw %}
 
-Note that these commands are run inside the container's root directory, so you may have to `cd` into your docker working directory first.
+Note that these commands are run inside the container's root directory, so you may have to `cd` into your Docker working directory first.
 
 ## Caching Docker layers
 
@@ -308,7 +308,7 @@ What makes them hard to cache is that the COW linking and structure sharing
 is all maintained in kernel-space.
 
 User-space is completely unaware that a filesystem is really a copy-on-write
-filesystem. If you were to try to back up docker images you would
+filesystem. If you were to try to back up Docker images you would
 end up with each layer as an entirely separate complete copy of the layer
 with all the COW structure sharing lost.
 
@@ -340,7 +340,7 @@ other tags will be re-pulled on every build if a tag is not specified in the FRO
 
 ## Connecting to services outside of the container
 
-You can connect to services outside your docker container (like our
+You can connect to services outside your Docker container (like our
 pre-installed databases) by using the [docker0 ethernet bridge
 device](https://docs.docker.com/engine/userguide/networking/dockernetworks/). Just make sure
 that the outside services are listening for connections on `docker0`—the

--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -232,7 +232,7 @@ The following section details the steps you would need, from start to finish, to
     -d '{ "branch": "bar" }' 
     ```
 
-6. Let's move on to a more complex example: triggering a pipeline and passing a parameter that can be dynamically substituted into your configuration. In this example, we will pass a docker image tag to our docker-executor key. First, we will need to modify the `.circleci/config.yml` to be a little more complex than the standard "Hello World" sample provided by the onboarding.
+6. Let's move on to a more complex example: triggering a pipeline and passing a parameter that can be dynamically substituted into your configuration. In this example, we will pass a Docker image tag to our docker-executor key. First, we will need to modify the `.circleci/config.yml` to be a little more complex than the standard "Hello World" sample provided by the onboarding.
 
     ```yaml
     version: 2.1

--- a/jekyll/_cci2/api-job-trigger.md
+++ b/jekyll/_cci2/api-job-trigger.md
@@ -57,7 +57,7 @@ For a complete reference of the API, see the [CircleCI API Documentation](https:
 
 ## Conditionally Running Jobs With the API
 
-The next example demonstrates a configuration for building docker images with `setup_remote_docker` only for builds that should be deployed.
+The next example demonstrates a configuration for building Docker images with `setup_remote_docker` only for builds that should be deployed.
 
 ```yaml
 version: 2

--- a/jekyll/_cci2/build.md
+++ b/jekyll/_cci2/build.md
@@ -23,7 +23,7 @@ Document | Description
 <a href="{{ site.baseurl }}/2.0/circleci-images/">Prebuilt Images</a> | Complete list of prebuilt CircleCI Docker images.
 <a href="{{ site.baseurl }}/2.0/custom-images/">Using Custom Images</a> | How to create and use custom Docker images with CircleCI.
 <a href="{{ site.baseurl }}/2.0/private-images/">Using Docker Authenticated Pulls</a> | Use Docker authenticated pulls to access private images and avoid rate limits.
-<a href="{{ site.baseurl }}/2.0/building-docker-images/">Running Docker Commands</a> | How to build Docker images for deploying elsewhere or for further testing and how to start services in remote docker containers.
+<a href="{{ site.baseurl }}/2.0/building-docker-images/">Running Docker Commands</a> | How to build Docker images for deploying elsewhere or for further testing and how to start services in remote Docker containers.
 <a href="{{ site.baseurl }}/2.0/docker-compose/">Using Docker Compose</a> | How to use docker-compose by installing it in your primary container during the job execution.
 <a href="{{ site.baseurl }}/2.0/docker-layer-caching/">Docker Layer Caching (DLC)</a> | How to request the DLC feature and add it to your configuration file.
 {: class="table table-striped"}

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -9,7 +9,7 @@ version:
 - Server v2.x
 ---
 
-This document explains how to build Docker images for deployment elsewhere or further testing, and how to start services in a remote docker environment.
+This document explains how to build Docker images for deployment elsewhere or further testing, and how to start services in a remote Docker environment.
 
 * TOC
 {:toc}
@@ -30,7 +30,7 @@ jobs:
 
 When `setup_remote_docker` executes, a remote environment will be created, and your current [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) will be configured to use it. Then, any docker-related commands you use will be safely executed in this new environment.
 
-**Note:** The use of the `setup_remote_docker` key is reserved for configs in which your primary executor _is_ a docker container. If your executor is `machine` (and you want to use docker commands in your config) you do **not** need to use the `setup_remote_docker` key.
+**Note:** The use of the `setup_remote_docker` key is reserved for configs in which your primary executor _is_ a Docker container. If your executor is `machine` (and you want to use Docker commands in your config) you do **not** need to use the `setup_remote_docker` key.
 
 ### Specifications
 {:.no_toc}
@@ -67,7 +67,7 @@ jobs:
      - run: docker push company/app:$CIRCLE_BRANCH
 ```
 
-The example below shows how you can build and deploy a Docker image for our [demo docker project](https://github.com/CircleCI-Public/circleci-demo-docker) using the Docker executor, with remote Docker:
+The example below shows how you can build and deploy a Docker image for our [demo Docker project](https://github.com/CircleCI-Public/circleci-demo-docker) using the Docker executor, with remote Docker:
 
 {% highlight yaml linenos %}
 version: 2.1
@@ -138,7 +138,7 @@ The job and [remote docker]({{ site.baseurl }}/2.0/glossary/#remote-docker) run 
 ### Accessing Services
 {:.no_toc}
 
-It is **not** possible to start a service in remote docker and ping it directly from a primary container or to start a primary container that can ping a service in remote docker. To solve that, you’ll need to interact with a service from remote docker, as well as through the same container:
+It is **not** possible to start a service in remote Docker and ping it directly from a primary container or to start a primary container that can ping a service in remote docker. To solve that, you’ll need to interact with a service from remote docker, as well as through the same container:
 
 ```
 #...

--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -90,7 +90,7 @@ Jobs are the building blocks of your config. Jobs are collections of [steps](#st
 
 ## Executors and Images
 
-Each separate job defined within your config will run in a unique executor. An executor can be a docker container or a virtual machine running Linux, Windows, or MacOS. Note, macOS is not currently available on self-hosted installations of CircleCI Server.
+Each separate job defined within your config will run in a unique executor. An executor can be a Docker container or a virtual machine running Linux, Windows, or MacOS. Note, macOS is not currently available on self-hosted installations of CircleCI Server.
 
 ![job illustration]( {{ site.baseurl }}/assets/img/docs/executor_types.png)
 
@@ -172,7 +172,7 @@ jobs:
 
 The Primary Container is defined by the first image listed in [`.circleci/config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file. This is where commands are executed. The Docker executor spins up a container with a Docker image. The machine executor spins up a complete Ubuntu virtual machine image. See [Choosing an Executor Type]({{ site.baseurl }}/2.0/executor-types/) document for a comparison table and considerations. Subsequent images can be added to spin up Secondary/Service Containers.
 
-When using the docker executor and running docker commands, the `setup_remote_docker` key can be used to spin up another docker container in which to run these commands, for added security. For more information see the [Running Docker Commands]({{ site.baseurl }}/2.0/building-docker-images/#accessing-the-remote-docker-environment) guide.
+When using the Docker executor and running Docker commands, the `setup_remote_docker` key can be used to spin up another Docker container in which to run these commands, for added security. For more information see the [Running Docker Commands]({{ site.baseurl }}/2.0/building-docker-images/#accessing-the-remote-docker-environment) guide.
 
 ## Steps
 

--- a/jekyll/_cci2/config-intro.md
+++ b/jekyll/_cci2/config-intro.md
@@ -16,7 +16,7 @@ This guide focuses on getting you started with the core of the CircleCI experien
 {:.no_toc}
 
 This guide describes how CircleCI finds and runs `config.yml` and how you can use shell commands to do things, then it outlines how `config.yml` can interact with code and kick-off a build
-followed by how to use docker containers to run in precisely the environment that you need. Finally, there is a short exploration of workflows so you can learn to orchestrate your build, tests, security scans, approval steps, and deployment.
+followed by how to use Docker containers to run in precisely the environment that you need. Finally, there is a short exploration of workflows so you can learn to orchestrate your build, tests, security scans, approval steps, and deployment.
 
 CircleCI believes in *configuration as code*.  As a result, the entire delivery process from build to deploy is orchestrated through a single file called `config.yml`.  The `config.yml` file is located in a folder called `.circleci` at the top of your project.  CircleCI uses the YAML syntax for config, see the [Writing YAML]({{ site.baseurl }}/2.0/writing-yaml/) document for basics.
 
@@ -101,11 +101,11 @@ Although we’ve only made two small changes to the config, these represent sign
 - Line 13-17: The second run on the `build` job is listing (through `ls -al`) the contents of the checkout.  Your branch is now available for you to interact with.
 
 ## Part Three: That’s nice but I need...
-Every code base and project is different.  That’s okay.  We like diversity.  This is one of the reasons we allow you to run in your machine or docker container of choice.  In this case we will demonstrate running in a container with node available.  Other examples might include macOS machines, java containers, or even GPU.
+Every code base and project is different.  That’s okay.  We like diversity.  This is one of the reasons we allow you to run in your machine or Docker container of choice.  In this case we will demonstrate running in a container with node available.  Other examples might include macOS machines, java containers, or even GPU.
 
 1. This section expands on Part One and Two.  If you haven’t already, go through at least Part One to ensure you have a working `config.yml` file in your branch.
 
-2. This is a very simple and yet amazingly powerful change.  We are going to add a reference to a docker image for the build job.
+2. This is a very simple and yet amazingly powerful change.  We are going to add a reference to a Docker image for the build job.
 
 
 {% highlight yaml linenos %}
@@ -141,10 +141,10 @@ We also added a small `run` block that demonstrates we are running in a node con
 ### Learnings
 {:.no_toc}
 
-The above two changes to the config significantly affect how you get work done.  By associating a docker container to a job and then dynamically running the job in the container, you don’t need to perform special magic or operational gymnastics to upgrade, experiment or tune the environment you run in.  With a small change you can dramatically upgrade a mongo environment, grow or shrink the base image, or even change languages.
+The above two changes to the config significantly affect how you get work done.  By associating a Docker container to a job and then dynamically running the job in the container, you don’t need to perform special magic or operational gymnastics to upgrade, experiment or tune the environment you run in.  With a small change you can dramatically upgrade a mongo environment, grow or shrink the base image, or even change languages.
 
 - Line 4: Here we see a comment in-line in yml.  Like any other unit of code, comments are a useful tool as config gets complicated.
-- Line 5-6: These lines indicate that docker image to use for the job.  Because you can have more than one job in your config (as we will see next) you can also run different parts of your config in different environments.  For example, you could perform a build job in a thin java container and then perform a test job using a container with browsers pre-installed. In this case, it uses  a [pre-built container from CircleCI]({{ site.baseurl }}/2.0/circleci-images/) that already has a browser and other useful tools built in.  
+- Line 5-6: These lines indicate that Docker image to use for the job.  Because you can have more than one job in your config (as we will see next) you can also run different parts of your config in different environments.  For example, you could perform a build job in a thin java container and then perform a test job using a container with browsers pre-installed. In this case, it uses  a [pre-built container from CircleCI]({{ site.baseurl }}/2.0/circleci-images/) that already has a browser and other useful tools built in.  
 - Line 19-22: These lines add a run step that returns the version of node available in the container. Try experimenting with different containers from CircleCI’s pre-built convenience images or even public containers from Docker hub.
 
 ## Part Four: Approved to Start

--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -189,7 +189,7 @@ workflows:
 
 ### Publishing and Rolling Out The Image to the GKE Cluster
 
-Using the CircleCI GKE orb makes publishing and rolling out a docker image to your GKE cluster very simple, as shown in the example below. All you need is the orbs built-in command `publish-and-rollout-image`, along with definitions for a few required parameters. For a full list of of parameters available for this job, check the [GKE page](https://circleci.com/developer/orbs/orb/circleci/gcp-gke?version=1.0.4#jobs-publish-and-rollout-image) in the CircleCI Orbs Registry.
+Using the CircleCI GKE orb makes publishing and rolling out a Docker image to your GKE cluster very simple, as shown in the example below. All you need is the orbs built-in command `publish-and-rollout-image`, along with definitions for a few required parameters. For a full list of of parameters available for this job, check the [GKE page](https://circleci.com/developer/orbs/orb/circleci/gcp-gke?version=1.0.4#jobs-publish-and-rollout-image) in the CircleCI Orbs Registry.
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -204,7 +204,7 @@ See [Parameter Syntax]({{ site.baseurl }}/2.0/reusing-config/#parameter-syntax) 
 
 #### **`docker`** / **`machine`** / **`macos`** / **`windows`** (_executor_)
 
-An "executor" is roughly "a place where steps occur". CircleCI 2.0 can build the necessary environment by launching as many docker containers as needed at once, or it can use a full virtual machine. Learn more about [different executors]({{ site.baseurl }}/2.0/executor-types/).
+An "executor" is roughly "a place where steps occur". CircleCI 2.0 can build the necessary environment by launching as many Docker containers as needed at once, or it can use a full virtual machine. Learn more about [different executors]({{ site.baseurl }}/2.0/executor-types/).
 
 #### `docker`
 {:.no_toc}
@@ -213,7 +213,7 @@ Configured by `docker` key which takes a list of maps:
 
 Key | Required | Type | Description
 ----|-----------|------|------------
-image | Y | String | The name of a custom docker image to use
+image | Y | String | The name of a custom Docker image to use
 name | N | String | The name the container is reachable by.  By default, container services are accessible through `localhost`
 entrypoint | N | String or List | The command used as executable when launching the container
 command | N | String or List | The command used as pid 1 (or args for entrypoint) when launching the container
@@ -241,7 +241,7 @@ container only.
 
 `name` defines the name for reaching the secondary service containers.  By default, all services are exposed directly on `localhost`.  The field is appropriate if you would rather have a different host name instead of localhost, for example, if you are starting multiple versions of the same service.
 
-The `environment` settings apply to entrypoint/command run by the docker container, not the job steps.
+The `environment` settings apply to entrypoint/command run by the Docker container, not the job steps.
 
 You can specify image versions using tags or digest. You can use any public images from any public Docker registry (defaults to Docker Hub). Learn more about [specifying images]({{ site.baseurl }}/2.0/executor-types).
 
@@ -906,7 +906,7 @@ Creates a remote Docker environment configured to execute Docker commands. See [
 Key | Required | Type | Description
 ----|-----------|------|------------
 docker_layer_caching | N | boolean | set this to `true` to enable [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching/) in the Remote Docker Environment (default: `false`)
-version | N        | String | Version string of Docker you would like to use (default: `17.09.0-ce`). View the list of supported docker versions [here]({{site.baseurl}}/2.0/building-docker-images/#docker-version).
+version | N        | String | Version string of Docker you would like to use (default: `17.09.0-ce`). View the list of supported Docker versions [here]({{site.baseurl}}/2.0/building-docker-images/#docker-version).
 {: class="table table-striped"}
 
 **Notes**:

--- a/jekyll/_cci2/credits.md
+++ b/jekyll/_cci2/credits.md
@@ -78,7 +78,7 @@ it is "preparing", it means that CircleCI is setting up or _dispatching_ your
 job so that it may run.
 
 If you find that jobs are "preparing" for quite some time, you may be able to
-reduce it if your jobs use the docker executor; try using more recent docker
+reduce it if your jobs use the Docker executor; try using more recent docker
 images to decrease preparation time.
 
 ## Questions And Comments

--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -63,7 +63,7 @@ In the following example, the whole system starts, then verifies it is running a
 
 See the [Example docker-compose Project](https://github.com/circleci/cci-demo-docker/tree/docker-compose) on GitHub for a demonstration and use the [full configuration file](https://github.com/circleci/cci-demo-docker/blob/docker-compose/.circleci/config.yml) as a template for your own projects. 
 
-**Note**: The primary container runs in a separate environment from Remote Docker and the two cannot communicate directly. To interact with a running service, use docker and a container running in the service's network. 
+**Note**: The primary container runs in a separate environment from Remote Docker and the two cannot communicate directly. To interact with a running service, use Docker and a container running in the service's network. 
 
 ## Using Docker Compose with Machine Executor
 
@@ -72,9 +72,9 @@ If you want to use docker compose to manage a multi-container setup with a docke
 
 ## Using Docker Compose with Docker Executor
 
-Using `docker` combined with `setup_remote_docker` provides a remote engine similar to the one created with docker-machine, but volume mounting and port forwarding do **not** work the same way in this setup. The remote docker daemon runs on a different system than the docker CLI and docker compose, so you must move data around to make this work. Mounting can usually be solved by making content available in a docker volume. It is possible to load data into a docker volume by using `docker cp` to get the data from the CLI host into a container running on the docker remote host. 
+Using `docker` combined with `setup_remote_docker` provides a remote engine similar to the one created with docker-machine, but volume mounting and port forwarding do **not** work the same way in this setup. The remote Docker daemon runs on a different system than the Docker CLI and docker compose, so you must move data around to make this work. Mounting can usually be solved by making content available in a Docker volume. It is possible to load data into a Docker volume by using `docker cp` to get the data from the CLI host into a container running on the Docker remote host. 
 
-This combination is required if you want to build docker images for deployment. 
+This combination is required if you want to build Docker images for deployment. 
 
 ## Limitations
 

--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -36,7 +36,7 @@ If you are experiencing issues with cache-misses or need high-parallelism, consi
 
 **Note:** DLC has **no** effect on Docker images used as build containers. That is, containers that are used to _run_ your jobs are specified with the `image` key when using the [`docker` executor]({{ site.baseurl }}/2.0/executor-types/#using-docker) and appear in the Spin up Environment step on your Jobs pages.
 
-DLC is only useful when creating your own Docker image  with docker build, docker compose, or similar docker commands), it does not decrease the wall clock time that all builds take to spin up the initial environment. 
+DLC is only useful when creating your own Docker image  with docker build, docker compose, or similar Docker commands), it does not decrease the wall clock time that all builds take to spin up the initial environment. 
 
 ``` YAML
 version: 2 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -142,7 +142,7 @@ Notice there are two similar steps in the above image and config - "What branch 
 
 In general, CircleCI does not support interpolating environment variable into build config. Values used are treated as literals. This can cause issues when defining `working_directory`, modifying `PATH`, and sharing variables across multiple `run` steps.
 
-An exception to this rule is the docker image section in order to support [Private Images]({{ site.baseurl }}/2.0/private-images/).
+An exception to this rule is the Docker image section in order to support [Private Images]({{ site.baseurl }}/2.0/private-images/).
 
 In the example below, `$ORGNAME` and `$REPONAME` will not be interpolated.
 

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -429,7 +429,7 @@ A container is a 2 CPU 4GB RAM machine that you pay for access to. Containers ma
 
 #### Why am I being charged for remote Docker spin up time? 
 {:.no_toc}
-When CircleCI spins up a remote docker instance, it requires the primary container to be running and spending compute. Thus while you are not charged for the remote docker instance itself, you are charged for the time that the primary container is up.
+When CircleCI spins up a remote Docker instance, it requires the primary container to be running and spending compute. Thus while you are not charged for the remote Docker instance itself, you are charged for the time that the primary container is up.
 
 ---
 


### PR DESCRIPTION
# Description
Resolved cases of references to "Docker" and "BTRFS" throughout parts of the documentation

# Reasons
To make references to Docker as a proper noun for the framework (not commands) and the BTRFS filesystem consistent in large parts of the documentation sourced by the CircleCI static website.