### PR TITLE
Patch/oss

### DIFF
--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -22,7 +22,7 @@ To support the open source community, organizations on Github or Bitbucket will 
 If you are building an open source project on macOS, contact billing@circleci.com to enable these additional containers.
 
 **Note:**
-There is a concurrency limit of 4 containers. Additional containers will be queued.
+There is a concurrency limit of 4 containers for Docker and Linux machine executors whereas macOS executors are limited to 1 container. Additional containers will be queued.
 
 ## Security
 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -22,7 +22,7 @@ To support the open source community, organizations on Github or Bitbucket will 
 If you are building an open source project on macOS, contact billing@circleci.com to enable these additional containers.
 
 **Note:**
-There is a concurrency limit of 4 containers for Docker and Linux machine executors whereas macOS executors are limited to 1 container. Additional containers will be queued.
+There is a concurrency limit of 4 containers for Docker, Linux, and Window machine executors whereas macOS executors are limited to 1 container. Additional containers will be queued.
 
 ## Security
 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -21,6 +21,9 @@ To support the open source community, organizations on Github or Bitbucket will 
 **Note:**
 If you are building an open source project on macOS, contact billing@circleci.com to enable these additional containers.
 
+**Note:**
+There is a concurrency limit of 4 containers. Additional containers will be queued.
+
 ## Security
 
 While open source can be a liberating practice, take care not to liberate sensitive information.

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -22,7 +22,7 @@ To support the open source community, organizations on Github or Bitbucket will 
 If you are building an open source project on macOS, contact billing@circleci.com to enable these additional containers.
 
 **Note:**
-There is a concurrency limit of 4 containers for Docker, Linux, and Window machine executors whereas macOS executors are limited to 1 container. Additional containers will be queued.
+There is a concurrency limit of 4 containers for Docker and Machine executors whereas macOS executors are limited to 1 container. Additional containers will be queued.
 
 ## Security
 


### PR DESCRIPTION
# Description
To add a note containing the concurrency limits for Docker, Linux, Windows, and macOS executors.

# Reasons
Customer sent in a ticket wondering why their jobs were being queued even though they had enough remaining credits.

https://circleci.zendesk.com/agent/tickets/83035