### PR TITLE
Clean: remove unused language guide index pages.

### DIFF
--- a/jekyll/_cci2/language-guides.md
+++ b/jekyll/_cci2/language-guides.md
@@ -1,5 +1,0 @@
----
-layout: category-page
-title: "Language Guides"
-category: [language-guides]
----

--- a/jekyll/_cci2_ja/language-guides.md
+++ b/jekyll/_cci2_ja/language-guides.md
@@ -1,7 +1,0 @@
----
-layout: category-page
-title: "言語ガイド"
-category:
-  - language-guides
----
-


### PR DESCRIPTION

This PR removes two index pages that auto aggregate files categorized with "language-guides" in jekyll. Reason for removal:

-These pages often confuse users when they land on them.
- There are properly maintained pages located [here](https://circleci.com/docs/2.0/tutorials/)

<img width="1640" alt="Screen Shot 2021-06-22 at 11 30 44 AM" src="https://user-images.githubusercontent.com/12987958/122974983-e0657a00-d360-11eb-9e42-8b8184a84595.png">
<img width="1640" alt="Screen Shot 2021-06-22 at 11 30 46 AM" src="https://user-images.githubusercontent.com/12987958/122974988-e0fe1080-d360-11eb-844c-bbf72353e9cd.png">
