### PR TITLE
fix proxy setting

### DIFF
--- a/jekyll/_cci2/proxy.adoc
+++ b/jekyll/_cci2/proxy.adoc
@@ -71,7 +71,7 @@ EOF
 systemctl restart replicated\*
 ```
 
-NOTE: NOTE: If the proxy requires user authentication, you will need to be added user authentication information into <proxy-ip>.
+NOTE: NOTE: If the proxy requires user authentication, you will need to add user authentication information into <proxy-ip> like below:
 
 ```
 export HTTP_PROXY=http://<userid>:<password>@<proxy-ip>:<port>

--- a/jekyll/_cci2/proxy.adoc
+++ b/jekyll/_cci2/proxy.adoc
@@ -81,7 +81,7 @@ export HTTPS_PROXY=https://<userid>:<password>@<proxy-ip>:<port>
 NOTE: The above is not handled by by our enterprise-setup script and will need to be added to the user data for the Services Machine startup or done manually.
 
 // not quite clear what is meant by this note... what's user data in this context?
-// If the cusotmer automatically apply the above setting, they need to add them into ServiceBox's user data.
+// If the customer wants to apply the above setting automatically, they need to add them into ServiceBox's user data.
 //  User data is a script, and the metadata of the EC2 instances, which is executed at lunchtime of an EC2 instance.
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html#user-data-shell-scripts
 // https://github.com/circleci/enterprise-setup/blob/master/templates/services_user_data.tpl

--- a/jekyll/_cci2/proxy.adoc
+++ b/jekyll/_cci2/proxy.adoc
@@ -48,9 +48,10 @@ For a static installation, not on AWS, SSH into the Services machine and run the
 ```
 echo '{"HttpProxy": "http://<proxy-ip:port>"}' | sudo tee /etc/replicated.conf
 (cat <<'EOF'
-HTTP_PROXY=<proxy-ip:port>
-HTTPS_PROXY=<proxy-ip:port>
-EOF) | sudo tee -a /etc/circle-installation-customizations
+export HTTP_PROXY=<proxy-ip:port>
+export HTTPS_PROXY=<proxy-ip:port>
+EOF
+) | sudo tee -a /etc/circle-installation-customizations
 
 systemctl restart replicated\*
 ```
@@ -60,18 +61,31 @@ If you run in Amazon's EC2 service then you'll need to include `169.254.169.254`
 ```
 echo '{"HttpProxy": "http://<proxy-ip:port>"}' | sudo tee /etc/replicated.conf
 (cat <<EOF
-HTTP_PROXY=<proxy-ip:port>
-HTTPS_PROXY=<proxy-ip:port>
-NO_PROXY=169.254.169.254,<circleci-service-ip>,127.0.0.1,localhost,ghe.example.com
-JVM_OPTS="-Dhttp.proxyHost=<proxy-ip> -Dhttp.proxyPort=<proxy-port> -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=<proxy-port> -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|127.0.0.1|localhost|ghe.example.com"
-EOF) | sudo tee -a /etc/circle-installation-customizations
+export HTTP_PROXY=<proxy-ip:port>
+export HTTPS_PROXY=<proxy-ip:port>
+export NO_PROXY=169.254.169.254,<circleci-service-ip>,127.0.0.1,localhost,ghe.example.com
+export JVM_OPTS="-Dhttp.proxyHost=<proxy-ip> -Dhttp.proxyPort=<proxy-port> -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=<proxy-port> -Dhttp.nonProxyHosts=169.254.169.254|<circleci-service-ip>|127.0.0.1|localhost|ghe.example.com"
+EOF
+) | sudo tee -a /etc/circle-installation-customizations
 
 systemctl restart replicated\*
+```
+
+NOTE: NOTE: If the proxy requires user authentication, you will need to be added user authentication information into <proxy-ip>.
+
+```
+export HTTP_PROXY=http://<userid>:<password>@<proxy-ip>:<port>
+export HTTPS_PROXY=https://<userid>:<password>@<proxy-ip>:<port>
 ```
 
 NOTE: The above is not handled by by our enterprise-setup script and will need to be added to the user data for the Services Machine startup or done manually.
 
 // not quite clear what is meant by this note... what's user data in this context?
+// If the cusotmer automatically apply the above setting, they need to add them into ServiceBox's user data.
+//  User data is a script, and the metadata of the EC2 instances, which is executed at lunchtime of an EC2 instance.
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html#user-data-shell-scripts
+// https://github.com/circleci/enterprise-setup/blob/master/templates/services_user_data.tpl
+
 <<<
 === Corporate Proxies
 


### PR DESCRIPTION
# Description
Change the scripts for setting proxy

# Reasons
The initial document's script doesn't work for the current server, and we noticed `/etc/circle-installation-customizations` is just a shell script, so to set environment variables, it needs to set `export` before the environment variables.