### PR TITLE
Add sans-serif to all font-family entries.

### DIFF
--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -15,11 +15,11 @@ body{
 	font-family: 'Roboto', sans-serif;
 }
 h1, h2, h3, h4, h5, h6 {
-	font-family: 'Roboto';
+	font-family: 'Roboto', sans-serif;
   font-weight: 500;
 }
 p {
-	font-family: 'Roboto';
+	font-family: 'Roboto', sans-serif;
 	color: $body-text-color;
 }
 


### PR DESCRIPTION
# Description

Helps smooth out the fallback behavior when Roboto isn't present (e.g Google Fonts down/blocked).

# Reasons

I have Google Fonts blocked (mostly for performance reasons), which leads to the docs falling back to a serif font.