### PR TITLE
Drop GPU documenation for Server 3.x

### DIFF
--- a/jekyll/_cci2/gpu.adoc
+++ b/jekyll/_cci2/gpu.adoc
@@ -1,7 +1,6 @@
 ---
 version:
 - Server v2.x
-- Server v3.x
 - Server Admin
 ---
 = Running GPU Executors


### PR DESCRIPTION
### Description
Removes GPU documentation from Server 3.x docs

### Reasons
We haven't got proper GPU support right now, lets drop this
documentation from the 3.x section for now and add it back with
3.x specifics when we add GPU configuration properly