### PR TITLE
Update configuration-cookbook.md

### DIFF
--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -625,6 +625,8 @@ In the above configuration, we:
     - Continues running the pipeline based on what configuration is provided to the required `configuration_path`.
 - Lastly, we call the `setup` job defined above as a part of our `workflow`
 
+Note: You can only use one workflow per `config.yml` when using CircleCI's dynamic configuration feature
+
 For a more in-depth explanation of what the `continuation` orb does, review the orb's source code in the
 [CircleCI Developer Hub](https://circleci.com/developer/orbs/orb/circleci/continuation?version=0.1.2) or review the
 [Dynamic configuration FAQ]({{ site.baseurl }}/2.0/dynamic-config#dynamic-config-faqs).


### PR DESCRIPTION
Updated docs to include that you can only use 1 workflow per `config.yml` file

# Description
Added a "note" that you can only use 1 workflow per `config.yml` file

# Reasons
It is not clearly stated in the docs that you cannot use more than 1 workflow when using setup workflows