### PR TITLE
.NET Core SDK 3.1.406 Update

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -279,6 +279,7 @@ Also, consider reading documentation on some of CircleCI’s features:
     * cmd
 * .NET Framework 4.8
 * .NET Core
+    * SDK 3.1.406 (x64)
     * SDK 3.0.100-preview7-012821
     * Runtime 3.0.0-preview6-27804-01
     * SDK 2.2.401 


### PR DESCRIPTION
Updated page to include .NET Core SDK 3.1.406

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.