### PR TITLE
iOS Testing Update Missing Cell Block

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -49,8 +49,8 @@ Running or testing Apple Silicon apps natively is currently not possible as Circ
 
  Config   | Xcode Version                   | macOS Version | macOS UI Testing Supported | Software Manifest | Release Notes
 ----------|---------------------------------|---------------|-------------------|--------------
-+ `12.2.0` | Xcode 12.2 RC (12B5044c) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4061/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-2-rc-released/38038)
-+ `12.1.1` | Xcode 12.1.1 RC (12A7605b) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4054/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-1-rc-released/38023)
++ `12.2.0` | Xcode 12.2 RC (12B5044c) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4061/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-2-rc-released/38038)
++ `12.1.1` | Xcode 12.1.1 RC (12A7605b) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4054/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-1-rc-released/38023)
  `12.1.0` | Xcode 12.1 (12A7403) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3985/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-gm-released/37809)
  `12.0.1` | Xcode 12.0.1 (12A7300) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3933/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-0-1-released-xcode-12-0-0-deprecated/37630)
  `11.7.0` | Xcode 11.7 (11E801a) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3587/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-11-7-released/37312)

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -49,8 +49,8 @@ Running or testing Apple Silicon apps natively is currently not possible as Circ
 
  Config   | Xcode Version                   | macOS Version | macOS UI Testing Supported | Software Manifest | Release Notes
 ----------|---------------------------------|---------------|-------------------|--------------
-+ `12.2.0` | Xcode 12.2 RC (12B5044c) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4061/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-2-rc-released/38038)
-+ `12.1.1` | Xcode 12.1.1 RC (12A7605b) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4054/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-1-rc-released/38023)
+ `12.2.0` | Xcode 12.2 RC (12B5044c) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4061/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-2-rc-released/38038)
+ `12.1.1` | Xcode 12.1.1 RC (12A7605b) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4054/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-1-rc-released/38023)
  `12.1.0` | Xcode 12.1 (12A7403) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3985/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-gm-released/37809)
  `12.0.1` | Xcode 12.0.1 (12A7300) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3933/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-0-1-released-xcode-12-0-0-deprecated/37630)
  `11.7.0` | Xcode 11.7 (11E801a) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3587/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-11-7-released/37312)

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -48,7 +48,7 @@ Running or testing Apple Silicon apps natively is currently not possible as Circ
 ## Supported Xcode versions
 
  Config   | Xcode Version                   | macOS Version | macOS UI Testing Supported | Software Manifest | Release Notes
-----------|---------------------------------|---------------|-------------------|--------------
+----------|---------------------------------|---------------|----------------------------|-------------------|--------------
  `12.2.0` | Xcode 12.2 RC (12B5044c) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4061/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-2-rc-released/38038)
  `12.1.1` | Xcode 12.1.1 RC (12A7605b) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v4054/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-1-rc-released/38023)
  `12.1.0` | Xcode 12.1 (12A7403) | 10.15.5 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3985/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-1-gm-released/37809)


### PR DESCRIPTION
# Description
There is a missing cell block in the table as shown [here](https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions). This adds in the missing field. 
The missing data is in the first two rows, in the `macOS UI Testing Supported` column.

# Reasons
We do not want missing data cells on our public documents. 