### PR TITLE
Update link to orb categorization docs

### DIFF
--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -28,7 +28,7 @@ An orb "slug" is made up of a _namespace_ and _orb_ name separated by a forward 
 #### Categorize your Orb
 {:.no_toc}
 
-Categorizing your orb allows it to be searchable on the [Orb Registry](https://circleci.com/developer/orbs) by category. To see how you can categorize your orb using the CircleCI CLI, refer to the [Orb Authoring Process]({{site.baseurl}}/2.0/orb-author) guide.
+Categorizing your orb allows it to be searchable on the [Orb Registry](https://circleci.com/developer/orbs) by category. To see how you can categorize your orb using the CircleCI CLI, refer to the relevant section in the [Orb Authoring Process]({{site.baseurl}}/2.0/orb-author/#categorizing-your-orb) guide.
 
 #### Ensure All Orb Components Include Descriptions
 {:.no_toc}


### PR DESCRIPTION
# Description
Link directly to the relevant orb categorization section in the orb authoring page

# Reasons
The current link to the orb categorization reference links to the entire orb authoring page instead of to the relevant section.