### PR TITLE
Update caching.md

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -225,7 +225,7 @@ The above example will output a unique string to represent this key. Here, the e
 The example may output a string that looks like the following:
 
 ```sh
-{% raw %}myapp-+KlBebDceJh_zOWQIAJDLEkdkKoeldAldkaKiallQ<etc>{% endraw %}
+{% raw %}myapp-+KlBebDceJh_zOWQIAJDLEkdkKoeldAldkaKiallQ={% endraw %}
 ```
 
 If the contents of the `package-lock` file were to change, the `checksum` function would return a different, unique string, indicating the need to invalidate the cache.


### PR DESCRIPTION
# Description
It looks like some html artifact was added to the cache key? `<etc>` wouldn't be valid b64 output. or maybe it was supposed to represent padded output and became malformed? You can see [examples here](https://en.wikipedia.org/wiki/Base64#Examples). 

# Reasons
it looks a bit odd. I added the output padding, but just removing the `<etc>` would work as well I think