### PR TITLE
Correct path to modules folder in Yarn 1 example

### DIFF
--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -68,7 +68,7 @@ An example for Yarn 1.x:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn
+            - ./node_modules
 #...
 ```
 {% endraw %}


### PR DESCRIPTION
# Description
Correct the path to the modules folder in the Yarn 1.x caching example.

# Reasons
The current suggested path to cache in the Yarn 1.x example actually points to the Yarn 2 install cache folder, making this a rather misleading example. Yarn 1.x creates a project level `node_modules` folder when installing, in the same way as NPM does. The path `./node_modules` is much more likely to point to the correct folder.