### PR TITLE
Drop systemd-run in favour of sudo -u

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -193,7 +193,7 @@ sudo chmod 600 /opt/circleci/launch-agent-config.yaml
 
 === Create the circleci user & working directory
 
-These will be used when executing the `build-agent`.
+These will be used when executing the task agent. These commands must be run as a user with permissions to create other users (e.g. `root`).
 
 ```bash
 id -u circleci &>/dev/null || adduser --uid 1500 --disabled-password --gecos GECOS circleci

--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -177,7 +177,7 @@ api:
   auth_token: AUTH_TOKEN
 runner:
   name: RUNNER_NAME
-  command_prefix: ["/opt/circleci/launch-task"]
+  command_prefix: ["sudo", "-niHu", "circleci", "--"]
   working_directory: /opt/circleci/workdir/%s
   cleanup_working_directory: true
 ```
@@ -200,40 +200,6 @@ id -u circleci &>/dev/null || adduser --uid 1500 --disabled-password --gecos GEC
 
 mkdir -p /opt/circleci/workdir
 chown -R circleci /opt/circleci/workdir
-```
-
-=== Install the launch script
-
-This wrapper script will be used by launch agent to execute the task agent, while ensuring appropriate sandboxing and a clean shutdown.
-
-Create `/opt/circleci/launch-task` owned by `root` with permissions `755`
-
-```bash
-#!/bin/bash
-
-set -euo pipefail
-
-## This script launches the build-agent using systemd-run in order to create a
-## cgroup which will capture all child processes so they're cleaned up correctly
-## on exit.
-
-# The user to run the build-agent as - must be numeric
-USER_ID=$(id -u circleci)
-
-# Give the transient systemd unit an inteligible name
-unit="circleci-$CIRCLECI_LAUNCH_ID"
-
-# When this process exits, tell the systemd unit to shut down
-abort() {
-  if systemctl is-active --quiet "$unit"; then
-    systemctl stop "$unit"
-  fi
-}
-trap abort EXIT
-
-systemd-run \
-    --pipe --collect --quiet --wait \
-    --uid "$USER_ID" --unit "$unit" -- "$@"
 ```
 
 === Enable the `systemd` unit


### PR DESCRIPTION
# Description
While systemd-run does offer slightly more isolation, the additional
complexity and compatibility concerns make this awkward, and leads
to some users struggling to get up and running

As the user already needs to be careful with leaking state to the
filesystem, it doesn't seem unreasonable to leave the also responsible
for leaking processes