### PR TITLE
fix wrong orb name template in orb-concept and using-orbs pages.

### DIFF
--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -122,7 +122,7 @@ When importing an orb which has jobs, you can reference them directly from your 
 version: 2.1
 
 orbs:
-  <orb>: <orb>/<namespace>@x.y #orb version
+  <orb>: <namespace>/<orb>@x.y #orb version
 
 workflows:
   use-orb-job:

--- a/jekyll/_cci2/using-orbs.md
+++ b/jekyll/_cci2/using-orbs.md
@@ -122,7 +122,7 @@ When importing an orb which has jobs, you can reference them directly from your 
 version: 2.1
 
 orbs:
-  <orb>: <orb>/<namespace>@x.y #orb version
+  <orb>: <namespace>/<orb>@x.y #orb version
 
 workflows:
   use-orb-job:


### PR DESCRIPTION
fix some incorrect orb name template in two document pages.

related to #4883