### PR TITLE
Clarify workspaces cache expiration.

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1216,7 +1216,7 @@ Note the following distinctions between Artifacts, Workspaces, and Caches:
 | Type      | lifetime        | Use                      | Example |
 |-----------|-----------------|------------------------------------|---------
 | Artifacts | 1 Month         | Preserve long-term artifacts. |  Available in the Artifacts tab of the **Job page** under the `tmp/circle-artifacts.<hash>/container`   or similar directory.     |
-| Workspaces | Duration of workflow        | Attach the workspace in a downstream container with the `attach_workspace:` step. | The `attach_workspace` copies and re-creates the entire workspace content when it runs.    |
+| Workspaces | Duration of workflow (up to 15 days)        | Attach the workspace in a downstream container with the `attach_workspace:` step. | The `attach_workspace` copies and re-creates the entire workspace content when it runs.    |
 | Caches    | 15 Days         | Store non-vital data that may help the job run faster, for example npm or Gem packages.          |  The `save_cache` job step with a `path` to a list of directories to add and a `key` to uniquely identify the cache (for example, the branch, build number, or revision).   Restore the cache with `restore_cache` and the appropriate `key`. |
 {: class="table table-striped"}
 


### PR DESCRIPTION
# Description
Workspace caches have a hard limit of 15 days.

# Reasons
We received a ticket from someone who has designed a workflow that can have a lifetime between 1-90 days through the use of an on-hold job. They attempted to approve the on-hold job after 16 days, which failed the deployment because the files no longer exist. they were lead to believe the workspaces would exist indefinitely because of the wording here. 