### PR TITLE
Correct version of Python in example config

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -895,7 +895,7 @@ jobs:
   build:
     steps: []
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:2.7
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference


### PR DESCRIPTION
# Description
Corrected the version of python specified in the compiled config snippet to match that of the parameter being passed in
3.8 -> 2.7

# Reasons
Having two conflicting version numbers in the config would lead to people getting confused when reading the docs, and perhaps reuse that incorrect config for their builds.