### PR TITLE
SERVER-1183: Update minimum cluster requirements

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -35,7 +35,7 @@ CircleCI Server users: +
 
 | < 500
 | 3
-| 8 cores
+| 12 cores
 | 32 GB
 | 1 Gbps
 


### PR DESCRIPTION
# Description
The minimum requirements listed for a cluster were not sufficient for actually running a server installation

# Reasons
SERVER-1183