### PR TITLE
Language selector now redirects to the same content

### DIFF
--- a/src-js/lang.js
+++ b/src-js/lang.js
@@ -9,8 +9,8 @@ function getElById(id) {
 }
 
 var languages = {
-  "en": {name: "English", url: "docs/2.0/"},
-  "ja": {name: "日本語", url: "docs/ja/2.0/"}
+  "en": {name: "English", url: "docs/"},
+  "ja": {name: "日本語", url: "docs/ja/"}
 }
 
 // List of elements that have dynamic content based on our selected language
@@ -21,8 +21,17 @@ var els = {
   footerLangOptions: getElById("footerLangOptions")
 };
 
+function redirectLocation(langCode) {
+  const parser = new RegExp('^(https?:\/\/' + window.location.host + '\/)(docs\/[a-z]{2}\/|docs\/)(.*)', 's')
+  const baseURL = "https://circleci.com/" + languages[langCode].url + "2.0"
+  if (!parser.test(window.location.href)) {
+    return baseURL
+  }
+  return window.location.href.replace(parser, '$1' + languages[langCode].url + '$3')
+}
+
 function reloadWithNewLocale(langCode) {
-  window.location.href = "https://circleci.com/" + languages[langCode].url
+  window.location.href = redirectLocation(langCode)
 }
 
 // Sets the sidebar language picker to the currently selected language


### PR DESCRIPTION
Make sidebar language selector redirect to the same content.

# Reasons

It used to redirect to the base URL. So, I was not using this selector,
because directly writing `ja` to the URL were much easier.

# Description

This implementation relies on regexp to parse the current full URL to
replace the `docs/ja` or `docs` part to the target slug.

It also redirects to the base URL as a fallback if the URL does not match.