### PR TITLE
[Prototype] Add: Scroll to active sidebar element.

### DIFF
--- a/jekyll/assets/js/sidebar.js
+++ b/jekyll/assets/js/sidebar.js
@@ -30,6 +30,7 @@
 
       sidenavAutoExpand(sidebar);
       sidenavAutoExpand(mobileSidebar);
+      scrollToActiveSidebarItem();
 
       // for mobile sidebar, if sidebar is set, display proper item
       var mobileCurrentElement = mobileSidebar.querySelector('[data-id=' + localStorage.sidenavActive + ']');
@@ -67,6 +68,14 @@
         sidebar.style.height = null;
       }
     };
+
+    function scrollToActiveSidebarItem() {
+      var activeEl = $('nav.sidebar .active')[0];
+      var sidebarTop = $("nav.sidebar")[0].offsetTop;
+      var activeElTop = activeEl && activeEl.offsetTop;
+      var elementRelativeTop = activeElTop - sidebarTop;
+      $("nav.sidebar").scrollTop(elementRelativeTop);
+    }
 
     window.addEventListener('scroll', setSidebar);
     window.addEventListener('load', setSidebar);


### PR DESCRIPTION
See [pertinent conversation](https://circleci.slack.com/archives/C0KBNJGRH/p1607020012220300).

Demo that compares `Prod<>Local`:

![sidebar screen](https://user-images.githubusercontent.com/12987958/101081598-441c8700-3578-11eb-8bd1-2579e0a13baa.gif)
