### PR TITLE
Update disclaimer to note both glob and split are unable to be used locally

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -46,7 +46,7 @@ CircleCI supports automatic test allocation across your containers. The allocati
 
 To install the CLI locally, see the [Using the CircleCI Local CLI]({{ site.baseurl }}/2.0/local-cli/) document.
 
-Note: The `circleci tests split` command cannot be run locally as it requires information that only exists within a CircleCI container.
+Note: The `circleci tests` commands (`glob` and `split`) cannot be run locally via the CLI as they require information that only exists within a CircleCI container.
 
 ### Splitting test files
 {:.no_toc}
@@ -161,6 +161,8 @@ The contents of the file `/tmp/tests-to-run` will be different in each container
 
 ### Video: troubleshooting globbing
 {:.no_toc}
+
+Note: To follow along with the commands in the video below you will need to be [`SSH-ed into a job`]({{ site.baseurl }}/2.0/ssh-access-jobs/).
 
 <iframe width="854" height="480" src="https://www.youtube.com/embed/fq-on5AUinE" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 


### PR DESCRIPTION
# Description
I recently updated the docs to add a note that the split command couldn't be run locally with the CLI:

https://github.com/circleci/circleci-docs/pull/5049

However, you also can't run the `glob` command. This PR will update the note to add that information and also add a disclaimer above the tutorial video that the commands being run would have to be done in an SSH session.

# Reasons
Wanted to further clarify what could and couldn't be run locally and how to follow the video in the docs.