### PR TITLE
[CIRCLE-32867] a bit of re-wording to provide more clarity around contexts

### DIFF
--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -117,16 +117,16 @@ jobs:
 
 If you move your repository to a new organization, you must also have the context with that unique name set in the new organization.
 
-### Contexts & Environment variables validation
+### Contexts & Environment variables constraints
 
 When creating contexts/environment variables, please note the following:
 
 - The context name must be 200 or fewer characters, must contain at least one non-whitespace character, and must not contain leading, trailing or vertical whitespaces.
-- An organization may contain no more than 500 contexts.
-- The environment variable name must be 300 or fewer characters, must have alpha or `_` as the first character and can *only* contain  alphanumeric or `_` as the remaining characters.
-- An environment variable value must be 32000 or fewer characters and must NOT contain `null`. 
+- Each organization is limited to 500 contexts.
+- The environment variable name must be 300 or fewer characters, beging with alpha or `_` as the first character, and use alphanumeric or `_` for the remaining characters.
+- An environment variable value must have 32k or fewer characters. 
 - An empty environment variable is considered valid.
-- A context may contain no more than 100 environment variables.
+- Each context is limited to 100 environment variables.
 
 ## Combining contexts
 


### PR DESCRIPTION
We thought the wording around `null` seemed misleading
* Got rid of the `null` constraints 
* Renamed it to constraints instead of validation