### PR TITLE
Add: notes on using new app store connect api vs 2fa.

### DIFF
--- a/jekyll/_cci2/deploying-ios.md
+++ b/jekyll/_cci2/deploying-ios.md
@@ -70,6 +70,19 @@ apple_id "ci@yourcompany.com"
 app_identifier "com.example.HelloWorld"
 ```
 
+#### Two-Factor Authentication
+{: #two-factor-authentication}
+{:.no_toc}
+
+Please note that when using previous authentication methods with Fastlane (which
+was a cookie-based web session), depending on the actions in your configuration,
+you may need to setup a 2-Factor Authentication (2FA) with your Apple account.
+Unfortunately, this requires an account owner to manually respond to a 2FA
+request during a build, which is less than ideal.
+
+Fastlane now recommends using the [App Store Connect API](https://docs.fastlane.tools/app-store-connect-api/) key, which does not require 2FA. Please consult Fastlane's [documentation](https://docs.fastlane.tools/best-practices/continuous-integration/#authenticating-with-apple-services) on integrating with continuous integration services for more information.
+
+
 ### Deploying to the App Store
 {: #deploying-to-the-app-store }
 

--- a/jekyll/_cci2/deploying-ios.md
+++ b/jekyll/_cci2/deploying-ios.md
@@ -75,7 +75,7 @@ app_identifier "com.example.HelloWorld"
 {:.no_toc}
 
 Please note that when using previous authentication methods with Fastlane (which
-was a cookie-based web session), depending on the actions in your configuration,
+uses a cookie-based web session), depending on the actions in your configuration,
 you may need to setup a 2-Factor Authentication (2FA) with your Apple account.
 Unfortunately, this requires an account owner to manually respond to a 2FA
 request during a build, which is less than ideal.


### PR DESCRIPTION
Fixes #5380 

It looks like we may need to do a bit of a one over on the Fastlane content in our docs as things have changed from an authentication perspective. For the time being, I'm adding a section calling out some of the changes, as raised in the linked issue. 