### PR TITLE
[CIRCLE-30948] Document that modern SSH keys are supported

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -30,13 +30,10 @@ follow the steps below for the version of CircleCI you are using (Cloud/Server) 
 **Note:**
 Since CircleCI cannot decrypt SSH keys,
 every new key must have an empty passphrase.
-CircleCI also will not accept OpenSSH's default file format - use `ssh-keygen -m pem` if you are using OpenSSH to generate your key. 
-
-**Caution:** Recent updates in `ssh-keygen` don't generate the key in PEM format by default. If your private key does not start with `-----BEGIN RSA PRIVATE KEY-----`, enforce PEM format by generating the key with `ssh-keygen -m PEM -t rsa -C "your_email@example.com"`
 
 ### CircleCI Cloud
 
-1. In a terminal, generate the key with `ssh-keygen -m PEM -t rsa -C "your_email@example.com"`. See the [(SSH) Secure Shell documentation](https://www.ssh.com/ssh/keygen/) web site for additional details.
+1. In a terminal, generate the key with `ssh-keygen -t ed25519 -C "your_email@example.com"`. See the [(SSH) Secure Shell documentation](https://www.ssh.com/ssh/keygen/) web site for additional details.
 
 2. In the CircleCI application,
 go to your project's settings

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -248,13 +248,10 @@ the GitHub repository is `https://github.com/you/test-repo`,
 and the CircleCI project is `https://circleci.com/gh/you/test-repo`.
 
 1. Create an SSH key pair by following the [GitHub instructions](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/).
-When prompted to enter a passphrase,
-do **not** enter one.
-
-    **Caution:** Recent updates in `ssh-keygen` don't generate the key in PEM
-    format by default. If your private key does not start with `-----BEGIN RSA
-    PRIVATE KEY-----`, enforce PEM format by generating the key with `ssh-keygen
-    -m PEM -t rsa -C "your_email@example.com"`
+When prompted to enter a passphrase, do **not** enter one:
+```
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
 
 2. Go to `https://github.com/you/test-repo/settings/keys`,
 and click "Add deploy key".

--- a/jekyll/_cci2_ja/add-ssh-key.md
+++ b/jekyll/_cci2_ja/add-ssh-key.md
@@ -19,7 +19,9 @@ CircleCI に SSH 鍵を登録する必要があるケースは、以下の 2 パ
 
 ## 手順
 
-1. ターミナルから、`ssh-keygen -m PEM -t rsa -C "your_email@example.com"` コマンドを入力して鍵を生成します。 詳細については、[Secure Shell (SSH) のドキュメント](https://www.ssh.com/ssh/keygen/)を参照してください。
+FIXME: BELOW TEXT NEEDS UPDATING WITH THE SAME CHANGES AS OTHER PLACES:
+
+1. ターミナルから、`ssh-keygen -t ed25519 -C "your_email@example.com"` コマンドを入力して鍵を生成します。 詳細については、[Secure Shell (SSH) のドキュメント](https://www.ssh.com/ssh/keygen/)を参照してください。
 
 2. CircleCI アプリケーションで、プロジェクトの横にある歯車のアイコンをクリックして、プロジェクトの設定に移動します。
 
@@ -32,6 +34,8 @@ CircleCI に SSH 鍵を登録する必要があるケースは、以下の 2 パ
 6. **[Private Key (非公開鍵)]** フィールドに登録する SSH 鍵を貼り付けます。
 
 7. **[Add SSH Key (SSH 鍵を追加する)]** ボタンをクリックします。
+
+FIXME: BELOW TEXT NEEDS UPDATING WITH THE SAME CHANGES AS OTHER PLACES:
 
 **メモ:** CircleCI が SSH 鍵を復号化できるよう、鍵には常に空のパスフレーズを設定してください。 また、CircleCI は OpenSSH のデフォルトのファイル形式をサポートしていません。OpenSSH を使用して鍵を生成する場合は、`ssh-keygen -m pem` コマンドを使用します。
 

--- a/jekyll/_cci2_ja/add-ssh-key.md
+++ b/jekyll/_cci2_ja/add-ssh-key.md
@@ -4,6 +4,9 @@ title: "CircleCI に SSH 鍵を登録する"
 short-title: "CircleCI に SSH 鍵を登録する"
 description: "CircleCI に SSH 鍵を追加する方法"
 order: 20
+version:
+- Cloud
+- Server v2.x
 ---
 
 サーバーへのデプロイに SSH アクセスが必要な場合は、CircleCI に SSH 鍵を登録する必要があります。
@@ -19,27 +22,43 @@ CircleCI に SSH 鍵を登録する必要があるケースは、以下の 2 パ
 
 ## 手順
 
-FIXME: BELOW TEXT NEEDS UPDATING WITH THE SAME CHANGES AS OTHER PLACES:
+**メモ:**
+SSH 鍵を作成する際は必ず空のパスワードを設定してください。
+CircleCI ではパスワードを使った SSH 鍵の復号はできません。
 
-1. ターミナルから、`ssh-keygen -t ed25519 -C "your_email@example.com"` コマンドを入力して鍵を生成します。 詳細については、[Secure Shell (SSH) のドキュメント](https://www.ssh.com/ssh/keygen/)を参照してください。
+### Cloud 版 CircleCI の場合
+
+1. ターミナルで、`ssh-keygen -t ed25519 -C "your_email@example.com"` コマンドを実行して鍵を生成します。 詳細については、[Secure Shell (SSH) のドキュメント](https://www.ssh.com/ssh/keygen/)を参照してください。
+
+2. CircleCI アプリケーションで、 **Project Settings** ボタン (作業対象のプロジェクトの **Pipelines** ページの右上にあります) をクリックして、プロジェクトの設定に移動します。
+
+3. **Project Settings** ページにて、 **SSH Keys** をクリックします (画面左側のメニューにあります)。
+
+4. スクロールし、 **Additional SSH Keys** のセクションに移動します。
+
+5. **Add SSH Key** ボタンをクリックします。
+
+5. **Hostname** フィールドに鍵に関連付けるホスト名を入力します (例: git.heroku.com)。 ホスト名を指定しない場合は、どのホストに対しても同じ鍵が使われます。
+
+7. **Private Key** フィールドに登録する SSH 鍵を貼り付けます。
+
+8. **Add SSH Key** ボタンをクリックします。
+
+### CircleCI Server の場合
+
+1. ターミナルで、`ssh-keygen -t ed25519 -C "your_email@example.com"` コマンドを実行して鍵を生成します。 詳細については、[Secure Shell (SSH) のドキュメント](https://www.ssh.com/ssh/keygen/)を参照してください。
 
 2. CircleCI アプリケーションで、プロジェクトの横にある歯車のアイコンをクリックして、プロジェクトの設定に移動します。
 
-3. **[Permissions (権限)]** セクションで、**[SSH Permissions (SSH の権限)]** をクリックします。
+3. **Permissions** セクションで、**SSH Permissions** をクリックします。
 
-4. **[Add SSH Key (SSH 鍵を追加する)]** ボタンをクリックします。
+4. **Add SSH Key** ボタンをクリックします。
 
-5. **[Hostname (ホスト名)]** フィールドに鍵に関連付けるホスト名を入力します (例: git.heroku.com)。 ホスト名を指定しない場合は、どのホストに対しても同じ鍵が使われます。
+5. **Hostname** フィールドに鍵に関連付けるホスト名を入力します (例: git.heroku.com)。 ホスト名を指定しない場合は、どのホストに対しても同じ鍵が使われます。
 
-6. **[Private Key (非公開鍵)]** フィールドに登録する SSH 鍵を貼り付けます。
+6. **Private Key** フィールドに登録する SSH 鍵を貼り付けます。
 
-7. **[Add SSH Key (SSH 鍵を追加する)]** ボタンをクリックします。
-
-FIXME: BELOW TEXT NEEDS UPDATING WITH THE SAME CHANGES AS OTHER PLACES:
-
-**メモ:** CircleCI が SSH 鍵を復号化できるよう、鍵には常に空のパスフレーズを設定してください。 また、CircleCI は OpenSSH のデフォルトのファイル形式をサポートしていません。OpenSSH を使用して鍵を生成する場合は、`ssh-keygen -m pem` コマンドを使用します。
-
-**メモ:** 最近 `ssh-keygen` は、デフォルトで PEM 形式の鍵を生成しないように更新されました。 非公開鍵が `-----BEGIN RSA PRIVATE KEY-----` で始まらない場合、`ssh-keygen -m PEM -t rsa -C "your_email@example.com"` コマンドで鍵を生成すると、強制的に PEM 形式で生成できます。
+7. **Add SSH Key** ボタンをクリックします。
 
 ## ジョブに SSH 鍵を登録する
 

--- a/jekyll/_cci2_ja/gh-bb-integration.md
+++ b/jekyll/_cci2_ja/gh-bb-integration.md
@@ -183,6 +183,8 @@ CircleCI が使用しているアカウントと権限のシステムは、ま�
 
 この例では、GitHub リポジトリは `https://github.com/you/test-repo`、CircleCI のプロジェクトは <https://circleci.com/gh/you/test-repo>{:rel="nofollow"} です。
 
+FIXME: BELOW TEXT NEEDS UPDATING WITH THE SAME CHANGES AS OTHER PLACES:
+
 1. [GitHub の説明](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)に従って、SSH 鍵ペアを作成します。 パスフレーズの入力を求められても、**入力しない**でください。
 
 **注意:** 最近 `ssh-keygen` は、デフォルトで PEM 形式の鍵を生成しないように更新されました。 秘密鍵が `-----BEGIN RSA PRIVATE KEY-----` で始まらない場合、`ssh-keygen -m PEM -t rsa -C "your_email@example.com"` コマンドで鍵を生成すると、強制的に PEM 形式で生成できます。

--- a/jekyll/_cci2_ja/gh-bb-integration.md
+++ b/jekyll/_cci2_ja/gh-bb-integration.md
@@ -5,6 +5,8 @@ description: GitHub または Bitbucket の使用
 categories:
   - migration
 Order: 60
+version:
+- Cloud
 ---
 
 以下のセクションに沿って、CircleCI での GitHub、GitHub Enterprise、または Bitbucket Cloud の利用について概説します。
@@ -15,7 +17,7 @@ Order: 60
 ## 概要
 {:.no_toc}
 
-プロジェクトを CircleCI に追加すると、ユーザー登録時に CircleCI に与えた権限に基づいて、以下の GitHub または Bitbucket Cloud の設定がリポジトリに追加されます。
+CircleCI を使用する際には、 VCS として GitHub もしくは BitBucket を使用する必要があります。プロジェクトを CircleCI に追加すると、ユーザー登録時に CircleCI に与えた権限に基づいて、以下の GitHub または Bitbucket Cloud の設定がリポジトリに追加されます。
 
 - **デプロイ キー**: GitHub または Bitbucket Cloud からプロジェクトをチェックアウトするために使用されます。
 - **サービス フック**: GitHub または Bitbucket Cloud にプッシュしたときに CircleCI に通知を送信するために使用されます。
@@ -41,6 +43,10 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.4.1-jessie
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+
     steps:
       - run: |
           bundle install
@@ -70,9 +76,9 @@ CircleCI は、毎回クリーンなコンテナでテストを実行します�
 
 ## プロジェクトで追加のプライベート リポジトリのチェックアウトの有効化
 
-テスト プロセスが複数のリポジトリを参照する場合、CircleCI ではデプロイ キーに加えて GitHub ユーザー キーも必要となります。デプロイ キーは *1 つ*のリポジトリに対してのみ有効であるのに対して、GitHub ユーザー キーはユーザーの*すべて*の GitHub リポジトリに対してアクセス権を持つためです。
+テスト プロセスが複数のリポジトリを参照する場合、CircleCI ではデプロイ キーに加えて GitHub ユーザー キーも必要となります。これは、 GitHub ユーザー キーはユーザーの*すべて*の GitHub リポジトリに対してアクセス権を持ちますが、デプロイ キーは*単一の*リポジトリに対してのみ有効であるためです。
 
-プロジェクトの **[Project Settings (プロジェクト設定)] > [Checkout SSH keys (SSH 鍵のチェック アウト)]** ページで、CircleCI に渡す GitHub のユーザー キーを指定します。 CircleCI は、この新しい SSH 鍵を作成し、それを GitHub のユーザー アカウントに関連付けて、ユーザーのすべてのリポジトリにアクセスできるようにします。
+プロジェクトの **[Project Settings (プロジェクト設定)] > [SSH Keys (SSH 鍵)]** のページで、 **[User Key (ユーザー鍵)]** のセクションまでスクロールで移動し、 **[Authorize with GitHub (GitHub で認証する)]** ボタンをクリックします。 CircleCI は、この新しい SSH 鍵を作成し、それを GitHub のユーザー アカウントに関連付けて、ユーザーのすべてのリポジトリにアクセスできるようにします。
 
 <h2 id="security">ユーザー キーのセキュリティ</h2>
 
@@ -108,7 +114,7 @@ SSH 鍵は信頼するユーザーとのみ共有してください。また、�
 
 3. [CircleCI にログイン](https://circleci.com/login)します。 CircleCI を承認するよう GitHub から要求されたら、[**Authorize application (アプリケーションを承認)**] ボタンをクリックします。
 
-4. [[Add Projects (プロジェクトの追加)] ページ](https://circleci.com/add-projects){:rel="nofollow"}で、マシン ユーザーにアクセスを許可するすべてのプロジェクトをフォローします。
+4. [Add Projects (プロジェクトの追加)] ページで、マシン ユーザーにアクセスを許可するすべてのプロジェクトをフォローします。
 
 5. **[Project Settings (プロジェクト設定)] > [Checkout SSH keys (SSH 鍵のチェック アウト)]** ページで、[**Authorize With GitHub (GitHub で承認)**] ボタンをクリックします。 これで、マシン ユーザーの代わりに SSH 鍵を作成して GitHub にアップロードする権限が CircleCI に付与されます。
 
@@ -131,7 +137,12 @@ CircleCI は、VCS プロバイダーに対して、[GitHub の権限モデル](
 - ユーザーのリポジトリ リストを取得する
 - ユーザー アカウントへの SSH 鍵の追加
 
-**メモ:** CircleCI は絶対に必要な権限しか要求しません。 また、CircleCI が要求できる権限は、各 VCS プロバイダーが提供すると決めた権限のみに制限されます。 たとえば、GitHub は読み取り専用のアクセス権を提供していないため、ユーザーのリポジトリ リストを GitHub から取得するには、書き込みアクセス権が必要です。
+**管理者権限**
+- デプロイ キーのリポジトリへの追加
+- サービス フックのレポジトリへの追加
+
+**メモ:** CircleCI は絶対に必要な権限しか要求しません。 また、CircleCI が要求できる権限は、各 VCS プロバイダーが提供すると決めた権限のみに制限されます。 たとえば、 GitHub からユーザーのリポジトリ (公開・非公開の両方) の一覧を GitHub から取得する際には、 [`repo`
+スコープ](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes) の権限が必要で、これは書き込みアクセス権に相当します。 GitHub は読み取り専用のアクセス権の設定に対応していないため、このような設定が必要になります。
 
 CircleCI が使用する権限の数をどうしても減らしたい場合は、VCS プロバイダーに連絡して、その旨を伝えてください。
 
@@ -181,17 +192,16 @@ CircleCI が使用しているアカウントと権限のシステムは、ま�
 ### GitHub のデプロイ キーの作成
 {:.no_toc}
 
-この例では、GitHub リポジトリは `https://github.com/you/test-repo`、CircleCI のプロジェクトは <https://circleci.com/gh/you/test-repo>{:rel="nofollow"} です。
+この例では、GitHub リポジトリは `https://github.com/you/test-repo`、CircleCI のプロジェクトは <https://circleci.com/gh/you/test-repo>{:rel="nofollow"} とします。
 
-FIXME: BELOW TEXT NEEDS UPDATING WITH THE SAME CHANGES AS OTHER PLACES:
-
-1. [GitHub の説明](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)に従って、SSH 鍵ペアを作成します。 パスフレーズの入力を求められても、**入力しない**でください。
-
-**注意:** 最近 `ssh-keygen` は、デフォルトで PEM 形式の鍵を生成しないように更新されました。 秘密鍵が `-----BEGIN RSA PRIVATE KEY-----` で始まらない場合、`ssh-keygen -m PEM -t rsa -C "your_email@example.com"` コマンドで鍵を生成すると、強制的に PEM 形式で生成できます。
+1. [GitHub の説明](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)に従い、下記コマンドを実行しSSH 鍵ペアを作成します。 パスフレーズの入力を求められても、**入力しない**でください。
+```
+ssh-keygen -t ed25519 -C "your_email@example.com"
+```
 
 2. `https://github.com/you/test-repo/settings/keys` に移動し、[Add deploy key (デプロイ キーを追加)] をクリックします。 [Title (タイトル)] フィールドにタイトルを入力し、手順 1 で作成した鍵をコピーして貼り付けます。 [Allow write access (書き込みアクセスを許可)] をオンにし、[Add key (キーを追加)] をクリックします。
 
-3. <https://circleci.com/gh/you/test-repo/edit#ssh>{:rel="nofollow"} に移動し、手順 1 で作成した鍵を追加します。 [Hostname (ホスト名)] フィールドに「github.com」と入力し、送信ボタンを押します。
+3. プロジェクトの設定画面に移動し、 [SSH Key (SSH 鍵)]、 [Add SSH key (SSH 鍵の追加)] の順にクリックし、手順 1 で作成した鍵を追加します。 [Hostname (ホスト名)] フィールドに「github.com」と入力し、送信ボタンを押します。
 
 4. config.yml で `add_ssh_keys` キーを使用して、以下のようにフィンガープリントを追加します。
 
@@ -249,7 +259,7 @@ CircleCI がプロジェクトをビルドするときには、秘密鍵が `.ss
 
 ### これらのキーのセキュリティ
 
-CircleCI が生成するチェックアウト キー ペアの秘密鍵は CircleCI システムを出ることはなく (公開鍵のみ GitHub に転送)、また、ストレージ上では安全に暗号化されています。 しかし、これらはビルド コンテナにインストールされるため、CircleCI で実行されるすべてのコードによって読み取ることができます。 同様に、SSH 鍵を使用できる開発者は、この鍵に直接アクセスできます。
+CircleCI が生成するチェックアウト キー ペアの秘密鍵は CircleCI システムを出ることはなく (公開鍵のみ GitHub に転送)、また、ストレージ上では安全に暗号化されています。 しかし、これらはビルド コンテナにインストールされるため、CircleCI で実行されるすべてのコードによって読み取ることができます。 同様に、SSH でビルド環境にログインする権限を持つ開発者は、この鍵に直接アクセスできます。
 
 **デプロイ キーとユーザー キーの違い**
 
@@ -259,20 +269,23 @@ GitHub がサポートするキーの種類は、デプロイ キーとユーザ
 
 ## SSH ホストの信頼性の確立
 
-SSH キーを使用してレポジトリをチェックアウトするとき、既知のホスト ファイル (`~/.ssh/known_hosts`) に GitHub または Bitbucket のフィンガープリントを追加する必要があります。そうすることで、Executor は接続しているホストの信頼性を検証できます。 これは `checkout` ジョブ ステップによって自動的に処理されます。カスタムのチェックアウト コマンドを使用したい場合には、以下のコマンドを使用する必要があります。
+SSH キーを使用してレポジトリをチェックアウトするとき、 `~/.ssh/known_hosts` に GitHub または Bitbucket のフィンガープリントを追加する必要があります。そうすることで、Executor は接続しているホストの信頼性を検証できます。 これは `checkout` ジョブ ステップによって自動的に処理されます。カスタムのチェックアウト コマンドを使用したい場合には、以下のコマンドを使用する必要があります。
 
-    mkdir -p ~/.ssh
+```
+mkdir -p ~/.ssh
 
-    echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
-    bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
-    ' >> ~/.ssh/known_hosts
+echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
+' >> ~/.ssh/known_hosts
+```
 
+対象サーバーの SSH 公開鍵は `ssh-keyscan <host>` コマンドで取得できます。そして、取得されたテキストのうち `ssh-rsa` プレフィックスがついているものをジョブの `known_hosts` ファイルに追加することで、利用できるようになります。以下は動作例です:
 
-`ssh-keyscan <host>` を実行し、サーバーの SSH キーをフェッチします。次に、このキーに `ssh-rsa` をプレフィックスして、ジョブの `known_hosts` ファイルに追加します。 たとえば、以下のようになります。
-
-    ➜  ~ ssh-keyscan github.com
-    # github.com:22 SSH-2.0-babeld-2e9d163d
-    github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
-    # github.com:22 SSH-2.0-babeld-2e9d163d
-    # github.com:22 SSH-2.0-babeld-2e9d163d
-    ➜  ~ ✗
+```
+➜  ~ ssh-keyscan github.com           
+# github.com:22 SSH-2.0-babeld-2e9d163d
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+# github.com:22 SSH-2.0-babeld-2e9d163d
+# github.com:22 SSH-2.0-babeld-2e9d163d
+➜  ~ ✗ 
+```


### PR DESCRIPTION
# Description
Modern SSH key formats are now supported.
Additionally we support keys in OpenSSH's default "openssh" encoding, and no-longer require users to specify `-m PEM`.

# Reasons
https://circleci.atlassian.net/browse/CIRCLE-30948
