### PR TITLE
Add app store connect api key info to ios deployment guide

### DIFF
--- a/jekyll/_cci2/deploying-ios.md
+++ b/jekyll/_cci2/deploying-ios.md
@@ -51,16 +51,21 @@ increment_build_number(
 ### Setting up
 {: #setting-up }
 
-To set up Fastlane to automatically upload iOS binaries to App Store Connect and/or TestFlight, a few steps need to be followed to allow Fastlane access to your App Store Connect account. For ease of use and security, it is advisable to create a new user, with limited privileges, in App Store Connect that will only be used for your CI jobs.
+To set up Fastlane to automatically upload iOS binaries to App Store Connect and/or TestFlight, a few steps need to be followed to allow Fastlane access to your App Store Connect account. 
 
-1. Head over to the [Users and Access](https://appstoreconnect.apple.com/access/users) section of App Store Connect
-2. Click on the `+` to add a new user
-3. Fill out the form, giving the user a unique email (such as `ci@yourcompany.com`) and select the "App Manager" role along with selecting the app to provide access to.
-4. Check the email inbox for the user you just created and click on the confirmation link
+The recommended way to set this up is to generate and use an App Store Connect API key. This prevents issues occurring with 2FA, which is now mandatory for Apple IDs, and is the most reliable way of interacting with the service.
 
-**Note:** If this is a new Apple ID, you may need to log in to [Apple ID](https://appleid.apple.com/) and App Store Connect/Developer Portal at least once to agree to any privacy policies before being able to use the account for Fastlane
+To create an API Key, follow the steps outlined in the [Apple Developer Documentation](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api). Once you have the resulting `.p8` file, make a note of the *Issuer ID* and *Key ID* which can be found on the [App Store Connect API Keys page](https://appstoreconnect.apple.com/access/api).
 
-Next, the password for the App Store Connect user needs to be added to the CircleCI project as an environment variable. In the project settings on CircleCI, navigate to **Build Settings -> Environment Variables** and add the `FASTLANE_PASSWORD` variable, and set its value to the password for the App Store Connect account. The password will be stored encrypted at rest.
+**Note:** Ensure you download the `.p8` file and store it somewhere safe. The file cannot be downloaded again once you navigate away from the App Store Connect portal.
+
+Next, a few environment variables need to be set. In your CircleCI project, navigate to **Build Settings -> Environment Variables** and set the following:
+
+* `APP_STORE_CONNECT_API_KEY_ISSUER_ID` to the Issuer ID. Example: `6053b7fe-68a8-4acb-89be-165aa6465141`
+* `APP_STORE_CONNECT_API_KEY_KEY_ID` to your Key ID. Example: `D383SF739`
+* `APP_STORE_CONNECT_API_KEY_KEY` to the contents of your `.p8` file. Example: `-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHknlhdlYdLu\n-----END PRIVATE KEY-----`
+
+**Note:** To find the contents of the `.p8` file, open it in a text editor. You will need to replace each new line with `\n` so that it forms one long string.
 
 Finally, Fastlane requires some information from us in order to know which Apple ID to use and which app identifier we are targeting. These can be set in the `fastlane/Appfile` as follows:
 
@@ -70,18 +75,7 @@ apple_id "ci@yourcompany.com"
 app_identifier "com.example.HelloWorld"
 ```
 
-#### Two-Factor Authentication
-{: #two-factor-authentication}
-{:.no_toc}
-
-Please note that when using previous authentication methods with Fastlane (which
-uses a cookie-based web session), depending on the actions in your configuration,
-you may need to setup a 2-Factor Authentication (2FA) with your Apple account.
-Unfortunately, this requires an account owner to manually respond to a 2FA
-request during a build, which is less than ideal.
-
-Fastlane now recommends using the [App Store Connect API](https://docs.fastlane.tools/app-store-connect-api/) key, which does not require 2FA. Please consult Fastlane's [documentation](https://docs.fastlane.tools/best-practices/continuous-integration/#authenticating-with-apple-services) on integrating with continuous integration services for more information.
-
+Once this is configured, you just need to call `app_store_connect_api_key` in your lane before calling any actions that interact with App Store Connect (such as `pilot` and `deliver`).
 
 ### Deploying to the App Store
 {: #deploying-to-the-app-store }
@@ -116,6 +110,7 @@ platform :ios do
     match(type: "appstore")
     gym(scheme: "HelloCircle")
     # Upload the binary to App Store Connect
+    app_store_connect_api_key
     deliver(
       submit_for_review: false,
       force: true
@@ -157,6 +152,7 @@ platform :ios do
     gym(scheme: "HelloWorld")
     # Upload the binary to TestFlight and automatically publish
     # to the configured beta testing group
+    app_store_connect_api_key
     pilot(
       distribute_external: true,
       notify_external_testers: true,

--- a/jekyll/_cci2/deploying-ios.md
+++ b/jekyll/_cci2/deploying-ios.md
@@ -51,7 +51,7 @@ increment_build_number(
 ### Setting up
 {: #setting-up }
 
-To set up Fastlane to automatically upload iOS binaries to App Store Connect and/or TestFlight, a few steps need to be followed to allow Fastlane access to your App Store Connect account. 
+To set up Fastlane to automatically upload iOS binaries to App Store Connect and/or TestFlight, a few steps need to be followed to allow Fastlane access to your App Store Connect account.
 
 The recommended way to set this up is to generate and use an App Store Connect API key. This prevents issues occurring with 2FA, which is now mandatory for Apple IDs, and is the most reliable way of interacting with the service.
 


### PR DESCRIPTION
Description
Update the document to reflect the new method for authenticating with app store connect for deplyoment

Reasons
MacOS document improvements initiative