### PR TITLE
Update lerna command to latest version

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -138,7 +138,7 @@ commands:
     steps:
       - run:
           name: Combine package-lock.json files to single file
-          command: npx lerna list -p -a | awk -F packages '{printf "\"packages%s/package-lock.json\" ", $2}' | xargs cat > << parameters.filename >>
+          command: npx lerna la -a | awk -F packages '{printf "\"packages%s/package-lock.json\" ", $2}' | xargs cat > << parameters.filename >>
 ```
 {% endraw %}
 


### PR DESCRIPTION
# Description
Lerna has changed the command for package output in the latest major release: https://github.com/lerna/lerna/blob/master/CHANGELOG.md#breaking-changes

# Reasons
this should prevent any errors for people copy/pasting the command. I've tested this locally and it produces the expected output. 