### PR TITLE
Fix orb reference bug

### DIFF
--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -593,7 +593,7 @@ setup: true
 
 # the continuation orb is required in order to use dynamic configuration
 orbs:
-  continuation: circleci/continuation:0.1.2
+  continuation: circleci/continuation@0.1.2
 
 # our defined job, and its steps
 jobs:


### PR DESCRIPTION
# Description

Fixes a bug in an orb reference in the sample that uses a colon instead of an @ to delimit the orb name and the orb version.

# Reasons

Copying and pasting the example gives a build error in CircleCI.