### PR TITLE
Add note for requires option 

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1370,7 +1370,7 @@ Jobs are run in parallel by default, so you must explicitly require any dependen
 
 Key | Required | Type | Description
 ----|-----------|------|------------
-requires | N | List | A list of jobs that must succeed for the job to start
+requires | N | List | A list of jobs that must succeed for the job to start. Note: When jobs in the current workflow that are listed as dependencies are not executed (due to a filter function for example), their requirement as a dependency for other jobs will be ignored by the requires option.
 name | N | String | A replacement for the job name. Useful when calling a job multiple times. If you want to invoke the same job multiple times and a job requires one of the duplicate jobs, this is required. (2.1 only)
 {: class="table table-striped"}
 


### PR DESCRIPTION
# Description
Add a note for the `requires` option

# Reasons
> https://circleci.atlassian.net/browse/CIRCLE-28227

A customer reported an issue that the requires option ignores the filter job dependency.
For example, the customer expected job C won't run when the customer pushes a commit to master, because job B won't run due to the filter option. However, the `requires` option ignores the filter job dependency so that after Job A finished, Job C will run. 

```
workflows:
  version: 2
  workflow:
    jobs:
    - A
    - B:
        filters:
          branches:
            only: master
    - C:
        requires:
        - A
        - B
```