### PR TITLE
fix: command bash script for create_concatenated_package_lock

### DIFF
--- a/jekyll/_cci2/caching.md
+++ b/jekyll/_cci2/caching.md
@@ -138,7 +138,8 @@ commands:
     steps:
       - run:
           name: Combine package-lock.json files to single file
-          command: npx lerna la -a | awk -F packages '{printf "\"packages%s/package-lock.json\" ", $2}' | xargs cat > << parameters.filename >>
+          command: cat $(ls packages/*/package-lock.json) > << parameters.filename >>
+
 ```
 {% endraw %}
 


### PR DESCRIPTION
Running `npx lerna la -a | awk -F...` as is will produce a `No such file or directory` error.

```
lerna info ci enabled
lerna success found 2 packages
cat: packages/hub    (PRIVATE)/package-lock.json: No such file or directory
cat: packages/shared (PRIVATE)/package-lock.json: No such file or directory
```

# Description
Fixes the command argument for the create_concatenated_package_lock command.

# Reasons
Simplifies & fixes the `create_concatenated_package_lock` fn