### PR TITLE
SEO audit: /2.0/circleci-images/

### DIFF
--- a/jekyll/_cci2_ja/language-ruby.md
+++ b/jekyll/_cci2_ja/language-ruby.md
@@ -27,7 +27,7 @@ CircleCI は、以下のページで Ruby on Rails サンプル プロジェク�
 
 このアプリケーションでは、最新の安定した Rails バージョン 5.1 (`rspec-rails`)、[RspecJunitFormatter](https://github.com/sj26/rspec_junit_formatter)、および PostgreSQL データベースを使用しています。
 
-このアプリケーションのビルドには、ビルド済み [CircleCI Docker イメージ](http://circleci.com/ja/docs/2.0/circleci-images)の 1 つを使用しています。
+このアプリケーションのビルドには、ビルド済み [CircleCI Docker イメージ](http://circleci.com/docs/ja/2.0/circleci-images)の 1 つを使用しています。
 
 ## CircleCI のビルド済み Docker イメージ
 


### PR DESCRIPTION
# Description
Link to http://circleci.com/docs/ja/2.0/circleci-images instead of http://circleci.com/ja/docs/2.0/circleci-images on https://circleci.com/docs/ja/2.0/language-ruby/ 

# Reasons
Part of Q3 2021 SEO audit. Update link so it no longer redirects. 