### PR TITLE
Include preview Android machine image

### DIFF
--- a/jekyll/_cci2/language-android.md
+++ b/jekyll/_cci2/language-android.md
@@ -25,10 +25,8 @@ If you are looking for a `.circleci/config.yml` template for Android,
 see the [Sample Configuration](#sample-configuration) section of this document.
 
 **Note:**
-Running the Android emulator is not supported
-by the type of virtualization CircleCI uses on Linux.
-To run emulator tests from a job,
-consider using an external service like [Firebase Test Lab](https://firebase.google.com/docs/test-lab).
+We now have an Android machine image available in preview on CircleCI Cloud that supports x86 Android emulators and nested virtualization. Documentation on how to access it is available [here](https://github.com/CircleCI-Public/android-image-preview-docs).
+Another way to run emulator tests from a job is to consider using an external service like [Firebase Test Lab](https://firebase.google.com/docs/test-lab).
 For more details,
 see the [Testing With Firebase Test Lab](#testing-with-firebase-test-lab) section below.
 


### PR DESCRIPTION
# Description
Include mention of the Android machine image that is now available for preview and which supports x86 Android emulator tests

# Reasons
Keep our docs up-to-date