### PR TITLE
add Private orb information

### DIFF
--- a/jekyll/_cci2/orbs-faq.md
+++ b/jekyll/_cci2/orbs-faq.md
@@ -14,9 +14,7 @@ This document describes various questions and technical issues that you may find
 
 * **Question:** Can orbs be made private?
 
-* **Answer:** Currently, all orbs published to the [Orb Registry]() are open source. Please subscribe to this feature request for updates: [Feature Request: private orbs](https://ideas.circleci.com/ideas/CCI-I-606).
-
-  Consider using orbs for importing code hosted on private package registries such as [npm](https://docs.npmjs.com/about-private-packages), or [GitHub](https://github.com/features/packages).
+* **Answer:** [Private orbs](https://circleci.com/docs/2.0/orb-intro/#private-orbs) are currently only available if you are on the [Scale Plan](https://circleci.com/pricing). Please reach out to your sales representative for information on how to sign up for the Scale Plan.
 
 ## Difference between commands and jobs
 


### PR DESCRIPTION
# Description

We recently launched the private orb function for scale customers, so I updated the Private Orb faq section.

# Reasons
> https://circleci.slack.com/archives/CNHFJ07LZ/p1612340604057800