### PR TITLE
clarifications around github status updates and github checks

### DIFF
--- a/jekyll/_cci2/enable-checks.md
+++ b/jekyll/_cci2/enable-checks.md
@@ -18,7 +18,7 @@ GitHub Checks should not be confused with GitHub status updates:
 * GitHub Checks are administered from the GitHub UI, and are reported in the GitHub UI per _workflow_.
 * GitHub status updates are the default way status updates from your builds are reported in the GitHub UI, and they are reported per _job_. 
 
-If both these features are enabled, the Checks tab in your GitHub PRs will show both job and workflow statuses.
+If both these features are enabled, in a GitHub PR view the Checks tab will show workflow status and the Checks section in the PR conversation view will show job status.
 
 ## Overview
 
@@ -89,4 +89,3 @@ If you have enabled GitHub Checks in your GitHub repository, but the status chec
 Having the `ci/circleci:build` checkbox enabled will prevent the status from showing as completed in GitHub when using a GitHub Checks because CircleCI posts statuses to GitHub at a workflow level rather than a job level.
 
 Go to **Settings** > **Branches** in GitHub and click the **Edit** button on the protected branch to deselect the settings, for example `https://github.com/your-org/project/settings/branches`.
-

--- a/jekyll/_cci2/enable-checks.md
+++ b/jekyll/_cci2/enable-checks.md
@@ -9,7 +9,7 @@ version:
 - Cloud
 ---
 
-This document describes how to enable the GitHub Checks CircleCI Setting and authorize the CircleCI Checks app to report workflow status to the GitHub app. **The GitHub checks integration feature is not currently available on CircleCI Server**.
+This document describes how to enable the GitHub Checks feature and authorize CircleCI to report workflow status to the GitHub app. **The GitHub checks integration feature is not currently available on CircleCI Server**.
 
 ## GitHub Check and GitHub status updates
 

--- a/jekyll/_cci2/enable-checks.md
+++ b/jekyll/_cci2/enable-checks.md
@@ -47,13 +47,13 @@ To use the CircleCI Check integration, you first need to navigate to your **Orga
 3. Click the **Manage GitHub Checks** button. ![CircleCI VCS Settings Page]( {{ site.baseurl }}/assets/img/docs/screen_github_checks_new_ui.png)
 4. Select the repositories that should utilize checks and click the Install button. 
 
-After installation completes, the Checks tab in GitHub will be populated with workflow status information. 
+After installation completes, the Checks tab when viewing a PR in GitHub will be populated with workflow status information, and from here you can rerun workflows or navigate to the CircleCI app to view further information. 
 
 ## Checks Status Reporting
 
-CircleCI reports the status of workflows and all corresponding jobs under the Checks tab on GitHub. Additionally, Checks provides a button to rerun each workflow from GitHub Checks tab. 
+CircleCI reports the status of workflows and all corresponding jobs under the Checks tab on GitHub. Additionally, Checks provides a button to rerun all workflows configured for your project. 
 
-After the rerun is initiated, CircleCI reruns the workflow from the start and reports the status in the Checks tab. To navigate to the CircleCI app from GitHub, click the **View more details on CircleCI Checks** link. 
+After a rerun is initiated, CircleCI reruns the workflows from the start and reports the status in the Checks tab. To navigate to the CircleCI app from GitHub, click the **View more details on CircleCI Checks** link. 
 
 **Note:** Your project will stop receiving job level status after GitHub Checks is turned on. You can re-enable this in the GitHub Status updates section of the **Project Settings** > **Advanced Settings** page in the CircleCI app. 
 
@@ -67,9 +67,7 @@ To disable the GitHub checks integration, navigate to the **Organization Setting
 2. Select VCS. 
 3. Click the Manage GitHub Checks button. The Update CircleCI Checks repository access page appears. 
 4. Deselect the repository to uninstall the Checks integration. Click Save. - If you are removing GitHub checks from the only repo you have it installed on, you will need to either Suspend or Uninstall CircleCI Checks.
-5. Confirm that GitHub status updates have been enabled on your project: Go to the CircleCI app and navigate to **Project
-   Settings** > **Advanced Settings** > Confirm that the setting `GitHub Status
-   Updates` is set to `on`.
+5. Confirm that GitHub status updates have been enabled on your project so you will see job level status within PRs in GitHub: Go to the CircleCI app and navigate to **Project Settings** > **Advanced Settings** > Confirm that the setting `GitHub Status Updates` is set to `on`.
 
 ![CircleCI VCS Settings Page]( {{ site.baseurl }}/assets/img/docs/screen_github_checks_disable_new_ui.png)
 

--- a/jekyll/_cci2/enable-checks.md
+++ b/jekyll/_cci2/enable-checks.md
@@ -9,13 +9,22 @@ version:
 - Cloud
 ---
 
-This document describes how to enable the GitHub Checks CircleCI Setting and authorize the CircleCI Checks app to report workflow status to the GitHub app. The GitHub checks integration feature is not currently available on CircleCI Server.
+This document describes how to enable the GitHub Checks CircleCI Setting and authorize the CircleCI Checks app to report workflow status to the GitHub app. **The GitHub checks integration feature is not currently available on CircleCI Server**.
+
+## GitHub Check and GitHub status updates
+
+GitHub Checks should not be confused with GitHub status updates:
+
+* GitHub Checks are administered from the GitHub UI, and are reported in the GitHub UI per _workflow_.
+* GitHub status updates are the default way status updates from your builds are reported in the GitHub UI, and they are reported per _job_. 
+
+If both these features are enabled, the Checks tab in your GitHub PRs will show both job and workflow statuses.
 
 ## Overview
 
-GitHub Checks provides your workflow status messages on the GitHub Checks page and enables you to rerun a workflow from the GitHub Checks page. 
+GitHub Checks provides you with workflow status messages and gives the option to rerun workflows from the GitHub Checks page.
 
-After checks are enabled, CircleCI workflow and job status is reported under the checks tab on GitHub. 
+After GitHub Checks is enabled, CircleCI workflow status is reported under the checks tab on GitHub. 
 
 ![CircleCI Checks]( {{ site.baseurl }}/assets/img/docs/checks_tab.png)
 
@@ -23,63 +32,63 @@ After checks are enabled, CircleCI workflow and job status is reported under the
 
 ## To Enable GitHub Checks
 
-To use the CircleCI Check integration, you first need to navigate to the Org Setting, then authenticate the repository to use CircleCI Checks as follows:
+To use the CircleCI Check integration, you first need to navigate to your **Organization Settings**, then authenticate the repository to use Checks as follows:
 
 ### Prerequisites
 
 - You must be using the cloud-hosted version of CircleCI.
-- Your project must be using CircleCI 2.0 with [Workflows]( {{ site.baseurl }}/2.0/workflows/).
+- Your project must be using [Workflows]( {{ site.baseurl }}/2.0/workflows/).
 - You must be an Admin on your GitHub repository to authorize installation of the CircleCI Checks integration.
 
 ### Steps
 
-1. In the CircleCI sidebar, select "Organization Settings"
-2. Select VCS. 
+1. In the CircleCI app sidebar, select **Organization Settings**.
+2. Select **VCS**. 
 3. Click the **Manage GitHub Checks** button. ![CircleCI VCS Settings Page]( {{ site.baseurl }}/assets/img/docs/screen_github_checks_new_ui.png)
 4. Select the repositories that should utilize checks and click the Install button. 
 
-After installation completes, the Checks tab in GitHub will be populated with workflow run status information. 
+After installation completes, the Checks tab in GitHub will be populated with workflow status information. 
 
 ## Checks Status Reporting
 
 CircleCI reports the status of workflows and all corresponding jobs under the Checks tab on GitHub. Additionally, Checks provides a button to rerun each workflow from GitHub Checks tab. 
 
-After the rerun is initiated, CircleCI reruns the workflow from beginning and reposts the status on the Checks tab. To navigate to the CircleCI app from GitHub, click the View more details on CircleCI Checks link. 
+After the rerun is initiated, CircleCI reruns the workflow from the start and reports the status in the Checks tab. To navigate to the CircleCI app from GitHub, click the **View more details on CircleCI Checks** link. 
 
-**Note:** Your project will stop receiving job level status after GitHub Checks is turned on. You can change this in the GitHub Status updates section of the Project Settings > Advanced Settings page. 
+**Note:** Your project will stop receiving job level status after GitHub Checks is turned on. You can re-enable this in the GitHub Status updates section of the **Project Settings** > **Advanced Settings** page in the CircleCI app. 
 
 ## To Disable GitHub Checks for a Project
 
-To disable the CircleCI Check integration, navigate to the "Organization Settings" page, then remove the repositories using CircleCI Checks as follows:
+To disable the GitHub checks integration, navigate to the **Organization Settings** page in the CircleCI app, then remove the repositories using GitHub Checks, as follows:
 
 ### Steps
 
-1. Click the "Organization Settings" option in the CircleCI sidebar
+1. Click the **Organization Settings** option in the CircleCI sidebar.
 2. Select VCS. 
 3. Click the Manage GitHub Checks button. The Update CircleCI Checks repository access page appears. 
-4. Deselect the repository to uninstall the Checks integration.
-5. Confirm the status settings on your projects: Go to CircleCI > Project
-   Settings > Advanced Settings > Confirm that the setting `GitHub Status
+4. Deselect the repository to uninstall the Checks integration. Click Save. - If you are removing GitHub checks from the only repo you have it installed on, you will need to either Suspend or Uninstall CircleCI Checks.
+5. Confirm that GitHub status updates have been enabled on your project: Go to the CircleCI app and navigate to **Project
+   Settings** > **Advanced Settings** > Confirm that the setting `GitHub Status
    Updates` is set to `on`.
 
 ![CircleCI VCS Settings Page]( {{ site.baseurl }}/assets/img/docs/screen_github_checks_disable_new_ui.png)
 
 ## To Uninstall Checks for the Organization
 
-1. Click the Settings tab in the CircleCI app main menu.
+1. Click the **Organization Settings** option in the CircleCI sidebar.
 2. Select VCS.
 3. Click the Manage GitHub Checks button.
 4. Scroll down and click the Uninstall button to uninstall the GitHub Checks app.
 
-## GitHub Checks Waiting for Status in GitHub
+## Troubleshooting – GitHub Checks Waiting for Status in GitHub
 
 `ci/circleci:build — Waiting for status to be reported`
 
-If you have enabled GitHub Checks in your GitHub repository, but the status check never completes on GitHub Checks tab, there may be status settings in GitHub that you need to deselect. For example, if you choose to protect your branches, you may need to deselect the `ci/circleci:build` status key as this check refers to the job status from CircleCI 2.0, as follows:
+If you have enabled GitHub Checks in your GitHub repository, but the status check never completes on GitHub Checks tab, there may be status settings in GitHub that you need to deselect. For example, if you choose to protect your branches, you may need to deselect the `ci/circleci:build` status key as this check refers to the job status from CircleCI, as follows:
 
 ![Uncheck GitHub Job Status Keys]({{ site.baseurl }}/assets/img/docs/github_job_status.png)
 
-Having the `ci/circleci:build` checkbox enabled will prevent the status from showing as completed in GitHub when using a GitHub Checks because CircleCI posts statuses to GitHub at a workflow level rather than a workflow job level.
+Having the `ci/circleci:build` checkbox enabled will prevent the status from showing as completed in GitHub when using a GitHub Checks because CircleCI posts statuses to GitHub at a workflow level rather than a job level.
 
-Go to Settings > Branches in GitHub and click the Edit button on the protected branch to deselect the settings, for example `https://github.com/your-org/project/settings/branches`.
+Go to **Settings** > **Branches** in GitHub and click the **Edit** button on the protected branch to deselect the settings, for example `https://github.com/your-org/project/settings/branches`.
 


### PR DESCRIPTION
fixes #4871 

Parts of the GitHub checks guide are currently confusing: GitHub checks and GitHub status updates are separate features that enable/disable each other to avoid having workflow and job status shown concurrently, although projects can be set like that if desired.

I still need to do some testing but this PR is to make the guide clear and correct.