### PR TITLE
Speed up `html-proofer`  test 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
     executor:
       name: ruby/default
       tag: '2.6.3-node-browsers'
-
+    resource_class: medium+
     working_directory: ~/circleci-docs
     environment:
       JEKYLL_ENV: production
@@ -236,12 +236,10 @@ jobs:
             set -exu
             mkdir -p /tmp/workspace/js
             mv /tmp/workspace/js/* jekyll/assets/js/
-
             mkdir -p /tmp/workspace/api
             cp -r /tmp/workspace/api/ jekyll/_api/
             # remove unusued /api folder.
             rm -rf jekyll/_api/api
-
             mkdir -p /tmp/workspace/pdfs
             cp -r /tmp/workspace/api/* jekyll/_api/
       - run: sudo apt-get update; sudo apt-get --yes install nkf
@@ -250,12 +248,8 @@ jobs:
           command: ./scripts/shim-translation.sh jekyll/_cci2 jekyll/_cci2_ja
       - set-jekyll-basename
       - run:
-          name: Create jekyll config file to override things
-          command: |
-            echo "baseurl: \"/${JEKYLL_BASENAME}\"" > jekyll/_config_override.yml
-      - run:
           name: Build the Jekyll site
-          command: bundle exec jekyll build --config jekyll/_config.yml,jekyll/_config_production.yml,jekyll/_config_override.yml --source jekyll --destination jekyll/_site/${JEKYLL_BASENAME} 2>&1 | tee $JOB_RESULTS_PATH/build-results.txt
+          command: bundle exec rake build
       - run:
           name: Workaround to pass htmlproofer for docs where baseurl (/docs) is hardcoded
           command: |
@@ -267,9 +261,13 @@ jobs:
       - run:
           name: Test with HTMLproofer
           command: |
-            bundle exec htmlproofer jekyll/_site --allow-hash-href --check-favicon --check-html --disable-external --file-ignore "jekyll/_site/${JEKYLL_BASENAME}/api/v2/index.html,${JEKYLL_BASENAME}/api/v2/,/${JEKYLL_BASENAME}/ja/2.0/runner-installation/,/${JEKYLL_BASENAME}/ja/2.0/security-server/,/${JEKYLL_BASENAME}/ja/2.0/v.2.19-overview/,/${JEKYLL_BASENAME}/ja/2.0/customizations/,/${JEKYLL_BASENAME}/ja/2.0/aws-prereq/,/${JEKYLL_BASENAME}/ja/2.0/ops/,/${JEKYLL_BASENAME}/ja/2.0/about-circleci/,/${JEKYLL_BASENAME}/ja/2.0/demo-apps/,/${JEKYLL_BASENAME}/ja/2.0/google-auth/,/${JEKYLL_BASENAME}/ja/2.0/orb-concepts/,/${JEKYLL_BASENAME}/ja/2.0/tutorials/,/${JEKYLL_BASENAME}/reference-2-1/" --empty-alt-ignore 2>&1 | nkf -w --url-input | tee $JOB_RESULTS_PATH/htmlproofer-results.txt
+            bundle exec rake test
+      - run:
+          name: compress jekyll output
+          command: |
+            tar -zcvf circleci-docs.tar.gz jekyll/_site/
       - store_artifacts: # stores the built files of the Jekyll site
-          path: jekyll/_site/
+          path: circleci-docs.tar.gz
           destination: circleci-docs
       - store_artifacts: # stores build log output.
           path: run-results/
@@ -297,7 +295,6 @@ jobs:
           name: Update Algolia Index
           command: |
             ALGOLIA_API_KEY=$ALGOLIA_PRIVATE_KEY bundle exec jekyll algolia --source jekyll --config jekyll/_config.yml
-
   deploy:
     docker:
       - image: cibuilds/aws:1.16.185

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ src-api/build/
 # jekyll/_algolia_api_key can be used to store an algolia API key for
 # indexing the content. Useful for local development.
 *_algolia_api_key
+
+# local test
+vendor
+jekyll/_config_override.yml

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem "rack", ">= 2.0.6"
 gem 'asciidoctor'
 gem 'asciidoctor-pdf', '~> 1.5.3'
 gem 'pygments.rb', '~> 1.1.2'
+gem 'rake'
+gem 'dotenv'
 
 group :jekyll_plugins do
   gem 'jekyll-algolia', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
     concurrent-ruby (1.1.6)
     css_parser (1.7.1)
       addressable
+    dotenv (2.7.6)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -153,6 +154,7 @@ GEM
       multi_json (>= 1.0.0)
     rack (2.1.4)
     rainbow (3.0.0)
+    rake (13.0.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -185,6 +187,7 @@ PLATFORMS
 DEPENDENCIES
   asciidoctor
   asciidoctor-pdf (~> 1.5.3)
+  dotenv
   html-proofer
   jekyll (= 3.8.6)
   jekyll-algolia (~> 1.0)
@@ -194,6 +197,7 @@ DEPENDENCIES
   jekyll-target-blank
   pygments.rb (~> 1.1.2)
   rack (>= 2.0.6)
+  rake
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/Rakefile
+++ b/Rakefile
@@ -5,13 +5,13 @@ require 'dotenv/load'
 
 JEKYLL_BASENAME = ENV['JEKYLL_BASENAME'] || 'docs'
 
-task :set_untranslated do
-  puts 'Shim untranslated Japanese pages'
+desc 'Shim untranslated Japanese pages'
+task :shim_untranslated do
   sh './scripts/shim-translation.sh jekyll/_cci2 jekyll/_cci2_ja'
 end
 
+desc 'Build Jekyll site'
 task :build do
-  puts 'build Jekyll'
   # Create jekyll config file to override things
   sh "echo 'baseurl: \"\/#{JEKYLL_BASENAME}\"' > jekyll/_config_override.yml"
   # Build the Jekyll site
@@ -24,8 +24,8 @@ task :build do
   Jekyll::Commands::Build.build site, config
 end
 
+desc 'Make mock API docs'
 task :make_mock_api do
-  puts 'Make mock API docs'
   sh "echo \"<html lang=''><head><link href='/docs/assets/img/icons/favicon.png' rel='icon' type='image/png' /></head></html>\" > ./jekyll/_site/index.html"
   sh "mkdir -p ./jekyll/_site/docs/api/2.0/"
   sh "mkdir -p ./jekyll/_site/docs/api/v2/"
@@ -35,8 +35,13 @@ task :make_mock_api do
   sh "rm ./jekyll/_site/index.html"
 end
 
+desc 'Build your jekyll site in local env'
+task :build_local => [:set_untranslated, :build, :make_mock_api] do
+  puts 'Finish building your jekyll site, and now you can run `bundle exec rake test` to run `HTMLproofer` test'
+end
+
+desc 'Test with HTMLproofer'
 task :test do
-  puts 'Test with HTMLproofer'
   ignore_files = ["./jekyll/_site/#{JEKYLL_BASENAME}/api/v2/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/runner-installation/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/security-server/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/v.2.19-overview/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/customizations/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/aws-prereq/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/ops/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/about-circleci/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/demo-apps/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/google-auth/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/orb-concepts/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/tutorials/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/reference-2-1/index.html"]
 
   options = { :allow_hash_href => true,  :check_favicon => true, :check_html => true, :disable_external => true, :empty_alt_ignore => true, :parallel => { :in_processes => 4}, :file_ignore => ignore_files}

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+require 'html-proofer'
+require 'jekyll'
+require 'dotenv/load'
+
+JEKYLL_BASENAME = ENV['JEKYLL_BASENAME'] || 'docs'
+
+task :set_untranslated do
+  puts 'Shim untranslated Japanese pages'
+  sh './scripts/shim-translation.sh jekyll/_cci2 jekyll/_cci2_ja'
+end
+
+task :build do
+  puts 'build Jekyll'
+  # Create jekyll config file to override things
+  sh "echo 'baseurl: \"\/#{JEKYLL_BASENAME}\"' > jekyll/_config_override.yml"
+  # Build the Jekyll site
+  config = Jekyll.configuration({ 
+    'source' => './jekyll', 
+    'destination' => "./jekyll/_site/#{JEKYLL_BASENAME}",
+    'config' => ['./jekyll/_config.yml','./jekyll/_config_production.yml','./jekyll/_config_override.yml']
+  })
+  site = Jekyll::Site.new(config)
+  Jekyll::Commands::Build.build site, config
+end
+
+task :make_mock_api do
+  puts 'Make mock API docs'
+  sh "echo \"<html lang=''><head><link href='/docs/assets/img/icons/favicon.png' rel='icon' type='image/png' /></head></html>\" > ./jekyll/_site/index.html"
+  sh "mkdir -p ./jekyll/_site/docs/api/2.0/"
+  sh "mkdir -p ./jekyll/_site/docs/api/v2/"
+  sh "cp ./jekyll/_site/index.html ./jekyll/_site/docs/api/2.0/index.html"
+  sh "cp ./jekyll/_site/index.html ./jekyll/_site/docs/api/v2/index.html"
+  sh "cp ./jekyll/_site/index.html ./jekyll/_site/docs/api/index.html"
+  sh "rm ./jekyll/_site/index.html"
+end
+
+task :test do
+  puts 'Test with HTMLproofer'
+  ignore_files = ["./jekyll/_site/#{JEKYLL_BASENAME}/api/v2/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/runner-installation/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/security-server/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/v.2.19-overview/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/customizations/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/aws-prereq/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/ops/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/about-circleci/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/demo-apps/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/google-auth/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/orb-concepts/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/ja/2.0/tutorials/index.html","./jekyll/_site/#{JEKYLL_BASENAME}/reference-2-1/index.html"]
+
+  options = { :allow_hash_href => true,  :check_favicon => true, :check_html => true, :disable_external => true, :empty_alt_ignore => true, :parallel => { :in_processes => 4}, :file_ignore => ignore_files}
+
+  HTMLProofer.check_directory("./jekyll/_site", options).run
+end


### PR DESCRIPTION
# Description

- use `parallel` feature in `html-proofer` to speed up test
- use medium+ resouce_class in CircleCI
- export `html-proofer test` and `jekyll build` commands into Rakefile
- pack artifacts before uploading them into CircleCI artifacts

# Reasons

The `html-proofer` test generally takes 4 to 5 mins, so I customized it to use `parallel` feature in  `html-proofer` to speed up this test. Also, I changed circleci.yml to use `medium+` resource_class, and now the `html-proofer` test tasks about 1 min.

> https://app.circleci.com/pipelines/github/circleci/circleci-docs/27419/workflows/0309440a-a3fe-4bc0-8e5e-9667ab5002e6/jobs/75692/parallel-runs/0/steps/0-120

Also, the html-proofer and jekyll build commands were complexed. And it prevents running these commands locally.
So, I exported `html-proofer test` and `jekyll build` commands into Rakefile. 

```
$ bundle exec rake build
$ bundle exec rake test
```