### PR TITLE
Deploy preview

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
     parameters:
       dir:
         description: |
-          The directory relative to the root of the repo to run bundle for. 
+          The directory relative to the root of the repo to run bundle for.
           Leave empty for root directory.
         type: string
         default: ""
@@ -46,18 +46,28 @@ commands:
           key: circleci-docs-v1-{{ .Branch }}-<< parameters.dir >>-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install Ruby dependencies
-          command: 
+          command:
             |
             if [[ "<< parameters.dir >>" != "" ]]; then
               cd << parameters.dir >>
-            fi 
+            fi
             bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
       - save_cache:
           key: circleci-docs-v1-{{ .Branch }}-<< parameters.dir >>-{{ checksum "Gemfile.lock" }}
           paths:
             - "vendor/bundle"
             - "<< parameters.dir >>/vendor/bundle"
-
+  set-jekyll-basename:
+    description: Set JEKYLL_BASENAME env var and persist in $BASH_ENV
+    steps:
+      - run:
+          name: Populate JEKYLL_BASENAME env var
+          command: |
+            if [ ${CIRCLE_BRANCH} = master -o ${CIRCLE_BRANCH} = main ]; then
+              echo "export JEKYLL_BASENAME=docs" >> $BASH_ENV;
+            else
+              echo "export JEKYLL_BASENAME=${CIRCLE_BRANCH}" >> $BASH_ENV;
+            fi
 
 # Workflows orchestrate a set of jobs to be run;
 # the jobs for this pipeline are # configured below
@@ -86,13 +96,18 @@ workflows:
           filters:
             branches:
               only: master
+      - deploy-preview:
+          requires:
+            - build
+          filters:
+            branches:
+              only: /.*-preview/
       - deploy:
           requires:
             - build
           filters:
             branches:
               only: master
-
   # We run a nightly build for running build/maintenance tasks
   # such as pulling in docker image tags or automating our api documentation
   nightly-build:
@@ -157,7 +172,7 @@ jobs:
       - run:
           name: Build PDFs for Server
           command: ./scripts/build_pdfs_asciidoc.sh
-      - store_artifacts: 
+      - store_artifacts:
           path: release/tmp/
 
   build_config_builder: # this job runs the src-config-builder build process and moves the output into jekyll.
@@ -292,35 +307,44 @@ jobs:
             mkdir -p /tmp/workspace/config-builder
             mkdir -p jekyll/config-builder
             cp -R /tmp/workspace/config-builder/* jekyll/config-builder/
-            
+
             mkdir -p /tmp/workspace/crg
             mkdir -p jekyll/reference-2-1
             cp -R /tmp/workspace/crg/* jekyll/reference-2-1/
-            
+
             mkdir -p /tmp/workspace/pdfs
             cp -r /tmp/workspace/api/* jekyll/_api/
       - run: sudo apt-get update; sudo apt-get --yes install nkf
       - run:
           name: Shim untranslated Japanese pages
           command: ./scripts/shim-translation.sh jekyll/_cci2 jekyll/_cci2_ja
+      - set-jekyll-basename
+      - run:
+          name: Create jekyll config file to override things
+          command: |
+            echo "baseurl: \"/${JEKYLL_BASENAME}\"" > jekyll/_config_override.yml
       - run:
           name: Build the Jekyll site
-          command: bundle exec jekyll build --config jekyll/_config.yml,jekyll/_config_production.yml --source jekyll --destination jekyll/_site/docs/ 2>&1 | tee $JOB_RESULTS_PATH/build-results.txt
+          command: bundle exec jekyll build --config jekyll/_config.yml,jekyll/_config_production.yml,jekyll/_config_override.yml --source jekyll --destination jekyll/_site/${JEKYLL_BASENAME} 2>&1 | tee $JOB_RESULTS_PATH/build-results.txt
+      - run:
+          name: Workaround to pass htmlproofer for docs where baseurl (/docs) is hardcoded
+          command: ln -s ./${JEKYLL_BASENAME} jekyll/_site/docs
       ### NOTE: we are ignore some files in the HTML proofer as it fails on pending translated docs.
       - run:
-          name: Test with HTMLproofer
-          command: bundle exec htmlproofer jekyll/_site --allow-hash-href --check-favicon --check-html --disable-external --file-ignore "jekyll/_site/docs/api/v2/index.html,docs/api/v2/,/docs/ja/2.0/runner-installation/,/docs/ja/2.0/security-server/,/docs/ja/2.0/v.2.19-overview/,/docs/ja/2.0/customizations/,/docs/ja/2.0/aws-prereq/,/docs/ja/2.0/ops/,/docs/ja/2.0/about-circleci/,/docs/ja/2.0/demo-apps/,/docs/ja/2.0/google-auth/,/docs/ja/2.0/orb-concepts/,/docs/ja/2.0/tutorials/,/docs/reference-2-1/" --empty-alt-ignore 2>&1 | nkf -w --url-input | tee $JOB_RESULTS_PATH/htmlproofer-results.txt
+          namek: Test with HTMLproofer
+          command: |
+            bundle exec htmlproofer jekyll/_site --allow-hash-href --check-favicon --check-html --disable-external --file-ignore "jekyll/_site/${JEKYLL_BASENAME}/api/v2/index.html,${JEKYLL_BASENAME}/api/v2/,/${JEKYLL_BASENAME}/ja/2.0/runner-installation/,/${JEKYLL_BASENAME}/ja/2.0/security-server/,/${JEKYLL_BASENAME}/ja/2.0/v.2.19-overview/,/${JEKYLL_BASENAME}/ja/2.0/customizations/,/${JEKYLL_BASENAME}/ja/2.0/aws-prereq/,/${JEKYLL_BASENAME}/ja/2.0/ops/,/${JEKYLL_BASENAME}/ja/2.0/about-circleci/,/${JEKYLL_BASENAME}/ja/2.0/demo-apps/,/${JEKYLL_BASENAME}/ja/2.0/google-auth/,/${JEKYLL_BASENAME}/ja/2.0/orb-concepts/,/${JEKYLL_BASENAME}/ja/2.0/tutorials/,/${JEKYLL_BASENAME}/reference-2-1/" --empty-alt-ignore 2>&1 | nkf -w --url-input | tee $JOB_RESULTS_PATH/htmlproofer-results.txt
 
       - store_artifacts: # stores the built files of the Jekyll site
-          path: jekyll/_site/docs/
+          path: jekyll/_site/
           destination: circleci-docs
       - store_artifacts: # stores build log output.
           path: run-results/
           destination: run-results
       - persist_to_workspace:
-          root: ~/circleci-docs/jekyll/_site
+          root: ~/circleci-docs/jekyll/
           paths:
-            - docs
+            - _site/*
 
   reindex-search:
     executor:
@@ -347,7 +371,21 @@ jobs:
     steps:
       - attach_workspace:
           at: ./generated-site
+      - set-jekyll-basename
       - run:
           name: Deploy to S3 if tests pass and branch is Master
-          command: aws s3 sync generated-site/docs s3://circle-production-static-site/docs/ --delete
+          command: aws s3 sync generated-site/_site/${JEKYLL_BASENAME} s3://circle-production-static-site/${JEKYLL_BASENAME}/ --delete
 
+  deploy-preview:
+    docker:
+      - image: cibuilds/aws:1.16.185
+    steps:
+      - attach_workspace:
+          at: ./generated-site
+      - set-jekyll-basename
+      - run:
+          name: Deploy preview version
+          command: aws s3 sync generated-site/_site/${JEKYLL_BASENAME} s3://circleci-doc-preview/${JEKYLL_BASENAME}/ --delete
+      - run:
+          name: Preview deployment URL
+          command: echo "Preview is deployed at http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/${JEKYLL_BASENAME}"

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -62,7 +62,7 @@ asciidoctor:
   attributes:
     imagesdir: /docs/assets/img/docs/
     relfileprefix: ../
-    outfilesuffix: /index.html 
+    outfilesuffix: /index.html
     serverversion: 2.19.10
 
 collections:


### PR DESCRIPTION
Best reviewed by https://github.com/circleci/circleci-docs/pull/4997/files?w=1

# Description
This change allows us to automatically deploy docs that passed tests to a non-production s3 bucket.

# Reasons

To deploy from multiple branches at the same time so that they don't override each other, we need to have different `baseurl` instead of canonical "docs" baseurl.

e,g, http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/deploy-preview

This is mostly achieved by creating `_config_override.yml` with some CircleCI config tweaks.

If this approach looks, good, we can set lifecycle management for preview s3 bucket so that stale preview deployment can be automatically deleted.