### PR TITLE
Add: clarification on valid cron syntax.

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -278,6 +278,23 @@ The value of the `cron` key must be a [valid crontab entry](https://crontab.guru
 **Note:**
 Cron step syntax (for example, `*/1`, `*/20`) is **not** supported. Range elements within comma-separated lists of elements are also **not** supported. In addition, range elements for days (for example, `Tue-Sat`) is **not** supported. Use comma-separated digits instead.
 
+
+Example **invalid** cron range syntax:
+
+```yaml
+    triggers:
+      - schedule:
+          cron: "5 4 * * 1,3-5,6" # < the range separator with `-` is invalid
+```
+
+Example **valid** cron range syntax:
+
+```yaml
+    triggers:
+      - schedule:
+          cron: "5 4 * * 1,3,4,5,6" 
+```
+
 The value of the `filters` key must be a map that defines rules for execution on specific branches.
 
 For more details, see the `branches` section of the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/#branches-1) document.


### PR DESCRIPTION
Clarifies and closes #5000.

See discussion in https://github.com/circleci/circleci-docs/pull/5069