### PR TITLE
Adding Q&A item for dynamic config and scheduled workflows

### DIFF
--- a/jekyll/_cci2/dynamic-config.md
+++ b/jekyll/_cci2/dynamic-config.md
@@ -71,6 +71,13 @@ see our [public GitHub repository](https://github.com/CircleCI-Public/api-previe
 **A:** Previously, this was true. But using our dynamic configuration feature, you can set pipeline parameters dynamically,
 before the pipeline is executed, triggered from both the API, or a webhook (A push event to your VCS).
 
+### Scheduled workflows
+{: #scheduled-workflows }
+
+**Q:** What about dynamic config in scheduled workflows?
+
+**A:** Setup workflows cannot currently be used with the existing scheduler. However, the next version of our scheduler will enable you to trigger pipelines which have dynamic config.  
+
 ### The continuation Orb
 {: #the-continuation-orb }
 


### PR DESCRIPTION
# Description
Adding additional item in the Q&A section to explain that dynamic config and scheduled workflows do not work together at this time.

# Reasons
Multiple requests have come in about this issue because they started setting up dynamic config, but ended up getting stuck because they needed scheduled workflows. While this will be resolved by scheduled pipelines, it won't be GA for a few months, this should prevent some of that wasted effort. We can remove this section once scheduled pipelines is released.