### PR TITLE
Update description of "checkout" step

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -882,7 +882,7 @@ path | N | String | Checkout directory. Will be interpreted relative to the [`wo
 {: class="table table-striped"}
 
 If `path` already exists and is:
- * a git repo - step will not clone whole repo, instead will pull origin
+ * a git repo - step will not clone whole repo, instead will fetch origin
  * NOT a git repo - step will fail.
 
 In the case of `checkout`, the step type is just a string with no additional attributes:


### PR DESCRIPTION
# Description
The description on `checkout` states that if the path already exists in the workspace, then it will _pull_ origin. In reality, the script does a _fetch_ command and it doesn't integrate remote changes into the current branch, if there are any.
Updating the docs to use more accurate wording, as a `git pull` is different from a `git fetch`

# Reasons
I've recently updated my workflow to use `checkout`. Because the description states that the script does a pull, I assumed that meant `gill pull`, however, after my workflow failed and looking at the `checkout` script, it only does a `git fetch`. I'm suggestion an update to the docs to reflect a more accurate wording that mimics Git's commands