### PR TITLE
[Patch/proxy] fix wrong bash syntax

### DIFF
--- a/jekyll/_cci2/proxy.adoc
+++ b/jekyll/_cci2/proxy.adoc
@@ -112,7 +112,7 @@ JVM_OPTS="-Dhttp.proxyHost=<ip> -Dhttp.proxyPort=<port> -Dhttps.proxyHost=<proxy
 EOF) | sudo tee -a /etc/environment
 
 set -a
-./etc/environment
+. /etc/environment
 ```
 +
 If your containers need to use a proxy server you will need to set the following schedulerer environment variables: `DOCKER_HTTP_PROXY`, `DOCKER_HTTPS_PROXY`, `NO_PROXY`, corresponding to those listed in https://docs.docker.com/network/proxy/[the Docker instructions]. This will ensure your containers have outbound/proxy access. For more information on creating configuration overrides, see the <<customizations#service-configuration-overrides,Customizations Guide>>.

--- a/jekyll/_cci2/proxy.adoc
+++ b/jekyll/_cci2/proxy.adoc
@@ -46,38 +46,27 @@ The Service machine has many components that need to make network calls, as foll
 For a static installation, not on AWS, SSH into the Services machine and run the following code snippet with your proxy address:
 
 ```
-echo '{"HttpProxy": "http://<proxy-ip:port>"}' |
-sudo tee  /etc/replicated.conf
+echo '{"HttpProxy": "http://<proxy-ip:port>"}' | sudo tee /etc/replicated.conf
 (cat <<'EOF'
 HTTP_PROXY=<proxy-ip:port>
 HTTPS_PROXY=<proxy-ip:port>
+EOF) | sudo tee -a /etc/circle-installation-customizations
 
-EOF
-| sudo tee -a /etc/circle-installation-customizations
- sudo service replicated-ui stop; sudo service replicated stop;
- sudo service replicated-operator stop; sudo service replicated-ui start;
-  sudo service replicated-operator start; sudo service replicated start
+systemctl restart replicated\*
 ```
 
 If you run in Amazon's EC2 service then you'll need to include `169.254.169.254` EC2 services as shown below:
 
 ```
-echo '{"HttpProxy": "http://<proxy-ip:port>"}' |
-sudo tee  /etc/replicated.conf
-(cat <<'EOF'
+echo '{"HttpProxy": "http://<proxy-ip:port>"}' | sudo tee /etc/replicated.conf
+(cat <<EOF
 HTTP_PROXY=<proxy-ip:port>
 HTTPS_PROXY=<proxy-ip:port>
-NO_PROXY=169.254.169.254,<circleci-service-ip>,
-127.0.0.1,localhost,ghe.example.com
-JVM_OPTS="-Dhttp.proxyHost=<ip> -Dhttp.proxyPort=<port>
--Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=<port) -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|
-127.0.0.1|localhost|ghe.example.com"
+NO_PROXY=169.254.169.254,<circleci-service-ip>,127.0.0.1,localhost,ghe.example.com
+JVM_OPTS="-Dhttp.proxyHost=<proxy-ip> -Dhttp.proxyPort=<proxy-port> -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=<proxy-port> -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|127.0.0.1|localhost|ghe.example.com"
+EOF) | sudo tee -a /etc/circle-installation-customizations
 
-EOF
-| sudo tee -a /etc/circle-installation-customizations
- sudo service replicated-ui stop; sudo service replicated stop;
- sudo service replicated-operator stop; sudo service replicated-ui start;
-  sudo service replicated-operator start; sudo service replicated start
+systemctl restart replicated\*
 ```
 
 NOTE: The above is not handled by by our enterprise-setup script and will need to be added to the user data for the Services Machine startup or done manually.
@@ -111,22 +100,19 @@ CircleCI uses `curl`  and `awscli` scripts to download initialization scripts, a
 * If you are using Docker refer to the https://docs.docker.com/engine/admin/systemd/#/http-proxy[Docker HTTP Proxy Instructions] documentation.
 * If you are running a static installation, add the following to the server before installation:
 +
-```bash
+
+```
 #!/bin/bash
 
-(cat <<'EOF'
+(cat <<EOF
 HTTP_PROXY=<proxy-ip:port>
 HTTPS_PROXY=<proxy-ip:port>
-NO_PROXY=169.254.169.254,<circleci-service-ip>,
-127.0.0.1,localhost,ghe.example.com
-JVM_OPTS="-Dhttp.proxyHost=<ip> -Dhttp.proxyPort=<port>
--Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|
-127.0.0.1|localhost|ghe.example.com"
-EOF
-) | sudo tee -a /etc/environment
+NO_PROXY=169.254.169.254,<circleci-service-ip>,127.0.0.1,localhost,ghe.example.com
+JVM_OPTS="-Dhttp.proxyHost=<ip> -Dhttp.proxyPort=<port> -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|127.0.0.1|localhost|ghe.example.com"
+EOF) | sudo tee -a /etc/environment
 
 set -a
-. /etc/environment
+./etc/environment
 ```
 +
 If your containers need to use a proxy server you will need to set the following schedulerer environment variables: `DOCKER_HTTP_PROXY`, `DOCKER_HTTPS_PROXY`, `NO_PROXY`, corresponding to those listed in https://docs.docker.com/network/proxy/[the Docker instructions]. This will ensure your containers have outbound/proxy access. For more information on creating configuration overrides, see the <<customizations#service-configuration-overrides,Customizations Guide>>.

--- a/jekyll/_cci2_ja/proxy.md
+++ b/jekyll/_cci2_ja/proxy.md
@@ -39,20 +39,17 @@ Services マシンには多数のコンポーネントがあり、以下のネ�
 
 Services マシンに対して SSH 接続を実行し、プロキシアドレスから以下のコードスニペットを実行します。 Amazon の EC2 サービスで実行する場合、以下に示すとおり `169.254.169.254` の EC2 サービスを含める必要があります。
 
-    # 1.) コンテナのプルダウンにプロキシを使用するように、Replicated に指示します
-    echo '{"HttpProxy": "http://<proxy-ip:port>"}' | sudo tee  /etc/replicated.conf
-    # 2.) 通信時にプロキシを使用するように、すべての CircleCI コンテナに指示します
-    (cat <<'EOF'
-    HTTP_PROXY=<proxy-ip:port>
-    HTTPS_PROXY=<proxy-ip:port>
-    NO_PROXY=169.254.169.254,<circleci-service-ip>,127.0.0.1,localhost,ghe.example.com
-    JVM_OPTS="-Dhttp.proxyHost=<ip> -Dhttp.proxyPort=<port> -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|127.0.0.1|localhost|ghe.example.com"
-    
-    EOF
-    ) | sudo tee -a /etc/circle-installation-customizations
-    # 3.) Replicated を再起動して変更点を拾い出します
-    sudo service replicated-ui stop; sudo service replicated stop; sudo service replicated-operator stop; sudo service replicated-ui start; sudo service replicated-operator start; sudo service replicated start
-    
+```
+echo '{"HttpProxy": "http://<proxy-ip:port>"}' | sudo tee /etc/replicated.conf
+(cat <<EOF
+HTTP_PROXY=<proxy-ip:port>
+HTTPS_PROXY=<proxy-ip:port>
+NO_PROXY=169.254.169.254,<circleci-service-ip>,127.0.0.1,localhost,ghe.example.com
+JVM_OPTS="-Dhttp.proxyHost=<proxy-ip> -Dhttp.proxyPort=<proxy-port> -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=<proxy-port> -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|127.0.0.1|localhost|ghe.example.com"
+EOF) | sudo tee -a /etc/circle-installation-customizations
+
+systemctl restart replicated\*
+```
 
 **メモ：**上記は、CircleCI の enterprise-setup スクリプトでは処理されません。Services box の起動のためにユーザーデータに追加するか、または手動で実行する必要があります。
 
@@ -79,21 +76,18 @@ CircleCI の Replicated 管理コンソールのページにアクセスでき�
 
 AWS Terraform を使用している場合、Nomad クライアントの起動設定に以下を追加する必要があります。 以下の命令は、`/etc/environment` に追加します。 Docker を使用している場合は、[Docker での HTTP プロキシの設定に関するドキュメント](https://docs.docker.com/engine/admin/systemd/#/http-proxy)を参照してください。
 
-    #!/bin/bash
-    
-    # 1.) 任意のプロセスで読み込めるようにプロキシを設定します
-    (cat <<'EOF'
-    HTTP_PROXY=<proxy-ip:port>
-    HTTPS_PROXY=<proxy-ip:port>
-    NO_PROXY=169.254.169.254,<circleci-service-ip>,127.0.0.1,localhost,ghe.example.com
-    JVM_OPTS="-Dhttp.proxyHost=<ip> -Dhttp.proxyPort=<port> -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|127.0.0.1|localhost|ghe.example.com"
-    EOF
-    ) | sudo tee -a /etc/environment
-    
-    # 2.) 修正した環境を現在のシェルに読み込ませます
-    set -a
-    . /etc/environment
-    
-    
+```
+#!/bin/bash
+
+(cat <<EOF
+HTTP_PROXY=<proxy-ip:port>
+HTTPS_PROXY=<proxy-ip:port>
+NO_PROXY=169.254.169.254,<circleci-service-ip>,127.0.0.1,localhost,ghe.example.com
+JVM_OPTS="-Dhttp.proxyHost=<ip> -Dhttp.proxyPort=<port> -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|127.0.0.1|localhost|ghe.example.com"
+EOF) | sudo tee -a /etc/environment
+
+set -a
+./etc/environment
+```
 
 また、https://docs.docker.com/network/proxy/ の指示に従って、コンテナが確実にアウトバウンドおよびプロキシのアクセス権を持つようにしてください。

--- a/jekyll/_cci2_ja/proxy.md
+++ b/jekyll/_cci2_ja/proxy.md
@@ -87,7 +87,7 @@ JVM_OPTS="-Dhttp.proxyHost=<ip> -Dhttp.proxyPort=<port> -Dhttps.proxyHost=<proxy
 EOF) | sudo tee -a /etc/environment
 
 set -a
-./etc/environment
+. /etc/environment
 ```
 
 また、https://docs.docker.com/network/proxy/ の指示に従って、コンテナが確実にアウトバウンドおよびプロキシのアクセス権を持つようにしてください。


### PR DESCRIPTION
# Description

A customer failed to set up the proxy setting to the Replicated, and we noticed some scripts in this doc have the wrong syntax.

# Reasons
Tickets
> https://circleci.zendesk.com/agent/tickets/80913