### PR TITLE
[SERVER-1169] details on how to configure an external vault instance

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -158,7 +158,7 @@ NOTE: If using GitHub Enterprise, you will also need a personal access token and
 
 ### Vault
 *Internal* will deploy the default Vault instance inside the CircleCI K8s namespace.  The application will be automatically configured.
-*External* will not install the default Vault instance with the CircleCI application.  Select this option if using an existing Vault instance.  Will require the user to configure the following settings:
+*External* will not install the default Vault instance with the CircleCI application.  Select this option if using an existing Vault instance.  You need to configure the following settings:
 
 . URL: ex. `http://vault:8200`
 . Transit Path: The path of the transit secrets engine.  The default is `transit`. See the https://www.vaultproject.io/docs/secrets/transit#setup[Vault documentation] for more details.

--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -156,6 +156,41 @@ NOTE: If using GitHub Enterprise, you will also need a personal access token and
 . MongoDB authentication mechanism: The authentication mechanism to use, usually `SCRAM-SHA-1`.
 . Additional connection options: Any other connection options you would like to use. This needs to be formatted as a query string (key=value pairs, separated by &, special characters need to be URL encoded). See the https://docs.mongodb.com/v3.6/reference/connection-string/[MongoDB docs] for available options.
 
+### Vault
+*Internal* will deploy the default Vault instance inside the CircleCI K8s namespace.  The application will be automatically configured.
+*External* will not install the default Vault instance with the CircleCI application.  Select this option if using an existing Vault instance.  Will require the user to configure the following settings:
+
+. URL: ex. `http://vault:8200`
+. Transit Path: The path of the transit secrets engine.  The default is `transit`. See the https://www.vaultproject.io/docs/secrets/transit#setup[Vault documentation] for more details.
+. Token: The Vault token to be used by CircleCI.  The following example shows how to create a token with the recommend policy
+
+Create the policy:
+[source,sh]
+----
+vault policy write circleci -<<EOF
+path "mytransit/export/*" {
+  capabilities = ["deny"]
+}
+path "mytransit/encrypt/*" {
+  capabilities = ["update"]
+}
+path "mytransit/decrypt/*" {
+  capabilities = ["update"]
+}
+path "/auth/token/lookup-self" {
+    capabilities = ["read", "list"]
+}
+EOF
+
+vault token create -policy=circleci
+----
+
+Create a token using the policy:
+[source,sh]
+----
+vault token create -policy=circleci -period=30m
+----
+
 ### Object Storage
 
 Server 3.x hosts build artifacts, test results, and other state in object storage. We support

--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -162,7 +162,7 @@ NOTE: If using GitHub Enterprise, you will also need a personal access token and
 
 . URL: ex. `http://vault:8200`
 . Transit Path: The path of the transit secrets engine.  The default is `transit`. See the https://www.vaultproject.io/docs/secrets/transit#setup[Vault documentation] for more details.
-. Token: The Vault token to be used by CircleCI.  The following example shows how to create a token with the recommend policy
+. Token: The Vault token to be used by CircleCI.  The following example shows how to create a token with the recommended policy
 
 Create the policy:
 [source,sh]


### PR DESCRIPTION
This is a redo of https://github.com/circleci/circleci-docs/pull/5415 which was incorrectly based off of main

# Description
Server now supports Externalizing Vault. Add documentation so people know how to do it.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.atlassian.net/browse/SERVER-1169

Please critique the formatting. The internal/external part is particularly bad