### PR TITLE
[CIRCLE-31447] Add Convenience Images to search

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -21,6 +21,7 @@ algolia:
   api_key: dd49f5b81d238d474b49645a4daed322 # search-only API Key; safe for front-end code
   index_name: documentation
   index_name_orbs: orbs-prod
+  index_name_cimgs: images_prod
   extensions_to_index:
     - html
     - md

--- a/jekyll/_includes/js-config.html
+++ b/jekyll/_includes/js-config.html
@@ -4,10 +4,14 @@
       appId:     {{ site.algolia.application_id | jsonify }},
       apiKey:    {{ site.algolia.api_key | jsonify }},
       indexName: {{ site.algolia.index_name | jsonify }},
-      indexNameOrbs: {{ site.algolia.index_name_orbs | jsonify }}
+      indexNameOrbs: {{ site.algolia.index_name_orbs | jsonify }},
+      indexNameCimgs: {{ site.algolia.index_name_cimgs | jsonify }}
     },
     page: {
       lang: {{ page.lang | jsonify }}
+    },
+    url: {
+      devhub: {{ site.devhub_base_url | jsonify }}
     }
   }
 </script>

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -27,6 +27,11 @@
 										Orbs <span class="hits-count">(<span class="hits-count-orbs">0</span>)</span>
 									</a>
 								</li>
+								<li data-value="search-results-cimgs" data-subnav-item>
+									<a href="#search-results-cimgs">
+										Convenience Images <span class="hits-count">(<span class="hits-count-cimgs">0</span>)</span>
+									</a>
+								</li>
 							</ul>
 						</div>
 					</div>
@@ -36,6 +41,9 @@
 
 					<a id="search-results-orbs" class="deep-link-anchor subnav-offset anchor"></a>
 					<div id="instant-hits-orbs"></div>
+
+					<a id="search-results-cimgs" class="deep-link-anchor subnav-offset anchor"></a>
+					<div id="instant-hits-cimgs"></div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
# Description

Adds Convenience Image search, following the pattern established for Orbs Registry search. Includes config necessary to generate i18n Dev Hub URLs from image names.