### PR TITLE
Align runner docs with wording from build environments page

### DIFF
--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -15,7 +15,7 @@ toc::[]
 
 == Introduction
 
-CircleCI runner enables you to use your own infrastructure for running jobs. This means you will be able to build and test on a wider variety of architectures and environments, in addition to providing you with additional control over the security of the environment. The diagram below illustrates how CircleCI Runner can be implemented in an environment.
+CircleCI runner enables you to use your own infrastructure for running jobs. This means you will be able to build and test on a wider variety of architectures, as well as providing you with additional control over the environment. The diagram below illustrates how CircleCI runner extends our existing systems.
 
 .Runner Architecture
 image::runner-overview-diagram.png[CircleCI Runner Architecture]
@@ -24,7 +24,7 @@ image::runner-overview-diagram.png[CircleCI Runner Architecture]
 
 There are two key use cases CircleCI aims to meet with the runner:
 
-* Security & compliance requirements - CircleCI understands that some customers require running jobs on on-premises or limited-access infrastructure due to strict security requirements. Some things that the runner enables are:
+* Privileged access & controls - CircleCI understands that some customers require running jobs on on-premises or limited-access infrastructure due to stricter isolation requirements. Some things that the runner enables are:
 ** IP restrictions - Runners can have static IP addresses that you can control.
 ** Identity Access Management (IAM) permissions - If you set up runners in AWS, they can be assigned IAM permissions.
 ** Monitor the operating system.
@@ -59,7 +59,7 @@ The following features are not yet available, but may be in the future:
 
 * Rerun with SSH
 * Test splitting
-* add_ssh_keys
+* `add_ssh_keys`
 
 == Public repositories
 


### PR DESCRIPTION
# Description
Align runner docs with wording from the [build environments page](https://circleci.com/build-environments/runner/)

# Reasons
This wording pre-dates the environments page.