### PR TITLE
SEO audit: /2.0/about-circleci/

### DIFF
--- a/jekyll/_cci2_ja/about-circleci.md
+++ b/jekyll/_cci2_ja/about-circleci.md
@@ -30,7 +30,7 @@ CircleCI は、30,000 の組織をサポートし、1 日に 100 万近くのジ
 
 ## 概要
 
-GitHub または Bitbucket 上のソフトウェア リポジトリが承認され、プロジェクトとして [circleci.com](https://circleci.com/ja) に追加された後は、コードを変更するたびに、クリーン コンテナまたは VM で自動化されたテストがトリガーされます。 CircleCI は、各[ジョブ]({{site.baseurl}}/2.0/glossary/#job)をそれぞれ独立した[コンテナ]({{site.baseurl}}/2.0/glossary/#container)または VM で実行します。 つまり、ジョブが実行されるたびに、CircleCI がコンテナまたは VM をスピンアップし、そこでジョブを実行します。
+GitHub または Bitbucket 上のソフトウェア リポジトリが承認され、プロジェクトとして [circleci.com](https://circleci.com/ja/) に追加された後は、コードを変更するたびに、クリーン コンテナまたは VM で自動化されたテストがトリガーされます。 CircleCI は、各[ジョブ]({{site.baseurl}}/2.0/glossary/#job)をそれぞれ独立した[コンテナ]({{site.baseurl}}/2.0/glossary/#container)または VM で実行します。 つまり、ジョブが実行されるたびに、CircleCI がコンテナまたは VM をスピンアップし、そこでジョブを実行します。
 
 その後 CircleCI は、テストが完了すると、成功または失敗のメール通知を送信します。 CircleCI には Slack 通知と IRC 通知も統合されています。 コード テスト カバレッジの結果は、レポート ライブラリが追加されているプロジェクトの詳細ページから提供されます。
 


### PR DESCRIPTION
# Description
Link to https://circleci.com/ja/ instead of https://circleci.com/ja on https://circleci.com/docs/ja/2.0/about-circleci/ 

# Reasons
Part of Q3 2021 SEO audit. Update link to no longer go to a redirect.