### PR TITLE
Clarify use for docker layer caching

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -221,7 +221,7 @@ jobs:
 
 You can view the list of available images [here]({{ site.baseurl }}/2.0/configuration-reference/#available-machine-images).
 
-The following example uses an image and enables [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or Workflow. **Note:** Check our [pricing page]({{ site.baseurl }}/pricing/) to see which plans allow use of Docker Layer Caching
+The following example uses an image and enables [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or Workflow. **Note:** Check our [pricing page](https://circleci.com/pricing/) to see which plans include the use of Docker Layer Caching.
 
 {:.tab.machineblock.Server}
 ```yaml

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -221,7 +221,7 @@ jobs:
 
 You can view the list of available images [here]({{ site.baseurl }}/2.0/configuration-reference/#available-machine-images).
 
-The following example uses an image and enables [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or Workflow. **Note:** You must open a support ticket to have a CircleCI Sales representative contact you about enabling this feature on your account for an additional fee.
+The following example uses an image and enables [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or Workflow. **Note:** Check our [pricing page]({{ site.baseurl }}/pricing/) to see which plans allow use of Docker Layer Caching
 
 {:.tab.machineblock.Server}
 ```yaml


### PR DESCRIPTION
# Description
This line mentions users need to submit a support ticket to enable DLC. This is no longer the case. They simply need to be on a plan which has it enabled by default. They can see which plans have it available on the pricing page.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
It's outdated