### PR TITLE
Add a note that large resource for macOS is available only for annual plans

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -550,7 +550,7 @@ jobs:
 Class              | vCPUs | RAM
 -------------------|-------|-----
 medium (default)   | 4     | 8GB
-large<sup>(2)</sup>| 8     | 16GB
+large<sup>(3)</sup>| 8     | 16GB
 {: class="table table-striped"}
 
 ###### Example usage
@@ -640,6 +640,7 @@ jobs:
 ```
 
 <sup>(2)</sup> _This resource requires review by our support team. [Open a support ticket](https://support.circleci.com/hc/en-us/requests/new) if you would like to request access._
+<sup>(3)</sup> _This resource is available only for customers with an annual contract. [Open a support ticket](https://support.circleci.com/hc/en-us/requests/new) if you would like to learn more about our annual plans._
 
 **Note**: Java, Erlang and any other languages that introspect the `/proc` directory for information about CPU count may require additional configuration to prevent them from slowing down when using the CircleCI 2.0 resource class feature. Programs with this issue may request 32 CPU cores and run slower than they would when requesting one core. Users of languages with this issue should pin their CPU count to their guaranteed CPU resources.
 


### PR DESCRIPTION
Add a note that `large` resource class for macOS is available only for annual plans

# Description
Add a note that large resource class for macOS is available only for customer with annual contracts.

# Reasons
There is an increasing number of support tickets that requests for macOS large resources with M2M plans We had a feedback from those support requesters that being told posteriori that the resource is available only for annual plans is not a good experience. Adding this pre-emptive note mitigates such sentiment risks.

See also: https://circleci.slack.com/archives/CJNASDDEZ/p1614815062028700?thread_ts=1614809740.026300&cid=CJNASDDEZ
