### PR TITLE
Add a note that circleci tests split cannot be run locally

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -46,6 +46,8 @@ CircleCI supports automatic test allocation across your containers. The allocati
 
 To install the CLI locally, see the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/) document.
 
+Note: The `circleci tests split` command cannot be run locally as it requires information that only exists within a CircleCI container.
+
 ### Splitting test files
 {:.no_toc}
 


### PR DESCRIPTION
# Description
This PR will add a note that the `circleci tests split` command cannot be run locally.

# Reasons
We had customers asking if this was possible or not, and at the moment it isn't. We note in the docs steps on adding the CLI locally (since it can be used for other things) but could lead to confusion that the command could be run. 

See comment here for confirmation this command cannot be run locally:
https://github.com/CircleCI-Public/circleci-cli/issues/383#issuecomment-755330662