### PR TITLE
docs:  add_ssh_keys is not required

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -83,12 +83,11 @@ you are adding.
 
 ## Adding SSH Keys to a Job
 
-Even though all CircleCI jobs use `ssh-agent`
-to automatically sign all added SSH keys,
-you **must** use the `add_ssh_keys` key
-to actually add keys to a container.
+CircleCI jobs use `ssh-agent`
+to automatically sign all added SSH keys
+to a container.
 
-To add a set of SSH keys to a container,
+To explicitly add a set of SSH keys to a container,
 use the `add_ssh_keys` [special step]({{ site.baseurl }}/2.0/configuration-reference/#add_ssh_keys)
 within the appropriate [job]({{ site.baseurl }}/2.0/jobs-steps/)
 in your configuration file.


### PR DESCRIPTION
`add_ssh_keys` is not required, it will implicitly pull in all SSH keys from the project without this.

This document was misleading and led us to believe our keys, when not referenced in the job, were not being used. We thought we had a security vulnerability. It was only until we deleted the keys from the project that the build failed with being unable to SSH into the deployment host.

So
- without the add_ssh_key: Good
- without the add_ssh_key + without the SSH key in project settings: Bad
