### PR TITLE
Add note to runner docs that commands can only be run by org admin

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -84,6 +84,8 @@ The following platforms are not currently supported to work with CircleCI runner
 
 == Authentication
 
+NOTE: These commands can only be run by an owner/admin of your organization.
+
 In order to complete this process you will need to create a namespace and authentication token by performing the steps listed below:
 
 1. <<local-cli#installation,Install the circleci command-line tool>>.


### PR DESCRIPTION
# Description
This PR will add a note that the commands can only be run by the owner/admin of the Organization.

# Reasons
We note this information for claiming namespaces for orbs:

https://circleci.com/docs/2.0/orb-author-faq/#errors-claiming-namespace-or-publishing-orbs

But the same information was not noted for Runner and I received a ticket from a customer wondering why they couldn't setup runner. 