### PR TITLE
Update reusing-config.md

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -32,27 +32,28 @@ In the following example, a command named `greeting` is designed with a single p
 ```yaml
 version: 2.1
 commands: # a reusable command with parameters
-   greeting:
-      parameters:
-         to:
-           default: "world"
-           type: string
-      steps:
-         - run: echo "Hello <<parameters.to>>"
+  greeting:
+    parameters:
+      to:
+        default: "world"
+        type: string
+    steps:
+      - run: echo "Hello <<parameters.to>>"
 jobs:
-   my-job:
-      docker:
-         - image: cimg/base:stable
-           auth:
-             username: mydockerhub-user
-             password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-      steps:
-         - greeting:
-            to: "My-Name"
+  my-job:
+    docker:
+      - image: cimg/base:stable
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+    steps:
+      - greeting:
+          to: "My-Name"
 workflows:
-   my-workflow:
-      jobs:
-         - my-job        
+  my-workflow:
+    jobs:
+      - my-job        
+               
          
 ```
 


### PR DESCRIPTION
customer pointed out that yaml has 2 spaces. Previous Yaml is valid but updated version is "correct".

# Description
Edited the YAML example in "Using the parameters declaration" section. Fixed indentation to be 2 spaces. 

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
To be "correct" according to YAML rules. The previous YAML was valid. 