### PR TITLE
SEO audit: Update 404 link

### DIFF
--- a/jekyll/_cci2/usage-stats.adoc
+++ b/jekyll/_cci2/usage-stats.adoc
@@ -173,4 +173,4 @@ docker exec usage-stats /src/builds/extract
 
 === Security and Privacy
 
-Please reference exhibit C within your terms of contract and our https://circleci.com/outer/legal/enterprise-license-agreement.pd[standard license agreement] for our complete security and privacy disclosures.
+Please reference exhibit C within your terms of contract and our https://circleci.com/legal/enterprise-license-agreement/[standard license agreement] for our complete security and privacy disclosures.


### PR DESCRIPTION
# Description
Link to https://circleci.com/legal/enterprise-license-agreement/  instead of https://circleci.com/outer/legal/enterprise-license-agreement.pd on https://circleci.com/docs/2.0/usage-stats/ 

# Reasons
No longer will lead to a 404