### PR TITLE
Add note about range elements for days

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -276,7 +276,7 @@ A valid `schedule` requires a `cron` key and a `filters` key.
 The value of the `cron` key must be a [valid crontab entry](https://crontab.guru/).
 
 **Note:**
-Cron step syntax (for example, `*/1`, `*/20`) is **not** supported. Range elements within comma-separated lists of elements are also **not** supported. 
+Cron step syntax (for example, `*/1`, `*/20`) is **not** supported. Range elements within comma-separated lists of elements are also **not** supported. In addition, range elements for days (for example, `Tue-Sat`) is **not** supported, use comma seperated digits instead.
 
 The value of the `filters` key must be a map that defines rules for execution on specific branches.
 

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -276,7 +276,7 @@ A valid `schedule` requires a `cron` key and a `filters` key.
 The value of the `cron` key must be a [valid crontab entry](https://crontab.guru/).
 
 **Note:**
-Cron step syntax (for example, `*/1`, `*/20`) is **not** supported. Range elements within comma-separated lists of elements are also **not** supported. In addition, range elements for days (for example, `Tue-Sat`) is **not** supported, use comma seperated digits instead.
+Cron step syntax (for example, `*/1`, `*/20`) is **not** supported. Range elements within comma-separated lists of elements are also **not** supported. In addition, range elements for days (for example, `Tue-Sat`) is **not** supported. Use comma-separated digits instead.
 
 The value of the `filters` key must be a map that defines rules for execution on specific branches.
 


### PR DESCRIPTION
# Description
This PR adds a disclaimer that setting up a range of days written out is not supported. 

# Reasons
Crontab says this is valid:

https://crontab.guru/#0_5_*_*_Tue-Sat

And while that might be the case for some systems, it isn't valid within a CircleCI config. Instead, the values need to be comma separated digits like: https://crontab.guru/#0_5_*_*_2,3,4,5