### PR TITLE
Changed 'and' to 'on' for Ruby on Rails

### DIFF
--- a/jekyll/_cci2/demo-apps.md
+++ b/jekyll/_cci2/demo-apps.md
@@ -23,7 +23,7 @@ Code that builds on Linux or iOS will generally build on CircleCI 2.0. We’ve c
 - PHP (PHP 5 and later)
 - Python (Python 2 and later)
 - React Native
-- Ruby and Rails (Ruby 2 and later)
+- Ruby on Rails (Ruby 2 and later)
 - Scala and sbt
 
 Build projects in C, C#, C++, Clojure, Elixir, Erlang, Go, Groovy, Haskell, Haxe, Java, JavaScript, Node.js, Perl, PHP, Python, Ruby, Rust, Scala and many more.


### PR DESCRIPTION
# Description
Updated the language 'Ruby and Rails' to 'Ruby on Rails'.

# Additional ask
I could not make this change on the language-guides.md - can you make this update?  Thanks!

# Reasons
It should be called Ruby and Rails, not Ruby on Rails.