### PR TITLE
Removing incorrect info

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ human-readable summary
 [here](http://creativecommons.org/licenses/by-nc-sa/4.0/).
 
 Everything in this repository not covered above is licensed under the [included
-MIT license](./docs/licence.md).
+MIT license](./docs/licence.md). 

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -244,7 +244,6 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-1604:202007-01
       docker_layer_caching: true    # default - false
 ```
 


### PR DESCRIPTION
# Description
The server example for the docker machine executor section uses the image tag, but the image tag is not available on server. Removing.

# Reasons
The information was inaccurate.