### PR TITLE
Add note on where "sudo" should go

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -78,7 +78,7 @@ choco install circleci-cli -y
 curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash
 ```
 
-By default, the CircleCI CLI tool will be installed to the `/usr/local/bin` directory. If you do not have write permissions to `/usr/local/bin`, you may need to run the above command with `sudo`. Alternatively, you can install to an alternate location by defining the `DESTDIR` environment variable when invoking bash:
+By default, the CircleCI CLI tool will be installed to the `/usr/local/bin` directory. If you do not have write permissions to `/usr/local/bin`, you may need to run the above command with `sudo` after the pipe and before `bash`. Alternatively, you can install to an alternate location by defining the `DESTDIR` environment variable when invoking bash:
 
 ```sh
 curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | DESTDIR=/opt/bin bash


### PR DESCRIPTION
# Description
Specify where the `sudo` should go.

# Reasons
Since this is a piped operation, doing `sudo curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash` won't work.