### PR TITLE
Update api-intro.md

### DIFF
--- a/jekyll/_cci2/api-intro.md
+++ b/jekyll/_cci2/api-intro.md
@@ -115,7 +115,7 @@ Endpoint       | Description
 ## API v2 and server customers
 {: #api-v2-and-server-customers }
 
-API v2 is not supported for self-hosted installations of CircleCI Server 2.x. API v2 is supported for self-hosted installations of CircleCI Server 3.x. 
+API v2 is not supported for self-hosted installations of CircleCI Server 2.x. API v2 is supported for self-hosted installations of CircleCI Server 3.x.
 
 ## Data insights
 {: #data-insights }

--- a/jekyll/_cci2/api-intro.md
+++ b/jekyll/_cci2/api-intro.md
@@ -115,7 +115,7 @@ Endpoint       | Description
 ## API v2 and server customers
 {: #api-v2-and-server-customers }
 
-API v2 is not currently supported for self-hosted installations of CircleCI Server.
+API v2 is not supported for self-hosted installations of CircleCI Server 2.x. API v2 is supported for self-hosted installations of CircleCI Server 3.x. 
 
 ## Data insights
 {: #data-insights }


### PR DESCRIPTION
Server 3.0 now supports API V2. Updated to include a differentiation between 2.x and 3.x.

# Description
Updated to differentiate between server 2.x and 3.x

# Reasons
Previous documentation was inaccurate. 
https://circleci.atlassian.net/browse/SERVER-1092