### PR TITLE
Removing incorrect information

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ human-readable summary
 [here](http://creativecommons.org/licenses/by-nc-sa/4.0/).
 
 Everything in this repository not covered above is licensed under the [included
-MIT license](./docs/licence.md).
+MIT license](./docs/licence.md). 

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -243,8 +243,7 @@ The following example uses an image and enables [Docker Layer Caching]({{ site.b
 version: 2.1
 jobs:
   build:
-    machine:
-      image: ubuntu-1604:202007-01
+    machine: true
       docker_layer_caching: true    # default - false
 ```
 


### PR DESCRIPTION
The image key is not available on server, so I'm removing it from the machine executor server example.

# Description
Removing incorrect example for machine executors on Server.

# Reasons
The image key is not available on server for linux VMs, but it was being used in the server example config snippet, so I removed it.