### PR TITLE
Server/3.1/update private loadbalancer webhooks preview

### DIFF
--- a/jekyll/_cci2/server-3-operator-load-balancers.adoc
+++ b/jekyll/_cci2/server-3-operator-load-balancers.adoc
@@ -23,7 +23,7 @@ toc::[]
 **Webhooks:** If you choose to make the frontend load balancer private, the following conditions must be met, dependent on VCS, for webhooks to work: 
 
 * **GitHub Enterprise** – your CircleCI server installation must be in the same internal network as GHE. 
-* **github.com** – set up a proxy for incoming webhooks. This setting can be found under **Admin Settings** > **System Settings** > **Override webhook host URL** from the CircleCI app.
+* **github.com** – set up a proxy for incoming webhooks and set it as override for the webhook host URL. This setting can be found under **Admin Settings** > **System Settings** > **Override webhook host URL** from the CircleCI app.
 ====
 
 NOTE: The Private load balancers option only works with installations on CircleCI server on GKE or EKS.

--- a/jekyll/_cci2/server-3-operator-load-balancers.adoc
+++ b/jekyll/_cci2/server-3-operator-load-balancers.adoc
@@ -19,9 +19,8 @@ toc::[]
 == Make the frontend load balancer private
 
 [WARNING]
-.Webhooks
 ==== 
-If you choose to make the frontend load balancer private, the following conditions must be met, dependent on VCS, for webhooks to work: 
+**Webhooks:** If you choose to make the frontend load balancer private, the following conditions must be met, dependent on VCS, for webhooks to work: 
 
 * **GitHub Enterprise** – your CircleCI server installation must be in the same internal network as GHE. 
 * **github.com** – set up a proxy for incoming webhooks. This setting can be found under **Admin Settings** > **System Settings** > **Override webhook host URL** from the CircleCI app.

--- a/jekyll/_cci2/server-3-operator-load-balancers.adoc
+++ b/jekyll/_cci2/server-3-operator-load-balancers.adoc
@@ -18,7 +18,14 @@ toc::[]
 
 == Make the frontend load balancer private
 
-WARNING: If you select to make the frontend load balancer private, webhooks will only work if you are using a GitHub Enterprise installation that is in the same internal network as your server installation. Webhooks will fail when using GitHub.com.
+[WARNING]
+.Webhooks
+==== 
+If you choose to make the frontend load balancer private, the following conditions must be met, dependent on VCS, for webhooks to work: 
+
+* **GitHub Enterprise** – your CircleCI server installation must be in the same internal network as GHE. 
+* **github.com** – set up a proxy for incoming webhooks. This setting can be found under **Admin Settings** > **System Settings** > **Override webhook host URL** from the CircleCI app.
+====
 
 NOTE: The Private load balancers option only works with installations on CircleCI server on GKE or EKS.
 


### PR DESCRIPTION
A proxy must be set up if a github.com/server user with private frontend load balancer wants to have webhooks work. This note points to the setting in the CCI app.