### PR TITLE
Move information about tracking available memory to own note

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -611,7 +611,9 @@ jobs:
 <sup>(2)</sup> _This resource requires review by our support team. [Open a support ticket](https://support.circleci.com/hc/en-us/requests/new) if you would like to request access._
 
 **Note**: Java, Erlang and any other languages that introspect the `/proc` directory for information about CPU count may require additional configuration to prevent them from slowing down when using the CircleCI 2.0 resource class feature. Programs with this issue may request 32 CPU cores and run slower than they would when requesting one core. Users of languages with this issue should pin their CPU count to their guaranteed CPU resources.
-If you want to confirm how much memory you have been allocated, you can check the cgroup memory hierarchy limit with `grep hierarchical_memory_limit /sys/fs/cgroup/memory/memory.stat`.
+
+
+**Note**: If you want to confirm how much memory you have been allocated, you can check the cgroup memory hierarchy limit with `grep hierarchical_memory_limit /sys/fs/cgroup/memory/memory.stat`.
 
 #### **`steps`**
 


### PR DESCRIPTION
# Description
We have a note that combined two concepts:

1. Info about possibly needing to pin the number of CPU count
2. Info about how to find the amount of memory you have been allocated

Combined it reads that the command to find memory helps find information about CPU usage, but in reality, they are separate concepts.

This PR will move the information about finding memory allocation to it's own note so the concepts are split up.

# Reasons
Was working with a customer and was referencing this section and it caused some confusion. 