### PR TITLE
Update caching instructions for yarn 2

### DIFF
--- a/jekyll/_cci2/yarn.md
+++ b/jekyll/_cci2/yarn.md
@@ -33,7 +33,9 @@ curl -o- -L https://yarnpkg.com/install.sh | bash
 
 Yarn packages can be cached to improve CI build times.
 
-An example for Yarn 2:
+Yarn 2.x added the ability to do [Zero Installs](https://yarnpkg.com/features/zero-installs); if you're using Zero Installs, you shouldn't need to do any special caching.
+
+If you're using Yarn 2.x without Zero Installs, you can do something like this:
 
 {% raw %}
 ```yaml
@@ -49,7 +51,8 @@ An example for Yarn 2:
           name: Save Yarn Package Cache
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn
+            - .yarn/cache
+            - .yarn/unplugged
 #...
 ```
 {% endraw %}


### PR DESCRIPTION
# Description
Updated the instructions to mention Zero Installs, and fixed the example for non-Zero Installs.

# Reasons
It seems like the caching instructions for yarn 2 are outdated. The caching instructions are also completely unneeded if you're using Zero Installs.