### PR TITLE
[CIRCLE-31923] Internationalize header and footer

### DIFF
--- a/jekyll/_includes/ja/global-footer.html
+++ b/jekyll/_includes/ja/global-footer.html
@@ -1,0 +1,102 @@
+<footer class="footer" data-analytics="clicked-footer" data-analytics-parent>
+  <div class="container">
+    <div class="row">
+      <nav>
+        <div class="col-md-2 col-sm-3 col-xs-6">
+          <h6>製品概要</h6>
+          <ul class="list-unstyled">
+            <li><a href="{{ '/product/' | outer_url }}" data-analytics-child='{ "menu": "product" }'>製品概要</a></li>
+            <li><a href="{{ '/pricing/' | outer_url }}" data-analytics-child='{ "menu": "pricing" }'>料金プラン</a></li>
+            <li><a href="{{ '/integrations/' | outer_url }}" data-analytics-child='{ "menu": "integrations" }'>インテグレーション</a></li>
+            <li><a href="{{ '/open-source/' | outer_url }}" data-analytics-child='{ "menu": "open-source" }'>オープンソース</a></li>
+            <li><a href="{{ '/enterprise/' | outer_url }}" data-analytics-child='{ "menu": "enterprise" }'>エンタープライズ向け</a></li>
+            <li><a href="{{ '/changelog/' | outer_url }}" data-analytics-child='{ "menu": "changelog" }'>更新履歴</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2 col-sm-3 col-xs-6">
+          <h6>サポート</h6>
+          <ul class="list-unstyled">
+            <li><a href="https://academy.circleci.com/?access_code=public-2020" data-analytics-child='{ "menu": "training" }' target="_blank">トレーニング</a></li>
+            <li><a href="https://support.circleci.com/hc/ja" data-analytics-child='{ "menu": "get-support" }' target="_blank">サポート情報</a></li>
+            <li><a href="https://discuss.circleci.com/" data-analytics-child='{ "menu": "community-forum" }' target="_blank">コミュニティ フォーラム</a></li>
+            <li><a href="https://status.circleci.com/" data-analytics-child='{ "menu": "system-status" }' target="_blank">システム稼働状況</a></li>
+            <li><a href="https://ideas.circleci.com/" data-analytics-child='{ "menu": "feature-requests" }' target="_blank">改善要望</a></li>
+            <li><a href="{{ '/support/premium-support/' | outer_url }}" data-analytics-child='{ "menu": "premium-support" }'>プレミアム サポート</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2 col-sm-3 col-xs-6">
+          <h6>関連資料</h6>
+          <ul class="list-unstyled">
+            <li><a href="{{ '/blog/' | outer_url }}" data-analytics-child='{ "menu": "blog" }'>ブログ</a></li>
+            <li><a href="{{ '/customers/' | outer_url }}" data-analytics-child='{ "menu": "case-studies" }'>ケース スタディー</a></li>
+            <li><a href="{{ '/resources/#white-papers' | outer_url }}" data-analytics-child='{ "menu": "white-papers" }'>ホワイト ペーパー</a></li>
+            <li><a href="{{ '/resources/events/' | outer_url }}" data-analytics-child='{ "menu": "events" }'>イベント</a></li>
+            <li><a href="{{ '/resources/#webinars' | outer_url }}" data-analytics-child='{ "menu": "webinars" }'>ウェビナー</a></li>
+            <li><a href="{{ '/resources/#videos' | outer_url }}" data-analytics-child='{ "menu": "videos" }'>ビデオ</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2 col-sm-3 col-xs-6">
+          <h6>会社概要</h6>
+          <ul class="list-unstyled">
+            <li><a href="{{ '/about/' | outer_url }}" data-analytics-child='{ "menu": "about-us" }'>CircleCI について</a></li>
+            <li><a href="{{ '/careers/' | outer_url }}" data-analytics-child='{ "menu": "careers" }'>採用情報 <span class="text-blue">(メンバー募集中!)</span></a></li>
+            <li><a href="{{ '/about/team/' | outer_url }}" data-analytics-child='{ "menu": "team" }'>チーム紹介</a></li>
+            <li><a href="{{ '/contact/' | outer_url }}" data-analytics-child='{ "menu": "contact-us" }'>お問い合わせ</a></li>
+            <li><a href="{{ '/partners/' | outer_url }}" data-analytics-child='{ "menu": "partner-with-us" }'>パートナー募集</a></li>
+            <li><a href="{{ '/newsroom/' | outer_url }}" data-analytics-child='{ "menu": "newsroom" }'>メディア掲載</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2 col-sm-3 col-xs-6">
+          <h6>CircleCI 入門</h6>
+          <ul>
+            <li><a href="{{ '/continuous-integration/' | outer_url }}" data-analytics-child='{ "menu": "what-is-ci" }'>CI とは?</a></li>
+            <li><a href="{{ '/2.0/' | language_relative_url }}" data-analytics-child='{ "menu": "how-to-get-started" }'>CircleCI の導入手順</a></li>
+          </ul>
+        </div>
+      </nav>
+    </div>
+    <div class="row margin-top-medium">
+      <div class="col-md-2 col-xs-4">
+        <img src="{{site.baseurl}}/assets/img/logos/logo-wordmark.svg" class="logo-small margin-top-small" alt="circleci">
+      </div>
+      <div class="col-md-4 col-md-offset-6 col-xs-offset-0 col-xs-8">
+        <div class="text-center-small-float-right">
+          {% include social-buttons.html %}
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="margin-top-small text-center-small-float-left">
+          <nav>
+            <ul class="horizontal blue">
+              <li><a href="{{ '/terms-of-service/' | outer_url }}" data-analytics-child='{ "menu": "terms-of-service" }'>利用規約</a></li>
+              <li><a href="{{ '/privacy/' | outer_url }}" data-analytics-child='{ "menu": "privacy-policy" }'>プライバシー ポリシー</a></li>
+              <li><a href="{{ '/legal/cookie-policy/' | outer_url }}" data-analytics-child='{ "menu": "cookie-policy" }'>Cookie ポリシー</a></li>
+              <li><a href="{{ '/security/' | outer_url }}" data-analytics-child='{ "menu": "security" }'>セキュリティ</a></li>
+              <li class="language-select">
+                <div id="dropUp" class="dropup show">
+                  <a class="dropdown-toggle"
+                     role="button"
+                     id="footerLangSelect"
+                     data-toggle="dropdown"
+                     aria-haspopup="true"
+                     aria-expanded="false"
+                  >
+                    <img src="{{site.baseurl}}/assets/img/docs/ic-globe.svg" alt="globe" width="20"><span id="footerLangCurrentSelect"> English (US)</span><i class="fa fa-angle-up"></i></a>
+                  <div id="footerLangOptions" class="dropdown-menu hidden"  aria-labelledby="footerLangSelect">
+                    <a class="dropdown-item active" href="https://circleci.com">English (US)</a>
+                    <a class="dropdown-item" href="https://circleci.com/ja/" data-analytics-child='{ "menu": "japan" }'>日本語</a>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </nav>
+        </div>
+        <div class="margin-top-small text-center-small-float-right">
+          <span>Copyright © {{ site.time | date: '%Y' }} Circle Internet Services, Inc., All Rights Reserved.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/jekyll/_includes/ja/global-nav.html
+++ b/jekyll/_includes/ja/global-nav.html
@@ -1,0 +1,165 @@
+<nav class="nav-toggle two">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <a href="#main" class="nav-skip-button">
+          Skip to content
+        </a>
+
+        <div class="widescreen">
+          <a href="{{ '/' | outer_url }}" class="logo"><img src="{{ '/assets/img/logos/logo-wordmark.svg' | prepend: site.baseurl }}" class="logo" alt="CircleCI Home"></a>
+
+
+          <ul class="left-links main-nav">
+            <li class="nav-item"><a href="{{ '/product/' | outer_url }}">製品概要</a>
+              <div class="submenu">
+                <ul class="subnav">
+                  <li class="subnav-item"><a href="{{ '/product/' | outer_url }}">製品概要</a></li>
+                  <li class="subnav-item"><a href="{{ '/product/#how-it-works' | outer_url }}">CircleCI のメリット</a></li>
+                  <li class="subnav-item"><a href="{{ '/product/#features' | outer_url }}">機能</a></li>
+                  <li class="subnav-item"><a href="{{ '/build-environments/' | outer_url }}">ビルド環境</a></li>
+                  <li class="subnav-item"><a href="{{ '/product/#hosting-options' | outer_url }}">ホスティング オプション</a></li>
+                  <li class="subnav-item"><a href="{{ '/integrations/' | outer_url }}">インテグレーション</a></li>
+                </ul>
+              </div>
+            </li>
+
+            <li class="nav-item"><a href="{{ '/pricing/' | outer_url }}">料金プラン</a></li>
+            <li class="nav-item"><a href="{{ '/enterprise/' | outer_url }}">エンタープライズ向け</a></li>
+            <li class="nav-item">
+              <a href="{{ '' | devhub_url }}">
+                開発者向け
+              </a>
+              <div class="submenu">
+                <ul class="subnav">
+                  <li class="subnav-item"><a href="{{ '/2.0/hello-world/' | language_relative_url }}">Hello World</a></li>
+                  <li class="subnav-item"><a href="{{ '/' | language_relative_url }}">ドキュメント</a></li>
+                  <li class="subnav-item"><a href="https://discuss.circleci.com/" target="_blank">コミュニティ フォーラム</a></li>
+                  <li class="subnav-item"><a href="{{ '/orbs/' | outer_url }}">Orbs</a></li>
+                  <li class="subnav-item"><a href="{{ '/api/v2/' | language_relative_url }}">API</a></li>
+                  <li class="subnav-item"><a href="{{ '/open-source/' | outer_url }}">オープンソース</a></li>
+                </ul>
+              </div>
+            </li>
+            <li class="default-item nav-item"><a href="{{ '/about/' | outer_url }}">会社概要</a>
+              <div class="submenu">
+                <ul class="subnav">
+                  <li class="subnav-item"><a href="{{ '/about/' | outer_url }}">CircleCI について</a></li>
+                  <li class="subnav-item"><a href="{{ '/customers/' | outer_url }}"> ケース スタディー</a></li>
+                  <li class="subnav-item"><a href="{{ '/blog/' | outer_url }}">ブログ</a></li>
+                  <li class="subnav-item"><a href="{{ '/careers/' | outer_url }}">採用情報</a></li>
+                  <li class="subnav-item"><a href="{{ '/contact/' | outer_url }}">お問い合わせ</a></li>
+                  <li class="subnav-item"><a href="{{ '/partners/' | outer_url }}">パートナー募集</a></li>
+                </ul>
+              </div>
+            </li>
+          </ul>
+
+          <ul class="right-links main-nav">
+            <li class="default-item nav-item">
+              <a href="{{ '/contact/' | outer_url }}" data-analytics="top-nav-contact-us">
+                お問い合わせ
+              </a>
+            </li>
+            <li class="default-item nav-item">
+              <a href="#">
+                サポート
+              </a>
+              <div class="submenu">
+                <ul class="subnav">
+                  <li class="subnav-item"><a href="https://academy.circleci.com/?access_code=public-2020" target="_blank">トレーニング</a></li>
+                  <li class="subnav-item"><a href="https://support.circleci.com/hc/ja" target="_blank">サポート情報</a></li>
+                  <li class="subnav-item"><a href="https://status.circleci.com/" target="_blank">システム稼働状況</a></li>
+                  <li class="subnav-item"><a href="https://ideas.circleci.com/" target="_blank">改善要望</a></li>
+                  <li class="subnav-item"><a href="{{ '/support/premium-support/' | outer_url }}">プレミアム サポート</a></li>
+                </ul>
+              </div>
+            </li>
+            <li class="divider-left nav-item visitor-item"><a href="{{ '/vcs-authorize/' | outer_url }}" data-hj-masked>ログイン</a></li>
+            <li class="nav-item visitor-item"><a class="btn-primary small" href="{{ '/signup/' | outer_url }}" data-analytics-action="signup-clicked" data-analytics-location="nav" data-optimizely="signup_button_clicked">登録</a></li>
+            <li class="dashboard-link desktop-nav divider-left"><a href="https://circleci.com/dashboard">アプリへ移動</a></li>
+          </ul>
+
+        </div>
+
+        <div class="narrowscreen">
+
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#mobile-navigation" aria-expanded="false" aria-controls="#mobile-navigation">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar top-bar"></span>
+            <span class="icon-bar middle-bar"></span>
+            <span class="icon-bar bottom-bar"></span>
+          </button>
+
+          <a href="{{ '/' | outer_url }}"><img class="logo" src="{{ '/assets/img/logos/logo-wordmark.svg' | prepend: site.baseurl }}" alt="CircleCI Home"></a>
+
+
+          <span class="login">
+            <a href="{{ '/vcs-authorize/' | outer_url }}" data-hj-masked class="mobile-nav signup visitor-item" data-analytics-location="nav" >ログイン</a>
+            <a href="https://circleci.com/dashboard" class="dashboard-link mobile-nav">アプリへ移動</a>
+          </span>
+
+          <ul class="dropdown-menu2" id="mobile-navigation">
+            <li><a href="{{ '/signup/' | outer_url }}" data-analytics-action="signup-clicked" data-optimizely="signup_button_clicked" class="btn-primary">Sign Up for Free</a></li>
+            <li class="arrow collapsed border-bottom">
+              <span class="heading">
+                <i class="fa fa-angle-right" aria-hidden="true"></i>
+                製品概要
+              </span>
+              <ul class="subnav">
+                <li class="subnav-item"><a href="{{ '/product/' | outer_url }}">製品概要</a></li>
+                <li class="subnav-item"><a href="{{ '/product/#how-it-works' | outer_url }}">CircleCI のメリット</a></li>
+                <li class="subnav-item"><a href="{{ '/product/#features' | outer_url }}">機能</a></li>
+                <li class="subnav-item"><a href="{{ '/build-environments/' | outer_url }}">ビルド環境</a></li>
+                <li class="subnav-item"><a href="{{ '/product/#hosting-options' | outer_url }}">ホスティング オプション</a></li>
+                <li class="subnav-item"><a href="{{ '/integrations/' | outer_url }}">インテグレーション</a></li>
+              </ul>
+            </li>
+            <li class="border-bottom"><a href="{{ '/pricing/' | outer_url }}">料金プラン</a></li>
+            <li class="border-bottom"><a href="{{ '/enterprise/' | outer_url }}">エンタープライズ向け</a></li>
+            <li class="arrow collapsed border-bottom">
+              <span class="heading">
+                <i class="fa fa-angle-right" aria-hidden="true"></i>
+                開発者向け
+              </span>
+              <ul class="subnav">
+                <li class="subnav-item"><a href="{{ '' | devhub_url }}">デベロッパー ハブ</a></li>
+                <li class="subnav-item"><a href="{{ '/2.0/hello-world/' | language_relative_url }}">Getting Started</a></li>
+                <li class="subnav-item"><a href="{{ '/' | language_relative_url }}">ドキュメント</a></li>
+                <li class="subnav-item"><a href="https://discuss.circleci.com/" target="_blank">コミュニティ フォーラム</a></li>
+                <li class="subnav-item"><a href="{{ '/orbs/' | outer_url }}">Orbs</a></li>
+                <li class="subnav-item"><a href="{{ '/api/v2/' | language_relative_url }}">API</a></li>
+                <li class="subnav-item"><a href="{{ '/open-source/' | outer_url }}">オープンソース</a></li>
+              </ul>
+            </li>
+            <li class="arrow collapsed border-bottom">
+              <span class="heading">
+                <i class="fa fa-angle-right" aria-hidden="true"></i>
+                会社概要
+              </span>
+              <ul class="subnav">
+                <li class="subnav-item"><a href="{{ '/about/' | outer_url }}">CircleCI について</a></li>
+                <li class="subnav-item"><a href="{{ '/customers/' | outer_url }}">ケース スタディー</a></li>
+                <li class="subnav-item"><a href="{{ '/blog/' | outer_url }}">ブログ</a></li>
+                <li class="subnav-item"><a href="{{ '/careers/' | outer_url }}">採用情報</a></li>
+                <li class="subnav-item"><a href="{{ '/contact/' | outer_url }}">お問い合わせ</a></li>
+                <li class="subnav-item"><a href="{{ '/partners/' | outer_url }}">パートナー募集</a></li>
+              </ul>
+            </li>
+            <li class="arrow collapsed border-bottom">
+              <i class="fa fa-angle-right" aria-hidden="true"></i>
+              サポート
+              <ul class="subnav">
+                <li class="subnav-item"><a href="https://academy.circleci.com/?access_code=public-2020" target="_blank">トレーニング</a></li>
+                <li class="subnav-item"><a href="https://support.circleci.com/ja" target="_blank">サポート情報</a></li>
+                <li class="subnav-item"><a href="https://status.circleci.com/" target="_blank">システム稼働状況</a></li>
+                <li class="subnav-item"><a href="https://ideas.circleci.com/" target="_blank">改善要望</a></li>
+                <li class="subnav-item"><a href="{{ '/support/premium-support/' | outer_url }}">プレミアム サポート</a></li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/jekyll/_includes/ja/global-nav.html
+++ b/jekyll/_includes/ja/global-nav.html
@@ -36,7 +36,7 @@
                   <li class="subnav-item"><a href="{{ '/' | language_relative_url }}">ドキュメント</a></li>
                   <li class="subnav-item"><a href="https://discuss.circleci.com/" target="_blank">コミュニティ フォーラム</a></li>
                   <li class="subnav-item"><a href="{{ '/orbs/' | outer_url }}">Orbs</a></li>
-                  <li class="subnav-item"><a href="{{ '/api/v2/' | language_relative_url }}">API</a></li>
+                  <li class="subnav-item"><a href="https://circleci.com/docs/api/v2/">API</a></li>
                   <li class="subnav-item"><a href="{{ '/open-source/' | outer_url }}">オープンソース</a></li>
                 </ul>
               </div>
@@ -128,7 +128,7 @@
                 <li class="subnav-item"><a href="{{ '/' | language_relative_url }}">ドキュメント</a></li>
                 <li class="subnav-item"><a href="https://discuss.circleci.com/" target="_blank">コミュニティ フォーラム</a></li>
                 <li class="subnav-item"><a href="{{ '/orbs/' | outer_url }}">Orbs</a></li>
-                <li class="subnav-item"><a href="{{ '/api/v2/' | language_relative_url }}">API</a></li>
+                <li class="subnav-item"><a href="https://circleci.com/docs/api/v2/">API</a></li>
                 <li class="subnav-item"><a href="{{ '/open-source/' | outer_url }}">オープンソース</a></li>
               </ul>
             </li>

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -7,7 +7,7 @@
 {% endif %}
 
 <div class="outer">
-	{% include global-nav.html %}
+	{% include_localized global-nav.html %}
 	{% include main-searchbar.html %}
 	{% include mobile-sidebar.html %}
 	<!-- instant hit template container /-->

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -91,7 +91,7 @@
 		</div><!-- .article-container -->
 	</div><!-- .main-body -->
 
-	{% include global-footer.html %}
+	{% include_localized global-footer.html %}
 	{% include js-config.html %}
 	{% asset vendor.min.js %}
   <script src="https://unpkg.com/@popperjs/core@2.4.4/dist/umd/popper.min.js"></script>

--- a/jekyll/_plugins/include_localized.rb
+++ b/jekyll/_plugins/include_localized.rb
@@ -1,0 +1,13 @@
+require_relative 'language_url_prefix.rb'
+
+class IncludeLocalized < Jekyll::Tags::IncludeTag
+  include LanguageUrlPrefix
+
+  def locate_include_file(context, file, safe)
+    lang_prefix = language_url_prefix(context)
+    file_with_prefix = "#{lang_prefix}/#{file}"
+    super(context, file_with_prefix, safe)
+  end
+end
+
+Liquid::Template.register_tag('include_localized', IncludeLocalized)


### PR DESCRIPTION
Using the strategy discussed on the Jira ticket, this adds Japanese versions of the global header (nav) and footer, as well as a custom Liquid tag for automatically including the page's language's version of the given template.