### PR TITLE
Clarify regex usage

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1450,7 +1450,7 @@ workflows:
               only: /server\/.*/
 ```
 
-The above snippet causes the job  `build_server_pdfs` to only be run when the branch being built contains the word "server/" in it.
+The above snippet causes the job  `build_server_pdfs` to only be run when the branch being built starts with "server/" in it.
 
 You can read more about using regex in your config in the [Workflows document]({{ site.baseurl }}/2.0/workflows/#using-regular-expressions-to-filter-tags-and-branches).
 


### PR DESCRIPTION
# Description
The current regex example will trigger if a branch name starts with `server/`, but for it to match any string that contains `server/` it would need to be `/.*server\/.*/`.

# Reasons
 Changing the wording will help clarify the outcome.