### PR TITLE
Changed the words master to main

### DIFF
--- a/jekyll/_cci2/about-circleci.md
+++ b/jekyll/_cci2/about-circleci.md
@@ -36,7 +36,7 @@ CircleCI may be configured to deploy code to various environments, including AWS
 
 ## What is continuous integration?
 
-**Continuous integration** is a practice that encourages developers to integrate their code into a `master` branch of a shared repository early and often. Instead of building out features in isolation and integrating them at the end of a development cycle, code is integrated with the shared repository by each developer multiple times throughout the day.
+**Continuous integration** is a practice that encourages developers to integrate their code into a `main` branch of a shared repository early and often. Instead of building out features in isolation and integrating them at the end of a development cycle, code is integrated with the shared repository by each developer multiple times throughout the day.
 
 **Continuous Integration** is a key step to digital transformation.
 


### PR DESCRIPTION
# Description
I replace the word master with main

# Reasons
I saw this word master in our text and considering that the industry is replacing these words with more generic and acceptable terms I suggest we use main as a replacement for master moving forward.