### PR TITLE
merge the change in the original hits-target component

### DIFF
--- a/jekyll/_includes/hits-target.html
+++ b/jekyll/_includes/hits-target.html
@@ -1,39 +1,41 @@
 <div id="hits-target" style="display:none;">
-  <div class="container">
-    <div class="row">
-        <div id="subnav-placeholder">
-          <div class="component subnav dynamic-fixed" data-top-nav-offset="120">
-            <ul class="results-nav" role="tablist">
-              <li role="presentation" class="active">
-                <a role="tab" data-toggle="tab" aria-controls="search-results-documentation" href="#search-results-documentation">
-                  Documentation <span class="hits-count">(<span class="hits-count-docs">0</span>)</span>
-                </a>
-              </li>
-              <li role="presentation">
-                <a role="tab" data-toggle="tab" aria-controls="search-results-orbs" href="#search-results-orbs">
-                  Orbs <span class="hits-count">(<span class="hits-count-orbs">0</span>)</span>
-                </a>
-              </li>
-              <li role="presentation">
-                <a role="tab" data-toggle="tab" aria-controls="search-results-cimgs" href="#search-results-cimgs">
-                  Convenience Images <span class="hits-count">(<span class="hits-count-cimgs">0</span>)</span>
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <div class="tab-content">
-          <div role="tabpanel" class="tab-pane active" id="search-results-documentation">
-            <div id="instant-hits"></div>
-          </div>
-          <div role="tabpanel" class="tab-pane" id="search-results-orbs">
-            <div id="instant-hits-orbs"></div>
-          </div>
-          <div role="tabpanel" class="tab-pane" id="search-results-cimgs">
-            <div id="instant-hits-cimgs"></div>
-          </div>
-        </div>
+  <div class="container-semi-fluid">
+    <div id="subnav-placeholder">
+      <div class="component subnav dynamic-fixed" data-top-nav-offset="120">
+        <ul class="results-nav" role="tablist">
+          <li role="presentation" class="active">
+            <a role="tab" data-toggle="tab" aria-controls="search-results-documentation" href="#search-results-documentation">
+              <span class="hidden-xs">Documentation</span>
+              <span class="visible-xs-inline">Docs</span>
+              <span class="hits-count">(<span class="hits-count-docs">0</span>)</span>
+            </a>
+          </li>
+          <li role="presentation">
+            <a role="tab" data-toggle="tab" aria-controls="search-results-orbs" href="#search-results-orbs">
+              Orbs
+              <span class="hits-count">(<span class="hits-count-orbs">0</span>)</span>
+            </a>
+          </li>
+          <li role="presentation">
+            <a role="tab" data-toggle="tab" aria-controls="search-results-cimgs" href="#search-results-cimgs">
+              <span class="hidden-xs">Convenience Images</span>
+              <span class="visible-xs-inline">Images</span>
+              <span class="hits-count">(<span class="hits-count-cimgs">0</span>)</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="tab-content">
+      <div role="tabpanel" class="tab-pane active" id="search-results-documentation">
+        <div id="instant-hits"></div>
+      </div>
+      <div role="tabpanel" class="tab-pane" id="search-results-orbs">
+        <div id="instant-hits-orbs"></div>
+      </div>
+      <div role="tabpanel" class="tab-pane" id="search-results-cimgs">
+        <div id="instant-hits-cimgs"></div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Description

I updated the classic-docs in [this PR](https://github.com/circleci/circleci-docs/pull/5245) to use hits-target template, but the inline version of hits-target component has changed. So, I merge the change in the original hits-target component.

# screenshot
![image](https://user-images.githubusercontent.com/1702483/114951570-9c9d5280-9e8f-11eb-9e67-cb236f618cc3.png)

