### PR TITLE
Update URLs in local development guide

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,11 +1,11 @@
 # Local Development Instructions
 
 
-There are two ways to work on CircleCI docs locally: with Docker and with [Ruby](https://www.ruby-lang.org/en/)/[Bundler](http://bundler.io/).
+There are two ways to work on CircleCI docs locally: with Docker and with [Ruby](https://www.ruby-lang.org/en/)/[Bundler](https://bundler.io/).
 
 ## 1. Local Development with Docker (recommended)
 
-1. Install Docker for your platform: <https://docs.docker.com/engine/installation/>
+1. Install Docker for your platform: <https://docs.docker.com/engine/install/>
 1. Clone the CircleCI docs repo: `git clone --recurse-submodules https://github.com/circleci/circleci-docs.git`
 _(If you already cloned the project and forgot `--recurse-submodules`, run `git submodule update --init`)_
 1. Run `npm install` to fetch dependencies
@@ -18,13 +18,13 @@ _(If you already cloned the project and forgot `--recurse-submodules`, run `git 
 
 ## 2. Local Development with Ruby and Bundler (alternative to Docker)
 
-If you already have a stable Ruby environment (currently Ruby 2.3.3) and feel comfortable installing dependencies, install Jekyll by following [this guide](https://jekyllrb.com/docs/installation/).
+If you already have a stable Ruby environment (currently Ruby 2.7.2) and feel comfortable installing dependencies, install Jekyll by following [this guide](https://jekyllrb.com/docs/installation/).
 
 Check out the [Gemfile](https://github.com/circleci/circleci-docs/blob/master/Gemfile) for the Ruby version we're currently using. We recommend [RVM](https://rvm.io/) for managing multiple Ruby versions.
 
 We also use a gem called [HTMLProofer](https://github.com/gjtorikian/html-proofer) to test links, images, and HTML. The docs site will need a passing build to be deployed, so use HTMLProofer to test everything before you push changes to GitHub.
 
-You're welcome to use [Bundler](http://bundler.io/) to install these gems.
+You're welcome to use [Bundler](https://bundler.io/) to install these gems.
 
 ## Building js assets
 


### PR DESCRIPTION
# Description
This PR updates URLs in local development guide `/docs/local-development.md`

# Reasons
Ruby version is incorrect. Other URLs are updated to reduce unnecessary redirection on a browser. 

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

