### PR TITLE
Clean: simplify config-intro example

### DIFF
--- a/jekyll/_cci2/config-intro.md
+++ b/jekyll/_cci2/config-intro.md
@@ -36,9 +36,6 @@ jobs:
   build:
     docker:
       - image: alpine:3.7
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: The First Step

--- a/jekyll/_cci2/config-intro.md
+++ b/jekyll/_cci2/config-intro.md
@@ -73,9 +73,6 @@ jobs:
   build:
     docker:
       - image: alpine:3.7
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - run:
@@ -112,9 +109,6 @@ jobs:
     # pre-built images: https://circleci.com/docs/2.0/circleci-images/
     docker:
       - image: circleci/node:10-browsers
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - run:
@@ -159,9 +153,6 @@ jobs:
   Hello-World:
     docker:
       - image: alpine:3.7
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: Hello World
@@ -171,9 +162,6 @@ jobs:
   I-Have-Code:
     docker:
       - image: alpine:3.7
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - run:
@@ -184,9 +172,6 @@ jobs:
   Run-With-Node:
     docker:
       - image: circleci/node:10-browsers
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: Running In A Container With Node
@@ -195,9 +180,6 @@ jobs:
   Now-Complete:
     docker:
       - image: alpine:3.7
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: Approval Complete


### PR DESCRIPTION
Docker auth is not required except for in specific rate-limiting examples/private images; the examples in this introductory document should be simple and minimal. A recent PR that made note of optional docker image authentication misaligns the line numbers in code samples with the prose text.

Fixes #4996

