### PR TITLE
Fix line number references

### DIFF
--- a/jekyll/_cci2/config-intro.md
+++ b/jekyll/_cci2/config-intro.md
@@ -56,9 +56,9 @@ The CircleCI config syntax is very straight forward.  The trickiest part is typi
 
 - Line 1: This indicates the version of the CircleCI platform you are using. `2.1` is the most recent version.
 - Line 2-3: The `jobs` level contains a collection of arbitrarily named children.  `build` is the first named child in the `jobs` collection.  In this case `build` is also the only job.
-- Line 6-7: The `steps` collection is an ordered list of `run` directives.  Each `run` directive is executed in the order in which it was declared.
-- Line 8: The `name` attribute provides useful organizational information when returning warnings, errors, and output.  The `name` should be meaningful to you as an action within your build process
-- Line 9-11: This is the magic.  The `command` attribute is a list of shell commands that represent the work you want done.  The initial pipe, `|`, indicates that there will be more than one line of shell commands.  Here line 10 will print out `Hello World!` in your build shell and line 11 will print out `This is the delivery pipeline`
+- Line 9-10: The `steps` collection is an ordered list of `run` directives.  Each `run` directive is executed in the order in which it was declared.
+- Line 11: The `name` attribute provides useful organizational information when returning warnings, errors, and output.  The `name` should be meaningful to you as an action within your build process
+- Line 12-14: This is the magic.  The `command` attribute is a list of shell commands that represent the work you want done.  The initial pipe, `|`, indicates that there will be more than one line of shell commands.  Here line 13 will print out `Hello World!` in your build shell and line 14 will print out `This is the delivery pipeline`
 
 ## Part two: Info and preparing to build
 That was nice but let’s get real.  Delivery graphs start with code.  In this example we will add a few lines that will get your code and then list it.  We will also do this in a second run.
@@ -97,15 +97,15 @@ jobs:
 {:.no_toc}
 Although we’ve only made two small changes to the config, these represent significant organizational concepts.
 
-- Line 7: The `checkout` command is an example of a built-in reserved word that contextualizes your job.  In this case, it is pulling down your code so you can start a build.
-- Line 13-17: The second run on the `build` job is listing (through `ls -al`) the contents of the checkout.  Your branch is now available for you to interact with.
+- Line 10: The `checkout` command is an example of a built-in reserved word that contextualizes your job.  In this case, it is pulling down your code so you can start a build.
+- Line 16-20: The second run on the `build` job is listing (through `ls -al`) the contents of the checkout.  Your branch is now available for you to interact with.
 
 ## Part three: That’s nice but I need...
 Every code base and project is different.  That’s okay.  We like diversity.  This is one of the reasons we allow you to run in your machine or docker container of choice.  In this case we will demonstrate running in a container with node available.  Other examples might include macOS machines, java containers, or even GPU.
 
 1. This section expands on Part One and Two.  If you haven’t already, go through at least Part One to ensure you have a working `config.yml` file in your branch.
 
-2. This is a very simple and yet amazingly powerful change.  We are going to add a reference to a docker image for the build job.
+2. This is a very simple and yet amazingly powerful change.  We are going to change the docker image for the build job.
 
 
 {% highlight yaml linenos %}
@@ -145,7 +145,7 @@ The above two changes to the config significantly affect how you get work done. 
 
 - Line 4: Here we see a comment in-line in yml.  Like any other unit of code, comments are a useful tool as config gets complicated.
 - Line 5-6: These lines indicate that docker image to use for the job.  Because you can have more than one job in your config (as we will see next) you can also run different parts of your config in different environments.  For example, you could perform a build job in a thin java container and then perform a test job using a container with browsers pre-installed. In this case, it uses  a [pre-built container from CircleCI]({{ site.baseurl }}/2.0/circleci-images/) that already has a browser and other useful tools built in.  
-- Line 19-22: These lines add a run step that returns the version of node available in the container. Try experimenting with different containers from CircleCI’s pre-built convenience images or even public containers from Docker hub.
+- Line 22-25: These lines add a run step that returns the version of node available in the container. Try experimenting with different containers from CircleCI’s pre-built convenience images or even public containers from Docker hub.
 
 ## Part four: Approved to start
 So far so good?  Let’s spend a moment on orchestration.  In this example, we will spend more time doing analysis than step-by-step modification.
@@ -235,11 +235,11 @@ workflows:
 We now know how to create a workflow including a manual gate that you can use to protect promotion of expensive interactions.
 
 - Line 3: The command that echo’s `Hello World!` has been turned in a full fledged job with the name Hello-World
-- Line 12: The commands to get code are now in a job named `I-Have-Code`
-- Line 22: The Node example using the CircleCI pre-built image is now called `Run-With-Node`
-- Line 30: There is an additional job that operates similarly to `Hello-World` but it won’t run until the approval is complete - see line 57 in the workflow stanza.
-- Line 39-57: The config now has a workflow.  In the prior examples the CircleCI engine interpreted the config as having had a single-job workflow.  Here we are staying clear and spelling out the workflow we want to execute. This workflow demonstrates several useful capabilities. The `requires` statement represents a list of prior jobs that must complete successfully prior to the job in question starting.  In this example, both `I-Have-Code` and `Run-With-Node` must complete before `Hold-For-Approval` becomes active.  In addition, both `I-Have-Code` and `Run-With-Node` are dependent on `Hello-World` but not on each other. This means that those two jobs will run concurrently as soon as `Hello-World` is complete.  This is useful if you have multiple jobs that are not directly dependent on one another and you want to improve wall-clock time.
-- Line 50-51: Most of the jobs are generic.  However, this job has a type.  In this case the type is `approval` and requires a person through the CircleCI API or UI to take an action for the build to complete. Interleaving approval jobs allows you to create gates that must be approved or managed prior to downstream jobs executing.
+- Line 15: The commands to get code are now in a job named `I-Have-Code`
+- Line 28: The Node example using the CircleCI pre-built image is now called `Run-With-Node`
+- Line 39: There is an additional job that operates similarly to `Hello-World` but it won’t run until the approval is complete - see line 67 in the workflow stanza.
+- Line 51-69: The config now has a workflow.  In the prior examples the CircleCI engine interpreted the config as having had a single-job workflow.  Here we are staying clear and spelling out the workflow we want to execute. This workflow demonstrates several useful capabilities. The `requires` statement represents a list of prior jobs that must complete successfully prior to the job in question starting.  In this example, both `I-Have-Code` and `Run-With-Node` must complete before `Hold-For-Approval` becomes active.  In addition, both `I-Have-Code` and `Run-With-Node` are dependent on `Hello-World` but not on each other. This means that those two jobs will run concurrently as soon as `Hello-World` is complete.  This is useful if you have multiple jobs that are not directly dependent on one another and you want to improve wall-clock time.
+- Line 62-63: Most of the jobs are generic.  However, this job has a type.  In this case the type is `approval` and requires a person through the CircleCI API or UI to take an action for the build to complete. Interleaving approval jobs allows you to create gates that must be approved or managed prior to downstream jobs executing.
 
 
 The examples above were designed to provide a quick starter to the areas of functionality available through CircleCI config.  There remains a lot more.  Take a look at the rest of the documentation.  You will find that scheduled jobs, workspaces, artifacts, and more are all simple variations on the concepts you’ve learned here.  Now go forth and automate your CI/CD world!


### PR DESCRIPTION
# Description
Fix line number references to examples.

# Reasons
Changes to config (e.g., adding docker container and auth) has brought
the references to line number out of sync.

Fixes #4996 
