### PR TITLE
Clarify that api v1 /build endpoint is not available on Server

### DIFF
--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -405,6 +405,7 @@ curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/
 
 <aside class="notice">
 Prerequisite: You must go to your Project Settings in the CircleCI app and enable pipelines. This endpoint does not yet support the <code>build_parameters</code> options that the job-triggering endpoint supports.
+This also means that this endpoint is not available for CircleCI Server.
 </aside>
 
 **Parameter** | **Description**


### PR DESCRIPTION
# Description

Clearly state that `https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build` endpoint is not available for CircleCI Server.

# Reasons

To use this endpoint, one must enable pipelines, but the pipeline is a CircleCI 2.1 feature and it is not yet available for CircleCI Server. Since it is not stated clearly that is it not available, it is causing some confusion.