### PR TITLE
Clarify cache section for OSS

### DIFF
--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -96,10 +96,12 @@ If you are comfortable sharing secrets with anyone who forks your project and op
 
 Caches are isolated based on GitHub Repo for PRs. CircleCI uses the GitHub
 repository-id of the originator of the fork PR to identify the cache.
-- PRs from the same fork repo will share a cache (this includes, as previously
-  stated, that PRs in the master repo share a cache with master).
-- Two PRs in different Fork Repos will have different caches.
-- enabling the sharing of [environment variables]({{site.baseurl}}/2.0/env-vars)
+- PRs from the same fork repo will share a cache. For example, PRs from the
+  master repo share a cache with the master repo branches (for example the
+  `master` branch).
+- Two PRs in different fork repos will have different caches. That means
+  that a PR from a fork will not share a cache with the master repo `master` branch. 
+- enabling the [passing of secrets to build from forked pull requests](#pass-secrets-to-builds-from-forked-pull-requests) 
   will enable cache sharing between the original repo and all forked builds.
 
 Currently there is no pre-population of caches because this optimization hasn't

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -97,7 +97,7 @@ If you are comfortable sharing secrets with anyone who forks your project and op
 Caches are isolated based on GitHub Repo for PRs. CircleCI uses the GitHub
 repository-id of the originator of the fork PR to identify the cache.
 - PRs from the same fork repo will share a cache. For example, PRs from the
-  master repo share a cache with the master repo branches (for example the
+  master repo share a cache with the master repo branches (in particular the
   `master` branch).
 - Two PRs in different fork repos will have different caches. That means
   that a PR from a fork will not share a cache with the master repo `master` branch. 


### PR DESCRIPTION
# Description

This updates the section about caching for OSS builds and tries to clarify it.

# Reasons

The symptom "the build is slow on the first PR commit because it does not seem to find the cache" is hard to google and it took me a while to find this part of the documentation.

In an ideal world there would be a from the main [cache doc page](https://circleci.com/docs/2.0/caching/#restoring-cache) to this caveat.