### PR TITLE
update Xcode release list

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -49,7 +49,8 @@ Running or testing Apple Silicon apps natively is currently not possible as Circ
 
  Config   | Xcode Version                   | macOS Version | Software Manifest | Release Notes
 ----------|---------------------------------|---------------|-------------------|--------------
- `12.2.0` | Xcode 12.2 Beta 3 (12B5035g) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3995/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-2-beta-3-released/37810)
+ `12.2.0` | Xcode 12.2 RC (12B5044c) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4061/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-2-rc-released/38038)
+ `12.1.1` | Xcode 12.1.1 RC (12A7605b) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4054/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-1-rc-released/38023)
  `12.1.0` | Xcode 12.1 (12A7403) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3985/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-gm-released/37809)
  `12.0.1` | Xcode 12.0.1 (12A7300) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3933/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-0-1-released-xcode-12-0-0-deprecated/37630)
  `11.7.0` | Xcode 11.7 (11E801a) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3587/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-11-7-released/37312)


### PR DESCRIPTION
- update `12.2.0` to point from beta to `12.2 RC`
- add `12.1.1` (this will later redirect from `12.1.0`)