### PR TITLE
add analytics eventName query param

### DIFF
--- a/jekyll/assets/js/main.js
+++ b/jekyll/assets/js/main.js
@@ -56,7 +56,7 @@ var trackEvent = function (name, properties, options, callback) {
   });
 };
 
-// analytics tracking for CTA button clicks
+// analytics tracking for CTA button clicks and eventName query param
 window.addEventListener('load', function () {
   var buttons = Array.from(document.querySelectorAll('[data-analytics-action]'));
 
@@ -67,6 +67,11 @@ window.addEventListener('load', function () {
       trackEvent(action, analyticsTrackProps(this));
     });
   });
+
+  var queryParams = getUrlVars(window.location.href);
+  if (!!queryParams.eventName) {
+    trackEvent(eventName);
+  }
 });
 
 function getUrlVars(url) {


### PR DESCRIPTION
# Description
Adds the ability to fire an analytic event when passing the `eventName` query param.

# Reasons
Part of the requirements for the ticket below is to have an event fire when clicking on the doc link from github. If we had the ability to fire an event with a query we could use that in the github actions CTA.
[CIRCLE-33157](https://circleci.atlassian.net/browse/CIRCLE-33157)