### PR TITLE
Add note about 7 digit integers converting to exponential number

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -297,6 +297,8 @@ jobs:
       FOO: bar
 ```
 
+**Note: Integers longer than 6 digits will be converted to an exponential number. To avoid this, store them as a string instead (i.e. "1234567").** 
+
 ## Setting an environment variable in a context
 
 1. In the CircleCI application, go to your organization settings by clicking the link in the left hand navigation.


### PR DESCRIPTION
# Description
When setting the job level environment variable yaml will convert an integer that has 7 or more digits to an exponential number. I.e. `7777777` would become `7.777777e+06` in the job. 

To avoid this automatic conversion the value instead needs to be stored as a string so instead of `7777777` you would set it to `"7777777"`.

This only happens when setting these variables in the `config.yml` itself -- it doesn't happen when you set these as project-level variables.

# Reasons
CIRCLE-23958 -- this is something that was noted as a natural consequence of using YAML, so want to ensure this is documented has customers have encountered this previously. I will also be adding a support article as well.