### PR TITLE
Added in missing line separators

### DIFF
--- a/jekyll/_cci2/server-3-operator-backup-and-restore.adoc
+++ b/jekyll/_cci2/server-3-operator-backup-and-restore.adoc
@@ -163,8 +163,8 @@ velero install \
     --bucket $BUCKET \
     --backup-location-config region=$REGION \
     --snapshot-location-config region=$REGION \
-    --secret-file ./credentials-velero
-    --use-restic
+    --secret-file ./credentials-velero \
+    --use-restic \
     --wait
 ----
 


### PR DESCRIPTION
The velero command as written will not work because it's missing a few \'s. Adding them in.

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.