### PR TITLE
Only create symlink when jekyll base is not docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,16 +328,16 @@ jobs:
           command: bundle exec jekyll build --config jekyll/_config.yml,jekyll/_config_production.yml,jekyll/_config_override.yml --source jekyll --destination jekyll/_site/${JEKYLL_BASENAME} 2>&1 | tee $JOB_RESULTS_PATH/build-results.txt
       - run:
           name: Workaround to pass htmlproofer for docs where baseurl (/docs) is hardcoded
-          command: ln -s ./${JEKYLL_BASENAME} jekyll/_site/docs
+          command: |
+            if [ ! ${JEKYLL_BASENAME} = "docs" ]; then
+              cd jekyll/_site
+              ln -s ${JEKYLL_BASENAME} docs
+            fi
       ### NOTE: we are ignore some files in the HTML proofer as it fails on pending translated docs.
       - run:
           namek: Test with HTMLproofer
           command: |
             bundle exec htmlproofer jekyll/_site --allow-hash-href --check-favicon --check-html --disable-external --file-ignore "jekyll/_site/${JEKYLL_BASENAME}/api/v2/index.html,${JEKYLL_BASENAME}/api/v2/,/${JEKYLL_BASENAME}/ja/2.0/runner-installation/,/${JEKYLL_BASENAME}/ja/2.0/security-server/,/${JEKYLL_BASENAME}/ja/2.0/v.2.19-overview/,/${JEKYLL_BASENAME}/ja/2.0/customizations/,/${JEKYLL_BASENAME}/ja/2.0/aws-prereq/,/${JEKYLL_BASENAME}/ja/2.0/ops/,/${JEKYLL_BASENAME}/ja/2.0/about-circleci/,/${JEKYLL_BASENAME}/ja/2.0/demo-apps/,/${JEKYLL_BASENAME}/ja/2.0/google-auth/,/${JEKYLL_BASENAME}/ja/2.0/orb-concepts/,/${JEKYLL_BASENAME}/ja/2.0/tutorials/,/${JEKYLL_BASENAME}/reference-2-1/" --empty-alt-ignore 2>&1 | nkf -w --url-input | tee $JOB_RESULTS_PATH/htmlproofer-results.txt
-
-      - run:
-          name: Delete symlink workaround
-          command: rm jekyll/_site/docs
       - store_artifacts: # stores the built files of the Jekyll site
           path: jekyll/_site/
           destination: circleci-docs


### PR DESCRIPTION
# Description

Slightly simplifying the build process by only creating symbolic link when `${JEKYLL_BASENAME}` is not `docs`.  Removing symbolic link is not needed because it won't create symbolic loop since it always be linked to something that's not `docs`.