### PR TITLE
Xcode Cross Compilation documentation added

### DIFF
--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -90,6 +90,29 @@ Since this is a general introduction to building on MacOs, the `config.yml` abov
   
 You can learn more about the `config.yml` file in the [configuration reference guide]({{site.baseurl}}/2.0/configuration-reference/).
 
+## Xcode Cross Compilation
+
+### Universal Binaries
+Xcode currently supports the creation of universal binaries which can be run on both Intel and ARM64 CPU architectures without needing to ship separate executables. This is supported only under Xcode 12.2+ although older Xcode versions can still be used to compile separate Intel and ARM64 executables. 
+
+### Extracting Unwanted Architectures
+Xcode 12.2+ will by default create universal binaries, compiling to a single executable that supports both Intel and ARM64 based CPUs. If you need to remove an instruction set, you can do so by using the `lipo` utility. 
+
+Assuming that we are interested in creating a standalone x86_64 binary from a universal binary called `circleci-demo-macos`, we can do so by running the command
+
+```lipo -extract x86_64 circleci-demo-macos.app/Contents/MacOS/circleci-demo-macos -output circleci-demo-macos-x86_64```
+
+We can then confirm the supported architecture of the extracted binary with `lipo -info circleci-demo-macos-x86_64` which will output the following
+
+```Architectures in the fat file: circleci-demo-macos-x86_64 are: x86_64```
+
+
+### Cross Compiled Binaries
+
+While universal binaries are only supported under Xcode 12.2+, you can still cross compile binaries for architectures other than the architecture of the machine being used to build the binary. For xcodebuild the process is relatively straightforward. To build ARM64 binaries, prepend the `xcodebuild` command with `ARCHS=ARM64 ONLY_ACTIVE_ARCH=NO` such that it reads `xcodebuild ARCHS=ARM64 ONLY_ACTIVE_ARCH=NO ...`
+
+For Intel CPUs set `ARCHS` to `x86_64`.
+
 ## Next steps
 
 The macOS executor is commonly used for testing and building iOS applications,

--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -93,10 +93,10 @@ You can learn more about the `config.yml` file in the [configuration reference g
 ## Xcode Cross Compilation
 
 ### Universal Binaries
-Xcode currently supports the creation of universal binaries which can be run on both Intel and ARM64 CPU architectures without needing to ship separate executables. This is supported only under Xcode 12.2+ although older Xcode versions can still be used to compile separate Intel and ARM64 executables. 
+Xcode currently supports the creation of universal binaries which can be run on both x86_64 and ARM64 CPU architectures without needing to ship separate executables. This is supported only under Xcode 12.2+ although older Xcode versions can still be used to compile separate x86_64 and ARM64 executables. 
 
 ### Extracting Unwanted Architectures
-Xcode 12.2+ will by default create universal binaries, compiling to a single executable that supports both Intel and ARM64 based CPUs. If you need to remove an instruction set, you can do so by using the `lipo` utility. 
+Xcode 12.2+ will by default create universal binaries, compiling to a single executable that supports both x86_64 and ARM64 based CPUs. If you need to remove an instruction set, you can do so by using the `lipo` utility. 
 
 Assuming that we are interested in creating a standalone x86_64 binary from a universal binary called `circleci-demo-macos`, we can do so by running the command
 
@@ -109,9 +109,7 @@ We can then confirm the supported architecture of the extracted binary with `lip
 
 ### Cross Compiled Binaries
 
-While universal binaries are only supported under Xcode 12.2+, you can still cross compile binaries for architectures other than the architecture of the machine being used to build the binary. For xcodebuild the process is relatively straightforward. To build ARM64 binaries, prepend the `xcodebuild` command with `ARCHS=ARM64 ONLY_ACTIVE_ARCH=NO` such that it reads `xcodebuild ARCHS=ARM64 ONLY_ACTIVE_ARCH=NO ...`
-
-For Intel CPUs set `ARCHS` to `x86_64`.
+While universal binaries are only supported under Xcode 12.2+, you can still cross compile binaries for architectures other than the architecture of the machine being used to build the binary. For xcodebuild the process is relatively straightforward. To build ARM64 binaries, prepend the `xcodebuild` command with `ARCHS=ARM64 ONLY_ACTIVE_ARCH=NO` such that it reads `xcodebuild ARCHS=ARM64 ONLY_ACTIVE_ARCH=NO ...`. For the x86_64 architecture simply change `ARCHS` to `x86_64`.
 
 ## Next steps
 


### PR DESCRIPTION
# Description
Added a snippet explaining Xcode cross compilation and universal binaries to hopefully clear up how
these work for customers.

# Reasons
https://circleci.atlassian.net/browse/MAC-287