### PR TITLE
SEO audit: Update 404 link

### DIFF
--- a/jekyll/_cci2_ja/hello-world-windows.md
+++ b/jekyll/_cci2_ja/hello-world-windows.md
@@ -19,7 +19,7 @@ CircleCI の **Windows ビルド環境**で継続的インテグレーション�
 作業を行う前に、以下を準備しておく必要があります。
 
 * CircleCI の[アカウント](https://circleci.com/ja/signup/)。
-* Free プラン (デフォルト) または [Performance プラン](https://circleci.com/ｊａ／pricing/usage/)。 CircleCI Server をお使いの方向けには以下に別のコード例を掲載していますので、そちらをご参照ください。
+* Free プラン (デフォルト) または [Performance プラン](https://circleci.com/ja/pricing/)。 CircleCI Server をお使いの方向けには以下に別のコード例を掲載していますので、そちらをご参照ください。
 * クラウド版をお使いの場合にプロジェクトで Windows を使用するには、[パイプラインを有効化]({{site.baseurl}}/ja/2.0/build-processing/)する必要があります。
 
 # Windows Executor の概要


### PR DESCRIPTION
# Description
Link to https://circleci.com/ja/pricing/ instead of https://circleci.com/%EF%BD%8A%EF%BD%81%EF%BC%8Fpricing/usage/ on https://circleci.com/docs/ja/2.0/hello-world-windows/ 

# Reasons
No longer will lead to a 404