### PR TITLE
Fix: prevent long non-wrap of `code` tag.

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -352,7 +352,9 @@ installations of CircleCI. To install the legacy CLI on macOS and other Linux Di
 1. Install and configure Docker by using the [docker installation instructions](https://docs.docker.com/install/).
 2. To install the CLI, run the following command:
 
-`$ curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && chmod +x /usr/local/bin/circleci`
+```sh
+$ curl -o /usr/local/bin/circleci https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci && chmod +x /usr/local/bin/circleci
+```
 
 The CLI, `circleci`, is downloaded to the `/usr/local/bin` directory. If you do not have write permissions for `/usr/local/bin`, you might need to run the above commands with `sudo`. The CLI automatically checks for updates and will prompt you if one is available.
 


### PR DESCRIPTION
<img width="1003" alt="Screen Shot 2021-03-16 at 2 33 58 PM" src="https://user-images.githubusercontent.com/12987958/111361982-ad766080-8664-11eb-868a-71ca6f01f2aa.png">

Move the above into a code block.

*Note*: We should probably word wrap on `code` tags, but this will need a closer inspection across multiple pages to make sure style changes don't break; this is a temporary fix. 