### PR TITLE
CIRCLE-34038 Document the feature gaps between runner and normal jobs

### DIFF
--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -130,3 +130,11 @@ jobs:
 The job will then execute using your runner when you push the config to your VCS provider.
 
 NOTE: A namespace is a unique identifier claimed by a user or organization. Each user or organization can claim one unique and immutable namespace. Organizations are, by default, limited to claiming only one namespace. This policy is designed to limit name-squatting and namespace noise. If you need to change your namespace, please https://support.circleci.com/hc/en-us[contact support].
+
+== Limitations
+
+Almost all standard CircleCI features are available for use with runner jobs, but at present a few features are not yet supported. If these features are important for you to make use of runner jobs, please let us know via the relevant canny page.
+
+- [Rerun with SSH](https://circleci.canny.io/runner-feature-requests/p/support-rerun-with-ssh-on-runner)
+- [Test Splitting](https://circleci.canny.io/runner-feature-requests/p/support-test-splitting-on-self-hosted-runners)
+- [`add_ssh_keys`](https://circleci.canny.io/runner-feature-requests/p/support-addsshkey-on-self-hosted-runners)


### PR DESCRIPTION
# Description
There are a few standard features that aren't yet available on runner jobs - they were previously documented somewhere but got lost in a reshuffle.

https://circleci.atlassian.net/browse/CIRCLE-34038