### PR TITLE
Remove references to /project/:vcs-type/:username/:project/build-cache

### DIFF
--- a/jekyll/_cci2/api-intro.md
+++ b/jekyll/_cci2/api-intro.md
@@ -110,7 +110,6 @@ Endpoint       | Description
 -----------|-----------------------------------------------------
 `POST /project/:vcs-type/:username/:project`  | This endpoint allowed users to trigger a new build.
 `POST /project/:vcs-type/:username/:project/build` | This endpoint enables users to trigger a new build by project.
-`DELETE /project/:vcs-type/:username/:project/build-cache` | This endpoint enabled users to clear the project cache for a specific project.
 `GET /recent-builds` | This endpoint enabled users to retrieve an array of recent builds.
 
 ## API v2 and server customers

--- a/jekyll/_cci2_ja/api-intro.md
+++ b/jekyll/_cci2_ja/api-intro.md
@@ -103,7 +103,6 @@ API v2 のすべてのエンドポイントは、[API v2 リファレンス ガ�
 | ---------------------------------------------------------- | ------------------------------ |
 | `POST /project/:vcs-type/:username/:project`               | 新規ビルドをトリガーします。                 |
 | `POST /project/:vcs-type/:username/:project/build`         | 指定したプロジェクトで新規ビルドをトリガーします。      |
-| `DELETE /project/:vcs-type/:username/:project/build-cache` | 特定のプロジェクトのプロジェクト キャッシュをクリアします。 |
 | `GET /recent-builds`                                       | 最近のビルドのサマリーを配列で取得します。          |
 
 ## オンプレミス版をご利用のお客様

--- a/jekyll/_data/api.yml
+++ b/jekyll/_data/api.yml
@@ -492,15 +492,6 @@ project_branch:
       "timedout": false
     }
 
-project_build_cache:
-  url: "/api/v1.1/project/:vcs-type/:username/:project/build-cache"
-  description: "Clears the cache for a project"
-  method: "DELETE"
-  response: |
-    {
-      "status" : "build caches deleted"
-    }
-
 user_ssh-key:
   url: "/api/v1.1/user/ssh-key"
   method: "POST"

--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -179,5 +179,4 @@ All CircleCI API endpoints begin with `https://circleci.com/api/v1.1/`
 **API** | **Description**
 ------- | -------------
 /project/:vcs-type/:username/:project/checkout-key/:fingerprint | Deletes a checkout key.
-/project/:vcs-type/:username/:project/build-cache | Clears the cache for a project.
 /project/:vcs-type/:username/:project/ssh-key | Delete the SSH key from a project.

--- a/src-api/source/includes/_projects.md
+++ b/src-api/source/includes/_projects.md
@@ -288,17 +288,3 @@ The example to the right shows a user request for recent build information. Noti
 	"author_email": "trevor@circleci.com"
 }]
 ```
-
-## Clear Project Cache
-
-**`DELETE` Request:** Clears the cache for a project.
-
-```sh
-curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/build-cache -H "Circle-Token: <circle-token>"
-```
-
-```json
-{
-  "status" : "build caches deleted"
-}
-```


### PR DESCRIPTION
# Description

Remove references to the `DELETE /api/v1.1/project/:vcs-type/:username/:project/build-cache` API. This API became useless with the demise of CircleCI 1.0, returned 410 from 2020-09-25 to 2020-11-05 at which point it was removed permanently. It now returns a 404 for all customers.

# Reasons

At least [one customer](https://circleci.zendesk.com/agent/tickets/89483) has mistakenly tried to use this API.