### PR TITLE
SEO audit: Update http to https on /ja/2.0/reusing-config/  

### DIFF
--- a/jekyll/_cci2_ja/reusing-config.md
+++ b/jekyll/_cci2_ja/reusing-config.md
@@ -91,7 +91,7 @@ jobs:
 
 ## 特別なキー
 
-CircleCI では、すべての [circleci.com](http://circleci.com/ja) ユーザーが利用できる特別なキーが複数提供されており、CircleCI Server でデフォルトで使用できます。 その一部をご紹介します。
+CircleCI では、すべての [circleci.com](https://circleci.com/ja/) ユーザーが利用できる特別なキーが複数提供されており、CircleCI Server でデフォルトで使用できます。 その一部をご紹介します。
 
 - `checkout`
 - `setup_remote_docker`


### PR DESCRIPTION
# Description
Link to https://circleci.com/ja/ instead of http://circleci.com/ja on https://circleci.com/docs/ja/2.0/reusing-config

# Reasons
Part of Q3 2021 SEO audit. HTTPS page is linking to HTTP pages on our website.

