### PR TITLE
Fixed a typo in sample configuration

### DIFF
--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -593,7 +593,7 @@ setup: true
 
 # the continuation orb is required in order to use dynamic configuration
 orbs:
-  continuation: circleci/continuation:0.1.2
+  continuation: circleci/continuation@0.1.2
 
 # our defined job, and its steps
 jobs:


### PR DESCRIPTION
# Description
Fixed the typo in the sample configuration of dynamic configuration.

# Reasons
There was a typo in the sample configuration.