### PR TITLE
Update reusing-config.md

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -141,6 +141,8 @@ Boolean parameter evaluation is based on the [values specified in YAML 1.1](http
 * True: `y` `yes` `true` `on`
 * False: `n` `no` `false` `off`
 
+***Note:*** Boolean values may be returned as a '1' for True and '0' for False.
+
 Capitalized and uppercase versions of the above values are also valid.
 
 #### Integer


### PR DESCRIPTION
Added note in Boolean section mentioning that Boolean values may be returned as either 1 or 0.

This fixes #5304

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.