### PR TITLE
Add note about split defaulting to filename

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -119,6 +119,8 @@ cat my_java_test_classnames | circleci tests split --split-by=timings --timings-
 
 If you need to manually store and retrieve timing data, use the [`store_artifacts`]({{ site.baseurl }}/2.0/configuration-reference/#store_artifacts) step.
 
+Note: If no timing data is found, you will receive a message: `Error autodetecting timing type, falling back to weighting by name.`. The tests will then be split alphabetically by test name.
+
 #### Splitting by name
 {: #splitting-by-name }
 {:.no_toc}


### PR DESCRIPTION
# Description
This PR will add a note that if the timings for tests are not found when passing `--split-by=timings` that we will automatically default to splitting the tests alphabetically by filename. We note this when the split occurs in the job, but this wasn't documented.

# Reasons
This stems from a conversation with a customer.