### PR TITLE
docker/checks command only accepts env variable name

### DIFF
--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -78,8 +78,8 @@ jobs:
     machine: true
     steps:
       - docker/check:
-          docker-username: mydockerhub-user  # DOCKER_LOGIN is the default value, if it exists, it automatically would be used.
-          docker-password: $DOCKERHUB_PASSWORD  # DOCKER_PASSWORD is the default value
+          docker-username: DOCKERHUB_LOGIN  # DOCKER_LOGIN is the default value, if it exists, it automatically would be used.
+          docker-password: DOCKERHUB_PASSWORD  # DOCKER_PASSWORD is the default value
       - docker/pull:
           images: 'circleci/node:latest'
 ```


### PR DESCRIPTION
# Description

The usage of the `docker/checks` is wrong, and it needs to pass environment variable names into docker-password and docker-username.

I confirmed this example in the following build.
> https://app.circleci.com/pipelines/github/ganezasan/circleci-sandbox/3313/workflows/c61ce437-e083-4f5f-8687-fcabbed10079/jobs/8167

# Reasons
A customer pointed out this issue through a ticket.