### PR TITLE
Fix private-images.adoc

### DIFF
--- a/jekyll/_cci2/private-images.adoc
+++ b/jekyll/_cci2/private-images.adoc
@@ -20,7 +20,6 @@ CircleCI has partnered with Docker to ensure that our users can continue to acce
 toc::[]
 
 ## Docker executor
-{: #docker-executor }
 
 For the https://circleci.com/docs/2.0/executor-types/#using-docker[Docker executor], specify a username and password in
 the `auth` field of your https://circleci.com/docs/2.0/configuration-reference[config.yml] file. To protect the password,
@@ -66,7 +65,6 @@ username/password for the `auth` key. For example:
 
 
 ## Machine executor (with Docker orb)
-{: #machine-executor-with-docker-orb }
 
 Alternatively, you can utilize the `machine` executor to achieve the same result using the Docker orb:
 
@@ -97,7 +95,6 @@ jobs:
 
 
 ## Machine executor (with Docker CLI)
-{: #machine-executor-with-docker-cli }
 
 or with the CLI:
 
@@ -119,7 +116,6 @@ jobs:
 ----
 
 ## AWS ECR
-{: #aws-ecr }
 
 CircleCI now supports pulling private images from Amazon's ECR service.
 
@@ -200,6 +196,5 @@ workflows:
 ----
 
 ## See also
-{: #see-also }
 
 * https://circleci.com/docs/2.0/configuration-reference[Configuration Reference]


### PR DESCRIPTION
# Description
After fixing the style violations of private-images.md, it was converted to adoc file. And, I did not realize that when fixing conflicts, and merged them. I am removing the style fixes introduced in https://github.com/circleci/circleci-docs/pull/5187 from this adoc file.

# Reasons

It is a markdown jekyll style and does not apply to adoc files.