### PR TITLE
Add default setup_remote_docker version

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -125,6 +125,7 @@ CircleCI supports multiple versions of Docker. The following are the available v
 - `19.03.12`
 - `19.03.8`
 - `18.09.3`
+- `17.09.0-ce` (default)
 
 <!---
 Consult the [Stable releases](https://download.docker.com/linux/static/stable/x86_64/) or [Edge releases](https://download.docker.com/linux/static/edge/x86_64/) for the full list of supported versions.


### PR DESCRIPTION
# Description

Add 17.09.0-ce version which is the default version of the setup_remote_docker

# Reasons

A customer asked about it