### PR TITLE
Remove outdated range cron syntax limitation.

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -276,7 +276,7 @@ A valid `schedule` requires a `cron` key and a `filters` key.
 The value of the `cron` key must be a [valid crontab entry](https://crontab.guru/).
 
 **Note:**
-Cron step syntax (for example, `*/1`, `*/20`) is **not** supported. Range elements within comma-separated lists of elements are also **not** supported. 
+Cron step syntax (for example, `*/1`, `*/20`) is **not** supported.
 
 The value of the `filters` key must be a map that defines rules for execution on specific branches.
 


### PR DESCRIPTION
# Description
Remove sentence `Range elements within comma-separated lists of elements are also **not** supported.`
I believe this is no longer true.

# Reasons
We use such syntax without any issues.