### PR TITLE
not fixing circle_working_directory

### DIFF
--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -776,6 +776,7 @@ jobs:
           name: Build iperf3
           working_directory: iperf
           command: |
+            CIRCLE_WORKING_DIRECTORY=$(eval "echo $CIRCLE_WORKING_DIRECTORY")
             IPERF3_MAKE_PREFIX=$CIRCLE_WORKING_DIRECTORY/<< parameters.label >>
             ./configure --prefix=$IPERF3_MAKE_PREFIX << pipeline.parameters.common-build-params >>
             make


### PR DESCRIPTION
I tried fixing working directory expansion, but it appears to not be worth fixing. Adding this hack back
