### PR TITLE
Patch local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CircleCI Documentation 
+# CircleCI Documentation
 
 [![CircleCI Build Status](https://circleci.com/gh/circleci/circleci-docs.svg?style=shield)](https://circleci.com/gh/circleci/circleci-docs)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/circleci/circleci-docs/master/LICENSE)
@@ -22,10 +22,19 @@ If you have a question or need help debugging, please head to [CircleCI
 Discuss](https://discuss.circleci.com/) where our support team will help you
 out.
 
+## Preview
+
+Building the static Jekyll site can run without installation by using Docker.
+If you already configured Jekyll on your local machine, you need to delete `vendor` directory, before running the command.
+
+```
+$ docker-compose up
+```
+
 ## Documentation Components
 
 This repository houses and manages several arms of documentation for CircleCI.
-This section will provide a brief overview of each "component" and how to get 
+This section will provide a brief overview of each "component" and how to get
 started with making changes.
 
 ### `/Jekyll` - Main Site

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ out.
 
 ## Preview
 
-Building the static Jekyll site can run without installation by using Docker.
+It is possible to build and serve the Jekyll docs locally (without ruby or jekyll installed) using Docker and docker compose.
 If you already configured Jekyll on your local machine, you need to delete `vendor` directory, before running the command.
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 version: "3"
 services:
   jekyll:
-    command: jekyll serve -s jekyll --incremental --livereload
-    image: jekyll/jekyll:3.8.6
+    command: bash -c "bundle install && bundle exec jekyll serve -s jekyll --incremental --livereload --host=0.0.0.0"
+    working_dir: /root
+    image: ruby:2.7.2
     volumes:
-      - ".:/srv/jekyll"
+      - ".:/root"
     ports:
       - 127.0.0.1:4000:4000
       - 127.0.0.1:35729:35729


### PR DESCRIPTION
# Description

Changed the docker image on docker-compose to fix an issue in the local build. This is because we bumped the ruby version to `2.7.2`, and the previous image is no longer applicable. 

# Reasons
Slack: https://circleci.slack.com/archives/C0KBNJGRH/p1616802657027600

cc: @mvxt