### PR TITLE
Update circleci-images to better display next-gen images.

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -19,16 +19,20 @@ This document provides information about pre-built CircleCI images and a listing
 {: #overview }
 {:.no_toc}
 
-For convenience,
-CircleCI maintains several Docker images.
-These images are typically extensions of official Docker images
-and include tools especially useful for CI/CD.
-All of these pre-built images are available in the [CircleCI org on Docker Hub](https://hub.docker.com/search?q=circleci&type=image).
-Visit the `circleci-images` GitHub repo for the [source code for the legacy CircleCI Docker images](https://github.com/circleci/circleci-images).
-Visit the [Developer Hub](https://circleci.com/developer/images/) for links to all the repositories for each next-gen image.
-Visit the `circleci-dockerfiles` GitHub repo for the [Dockerfiles for the CircleCI Docker images](https://github.com/circleci-public/circleci-dockerfiles).
+For convenience, CircleCI maintains several Docker images. These images are
+typically extensions of official Docker images and include tools especially
+useful for CI/CD. This document will provide an overview of best practices when using a convenience image. Please note that we advise using the **next-generation** images convenience images rather than **legacy images** (as explained below).
 
-_**Note:** CircleCI occasionally makes scheduled changes to images to fix bugs or otherwise improve functionality, and these changes can sometimes cause affect how images work in CircleCI jobs. Please follow the [**convenience-images** tag on Discuss](https://discuss.circleci.com/tags/convenience-images) to be notified in advance of scheduled maintenance._
+If you would like to directly search for an image, you can browse CircleCI Docker images in the following locations:
+
+- Visit the [Developer Hub](https://circleci.com/developer/images/) for links to all the repositories for each next-gen image.
+- Visit the `circleci-images` GitHub repo for the [source code for the legacy CircleCI Docker images](https://github.com/circleci/circleci-images). 
+- All CircleCI pre-built images are available for browsing on [Docker Hub](https://hub.docker.com/search?q=circleci&type=image).
+
+_**Note:** CircleCI occasionally makes scheduled changes to images to fix bugs or
+otherwise improve functionality, and these changes can sometimes cause affect
+how images work in CircleCI jobs. Please follow the [**convenience-images** tag on
+Discuss](https://discuss.circleci.com/tags/convenience-images) to be notified in advance of scheduled maintenance._
 
 ### Examples
 {: #examples }
@@ -42,35 +46,44 @@ The next-generation convenience images in this section were built from the groun
 
 **Faster spin-up time** - In Docker terminology, these next-gen images will generally have fewer and smaller layers. Using these new images will lead to faster image downloads when a build starts, and a higher likelihood that the image is already cached on the host.
 
-**Improved reliability and stability** - The current images are rebuilt practically every day with potential changes from upstream that we can't always test fast enough. This leads to frequent breaking changes, which is not the best environment for stable, deterministic builds. Next-gen images will only be rebuilt for security and critical-bugs, leading to more stable and deterministic images.
+**Improved reliability and stability** - The existing legacy convenience images are
+rebuilt practically every day with potential changes from upstream that we can't
+always test fast enough. This leads to frequent breaking changes, which is not
+the best environment for stable, deterministic builds. Next-gen images will only
+be rebuilt for security and critical-bugs, leading to more stable and
+deterministic images.
 
 ### CircleCI base image
 {: #circleci-base-image }
+Using the `base` image in your config looks like so:
 
 ```yaml
-image: cimg/base:2021.04
+  myjob:
+    docker:
+      - image: cimg/base:2021.04
 ```
 
-This is a brand new Ubuntu-based image designed to install the very bare minimum. All of the next-generation convenience images that we will be releasing in the coming weeks are based on this image.
+This is a brand new Ubuntu-based image designed to install the bare minimum. The
+next-generation convenience images are based on this image.
 
 **When to use it?**
 
-If you need a generic image to run on CircleCI, to use with orbs, or to use as a base for your own custom Docker image, this image is for you.
+If you need a generic image to run on CircleCI, to use with orbs, or to use as a
+base for your own custom Docker image, this image is for you.
 
 **Resources**
 
 You can find more config examples for this image on the [Developer Hub](https://circleci.com/developer/images/image/cimg/base), and the source code and documentation on [GitHub](https://github.com/CircleCI-Public/cimg-base).
 
-## Next-gen CircleCI Images
-{: #next-gen-circleci-images }
-
-CircleCI is moving to a set of new image repositories that bring better documentation and more determinism. Below is an example image definition for the next-gen Go image.
+The example below demonstrates using the next-gen Go image, which is based off the `base` image above.
 
 ```yaml
-image: cimg/go:1.16
+  myjob:
+    docker:
+      - image:  cimg/go:1.16
 ```
 
-This is a direct replacement for the legacy CircleCI Go image (`circleci/golang`). Note, the Docker Hub namespace is `cimg`.
+This is a direct replacement for the legacy CircleCI Go image (`circleci/golang`). Note, the Docker Hub namespace is `cimg`. You can view other next generation images for other languages [below](#next-gen-language-images).
 
 
 ## Best practices
@@ -82,24 +95,31 @@ That is, to prevent unintended changes that come from upstream, instead of using
 
 For example, pin down those images to a specific point version, like `cimg/ruby:2.4.10-node`. Specifying the version is possible for any of the CircleCI images.
 
-It is also possible to specify all the way down to the specific SHA of the image you want to use. For example, you can use `cimg/ruby@sha256:e4aa60a0a47363eca3bbbb066620f0a5967370f6469f6831ad52231c87ca9390` instead of `cimg/ruby:2.4.10-node`. Doing so allows you to test specific images for as long as you like before making any changes.
+It is also possible to use the specific SHA of a image. For example, you can use
+`cimg/ruby@sha256:e4aa60a0a47363eca3bbbb066620f0a5967370f6469f6831ad52231c87ca9390`
+instead of `cimg/ruby:2.4.10-node`. Doing so allows you to test specific images
+for as long as you like before making any changes.
 
+
+### Notes on pinning images
 
 <div class="alert alert-warning" role="alert">
-It is not recommended that you use the SHA for extended periods of time. If there's a major bug or security issue what would require a rebuild of the image, your pipeline's dependency on the image could inhibit you from acquiring the update that fixes that bug or patches a security issue.
+It is not recommended that you use the SHA for extended periods of time. If there is a major bug or security issue what would require a rebuild of the image, your pipeline's dependency on the image could inhibit you from acquiring the update that fixes that bug or patches a security issue.
 </div>
 
-There are two ways
-to make an image more specific:
 
-- Use a tag
-to pin an image to a version or variant.
-- Use a Docker image ID
-to pin an image to a fixed version.
+**Note:** If you are using a legacy image and you do not specify a tag, Docker
+applies the `latest` tag. The `latest` tag refers to the most recent stable
+release of an image. However, since this tag may change unexpectedly, it is best
+practice to add an explicit image tag. 
 
-**NOTE:** For Node.js variant Docker images (tags that end in `-node`) the LTS release of Node.js is pre-installed. If you would like to include your own specific version of
-Node.js / NPM you can set it up in a series of `run` steps in your `.circleci/config.yml`. Consider the example below, which installs a specific version of Node.js
-alongside the Ruby image.
+There are two ways to make an image more specific:
+
+**NOTE:** For Node.js variant Docker images (tags that end in `-node`) the LTS
+release of Node.js is pre-installed. If you would like to include your own
+specific version of Node.js / NPM you can set it up in a series of `run` steps
+in your `.circleci/config.yml`. Consider the example below, which installs a
+specific version of Node.js alongside the Ruby image.
 
 ```yaml
 version: 2.0
@@ -122,60 +142,13 @@ jobs:
           command: node -v
 ```
 
-### Using an image tag to pin an image version
-{: #using-an-image-tag-to-pin-an-image-version }
-{:.no_toc}
-
-You can pin aspects of a Docker image
-by adding an [image tag](https://docs.docker.com/engine/reference/commandline/tag/#extended-description).
-
-For example,
-instead of `cimg/go:1.16`,
-specify the version
-by using `cimg/go:1.16.3`.
-Because the second image specifies a specific version
-it is less likely
-to change unexpectedly.
-
-See below for a list of the [Latest Image Tags by Language](#latest-image-tags-by-language).
-
-**Note:**
-If you do not specify a tag,
-Docker applies the `latest` tag.
-The `latest` tag refers to the most recent stable release of an image.
-However,
-since this tag may change unexpectedly,
-it is best practice
-to add an explicit image tag.
-Only legacy images from the `circleci` repository support the `latest` tag.
-Next-gen images from the `cimg` repository do not support `latest`.
-
-### Using a docker image id to pin an image to a fixed version
-{: #using-a-docker-image-id-to-pin-an-image-to-a-fixed-version }
-{:.no_toc}
-
-Every Docker image has a [unique ID](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier).
-You can use this image ID
-to pin an image to a fixed version.
-
-Each image ID is an immutable SHA256 digest
-and looks like this:
-
-```
-sha256:df1808e61a9c32d0ec110960fed213ab2339451ca88941e9be01a03adc98396e
-```
-
 #### Finding an image id
 {: #finding-an-image-id }
 {:.no_toc}
 
-1. In the CircleCI application,
-go to a past build
-that used the image.
-2. On the **Test Summary** tab,
-click the **Spin up environment** step.
-3. In the log output,
-locate the digest for the image.
+1. In the CircleCI application, go to a past build that used the image.
+2. On the **Test Summary** tab, click the **Spin up environment** step.
+3. In the log output, locate the digest for the image.
 4. Add the image ID to the image name as shown below.
 
 ```
@@ -185,15 +158,8 @@ cimg/python@sha256:bdabda041f88d40d194c65f6a9e2a2e69ac5632db8ece657b15269700b018
 ## Image types
 {: #image-types }
 
-CircleCI's convenience images fall into two categories:
-**language** images and **service** images.
-All images add a `circleci` user as a system user.
-
-**Note:**
-The images below are based on the most recently built upstream images for their respective languages.
-Because the most recent images are more likely to change,
-it is [best practice](#best-practices)
-to use a more specific tag.
+CircleCI's convenience images fall into two categories: **language** images and
+**service** images. All images add a `circleci` user as a system user. The sections below will walk through the available next-generation and legacy images.
 
 ### Legacy language images
 {: #legacy-language-images }
@@ -222,18 +188,15 @@ CircleCI maintains legacy images for the languages below.
 {: #language-image-variants }
 {:.no_toc}
 
-CircleCI maintains several variants for language images.
-To use these variants,
+CircleCI maintains several variants for language images. To use these variants,
 add one of the following suffixes to the end of an image tag.
 
 - `-node` includes Node.js for polyglot applications
 - `-browsers` includes Chrome, Firefox, OpenJDK v11, and Geckodriver
 - `-node-browsers` combines the `-node` and `-browsers` variants
 
-For example,
-if you want
-to add browsers to the `circleci/golang:1.9` image,
-use the `circleci/golang:1.9-browsers` image.
+For example, if you want to add browsers to the `circleci/golang:1.9` image, use
+the `circleci/golang:1.9-browsers` image.
 
 ### Next-gen language images
 {: #next-gen-language-images }
@@ -246,7 +209,6 @@ making it the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-conta
 
 CircleCI is developing next-gen images for the languages below.
 
-- Clojure
 - [Elixir](https://circleci.com/developer/images/image/cimg/elixir)
 - [Go (Golang)](https://circleci.com/developer/images/image/cimg/go)
 - [Node.js](https://circleci.com/developer/images/image/cimg/node)
@@ -256,12 +218,11 @@ CircleCI is developing next-gen images for the languages below.
 - [Ruby](https://circleci.com/developer/images/image/cimg/ruby)
 - [Rust](https://circleci.com/developer/images/image/cimg/rust)
 
-If your language is not listed,
-feel free to request an image on our [Ideas Board](https://ideas.circleci.com/).
-First, check to see if that "idea" is already on CircleCI Ideas.
-If it is, up-vote it.
-If not, create it and set the category as "images".
-Finally, go and market your "idea" to friends, co-workers, forums, and other communities in order to help it build traction.
+If your language is not listed, feel free to request an image on our [Ideas
+Board](https://ideas.circleci.com/). First, check to see if that "idea" is
+already on CircleCI Ideas. If it is, up-vote it. If not, create it and set the
+category as "images". Finally, go and market your "idea" to friends, co-workers,
+forums, and other communities in order to help it build traction.
 
 If we see an idea on the board take off, we'll consider building it officially.
 
@@ -269,17 +230,19 @@ If we see an idea on the board take off, we'll consider building it officially.
 {: #next-gen-language-image-variants }
 {:.no_toc}
 
-CircleCI maintains several variants for the next-gen language image.
-For next-gen images be sure to check each image listing for information on each variant. The `-browsers` variant for next-gen images is still in progress.
-See each image listing on the [Developer Hub](https://circleci.com/developer/images/) for details on which variants it supports.
+CircleCI maintains several variants for the next-gen language image. For
+next-gen images be sure to check each image listing for information on each
+variant. The `-browsers` variant for next-gen images is still in progress. See
+each image listing on the [Developer Hub](https://circleci.com/developer/images/) 
+for details on which variants it supports.
 
 ### Service images
 {: #service-images }
 {:.no_toc}
 
-Service images are convenience images for services like databases.
-These images should be listed **after** language images
-so they become secondary service containers.
+Service images are convenience images for services like databases. These images
+should be listed **after** language images so they become secondary service
+containers.
 
 CircleCI maintains legacy images for the services below.
 
@@ -295,15 +258,11 @@ CircleCI maintains legacy images for the services below.
 {: #service-image-variant }
 {:.no_toc}
 
-CircleCI maintains only one variant for service images.
-To speed up builds
-using RAM volume,
-add the `-ram` suffix to the end of a service image tag.
+CircleCI maintains only one variant for service images. To speed up builds using
+RAM volume, add the `-ram` suffix to the end of a service image tag.
 
-For example,
-if you want the `circleci/postgres:9.5-postgis` image
-to use RAM volume,
-use the `circleci/postgres:9.5-postgis-ram` image.
+For example, if you want the `circleci/postgres:9.5-postgis` image to use RAM
+volume, use the `circleci/postgres:9.5-postgis-ram` image.
 
 ### Next-gen service images
 {: #next-gen-service-images }
@@ -372,16 +331,18 @@ refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circ
 
 
 <div class="alert alert-warning" role="alert">
-For a list of the latest next-gen convenience images and details about the content of each image, visit the <a href="https://circleci.com/developer/">Developer Hub.</a>
+It is recommended to use next-generation images when possible. 
+For a list of the latest next-gen convenience images and 
+details about the content of each image, visit 
+the <a href="https://circleci.com/developer/">Developer Hub.</a>
 </div>
 
 
-**Note:**
-Excluding [language image variants](#language-image-variants) and [the service image variant](#service-image-variant), **for legacy images**
-CircleCI does **not** control which tags are used.
-These tags are chosen and maintained by upstream projects.
-Do not assume
-that a given tag has the same meaning across images!
+**Note:** Excluding [language image variants](#language-image-variants) and [the
+service image variant](#service-image-variant), **for legacy images** CircleCI
+does **not** control which tags are used. These tags are chosen and maintained
+by upstream projects. Do not assume that a given tag has the same meaning across
+images!
 
 {% assign images = site.data.docker-image-tags | sort %}
 {% for image in images %}
@@ -401,6 +362,10 @@ that a given tag has the same meaning across images!
 
 **Recent Tags:** <small>(View all available image tags [here]({{ site.baseurl }}/2.0/docker-image-tags.json){:target="_blank"})</small>
 
+<details>
+<br/>
+<summary> <b>Click to view all tags for {{ image[0] }}</b></summary>
+
 <ul class="list-3cols">
 {% assign tags = image[1].tags | sort | reverse %}
 {% assign tagCounter = 1 %}
@@ -415,6 +380,9 @@ that a given tag has the same meaning across images!
 {% endfor %}
 </ul>
 
+</details>
+
+<br/>
 Note: Any variants available for this image can be used by appending the variant tag to the tags above. View all available image tags [here]({{ site.baseurl }}/2.0/docker-image-tags.json){:target="_blank"}.
 
 ---

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -36,6 +36,7 @@ Discuss](https://discuss.circleci.com/tags/convenience-images) to be notified in
 
 ### Examples
 {: #examples }
+{:.no_toc}
 
 Refer to the [Tutorials]({{ site.baseurl }}/2.0/tutorials/) for examples of using pre-built CircleCI Docker Images in a demo application.
 
@@ -113,9 +114,7 @@ applies the `latest` tag. The `latest` tag refers to the most recent stable
 release of an image. However, since this tag may change unexpectedly, it is best
 practice to add an explicit image tag. 
 
-There are two ways to make an image more specific:
-
-**NOTE:** For Node.js variant Docker images (tags that end in `-node`) the LTS
+**Note:** For Node.js variant Docker images (tags that end in `-node`) the LTS
 release of Node.js is pre-installed. If you would like to include your own
 specific version of Node.js / NPM you can set it up in a series of `run` steps
 in your `.circleci/config.yml`. Consider the example below, which installs a
@@ -146,8 +145,10 @@ jobs:
 {: #finding-an-image-id }
 {:.no_toc}
 
-1. In the CircleCI application, go to a past build that used the image.
-2. On the **Test Summary** tab, click the **Spin up environment** step.
+Follow these steps to find your docker image id: 
+
+1. In the CircleCI application, navigate to the job in your pipeline for which you would like to know the docker image.
+2. Toggle open the **Spin up environment** step.
 3. In the log output, locate the digest for the image.
 4. Add the image ID to the image name as shown below.
 
@@ -297,11 +298,10 @@ All convenience images have been extended with additional tools, installed with 
 - `xvfb` (legacy images only)
 - `zip`
 
-The specific version of a particular package
-that gets installed in a particular CircleCI image variant
-depends on the default version included in the package directory
-for the Linux distribution/version installed in that variant's base image.
-The legacy CircleCI convenience images are [Debian Jessie](https://packages.debian.org/jessie/)-
+The specific version of a particular package that gets installed in a particular
+CircleCI image variant depends on the default version included in the package
+directory for the Linux distribution/version installed in that variant's base
+image. The legacy CircleCI convenience images are [Debian Jessie](https://packages.debian.org/jessie/)-
 or [Stretch](https://packages.debian.org/stretch/)-based images,
 however the next-gen images, `cimg`, extend the official [Ubuntu](https://packages.ubuntu.com) image.
 For details on individual variants of legacy CircleCI images, see the
@@ -319,9 +319,18 @@ The following packages are installed via `curl` or other means.
 ## Out of scope
 {: #out-of-scope }
 
-1. If an image isn't listed above, it is not available. As the Convenience Image program is revamped, proposals for new images are not currently being accepted.
-1. Old versions of software will not be rebuilt. Once an upstream image stops building the tag for a specific release, say Node.js v8.1.0, then we stop building it too. This means other tools in that image, such as `npm` in this example, will no longer be updated either.
-1. We don't support building preview, beta, or release candidate images tags. On occasion they'll be available but these tags tend to cause our build system for Convenience Images to fail. If you need a non-stable release of a language, we suggest installing it via [an orb](https://circleci.com/orbs/) or a custom Docker image instead.
+1. If an image isn't listed above, it is not available. As the Convenience Image
+   program is revamped, proposals for new images are not currently being
+   accepted.
+1. Old versions of software will not be rebuilt. Once an upstream image stops
+   building the tag for a specific release, say Node.js v8.1.0, then we stop
+   building it too. This means other tools in that image, such as `npm` in this
+   example, will no longer be updated either.
+1. We don't support building preview, beta, or release candidate images tags. On
+   occasion they'll be available but these tags tend to cause our build system
+   for Convenience Images to fail. If you need a non-stable release of a
+   language, we suggest installing it via [an orb](https://circleci.com/orbs/)
+   or a custom Docker image instead.
 
 
 ## Latest image tags by language

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -161,42 +161,6 @@ cimg/python@sha256:bdabda041f88d40d194c65f6a9e2a2e69ac5632db8ece657b15269700b018
 CircleCI's convenience images fall into two categories: **language** images and
 **service** images. All images add a `circleci` user as a system user. The sections below will walk through the available next-generation and legacy images.
 
-### Legacy language images
-{: #legacy-language-images }
-{:.no_toc}
-
-The legacy language images are convenience images for common programming languages.
-These images include both the relevant language and [commonly-used tools](#pre-installed-tools).
-A language image should be listed first under the `docker` key in your configuration,
-making it the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.
-
-CircleCI maintains legacy images for the languages below.
-
-- [Android](#android)
-- [Clojure](#clojure)
-- [Elixir](#elixir)
-- [Go (Golang)](#go-golang)
-- [JRuby](#jruby)
-- [Node.js](#nodejs)
-- [OpenJDK (Java)](#openjdk)
-- [PHP](#php)
-- [Python](#python)
-- [Ruby](#ruby)
-- [Rust](#rust)
-
-#### Language image variants
-{: #language-image-variants }
-{:.no_toc}
-
-CircleCI maintains several variants for language images. To use these variants,
-add one of the following suffixes to the end of an image tag.
-
-- `-node` includes Node.js for polyglot applications
-- `-browsers` includes Chrome, Firefox, OpenJDK v11, and Geckodriver
-- `-node-browsers` combines the `-node` and `-browsers` variants
-
-For example, if you want to add browsers to the `circleci/golang:1.9` image, use
-the `circleci/golang:1.9-browsers` image.
 
 ### Next-gen language images
 {: #next-gen-language-images }
@@ -235,6 +199,44 @@ next-gen images be sure to check each image listing for information on each
 variant. The `-browsers` variant for next-gen images is still in progress. See
 each image listing on the [Developer Hub](https://circleci.com/developer/images/) 
 for details on which variants it supports.
+
+
+### Legacy language images
+{: #legacy-language-images }
+{:.no_toc}
+
+The legacy language images are convenience images for common programming languages.
+These images include both the relevant language and [commonly-used tools](#pre-installed-tools).
+A language image should be listed first under the `docker` key in your configuration,
+making it the [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container){:target="_blank"} during execution.
+
+CircleCI maintains legacy images for the languages below.
+
+- [Android](#android)
+- [Clojure](#clojure)
+- [Elixir](#elixir)
+- [Go (Golang)](#go-golang)
+- [JRuby](#jruby)
+- [Node.js](#nodejs)
+- [OpenJDK (Java)](#openjdk)
+- [PHP](#php)
+- [Python](#python)
+- [Ruby](#ruby)
+- [Rust](#rust)
+
+#### Language image variants
+{: #language-image-variants }
+{:.no_toc}
+
+CircleCI maintains several variants for language images. To use these variants,
+add one of the following suffixes to the end of an image tag.
+
+- `-node` includes Node.js for polyglot applications
+- `-browsers` includes Chrome, Firefox, OpenJDK v11, and Geckodriver
+- `-node-browsers` combines the `-node` and `-browsers` variants
+
+For example, if you want to add browsers to the `circleci/golang:1.9` image, use
+the `circleci/golang:1.9-browsers` image.
 
 ### Service images
 {: #service-images }
@@ -362,10 +364,6 @@ images!
 
 **Recent Tags:** <small>(View all available image tags [here]({{ site.baseurl }}/2.0/docker-image-tags.json){:target="_blank"})</small>
 
-<details>
-<br/>
-<summary> <b>Click to view all tags for {{ image[0] }}</b></summary>
-
 <ul class="list-3cols">
 {% assign tags = image[1].tags | sort | reverse %}
 {% assign tagCounter = 1 %}
@@ -380,7 +378,6 @@ images!
 {% endfor %}
 </ul>
 
-</details>
 
 <br/>
 Note: Any variants available for this image can be used by appending the variant tag to the tags above. View all available image tags [here]({{ site.baseurl }}/2.0/docker-image-tags.json){:target="_blank"}.

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -26,7 +26,7 @@ useful for CI/CD. This document will provide an overview of best practices when 
 If you would like to directly search for an image, you can browse CircleCI Docker images in the following locations:
 
 - Visit the [Developer Hub](https://circleci.com/developer/images/) for links to all the repositories for each next-gen image.
-- Visit the `circleci-images` GitHub repo for the [source code for the legacy CircleCI Docker images](https://github.com/circleci/circleci-images). 
+- Visit the `circleci-images` GitHub repo for the [source code for the legacy CircleCI Docker images](https://github.com/circleci/circleci-images).
 - All CircleCI pre-built images are available for browsing on [Docker Hub](https://hub.docker.com/search?q=circleci&type=image).
 
 _**Note:** CircleCI occasionally makes scheduled changes to images to fix bugs or
@@ -103,6 +103,7 @@ for as long as you like before making any changes.
 
 
 ### Notes on pinning images
+{: #notes-on-pinning-images }
 
 <div class="alert alert-warning" role="alert">
 It is not recommended that you use the SHA for extended periods of time. If there is a major bug or security issue what would require a rebuild of the image, your pipeline's dependency on the image could inhibit you from acquiring the update that fixes that bug or patches a security issue.
@@ -112,7 +113,7 @@ It is not recommended that you use the SHA for extended periods of time. If ther
 **Note:** If you are using a legacy image and you do not specify a tag, Docker
 applies the `latest` tag. The `latest` tag refers to the most recent stable
 release of an image. However, since this tag may change unexpectedly, it is best
-practice to add an explicit image tag. 
+practice to add an explicit image tag.
 
 **Note:** For Node.js variant Docker images (tags that end in `-node`) the LTS
 release of Node.js is pre-installed. If you would like to include your own
@@ -145,7 +146,7 @@ jobs:
 {: #finding-an-image-id }
 {:.no_toc}
 
-Follow these steps to find your docker image id: 
+Follow these steps to find your docker image id:
 
 1. In the CircleCI application, navigate to the job in your pipeline for which you would like to know the docker image.
 2. Toggle open the **Spin up environment** step.
@@ -198,7 +199,7 @@ If we see an idea on the board take off, we'll consider building it officially.
 CircleCI maintains several variants for the next-gen language image. For
 next-gen images be sure to check each image listing for information on each
 variant. The `-browsers` variant for next-gen images is still in progress. See
-each image listing on the [Developer Hub](https://circleci.com/developer/images/) 
+each image listing on the [Developer Hub](https://circleci.com/developer/images/)
 for details on which variants it supports.
 
 
@@ -342,9 +343,9 @@ refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circ
 
 
 <div class="alert alert-warning" role="alert">
-It is recommended to use next-generation images when possible. 
-For a list of the latest next-gen convenience images and 
-details about the content of each image, visit 
+It is recommended to use next-generation images when possible.
+For a list of the latest next-gen convenience images and
+details about the content of each image, visit
 the <a href="https://circleci.com/developer/">Developer Hub.</a>
 </div>
 

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -30,7 +30,7 @@ If you would like to directly search for an image, you can browse CircleCI Docke
 - All CircleCI pre-built images are available for browsing on [Docker Hub](https://hub.docker.com/search?q=circleci&type=image).
 
 _**Note:** CircleCI occasionally makes scheduled changes to images to fix bugs or
-otherwise improve functionality, and these changes can sometimes cause affect
+otherwise improve functionality, and these changes can sometimes affect
 how images work in CircleCI jobs. Please follow the [**convenience-images** tag on
 Discuss](https://discuss.circleci.com/tags/convenience-images) to be notified in advance of scheduled maintenance._
 
@@ -48,7 +48,7 @@ The next-generation convenience images in this section were built from the groun
 **Faster spin-up time** - In Docker terminology, these next-gen images will generally have fewer and smaller layers. Using these new images will lead to faster image downloads when a build starts, and a higher likelihood that the image is already cached on the host.
 
 **Improved reliability and stability** - The existing legacy convenience images are
-rebuilt practically every day with potential changes from upstream that we can't
+rebuilt practically every day with potential changes from upstream that we cannot
 always test fast enough. This leads to frequent breaking changes, which is not
 the best environment for stable, deterministic builds. Next-gen images will only
 be rebuilt for security and critical-bugs, leading to more stable and
@@ -56,7 +56,7 @@ deterministic images.
 
 ### CircleCI base image
 {: #circleci-base-image }
-Using the `base` image in your config looks like so:
+Using the `base` image in your config looks like the example shown below:
 
 ```yaml
   myjob:
@@ -76,7 +76,7 @@ base for your own custom Docker image, this image is for you.
 
 You can find more config examples for this image on the [Developer Hub](https://circleci.com/developer/images/image/cimg/base), and the source code and documentation on [GitHub](https://github.com/CircleCI-Public/cimg-base).
 
-The example below demonstrates using the next-gen Go image, which is based off the `base` image above.
+The example below demonstrates how to use the next-gen Go image, which is based off the `base` image above.
 
 ```yaml
   myjob:
@@ -99,14 +99,14 @@ For example, pin down those images to a specific point version, like `cimg/ruby:
 It is also possible to use the specific SHA of a image. For example, you can use
 `cimg/ruby@sha256:e4aa60a0a47363eca3bbbb066620f0a5967370f6469f6831ad52231c87ca9390`
 instead of `cimg/ruby:2.4.10-node`. Doing so allows you to test specific images
-for as long as you like before making any changes.
+for as long as you would like before making any changes.
 
 
 ### Notes on pinning images
 {: #notes-on-pinning-images }
 
 <div class="alert alert-warning" role="alert">
-It is not recommended that you use the SHA for extended periods of time. If there is a major bug or security issue what would require a rebuild of the image, your pipeline's dependency on the image could inhibit you from acquiring the update that fixes that bug or patches a security issue.
+It is not recommended that you use the SHA for extended periods of time. If there is a major bug or security issue that requires a rebuild of the image, your pipeline's dependency on the image could inhibit you from acquiring the update that fixes that bug or patches a security issue.
 </div>
 
 
@@ -320,15 +320,15 @@ The following packages are installed via `curl` or other means.
 ## Out of scope
 {: #out-of-scope }
 
-1. If an image isn't listed above, it is not available. As the Convenience Image
+1. If an image is not listed above, it is not available. As the Convenience Image
    program is revamped, proposals for new images are not currently being
    accepted.
 1. Old versions of software will not be rebuilt. Once an upstream image stops
    building the tag for a specific release, say Node.js v8.1.0, then we stop
    building it too. This means other tools in that image, such as `npm` in this
    example, will no longer be updated either.
-1. We don't support building preview, beta, or release candidate images tags. On
-   occasion they'll be available but these tags tend to cause our build system
+1. We do not support building preview, beta, or release candidate images tags. On
+   occasion they will be available but these tags tend to cause our build system
    for Convenience Images to fail. If you need a non-stable release of a
    language, we suggest installing it via [an orb](https://circleci.com/orbs/)
    or a custom Docker image instead.

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -32,10 +32,6 @@ a {
 	}
 }
 
-summary {
-    display: list-item;
-}
-
 .container-semi-fluid {
   padding-left: 15px;
   padding-right: 15px;

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -32,6 +32,10 @@ a {
 	}
 }
 
+summary {
+    display: list-item;
+}
+
 .container-semi-fluid {
   padding-left: 15px;
   padding-right: 15px;


### PR DESCRIPTION
Updates to our convenience image document. This change reorganizes the order of paragraphs to first display next-gen convenience images  over legacy documentation.