### PR TITLE
Hardcoding version in, since this is a 2.19 specific upgrade guide

### DIFF
--- a/jekyll/_cci2/updating-server.adoc
+++ b/jekyll/_cci2/updating-server.adoc
@@ -11,7 +11,7 @@ version:
 :toc: macro
 :toc-title:
 
-This document describes the process for upgrading your CircleCI Server installation to v{serverversion}. 
+This document describes the process for upgrading your CircleCI Server installation to v2.19.
 
 toc::[]
 


### PR DESCRIPTION
Small typo fix in 2.19 upgrade guide.