### PR TITLE
Add external MongoDB documentation

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -143,6 +143,19 @@ The domain you selected for your CircleCI installation is the Homepage URL and *
 
 NOTE: If using GitHub Enterprise, you will also need a personal access token and the domain name of your GitHub Enterprise instance. You must also enable HTTP API Rate Limiting from the management console.
 
+### MongoDB
+*Internal* will deploy a completely configured MongoDB instance along with your server installation.
+*External* allows you to use your own MongoDB instance. CircleCI server is tested to work with MongoDB 3.6. You can customize the setup for your external MongoDB instance with the following settings:
+
+. MongoDB connection host(s) or IP(s): The hostname or IP of your MongoDB instance. Specifying a port using a colon and multiple hosts for sharded instances are both supported.
+. Use SSL for connection to MongoDB: Whether to use SSL when connecting to your external MongoDB instance
+. Allow insecure TLS connections: If you use a self-signed certificate or one signed by a custom CA, you will need to enable this setting. However, this is an insecure setting and you should use a TLS certificate signed by a valid CA if you can.
+. MongoDB user: The user name for the account to use. This account should have the dbAdmin role.
+. MongoDB password: The password for the account to use.
+. MongoDB authentication source database: The database that holds the account information, usually `admin`.
+. MongoDB authentication mechanism: The authentication mechanism to use, usually `SCRAM-SHA-1`.
+. Additional connection options: Any other connection options you would like to use. This needs to be formatted as a query string (key=value pairs, separated by &, special characters need to be URL encoded). See the https://docs.mongodb.com/v3.6/reference/connection-string/[MongoDB docs] for available options.
+
 ### Object Storage
 
 Server 3.x hosts build artifacts, test results, and other state in object storage. We support


### PR DESCRIPTION
# Description
This adds the documentation for using an external MongoDB instance

# Reasons
SERVER-1166