### PR TITLE
Indicate which version of Yarn examples are referring to and add Yarn 1.x example

### DIFF
--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -60,11 +60,9 @@ An example for Yarn 1.x:
           name: Restore Yarn Package Cache
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
-      - run: Configure Yarn Cache
-        command: yarn config set cache-folder ~/.cache/yarn
       - run:
           name: Install Dependencies
-          command: yarn install --frozen-lockfile
+          command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
       - save_cache:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}

--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -30,6 +30,7 @@ curl -o- -L https://yarnpkg.com/install.sh | bash
 ## Caching
 
 Yarn packages can be cached to improve CI build times.
+
 An example for Yarn 2:
 
 {% raw %}

--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -30,7 +30,7 @@ curl -o- -L https://yarnpkg.com/install.sh | bash
 ## Caching
 
 Yarn packages can be cached to improve CI build times.
-Here's an example:
+An example for Yarn 2:
 
 {% raw %}
 ```yaml
@@ -42,6 +42,29 @@ Here's an example:
       - run:
           name: Install Dependencies
           command: yarn install --immutable
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+#...
+```
+{% endraw %}
+
+An example for Yarn 1.x:
+
+{% raw %}
+```yaml
+#...
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
+      - run: Configure Yarn Cache
+        command: yarn config set cache-folder ~/.cache/yarn
+      - run:
+          name: Install Dependencies
+          command: yarn install --frozen-lockfile
       - save_cache:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
# Description
- Make it clear which Yarn version the example is for
- Adds example for caching with Yarn 1.x versions

# Reasons

The fourth  Documentation value states
> 4. Clear: documentation should be clear.
> https://github.com/circleci/circleci-docs/blob/master/docs/CONTRIBUTING.md#circleci-documentation-values

The documentation examples do not make it clear which version of Yarn they are referring to.

Yarn 1.x is still very popular and frequently used in projects. Users of Yarn 1.x may be confused by the current example.
