### PR TITLE
Update configuration-reference.md

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -145,7 +145,7 @@ Jobs have a maximum runtime of 5 hours. If your jobs are timing out, consider ru
 ### **<`job_name`>**
 {: #lessjobnamegreater }
 
-Each job consists of the job's name as a key and a map as a value. A name should be unique within a current `jobs` list. The value map has the following attributes:
+Each job consists of the job's name as a key and a map as a value. A name should be case insensitive unique within a current `jobs` list. The value map has the following attributes:
 
 Key | Required | Type | Description
 ----|-----------|------|------------


### PR DESCRIPTION
updated line 148 to include the descriptive word "case insensitive" when explaining a unique job name

# Description
job names must be case insensitive unique names.

# Reasons
Job names must be case insensitive unique names. This was not specified. 