### PR TITLE
Include further description of command line values

### DIFF
--- a/jekyll/_cci2/orb-author-intro.md
+++ b/jekyll/_cci2/orb-author-intro.md
@@ -57,6 +57,8 @@ Enter the following command to claim your namespace, if you have not yet claimed
 circleci namespace create <name> <vcs-type> <org-name> [flags]
 ```
 
+where `name` is the namespace you wish to claim, `vcs-type` is the type of your version control system (i.e. `github` or `bitbucket`), and `org-name` is the name of your organisation
+
 ### Next Steps
 
 Continue on to the  [Orb Authoring Process]({{site.baseurl}}/2.0/orb-author/) guide for information on developing your orb.

--- a/jekyll/_cci2/orb-author-intro.md
+++ b/jekyll/_cci2/orb-author-intro.md
@@ -57,7 +57,7 @@ Enter the following command to claim your namespace, if you have not yet claimed
 circleci namespace create <name> <vcs-type> <org-name> [flags]
 ```
 
-where `name` is the namespace you wish to claim, `vcs-type` is the type of your version control system (i.e. `github` or `bitbucket`), and `org-name` is the name of your organisation
+where `name` is the namespace you wish to claim, `vcs-type` is the type of your version control system (i.e. `github` or `bitbucket`), and `org-name` is the name of your organization.
 
 ### Next Steps
 


### PR DESCRIPTION
# Description
I have included further descriptions of the values in the command line to more easily understand and follow these setup instructions

# Reasons
When attempting to follow these instructions to set up a new namespace for the first time, the arguments were unclear, especially considering these are getting started docs. It would be helpful to include this brief description for first time authors to understand what they need to input to the command line