### PR TITLE
Update skip-build.md

### DIFF
--- a/jekyll/_cci2/skip-build.md
+++ b/jekyll/_cci2/skip-build.md
@@ -16,7 +16,7 @@ This document describes how to skip or cancel builds in the following sections.
 
 ## Skipping a build
 
-By default, CircleCI automatically builds a project whenever you push changes to a version control system (VCS). You can override this behavior by adding a `[ci skip]` or `[skip ci]` tag in the first line of the body of the commit or the commit's title. This not only skips the marked commit, but also **all other commits** in the push.
+By default, CircleCI automatically builds a project whenever you push changes to a version control system (VCS). You can override this behavior by adding a `[ci skip]` or `[skip ci]` tag within the first 250 characters of the body of the commit or the commit's title. This not only skips the marked commit, but also **all other commits** in the push.
 
 **Note:**
 This feature is not supported for fork PRs. Scheduled workflows will not be cancelled even if you push a commit with `[ci skip]` message. Changing the config file is the way to upgrade the current schedule.


### PR DESCRIPTION
Update description for skipping a build to include character limit for truncated commit messages

# Description
We request users to place [ci skip] or [skip ci] on the first line of the commit message body.
It technically can be placed anywhere in the body or title, but we truncate the commit messages at 250 characters,
so the description can be seen as misleading.

My commit changes the wording to include the character limit instead of mentioning the first line.

# Reasons
Users who put [ci skip] or [skip ci] after the first line could be confused when their build is still skipped.
Being more clear in the description will lead to less confusion.