### PR TITLE
[TODO JIRA LINK] Remove missing fields from audit log schema docs

### DIFF
--- a/jekyll/_cci2/security-server.adoc
+++ b/jekyll/_cci2/security-server.adoc
@@ -83,7 +83,7 @@ Following are the system events that are logged. See `action` in the Field secti
 - **version:** Version of the event schema. Currently the value will always be 1. Later versions may have different values to accommodate schema changes.
 - **scope:** If the target is owned by an Account in the CircleCI domain model, the account field should be filled in with the Account name and ID. This data is a JSON blob that will always contain `id` and `type` and will likely contain `name`.
 - **success:** A flag to indicate if the action was successful.
-- **request:** If this event was triggered by an external request this data will be populated and may be used to connect events that originate from the same external request. The format is a JSON blob containing `id` (the request ID assigned to this request by CircleCI), `ip_address` (the original IP address in IPV4 dotted notation from which the request was made, eg. 127.0.0.1), and `client_trace_id` (the client trace ID header, if present, from the 'X-Client-Trace-Id' HTTP header of the original request).
+- **request:** If this event was triggered by an external request this data will be populated and may be used to connect events that originate from the same external request. The format is a JSON blob containing `id` (the unique ID assigned to this request by CircleCI).
 
 == Checklist To Using CircleCI Securely as a Customer
 

--- a/jekyll/_cci2/security.md
+++ b/jekyll/_cci2/security.md
@@ -112,7 +112,7 @@ Following are the system events that are logged. See `action` in the Field secti
 - **version:** Version of the event schema. Currently the value will always be 1. Later versions may have different values to accommodate schema changes.
 - **scope:** If the target is owned by an Account in the CircleCI domain model, the account field should be filled in with the Account name and ID. This data is a JSON blob that will always contain `id` and `type` and will likely contain `name`.
 - **success:** A flag to indicate if the action was successful.
-- **request:** If this event was triggered by an external request this data will be populated and may be used to connect events that originate from the same external request. The format is a JSON blob containing `id` (the request ID assigned to this request by CircleCI), `ip_address` (the original IP address in IPV4 dotted notation from which the request was made, eg. 127.0.0.1), and `client_trace_id` (the client trace ID header, if present, from the 'X-Client-Trace-Id' HTTP header of the original request).
+- **request:** If this event was triggered by an external request this data will be populated and may be used to connect events that originate from the same external request. The format is a JSON blob containing `id` (the unique ID assigned to this request by CircleCI).
 
 ## Checklist to using CircleCI securely as a customer
 {: #checklist-to-using-circleci-securely-as-a-customer }


### PR DESCRIPTION
Some of the fields currently documented are not actually included today in our audit logs. Their addition is currently under review w/ SecOps, but for the time being, we should remove these fields from our public docs.

**Note: https://github.com/circleci/circleci-docs/blob/ae71de285dc72df4dd184fbb47e7a665e6904648/jekyll/_cci2_ja/security.md will also require an update, but it wasn't easy for me to figure out which part of the text to delete to make a clean edit.**

# Reasons
_TODO: Add Jira ticket link_