### PR TITLE
Update runner docs

### DIFF
--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -53,7 +53,7 @@ Currently, the runner officially supports the following platforms:
 * Arm64 + Ubuntu
 * Intel + macOS
 
-Additional platforms have been tested but are not yet officially supported by the runner. For more information on platforms that have been tested, but are not supported, and platforms that have not been tested, please refer to the <<runner-installation#,Runner Installation>> page.
+Additional platforms have been tested but are not yet officially supported by the runner. For more information on platforms that have been tested, but are not supported, and platforms that have not been tested, please refer to the <<runner-installation#,Runner Installation>> page. Given the active development of CircleCI Runner, please link:https://circleci.com/contact/[contact us] if you have questions around support for your use-case(s). We also invite you to contribute to our link:https://discuss.circleci.com/t/self-hosted-runners-are-here/38159[runner discuss page] to help prioritize development efforts from our team!
 
 The following features are not yet available, but may be in the future:
 

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -9,7 +9,7 @@ version:
 :toc: macro
 :toc-title:
 
-NOTE: The CircleCI runner is currently only available if you are on the https://circleci.com/pricing[Scale Plan]. Please reach out to your sales representative for information on how to sign up for the Scale Plan.
+NOTE: The CircleCI runner is currently only available if you are on the https://circleci.com/pricing[Scale Plan]. Please reach out to your sales representative for information on how to sign up for the Scale Plan or to learn more.
 
 toc::[]
 

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -53,7 +53,7 @@ Currently, the runner officially supports the following platforms:
 * Arm64 + Ubuntu
 * Intel + macOS
 
-Additional platforms have been tested but are not yet officially supported by the runner. For more information on platforms that have been tested, but are not supported, and platforms that have not been tested, please refer to the <<runner-installation#,Runner Installation>> page. Given the active development of CircleCI Runner, please link:https://circleci.com/contact/[contact us] if you have questions around support for your use-case(s). We also invite you to contribute to our link:https://discuss.circleci.com/t/self-hosted-runners-are-here/38159[runner discuss page] to help prioritize development efforts from our team!
+Additional platforms have been tested but are not yet officially supported by the runner. For more information on platforms that have been tested, but are not supported, and platforms that have not been tested, please refer to the <<runner-installation#,Runner Installation>> page. Given the active development of CircleCI Runner, please link:https://circleci.com/contact/[contact us] if you have questions around support for your use-case(s). We also invite you to https://circleci.canny.io/cloud-feature-requests[share feedback] and contribute to our link:https://discuss.circleci.com/t/self-hosted-runners-are-here/38159[runner discuss page] to help prioritize development efforts from our team!
 
 The following features are not yet available, but may be in the future:
 


### PR DESCRIPTION
This adds some clarification on steps customers can take if we don't currently support their runner use case.