### PR TITLE
Delete symlink workaround once htmlproof passes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,6 +335,9 @@ jobs:
           command: |
             bundle exec htmlproofer jekyll/_site --allow-hash-href --check-favicon --check-html --disable-external --file-ignore "jekyll/_site/${JEKYLL_BASENAME}/api/v2/index.html,${JEKYLL_BASENAME}/api/v2/,/${JEKYLL_BASENAME}/ja/2.0/runner-installation/,/${JEKYLL_BASENAME}/ja/2.0/security-server/,/${JEKYLL_BASENAME}/ja/2.0/v.2.19-overview/,/${JEKYLL_BASENAME}/ja/2.0/customizations/,/${JEKYLL_BASENAME}/ja/2.0/aws-prereq/,/${JEKYLL_BASENAME}/ja/2.0/ops/,/${JEKYLL_BASENAME}/ja/2.0/about-circleci/,/${JEKYLL_BASENAME}/ja/2.0/demo-apps/,/${JEKYLL_BASENAME}/ja/2.0/google-auth/,/${JEKYLL_BASENAME}/ja/2.0/orb-concepts/,/${JEKYLL_BASENAME}/ja/2.0/tutorials/,/${JEKYLL_BASENAME}/reference-2-1/" --empty-alt-ignore 2>&1 | nkf -w --url-input | tee $JOB_RESULTS_PATH/htmlproofer-results.txt
 
+      - run:
+          name: Delete symlink workaround
+          command: rm jekyll/_site/docs
       - store_artifacts: # stores the built files of the Jekyll site
           path: jekyll/_site/
           destination: circleci-docs


### PR DESCRIPTION
The existence of symlink made `aws s3 sync` to fail in deploy job https://app.circleci.com/pipelines/github/circleci/circleci-docs/26932/workflows/0dea04d6-07e6-474f-b4cc-d1bc5497bef3/jobs/73385