### PR TITLE
Remove need to eval for variable expansion

### DIFF
--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -776,7 +776,6 @@ jobs:
           name: Build iperf3
           working_directory: iperf
           command: |
-            CIRCLE_WORKING_DIRECTORY=$(eval "echo $CIRCLE_WORKING_DIRECTORY")
             IPERF3_MAKE_PREFIX=$CIRCLE_WORKING_DIRECTORY/<< parameters.label >>
             ./configure --prefix=$IPERF3_MAKE_PREFIX << pipeline.parameters.common-build-params >>
             make


### PR DESCRIPTION
I'm working on a build-agent change that will remove this need.

# Description

`CIRCLE_WORKING_DIRECTORY` was set as a pure string, so any variable expansion on the envvars does not take place, e.g.

```
circleci@default-314602d9-7782-4a60-9048-17ff8feba347:/$ echo $CIRCLE_WORKING_DIRECTORY
~/project
circleci@default-314602d9-7782-4a60-9048-17ff8feba347:/$ cd $CIRCLE_WORKING_DIRECTORY
-bash: cd: ~/project: No such file or directory
```

As stated in some docs examples, https://circleci.com/docs/2.0/sample-config/#sample-configuration-with-multiple-executor-types, it's suggested you do `eval cd $CIRCLE_WORKING_DIRECTORY`, however, this is not very straightforward or expected from a new user's perspective. 

The intended fix evaluates `~` to `$HOME` and evaluates any envvar before being set. 

The newly included sample config demonstrates success with these changes. Using this config without these changes would result in a failure.

# Reasons
Build-agent change