### PR TITLE
Add clarification around prefix matching for conditional logic match

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1830,7 +1830,7 @@ argument specifications, and to a maximum depth of 100 levels.
 `matches` uses [Java regular
 expressions](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html)
 for its `pattern`. It is recommended to enclose a pattern in `^` and
-`$` to avoid accidental partial matches.
+`$` to avoid accidental partial matches. However, by default we will not prefix match, a full pattern needs to be provided.
 
 **Note:**
 When using logic statements at the workflow level, do not include the `condition:` key (the `condition` key is only needed for `job` level logic statements).


### PR DESCRIPTION
# Description
This PR will add information around the `match` conditional logic. We don't automatically prefix match, so a full pattern needs to be provided.

# Reasons
We had a customer open a ticket on this situation and the docs could be a bit more clear on the subject. 