### PR TITLE
Add note about nil values in environment key

### DIFF
--- a/jekyll/_cci2/pipeline-variables.md
+++ b/jekyll/_cci2/pipeline-variables.md
@@ -55,6 +55,8 @@ jobs:
       - run: echo $CIRCLE_COMPARE_URL
 ```
 
+Note: When using the above method to set the variables in the `environment` key if the pipeline variable is empty it will set the variable to `<nil>`. If you need an empty string instead, [set the variable in a shell command]({{ site.baseurl }}/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command).
+
 ## Pipeline parameters in configuration
 {: #pipeline-parameters-in-configuration }
 


### PR DESCRIPTION
# Description
This PR will add a note about what occurs if an empty pipeline variable is passed into a variable set in the `environment` key. It also notes the proper way to get an empty string, which is to set it in a shell command.

# Reasons
This stemmed from a support case, the way to get this to work for `pipeline.git.tag` was to use the following:

```
      - run:
          name: Set tag variable
          command: |
            CIRCLECI_GIT_TAG=<< pipeline.git.tag >>
            echo "export CIRCLECI_GIT_TAG=$CIRCLECI_GIT_TAG" >> $BASH_ENV
```

As not all builds will have `tag` set. This ensures the variable is set to an empty string instead of `<nil>` as it will execute while the job is running instead of being set at config compilation time. 