### PR TITLE
SERVER-1081 | Edit object storage documentation for server 3

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -144,16 +144,42 @@ The domain you selected for your CircleCI installation is the Homepage URL and *
 NOTE: If using GitHub Enterprise, you will also need a personal access token and the domain name of your GitHub Enterprise instance. You must also enable HTTP API Rate Limiting from the management console.
 
 ### Object Storage
-Server 3.0 hosts build artifacts, test results, and other state in object storage. Please choose the one that best suits your needs.
-A *Storage Bucket Name* is required, in addition to the following fields, depending on if you are using AWS or GCP. Ensure
-that the bucket name you provide exists in your chosen object storage provider before proceeeding.
 
-#### AWS S3
-. *AWS S3* (required): Region your S3 bucket is in.
-. *AWS IAM Access Key ID* (required): https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[AWS Access Key ID] for S3 bucket access.
-. *AWS IAM Secret Key* (required): https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[IAM Secret Key] for S3 bucket access.
+Server 3.0 hosts build artifacts, test results, and other state in object
+storage. We support
 
-It is recommended to create a new user with programmatic access for this purpose. You should fill in <<Bucket Name>> and <<AWS Account ID>> and attach the following https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage.html[IAM policy] to the user:
+. S3 compatible storage
+. https://cloud.google.com/storage/[Google Cloud Storage]
+
+While any S3 compatible object storage may work, we test and support
+https://aws.amazon.com/s3/[AWS S3] and https://min.io[Minio]. For object storage
+providers that do not support the S3 API, such as
+https://docs.microsoft.com/en-ca/azure/storage/blobs/[Azure blob storage], we recommend
+using https://docs.min.io/minio/baremetal/reference/minio-server/minio-gateway.html[Minio Gateway]
+
+Please choose the one that best suits your needs.  A *Storage Bucket
+Name* is required, in addition to the following fields, depending on if you are
+using AWS or GCP. Ensure that the bucket name you provide exists in your chosen
+object storage provider before proceeeding.
+
+#### S3 Compatible Object Storage
+
+To configure S3 storage, set the following details in the object storage section of the
+configuration page:
+
+. *Storage Bucket Name* (required): The bucket used for server.
+. *Storage Object Expiry* (optional): Number of days to retain your test
+results and artifacts. Set to 0 to disable and retain objects indefinitely.
+. *AWS S3 Region* (optional): AWS region of bucket if your provider is AWS. S3
+Endpoint is ignored if this option is set.
+. *S3 Endpoint* (optional): API endpoint of S3 storage provider. Required if
+your provider is not AWS. AWS S3 Region is ignored if this option is set.
+. *Access Key ID* (required): Access Key ID for S3 bucket access.
+. *Secret Key* (required): Secret Key for S3 bucket access.
+
+It is recommended to create a new user with programmatic access for this
+purpose. If your provider support IAM policies, you should fill in <<Bucket
+Name>> and attach the following policy to the user:
 
 [source,json]
 ----
@@ -169,25 +195,26 @@ It is recommended to create a new user with programmatic access for this purpose
         "arn:aws:s3:::<<Bucket Name>>",
         "arn:aws:s3:::<<Bucket Name>>/*"
       ]
-    },
-    {
-      "Action": [
-        "sts:GetFederationToken"
-      ],
-      "Resource": [
-        "arn:aws:sts::<<AWS account ID>>:federated-user/build-*"
-      ],
-      "Effect": "Allow"
     }
   ]
 }
 ----
 
 #### Google Cloud Storage
-* *Service Account JSON*: A JSON format key of the Service Account to use for bucket access.
 
-A dedicated service account is recommended.  Add to it the `Storage Object Admin` role, with a condition on the resource
-name limiting access to only the bucket specified above.  For example, enter the following into the Google's Condition Editor:
+To configure Google Cloud Storage (GCS), set the following details in the object
+storage section of the configuration page:
+
+. *Storage Bucket Name* (required): The bucket used for server.
+. *Storage Object Expiry* (optional): Number of days to retain your test
+results and artifacts. Set to 0 to disable and retain objects indefinitely.
+. *Service Account JSON*: A JSON format key of the Service Account to use for
+bucket access.
+
+A dedicated service account is recommended.  Add to it the `Storage Object
+Admin` role, with a condition on the resource name limiting access to only the
+bucket specified above.  For example, enter the following into the Google's
+Condition Editor:
 
 [source,text]
 ----
@@ -195,10 +222,6 @@ resource.name.startsWith("projects/_/buckets/<bucket-name>")
 ----
 
 NOTE: Use `startsWith` and prefix the bucket name with `projects/_/buckets/`.
-
-#### Embedded Object Storage (coming soon)
-Server 3.0 will utilize Minio for alternative object storage options. Minio provides a S3 like interface on top of numerous
-object storage options. For more information on Minio please see https://min.io/.
 
 ### Email Notifications
 Build notifications are sent via email.


### PR DESCRIPTION
# Description
S3 object storage is now slighly more general as we support S3
compatible storage like Minio. Also edited the GCS object storage docs
to make them similar to the S3 docs

# Reasons
SERVER-1081