### PR TITLE
[CIRCLE-31528] Align search results with search bar and nav

### DIFF
--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -14,7 +14,6 @@
 	<div id="hits-target" style="display:none;">
 		<div class="container">
 			<div class="row">
-				<div class="col-md-10 col-md-offset-1">
 					<div id="subnav-placeholder">
 						<div class="component subnav dynamic-fixed" data-top-nav-offset="120">
 							<ul class="results-nav" data-active="search-results-documentation">
@@ -37,7 +36,6 @@
 
 					<a id="search-results-orbs" class="deep-link-anchor subnav-offset anchor"></a>
 					<div id="instant-hits-orbs"></div>
-				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This applies a design change to align the left side of search results with the left side of the search bar spyglass and header/nav. Previously it was indented.

I didn't un-indent the contents of the div that was removed in order to keep the diff clean and not muddy the line history, but I'm happy to change that if desired.

Note that using a `row` element without a child `col` element is a misuse of the Bootstrap grid system, but the header and search bar are already doing this so we have to make the same mistake here to get them to align with each other.