### PR TITLE
[CIRCLE-35329] Indicate launch-agent version for install with server 3.1

### DIFF
--- a/jekyll/_cci2/runner-server.md
+++ b/jekyll/_cci2/runner-server.md
@@ -46,7 +46,7 @@ A specific server version works with a specific runner version. The table below 
 
 Server Version  | Runner
 ----------------|---------------------------------
-3.0 | TBD
+3.1 | 1.0.11147-881b608
 {: class="table table-striped"}
 
 


### PR DESCRIPTION
# Description
Indicated in the Server on Runner doc a specific version of launch-agent to install with 3.0. The version is the latest stable release: `1.0.11147-881b608`
# Reasons
[Ticket](https://circleci.atlassian.net/browse/CIRCLE-35329), but probably more helpful is the following: as `launch-agent` version cannot be pinned in server, this docs update indicates a stable version for the initial `launch–agent` install.
Tickets to follow: [CIRCLE-35328](https://circleci.atlassian.net/browse/CIRCLE-35328?atlOrigin=eyJpIjoiMTBmYjVlYWM0YzNiNGQyNzlkZDY1MTk2NzdkOTliZGUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ) and [CIRCLE-33759](https://circleci.atlassian.net/browse/CIRCLE-33759?atlOrigin=eyJpIjoiOWEzY2UwYjczYzA2NDRkNTg2MjNlNGE5N2Q3NjkyODAiLCJwIjoiamlyYS1zbGFjay1pbnQifQ).