### PR TITLE
Update redirect link on /docs/ja/2.0/language-ruby/

### DIFF
--- a/jekyll/_cci2_ja/language-ruby.md
+++ b/jekyll/_cci2_ja/language-ruby.md
@@ -27,7 +27,7 @@ CircleCI は、以下のページで Ruby on Rails サンプル プロジェク�
 
 このアプリケーションでは、最新の安定した Rails バージョン 5.1 (`rspec-rails`)、[RspecJunitFormatter](https://github.com/sj26/rspec_junit_formatter)、および PostgreSQL データベースを使用しています。
 
-このアプリケーションのビルドには、ビルド済み [CircleCI Docker イメージ]({{ site.baseurl}}/ja/2.0/circleci-images)の 1 つを使用しています。
+このアプリケーションのビルドには、ビルド済み [CircleCI Docker イメージ]({{ site.baseurl}}/ja/2.0/circleci-images/)の 1 つを使用しています。
 
 ## CircleCI のビルド済み Docker イメージ
 


### PR DESCRIPTION
# Description
Update link from https://circleci.com/docs/ja/2.0/circleci-images to https://circleci.com/docs/ja/2.0/circleci-images/ on https://circleci.com/docs/ja/2.0/language-ruby/. Will no longer create a redirect chain.
# Reasons
Part of Q4 SEO audit fixing a redirect chain.