### PR TITLE
Fixes dependency issue on docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   jekyll:
-    command: bash -c "bundle install && bundle exec jekyll serve -s jekyll --incremental --livereload --host=0.0.0.0"
+    command: bash -c "apt-get update -y && apt-get install -y cmake pkg-config && bundle install && bundle exec jekyll serve -s jekyll --incremental --livereload --host=0.0.0.0"
     working_dir: /root
     image: ruby:2.7.2
     volumes:


### PR DESCRIPTION
closes. https://github.com/circleci/circleci-docs/issues/5270
Pronto requires `cmake` and `pkg-config`. So, it needs to be installed
before bundle install and docker-compose was not installing it.
