### PR TITLE
Update: Api developers guide

### DIFF
--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -9,7 +9,7 @@ version:
 - Cloud
 ---
 
-This *API Developer's Guide* was written to assist developers in quickly and easily making API calls to CircleCI services to return detailed information about users, pipelines, projects and workflows. The API v2 Specification itself may be viewed [here]({{site.baseurl}}/api/v2}).
+This *API Developer's Guide* was written to assist developers in quickly and easily making API calls to CircleCI services to return detailed information about users, pipelines, projects and workflows. The API v2 Specification itself may be viewed [here]({{site.baseurl}}/api/v2).
 
 * TOC
 {:toc}

--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -9,14 +9,10 @@ version:
 - Cloud
 ---
 
-This *API Developer's Guide* was written to assist developers in quickly and easily making API calls to CircleCI services to return detailed information about users, pipelines, projects and workflows.
+This *API Developer's Guide* was written to assist developers in quickly and easily making API calls to CircleCI services to return detailed information about users, pipelines, projects and workflows. The API v2 Specification itself may be viewed [here]({{site.baseurl}}/api/v2}).
 
 * TOC
 {:toc}
-
-# API overview
-
-The CircleCI platform provides an API that enables users to interact with the CircleCI platform (e.g. triggering pipelines, updating settings etc, in addition to retrieving detailed information about users, jobs, workflows and pipelines.
 
 ## API categories
 
@@ -38,10 +34,12 @@ The CircleCI API utilizes token-based authentication to manage access to the API
 **Note** You may use the API token as the username for HTTP Basic Authentication, by passing the `-u` flag to the `curl` command.
 
 ### Add an API token
+{:.no_toc}
 
 To add an API token, perform the steps listed below.
 
-1.  Add an API token from the [Personal API Tokens page](https://account.circleci.com/tokens). 
+1. Log in to the CircleCI web application.
+1. Visit the [Personal API Tokens page](https://app.circleci.com/settings/user/tokens) and follow the steps to add an API token.
 2.  To test your token call the API using the command below. You will need to set your API token as an environment variable before making a cURL call.
 
     ```sh
@@ -77,50 +75,15 @@ The `project_slug` is included in the payload when pulling information about a p
 
 ![API structure]({{ site.baseurl }}/assets/img/docs/api-structure.png)
 
-## HTTP status codes and response handling
-
-When you make an API request to the server, an HTTP status code is returned along with the JSON body response. The CircleCI API v2 adheres to standard HTTP response codes, which include the following status code definitions:
-
-* 200 - Success
-* 400 - Client error
-* 500 - Server error
-
-### 200 status codes
-
-If you receive a 200 HTTP status code, your API request is successful and the requested resource will be returned. The following 200 HTTP status codes could potentially be returned with your request:
-
-* 200 - OK
-* 201 - Created
-* 202 - Accepted
-
-### 400 status codes
-
-If you receive a 400 HTTP status code, there is a problem with the request and the server is unable to successfully process the request. The following status codes may be returned with your request:
-
-* 401 - Unauthorized
-* 403 - Forbidden
-* 404 - Not Found
-* 429 - Too Many Requests (see [rate limits](#rate-limits)).
-
-### 500 status code
-
-If you receive a 500 HTTP status code, there is a problem with the server and the request cannot be processed. If you encounter a 500 response, the error will be logged and CircleCI will work to resolve the error. The following 500 HTTP status codes could potentially be returned with your request:
-
-* 500 - Internal Server Error
-
 ## Rate limits
 
-The CircleCI API is protected by a number of rate limiting measures to ensure the stability of the system. We reserve the right to throttle the requests made by an individual user, or the requests made to individual resources in order to ensure a fair level of service to all of our users.
+The CircleCI API is protected by rate limiting measures to ensure the stability of the system. We reserve the right to throttle the requests made by an individual user, or the requests made to individual resources in order to ensure a fair level of service to all of our users.
 
 As the author of an API integration with CircleCI, your integration should expect to be throttled, and should be able to gracefully handle failure.
 There are different protections and limits in place for different parts of the API. In particular, we protect our API against **sudden large bursts of traffic**, and we protect against **sustained high volumes** of requests, for example, frequent polling.
 
 For HTTP APIs, when a request is throttled, you will receive [HTTP status code 429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429). If your integration requires that a throttled request is completed, then you should retry these requests after a delay, using an exponential backoff.
 In most cases, the HTTP 429 response code will be accompanied by the [Retry-After HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After). When this header is present, your integration should wait for the period of time specified by the header value before retrying a request.
-
-## Rest API tutorial
-
-For more detailed information about HTTP status codes, refer to the [rest api tutorial](http://www.restapitutorial.com/httpstatuscodes.html).
 
 ## Example end-to-end API request
 
@@ -130,10 +93,13 @@ The following section details the steps you would need, from start to finish, to
 
 ### Prerequisites
 
+{:.no_toc}
+
 * A GitHub or BitBucket account with a repository to setup with CircleCI.
 * Completion of the CircleCI onboarding.
 
 ### Steps
+{:.no_toc}
 
 1. On your VCS provider, create a repository. The repo for this example will be called `hello-world`.
 
@@ -275,6 +241,8 @@ endpoints currently available.
 Now that you have a general understanding of how the CircleCI API v2 service works through an end-to-end API example request and walkthrough, let's look at a few common tasks and operations you may perform on a regular basis when using the API. Whether you wish to return information about a job or project, or retrieve more detailed information about a project by reviewing its artifacts, the examples shown below should assist you in gaining a better understanding of how to make some API requests to the server so you can perform a deep dive into the specifics of your work.
 
 ### Prerequisites
+{:.no_toc}
+
 
 Before trying any of the API calls in this section, make sure you have met the following prerequisites:
 
@@ -290,6 +258,7 @@ This section provides detailed information on how you can perform the following 
 * [Gather Insights](#gather-insights)
 
 ### Get project details
+{:.no_toc}
 
 You may often find that it would be helpful to retrieve information about a specific project, including the name of the organization the project belongs to, the version control system (vcs) that hosts the project, and other details. The CircleCI API enables you to return this and other information by making a single GET request to the `project/{project-slug}` endpoint by passing the `project-slug` parameter.
 
@@ -304,6 +273,7 @@ The `project_slug` is included in the payload when you pull information about a 
 **Note** If you would like more detailed information about a project, or simply need a refresher on the specifics of a project, please refer to the CircleCI [Projects](https://circleci.com/docs/2.0/projects/) page.
 
 #### Steps
+{:.no_toc}
 
 Of the several project-related API endpoints available with CircleCI API v2, making a GET request to the `/project/{project-slug}` endpoint enables you to return detailed information about a specific project by passing the `project_slug` parameter with your request.
 
@@ -344,6 +314,7 @@ Much like the Get Project Details API request described in the previous example,
 Please remember, jobs are collections of steps. Each job must declare an executor that is either `docker`, `machine`, `windows` or `macos`. `machine` includes a default image if not specified, for `docker` you must specify an image to use for the primary container, for `macos` you must specify an Xcode version, and for `windows` you must use the Windows orb.
 
 #### Steps
+{:.no_toc}
 
 Of the several Jobs-related API endpoints available with CircleCI API v2, there is a specific endpoint you may wish to call to receive detailed information about your job. This API call to the `GET /project/{project_slug}/job/{job-number}`endpoint enables you to return detailed information about a specific job by passing the `project-slug` and `job-number` parameters with your request.
 
@@ -417,6 +388,9 @@ For a more detailed breakdown of each value returned in this request, please ref
 The following section details the steps you need to follow to download artifacts that are generated when a job is run, first, returning a list of artifacts for a job, and then downloading the full set of artifacts. If you are looking for instructions for downloading the _latest_ artifacts for a pipeline, without needing to specify a job number, see our [API v1.1 guide](https://circleci.com/docs/2.0/artifacts/#downloading-all-artifacts-for-a-build-on-circleci) – keep checking back here as this functionality will be added to API v2 in the future.
 
 #### Steps
+{:.no_toc}
+
+
 
 1. First, we will ensure your API token is set as an environment variable. You maybe have already done this during authentication, but if not, run the following command in your terminal, substituting your personal API token:
 
@@ -475,6 +449,7 @@ The following section details the steps you need to follow to download artifacts
 The CircleCI API v2 also includes several endpoints that enable you to retrieve detailed insights into your workflows and individual jobs. By making API calls to these endpoints, you can better understand how to optimize your workflows and jobs so you can increase workflow performance while minimizing credit usage and consumption. The example below describes how you can return information about a single workflow containg information about metrics and credit usage.
 
 #### Returning workflow metrics
+{:.no_toc}
 
 To return aggregated data for an individual workflow, perform the steps listed below.
 
@@ -575,6 +550,7 @@ Notice that in this JSON response, you will receive detailed metrics for the set
 **Note** The above example only shows just a few builds. When you run this command, you may receive up to 250 individual builds that you can review in much more detail.
 
 #### Reviewing individual job metrics
+{:.no_toc}
 
 Now that you have retrieved aggregated data for up to 250 different jobs, you will most likely want to review specific information about a single job, or smaller number of jobs, to ensure that your jobs are running efficiently. To review an individual job, follow the steps below.
 
@@ -652,80 +628,6 @@ When reviewing each individual review job, please note that the following inform
 - `credits_used` - The number of credits used during the job.
 
 ## Reference
-
-### API endpoints
-
-The CircleCI v2 API, and its associated endpoints allow you to make HTTP calls to designated endpoints developed in the underlying CircleCI API architecture. These endpoints provide programmatic access to CircleCI services, including pipelines, workflows, and jobs. 
-
-Before working with the API and making calls, you should first have an understanding of the various API requests you can make to API v2 endpoints. The sections below describe these API requests.
-
-#### User endpoints
-
-| Endpoint               | Description                       
-|------------------------|-------------------------------------------------------
-| GET /user/{id}         | This endpoint enables you to return information about a specific user by making a GET request and passing the `id` parameter in the request |
-| GET /me/collaborations | This endoint enables you to return a list of organizations that the user is a member of, or is a collaborator by making a GET request and passing the `collaborations` parameter in the request. |
-{: class="table table-striped"}
-
-#### Pipeline API requests
-
-| Endpoint                                  | Description                                                         | 
-|-------------------------------------------|---------------------------------------------------------------------|
-| GET /project/{project-slug}/pipeline/{pipeline-number}  | Returns an individual pipeline.                       |
-| GET /pipeline/{pipeline-id}/config        | Returns the configuration of a specific pipeline.                   |
-| GET /pipeline/{pipeline-id}/workflow      | Returns a list of workflows for a specific pipeline.                |
-| POST /project/{project-slug}/pipeline     | Triggers a pipeline.                                                |
-| GET /project/{project-slug}/pipeline      | Returns a list of all pipelines associated with a specific project. |
-| GET /project/{project-slug}/pipeline/mine | Returns all pipelines for the project that you have triggered.      |
-{: class="table table-striped"}
-
-#### Project API requests
-
-| Endpoint                                                  | Description                                                       |
-|-----------------------------------------------------------|-------------------------------------------------------------------|
-| GET /project/{project-slug}                               | Returns an individual project.                                    |
-| GET /project/{project-slug}/checkout-key                  | Returns all checkout keys for a specific project.                 | 
-| POST /project/{project-slug}/checkout-key                 | Creates a new checkout key for a project.                         |
-| DELETE /project/{project-slug}/checkout-key/{fingerprint} | Deletes a checkout key for a specific project.                    |
-| GET /project/{project-slug}/checkout-key/{fingerprint}    | Returns an individual checkout key for a specific project.        |
-| GET /project/{project-slug}/pipeline/mine                 | Returns all pipelines for the project that you have triggered.    |
-| GET /project/{project-slug}/envvar                        | Lists all current environment variables for a specific project.   |
-| POST /project/{project-slug}/envvar                       | Creates an environment variable for a project.                    | 
-| DELETE /project/{project-slug}/envvar/{name}              | Deletes an existing environment variable from a project.          |
-| GET /project/{project-slug}/envvar/{name}                 | Returns a masked value for an environment variable for a project. |
-{: class="table table-striped"}
-
-#### Job API requests
-
-| Endpoint                                             | Description                      |        
-|------------------------------------------------------|----------------------------------|
-| GET /project/{project-slug}/job/{job-number}         | Returns details of a job.        |
-| POST /project/{project-slug}/job/{job-number}/cancel | Cancels a job.                   |
-| GET /project/{project-slug}/{job-number}/artifacts   | Returns artifacts for a job.     |
-| GET /project/{project-slug}/{job-number}/tests       | Returns test metadata for a job. |
-{: class="table table-striped"}
-
-#### Workflow API requests
-
-| Endpoint                   | Description                                  |
-|----------------------------|----------------------------------------------|
-| GET /workflow/{id}         | Returns a workflow.                          |
-| POST /workflow/{id}/cancel | Cancels a workflow.                          |
-| GET workflow/{id}/job      | Returns all jobs associated with a workflow. |
-| POST /workflow/{id}/rerun  | Reruns a workflow.                           |
-{: class="table table-striped"}
-
-#### Insights requests
-
-| Endpoint                                                               | Description                                       |
-|------------------------------------------------------------------------|---------------------------------------------------|
-| GET /insights/{project-slug}/workflows                                 | Get summary metrics for a project's workflows.    |
-| GET /insights/{project-slug}/workflows/{workflow-name}                 | Get recent runs of a workflow                     |
-| GET /insights/{project-slug}/workflows/{workflow-name}/jobs            | Get summary metrics for a project workflow's jobs.|
-| GET /insights/{project-slug}/workflows/{workflow-name}/jobs/{job-name} | Get recent runs of a job within a workflow.       |
-{: class="table table-striped"}
-
-### See also
 
 - Refer to [API V2 Introduction]({{site.baseurl}}/2.0/api-intro/) for high-level information about the CircleCI V2 API.
 - Refer to [API V2 Reference Guide]({{site.baseurl}}/api/v2/) for a detailed list of all endpoints that make up the CircleCI V2 API.


### PR DESCRIPTION
Our API developers guide has a fair bit of content that is duplicated (in the actual API specification. This PR performs the following:

- Clean: remove duplicate content in intro.
- Fix: description of how to get api token.
- Clean: remove superfluous HTTP code section.
- Clean: simplify rate-limiting language.
- Clean: simplify table of contents.
- Clean: remove redundant api endpoint section
  - It is better that we link users to the actual api specification guide
    which will always be up-to-date (as it is generated from spec in
    the actual API) rather than re-create the documentation.
