### PR TITLE
SEO audit: http to https on /2.0/reusing-config/

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -440,7 +440,7 @@ Commands can use other commands in the scope of execution. For instance, if a co
 
 ### Special Keys
 
-CircleCI has several special keys available to all [circleci.com](http://circleci.com) customers and available by default in CircleCI server installations. Examples of these keys are:
+CircleCI has several special keys available to all [circleci.com](https://circleci.com) customers and available by default in CircleCI server installations. Examples of these keys are:
 
   * `checkout`
   * `setup_remote_docker`


### PR DESCRIPTION
# Description
Link to https://circleci.com instead of http://circleci.com on https://circleci.com/docs/2.0/reusing-config/ 

# Reasons
Part of Q3 2021 SEO audit. HTTPS page is linking to HTTP pages on our website.