### PR TITLE
[SERVER-1002] add warning about webhooks when using new hostname after migration

### DIFF
--- a/jekyll/_cci2/server-3-install-migration.adoc
+++ b/jekyll/_cci2/server-3-install-migration.adoc
@@ -41,7 +41,7 @@ toc::[]
 
 Input the required information and complete the migration process.
 
-If a different hostname is being used in the 3.0 environment, an extra step is required.  The GitHub webhooks will still be pointing to the hostname used in the 2.19 environment.  The easiest way to update this is to `Stop Building` and then `Set Up Project`, the contexts and environment variables associated with the project will still be present after doing this.
+NOTE: If a different hostname is being used in the 3.0 environment, the GitHub webhooks will still be pointing to the hostname used in the 2.19 environment.  The easiest way to update this is to click *Stop Building* and then *Set Up Project*. After doing this, the contexts and environment variables associated with the project will still be present.
 
 ### Step 2 - Validate your migration to Server 3.0
 Re-run https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[reality check]

--- a/jekyll/_cci2/server-3-install-migration.adoc
+++ b/jekyll/_cci2/server-3-install-migration.adoc
@@ -41,6 +41,8 @@ toc::[]
 
 Input the required information and complete the migration process.
 
+If a different hostname is being used in the 3.0 environment, an extra step is required.  The GitHub webhooks will still be pointing to the hostname used in the 2.19 environment.  The easiest way to update this is to `Stop Building` and then `Set Up Project`, the contexts and environment variables associated with the project will still be present after doing this.
+
 ### Step 2 - Validate your migration to Server 3.0
 Re-run https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[reality check]
 with contexts on your new Server 3.0 environment by pushing a fresh commit.


### PR DESCRIPTION
# Description
Change hostnames is not addressed in the migration script

# Reasons
Give guidances to customers on how to resolve broken webhooks if they change hostnames when migrating from 2.19 to 3

@annabaker as always, I will defer to you for formatting