### PR TITLE
Add Titles

### DIFF
--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -17,6 +17,9 @@ Authenticated pulls allow access to private Docker images.  It may also grant hi
 
 CircleCI has partnered with Docker to ensure that our users can continue to access Docker Hub without rate limits. As of November 1st 2020, with few exceptions, you should not be impacted by any rate limits when pulling images from Docker Hub through CircleCI. However, these rate limits may go into effect for CircleCI users in the future. That’s why we’re encouraging you and your team to add Docker Hub authentication to your CircleCI configuration and consider upgrading your Docker Hub plan, as appropriate, to prevent any impact from rate limits in the future.
 
+
+### Docker executor
+
 For the [Docker]({{ site.baseurl }}/2.0/executor-types/#using-docker) executor, specify username and password in the `auth` field of your [config.yml]({{ site.baseurl }}/2.0/configuration-reference/) file. To protect the password, place it in a [context]({{ site.baseurl }}/2.0/contexts), or use a per-project Environment Variable.
 
 **Note:** Server customers may instead [setup a pull through Docker Hub registry mirror]({{ site.baseurl }}/2.0/docker-hub-pull-through-mirror/).
@@ -52,6 +55,9 @@ You can also use images from a private repository like [gcr.io](https://cloud.go
     password: $QUAY_PASSWORD
 ```
 
+
+### Machine executor (with Docker orb)
+
 Alternatively, you can utilize the `machine` executor to achieve the same result using the Docker orb:
 
 ``` yaml
@@ -78,6 +84,9 @@ jobs:
           images: 'circleci/node:latest'
 ```
 
+
+### Machine executor (with Docker CLI)
+
 or with cli:
 
 ```yaml
@@ -95,6 +104,9 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker run -d --name db company/proprietary-db:1.2.3
 ```
+
+
+### AWS ECR
 
 CircleCI now supports pulling private images from Amazon's ECR service. You can start using private images from ECR in one of two ways:
 


### PR DESCRIPTION
# Description

Add titles sections for quick access and ease of reading.


# Reasons

From my experience, a structured document is much easier to read.

It also allows TL;DR for people without the need to overview the whole document while searching or go `ctrl+F`.