### PR TITLE
[WEB-95] Search Results for mobile

### DIFF
--- a/jekyll/_includes/main-searchbar.html
+++ b/jekyll/_includes/main-searchbar.html
@@ -1,11 +1,9 @@
 <div class="main-searchbar">
   <div class="container">
-    <div class="row">
-      <form>
-        <div id="search-box">
-          <!-- SearchBox widget will appear here -->
-        </div>
-      </form>
-    </div>
+    <form>
+      <div id="search-box">
+        <!-- SearchBox widget will appear here -->
+      </div>
+    </form>
   </div>
 </div>

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -13,7 +13,6 @@
 	<!-- instant hit template container /-->
 	<div id="hits-target" style="display:none;">
 		<div class="container">
-			<div class="row">
 					<div id="subnav-placeholder">
 						<div class="component subnav">
 							<ul class="results-nav" role="tablist">
@@ -47,7 +46,6 @@
 							<div id="instant-hits-cimgs"></div>
 						</div>
 					</div>
-			</div>
 		</div>
 	</div>
 	<div class="main-body">

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -14,7 +14,7 @@
 	<div id="hits-target" style="display:none;">
 		<div class="container">
 					<div id="subnav-placeholder">
-						<div class="component subnav">
+						<div class="component subnav dynamic-fixed" data-top-nav-offset="120">
 							<ul class="results-nav" role="tablist">
 								<li role="presentation" class="active">
 									<a role="tab" data-toggle="tab" aria-controls="search-results-documentation" href="#search-results-documentation">

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -18,17 +18,22 @@
 							<ul class="results-nav" role="tablist">
 								<li role="presentation" class="active">
 									<a role="tab" data-toggle="tab" aria-controls="search-results-documentation" href="#search-results-documentation">
-										Documentation <span class="hits-count">(<span class="hits-count-docs">0</span>)</span>
+										<span class="hidden-xs">Documentation</span>
+										<span class="visible-xs-inline">Docs</span>
+										<span class="hits-count">(<span class="hits-count-docs">0</span>)</span>
 									</a>
 								</li>
 								<li role="presentation">
 									<a role="tab" data-toggle="tab" aria-controls="search-results-orbs" href="#search-results-orbs">
-										Orbs <span class="hits-count">(<span class="hits-count-orbs">0</span>)</span>
+										Orbs
+										<span class="hits-count">(<span class="hits-count-orbs">0</span>)</span>
 									</a>
 								</li>
 								<li role="presentation">
 									<a role="tab" data-toggle="tab" aria-controls="search-results-cimgs" href="#search-results-cimgs">
-										Convenience Images <span class="hits-count">(<span class="hits-count-cimgs">0</span>)</span>
+										<span class="hidden-xs">Convenience Images</span>
+										<span class="visible-xs-inline">Images</span>
+										<span class="hits-count">(<span class="hits-count-cimgs">0</span>)</span>
 									</a>
 								</li>
 							</ul>

--- a/jekyll/_sass/_instantsearch.scss
+++ b/jekyll/_sass/_instantsearch.scss
@@ -141,3 +141,19 @@ ul.results-nav {
     }
   }
 }
+
+// Showing/hiding search screen
+body.search-open {
+  .main-body {
+    display: none;
+  }
+
+  .sidebar-mobile-wrapper {
+    display: none;
+  }
+
+  #hits-target {
+    // To override an element style being applied by some JS we don't own, probably instantsearch
+    display: block !important;
+  }
+}

--- a/jekyll/_sass/_instantsearch.scss
+++ b/jekyll/_sass/_instantsearch.scss
@@ -60,10 +60,7 @@
   padding: $spacing-small-vertical 0;
   background: #FAFAFA;
   min-height: 500px;
-
-  @media screen and (min-width: $screen-sm) {
-    margin-top: $spacing-medium-vertical;
-  }
+  margin-top: $spacing-medium-vertical;
 
   h2 {
     padding-left: $spacing-small-vertical;

--- a/jekyll/_sass/_instantsearch.scss
+++ b/jekyll/_sass/_instantsearch.scss
@@ -18,12 +18,6 @@
     position: relative;
     display: block;
     max-width: 400px;
-    margin-left: 18px;
-    margin-right: 18px;
-
-    @media screen and (min-width: $screen-md) {
-      margin: 0;
-    }
 
     .ais-SearchBox-submit {
       position: absolute;
@@ -81,11 +75,12 @@
 }
 
 .result-item-wrap {
-  $result-spacing: $spacing-medium-vertical / 2;
+  $result-vertical-spacing: $spacing-medium-vertical / 4;
+  $half-gutter-width: $grid-gutter-width / 2;
 
-  padding: $result-spacing/2 $result-spacing;
-  margin-left:  -$result-spacing;
-  margin-right: -$result-spacing;
+  padding: $result-vertical-spacing $half-gutter-width;
+  margin-left:  -$half-gutter-width;
+  margin-right: -$half-gutter-width;
 
   .result-title {
     font-size: 18px;

--- a/jekyll/_sass/_subnav.scss
+++ b/jekyll/_sass/_subnav.scss
@@ -46,3 +46,29 @@ $nav-offset-subnav: $nav-offset + $subnav-offset;
     top: -$nav-offset-subnav;
   }
 }
+
+// Another set of styles specific to this project:
+
+// 1. Override hiding of subnav on mobile
+.component.subnav {
+  @media screen and (max-width: $screen-xs-max) {
+    display: block;
+  }
+}
+#subnav-placeholder {
+  @media screen and (max-width: $screen-xs-max) {
+    display: block;
+  }
+}
+
+// 2. Add style for mobile
+.component.subnav {
+  @media screen and (max-width: $screen-xs-max) {
+    font-size: $font-size-small;
+
+    li {
+      padding-top: 8px;
+      padding-bottom: 8px;
+    }
+  }
+}

--- a/jekyll/_sass/_variables.scss
+++ b/jekyll/_sass/_variables.scss
@@ -14,6 +14,9 @@ $gray-100: #F7F7F7;
 $gray-200: #e2e0e0;
 $gray-dark: #898989;
 
+// Grid System
+$grid-gutter-width: 30px;
+
 // Screen Sizes
 $screen-xs:                  480px;
 $screen-xs-min:              $screen-xs;

--- a/jekyll/assets/css/navbar.css
+++ b/jekyll/assets/css/navbar.css
@@ -26,7 +26,6 @@
   .nav-toggle.two .widescreen a.logo {
     position: absolute;
     top: 18px;
-    left: 0;
     z-index: 3; }
   .nav-toggle.two .widescreen img.logo {
     height: 35px; }

--- a/src-js/instantsearch.js
+++ b/src-js/instantsearch.js
@@ -192,22 +192,17 @@ export function init () {
   // insert search results
   var searchResetButton = document.querySelector("#search-box .ais-SearchBox-reset");
   var searchBox = document.querySelector("input.instantsearch-search");
-  var pageBody = document.querySelector('.main-body');
-  var mobileNav = document.querySelector('.sidebar-mobile-wrapper');
+  var documentBody = document.querySelector('body');
   var resultDisplay = document.querySelector('#hits-target');
   var form = document.querySelector('.main-searchbar form');
 
   function renderResults (e) {
     if (searchBox.value.length > 0) {
       window.scrollTo(0, 0);
-      pageBody.style.display = "none";
-      mobileNav.style.display = "none";
-      resultDisplay.style.display = "block";
+      documentBody.classList.add('search-open');
       window.dispatchEvent(new Event('shown.subnav'));
     } else {
-      pageBody.style.display = "flex";
-      mobileNav.style.display = "block";
-      resultDisplay.style.display = "none";
+      documentBody.classList.remove('search-open');
     }
   };
 

--- a/src-js/instantsearch.js
+++ b/src-js/instantsearch.js
@@ -223,4 +223,9 @@ export function init () {
     searchBox.value = ''
     renderResults();
   });
+
+  // Scroll results back to top upon tab change
+  $(resultDisplay).find('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+    $("html, body").animate({ scrollTop: 0 });
+  });
 };

--- a/src-js/instantsearch.js
+++ b/src-js/instantsearch.js
@@ -193,6 +193,7 @@ export function init () {
   var searchResetButton = document.querySelector("#search-box .ais-SearchBox-reset");
   var searchBox = document.querySelector("input.instantsearch-search");
   var pageBody = document.querySelector('.main-body');
+  var mobileNav = document.querySelector('.sidebar-mobile-wrapper');
   var resultDisplay = document.querySelector('#hits-target');
   var form = document.querySelector('.main-searchbar form');
 
@@ -200,10 +201,12 @@ export function init () {
     if (searchBox.value.length > 0) {
       window.scrollTo(0, 0);
       pageBody.style.display = "none";
+      mobileNav.style.display = "none";
       resultDisplay.style.display = "block";
       window.dispatchEvent(new Event('shown.subnav'));
     } else {
       pageBody.style.display = "flex";
+      mobileNav.style.display = "block";
       resultDisplay.style.display = "none";
     }
   };


### PR DESCRIPTION
This adds a mobile version of the search result category subnav, as well as some page layout structure improvements to enable that change.

Those changes resolve some long-standing Bootstrap grid misuse in the header and search bar:

1. Search query bar and results container had a row without   accompanying columns (should just be a container sans row). The   query bar CSS had manually implemented (and incomplete for mobile)   margins to compensate, which are now removed.

2. The header logo was absolutely positioned, resulting in it appearing   outside its surrounding column/container (too far left). This commit   removes that, allowing it to be positioned on the left edge of its   container where it will align with other containers on the page,   such as the search query bar and results container.

3. The search results item wrapper had negative margins to allow space   around the hover/highlight background color, however this resulted   in horizontal scrolling on narrow screens because it was larger than   the gutter width. Note: there is still some horizontal scrolling   present on narrow screens being caused by something in the footer.
