### PR TITLE
Remove non-Match code signing link

### DIFF
--- a/jekyll/_cci2/ios-codesigning.md
+++ b/jekyll/_cci2/ios-codesigning.md
@@ -258,8 +258,3 @@ By setting the `FL_OUTPUT_DIR:` env, that will tell Fastlane to output the XCode
 See the [`circleci-demo-ios` GitHub repository](https://github.com/CircleCI-Public/circleci-demo-ios)
 for an example of how to configure code signing for iOS apps using
 Fastlane Match.
-
-## See Also
-{:.no_toc}
-
-To read a blog post by Franz Busch at Sixt about their setup for CI with Fastlane and CircleCI, refer to the [Continuous integration and delivery with fastlane and CircleCI](https://medium.com/sixt-labs-techblog/continuous-integration-and-delivery-at-sixt-91ca215670a0) blog post on Medium.


### PR DESCRIPTION
CircleCI only supports Fastlane match officially, so removing this old link to prevent confusion