### PR TITLE
[WEB-7] Make search result category tabs sticky

### DIFF
--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -15,7 +15,7 @@
 		<div class="container">
 			<div class="row">
 					<div id="subnav-placeholder">
-						<div class="component subnav">
+						<div class="component subnav dynamic-fixed" data-top-nav-offset="120">
 							<ul class="results-nav" role="tablist">
 								<li role="presentation" class="active">
 									<a role="tab" data-toggle="tab" aria-controls="search-results-documentation" href="#search-results-documentation">

--- a/src-js/instantsearch.js
+++ b/src-js/instantsearch.js
@@ -220,4 +220,9 @@ export function init () {
     searchBox.value = ''
     renderResults();
   });
+
+  // Scroll results back to top upon tab change
+  $(resultDisplay).find('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+    $("html, body").animate({ scrollTop: 0 });
+  });
 };


### PR DESCRIPTION
We can use the `dynamic-fixed` mode of the subnav component to accomplish this, with a custom top nav offset param to account for the fixed-position search bar.

We also need to scroll the document back to the top upon tab changes, which we can do by attaching a handler to the boostrap tab shown event.