### PR TITLE
CIRCLE-32157 Add documentation for the matches logic element

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1792,16 +1792,17 @@ Logic statements are evaluated to boolean values at configuration compilation
 time, that is - before the workflow is run. The group of logic statements
 includes:
 
-| Type                                                                                                | Arguments          | `true` if                              | Example                                                              |
-|-----------------------------------------------------------------------------------------------------|--------------------|----------------------------------------|----------------------------------------------------------------------|
-| YAML literal                                                                                        | None               | is truthy                              | `true`/`42`/`"a string"`                                             |
-| YAML alias                                                                                          | None               | resolves to a truthy value             | *my-alias                                                            |
-| [Pipeline Value]({{site.baseurl}}/2.0/pipeline-variables/#pipeline-values)                          | None               | resolves to a truthy value             | `<< pipeline.git.branch >>`                                          |
-| [Pipeline Parameter]({{site.baseurl}}/2.0/pipeline-variables/#pipeline-parameters-in-configuration) | None               | resolves to a truthy value             | `<< pipeline.parameters.my-parameter >>`                             |
-| and                                                                                                 | N logic statements | all arguments are truthy               | `and: [ true, true, false ]`                                         |
-| or                                                                                                  | N logic statements | any argument is truthy                 | `or: [ false, true, false ]`                                         |
-| not                                                                                                 | 1 logic statement  | the argument is not truthy             | `not: true`                                                          |
-| equal                                                                                               | N values           | all arguments evaluate to equal values | `equal: [ 42, << pipeline.number >>]`                                |
+| Type                                                                                                | Arguments             | `true` if                              | Example                                                                  |
+|-----------------------------------------------------------------------------------------------------+-----------------------+----------------------------------------+--------------------------------------------------------------------------|
+| YAML literal                                                                                        | None                  | is truthy                              | `true`/`42`/`"a string"`                                                 |
+| YAML alias                                                                                          | None                  | resolves to a truthy value             | *my-alias                                                                |
+| [Pipeline Value]({{site.baseurl}}/2.0/pipeline-variables/#pipeline-values)                          | None                  | resolves to a truthy value             | `<< pipeline.git.branch >>`                                              |
+| [Pipeline Parameter]({{site.baseurl}}/2.0/pipeline-variables/#pipeline-parameters-in-configuration) | None                  | resolves to a truthy value             | `<< pipeline.parameters.my-parameter >>`                                 |
+| and                                                                                                 | N logic statements    | all arguments are truthy               | `and: [ true, true, false ]`                                             |
+| or                                                                                                  | N logic statements    | any argument is truthy                 | `or: [ false, true, false ]`                                             |
+| not                                                                                                 | 1 logic statement     | the argument is not truthy             | `not: true`                                                              |
+| equal                                                                                               | N values              | all arguments evaluate to equal values | `equal: [ 42, << pipeline.number >>]`                                    |
+| matches                                                                                             | `pattern` and `value` | `value` matches the `pattern`          | `matches: { pattern: "^feature-.+$", value: << pipeline.git.branch >> }` |
 {: class="table table-striped"}
 
 The following logic values are considered falsy:
@@ -1818,6 +1819,11 @@ All other values are truthy. Further, Please also note that using logic with an 
 Logic statements always evaluate to a boolean value at the top level, and coerce
 as necessary. They can be nested in an arbitrary fashion, according to their
 argument specifications, and to a maximum depth of 100 levels.
+
+`matches` uses [Java regular
+expressions](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html)
+for its `pattern`. It is recommended to enclose a pattern in `^` and
+`$` to avoid accidental partial matches.
 
 **Note:**
 When using logic statements at the workflow level, do not include the `condition:` key (the `condition` key is only needed for `job` level logic statements).
@@ -1840,7 +1846,9 @@ workflows:
     when:
       and:
         - not:
-            equal: [ master, << pipeline.git.branch >> ]
+            matches:
+              pattern: "^master$"
+              value: << pipeline.git.branch >>
         - or:
             - equal: [ canary, << pipeline.git.tag >> ]
             - << pipeline.parameters.deploy-canary >>


### PR DESCRIPTION
This is a new config logic element which performs regular expression
matching and can be used e.g. to check a branch name.

Convenient link: https://circleci.atlassian.net/browse/CIRCLE-32157