### PR TITLE
[CIRCLE-31743] Add tip to use us-east-1 ECR

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -30,7 +30,7 @@ An *executor type* defines the underlying technology or environment in which to 
 
 It is possible to specify a different executor type for every job in your ['.circleci/config.yml']({{ site.baseurl }}/2.0/configuration-reference/) by specifying the executor type and an appropriate image. An *image* is a packaged system that has the instructions for creating a running environment.  A *container* or *virtual machine* is the term used for a running instance of an image. For example, you could specify an executor type and an image for every job:
 
-- Jobs that require Docker images (`docker`) may use an image for Node.js or Python. The [pre-built CircleCI Docker image]({{ site.baseurl }}/2.0/circleci-images/) from the CircleCI Dockerhub will help you get started quickly without learning all about Docker. These images are not a full operating system, so they will generally make building your software more efficient. 
+- Jobs that require Docker images (`docker`) may use an image for Node.js or Python. The [pre-built CircleCI Docker image]({{ site.baseurl }}/2.0/circleci-images/) from the CircleCI Dockerhub will help you get started quickly without learning all about Docker. These images are not a full operating system, so they will generally make building your software more efficient.
 - Jobs that require a complete Linux virtual machine (VM) image (`machine`) may use an Ubuntu version such as 16.04.
 - Jobs that require a macOS VM image (`macos`) may use an Xcode version such as 10.0.0.
 
@@ -56,9 +56,11 @@ In this example, all steps run in the container created by the first image liste
 
 - CircleCI has partnered with Docker to ensure that our users can continue to access Docker Hub without rate limits. As of November 1st 2020, with few exceptions, you should not be impacted by any rate limits when pulling images from Docker Hub through CircleCI. However, these rate limits may go into effect for CircleCI users in the future. That’s why we’re encouraging you and your team to [add Docker Hub authentication]({{ site.baseurl }}/2.0/private-images/) to your CircleCI configuration and consider upgrading your Docker Hub plan, as appropriate, to prevent any impact from rate limits in the future.
 
-- Avoid using mutable tags like `latest` or `1` as the image version in your `config.yml file`. It is best practice to use precise image versions or digests, like `redis:3.2.7` or `redis@sha256:95f0c9434f37db0a4f...` as shown in the examples. Mutable tags often lead to unexpected changes in your job environment.  CircleCI cannot guarantee that mutable tags will return an up-to-date version of an image. You could specify `alpine:latest` and actually get a stale cache from a month ago. 
+- Avoid using mutable tags like `latest` or `1` as the image version in your `config.yml file`. It is best practice to use precise image versions or digests, like `redis:3.2.7` or `redis@sha256:95f0c9434f37db0a4f...` as shown in the examples. Mutable tags often lead to unexpected changes in your job environment.  CircleCI cannot guarantee that mutable tags will return an up-to-date version of an image. You could specify `alpine:latest` and actually get a stale cache from a month ago.
 
-- If you experience increases in your run times due to installing additional tools during execution, it is best practice to use the [Building Custom Docker Images Documentation]({{ site.baseurl }}/2.0/custom-images/) to create a custom image with tools that are pre-loaded in the container to meet the job requirements. 
+- If you experience increases in your run times due to installing additional tools during execution, it is best practice to use the [Building Custom Docker Images Documentation]({{ site.baseurl }}/2.0/custom-images/) to create a custom image with tools that are pre-loaded in the container to meet the job requirements.
+
+- When you use [AWS ECR]({{ site.baseurl }}/2.0/private-images/#aws-ecr) images, it is best practice to use `us-east-1` region. Our job execution infrastructure is in `us-east-1` region, so having your image on the same region reduces the image download time.
 
 More details on the Docker Executor are available in the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/) document.
 
@@ -71,7 +73,7 @@ jobs:
     docker:
     # Primary container image where all steps run.
      - image: buildpack-deps:trusty
-    # Secondary container image on common network. 
+    # Secondary container image on common network.
      - image: mongo:2.6.8-jessie
        command: [mongod, --smallfiles]
 
@@ -131,7 +133,7 @@ jobs:
 
 ### Docker benefits and limitations
 Docker also has built-in image caching and enables you to build, run, and publish Docker images via [Remote Docker][building-docker-images]. Consider the requirements of your application as well. If the following are true for your application, Docker may be the right choice:
- 
+
 - Your application is self-sufficient
 - Your application requires additional services to be tested
 - Your application is distributed as a Docker Image (requires using [Remote Docker][building-docker-images])
@@ -248,7 +250,7 @@ jobs:
   build:
     macos:
       xcode: 11.3.0
-      
+
     steps:
       # Commands will execute in macOS container
       # with Xcode 11.3 installed
@@ -257,7 +259,7 @@ jobs:
 
 ## Using the Windows executor
 
-Using the `windows` executor allows you to run your job in a Windows environment. The following is an example configuration that will run a simple Windows job. The syntax for using the Windows executor in your config differs depending on whether you are using: 
+Using the `windows` executor allows you to run your job in a Windows environment. The following is an example configuration that will run a simple Windows job. The syntax for using the Windows executor in your config differs depending on whether you are using:
 * CircleCI Cloud – config version 2.1.
 * Self-hosted installation of CircleCI Server with config version 2.0 – this option is an instance of using the `machine` executor with a Windows image – _Introduced in CircleCI Server v2.18.3_.
 
@@ -308,7 +310,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      resource_class: gpu.nvidia.small 
+      resource_class: gpu.nvidia.small
       image: ubuntu-1604-cuda-10.1:201909-23
     steps:
       - run: nvidia-smi

--- a/jekyll/_cci2/private-images.md
+++ b/jekyll/_cci2/private-images.md
@@ -108,7 +108,13 @@ jobs:
 
 ### AWS ECR
 
-CircleCI now supports pulling private images from Amazon's ECR service. You can start using private images from ECR in one of two ways:
+CircleCI now supports pulling private images from Amazon's ECR service.
+
+<div class="alert alert-info" role="alert">
+<b>Tip:</b> You can pull your private images from ECR repositories in any regions. However, for the best experience, we strongly recommend to make a copy of your image in <code class="highlighter-rouge">us-east-1</code> region, and specify that <code class="highlighter-rouge">us-east-1</code> image for Docker executor. Our job execution infrastructure is in <code class="highlighter-rouge">us-east-1</code> region so using <code class="highlighter-rouge">us-east-1</code> images makes the <code class="highlighter-rouge"> Spin Up Environement</code> step faster.
+</div>
+
+You can start using private images from ECR in one of two ways:
 
 1. Set your AWS credentials using standard CircleCI private environment variables.
 2. Specify your AWS credentials in `.circleci/config.yml` using `aws_auth`:


### PR DESCRIPTION
# Description
We identified that image pulling from non us-east-1 ECR repositories is significantly slower than pulling from us-east-1 ECR repositories.
Adding a tip to encourage people to use us-east-1 ECR when using ECR image for Docker executor.

# Reasons
https://circleci.atlassian.net/browse/CIRCLE-31743

