### PR TITLE
[SERVER-1274] external datastores migration postgers update

### DIFF
--- a/jekyll/_cci2/server-3-install-migration.adoc
+++ b/jekyll/_cci2/server-3-install-migration.adoc
@@ -28,7 +28,7 @@ toc::[]
 . You have taken a backup of the 2.19 instance.  If you are using external datastores, they will need to be backed up separately.
 . You have a new CircleCI Server 3.x xref:server-3-install.adoc[installation].
 . You have successfully run https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[reality check] with contexts prior to starting.
-. The migration script must be run from a machine with
+. The migration script must be run from a machine with:
 - `kubectl` configured for the server 3.x instance
 - `ssh` access to the 2.19 services box
 

--- a/jekyll/_cci2/server-3-install-migration.adoc
+++ b/jekyll/_cci2/server-3-install-migration.adoc
@@ -38,7 +38,7 @@ toc::[]
 
 ### Internal Datastore Only
 . You have taken a backup of the 2.19 instance.
-. You have successfully run https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[reality check] on the new server 3.x instance with contexts prior to starting
+. You have successfully run https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[reality check] on the new server 3.x instance with contexts prior to starting.
 
 ## Migration
 

--- a/jekyll/_cci2/server-3-install-migration.adoc
+++ b/jekyll/_cci2/server-3-install-migration.adoc
@@ -26,7 +26,7 @@ toc::[]
 
 . Your current CircleCI Server installation is 2.19.
 . You have taken a backup of the 2.19 instance.  If you are using external datastores, they will need to be backed up separately.
-. You have a new CircleCI Server 3.0 xref:server-3-install.adoc[installation]
+. You have a new CircleCI Server 3.x xref:server-3-install.adoc[installation].
 . You have successfully run https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[reality check] with contexts prior to starting.
 . The migration script must be run from a machine with
 - `kubectl` configured for the server 3.x instance

--- a/jekyll/_cci2/server-3-install-migration.adoc
+++ b/jekyll/_cci2/server-3-install-migration.adoc
@@ -33,8 +33,8 @@ toc::[]
 - `ssh` access to the 2.19 services box
 
 ### External Datastores Only
-. Backups have been taken of all external data stores
-. Postgres has been updated to version 12
+. Backups have been taken of all external data stores.
+. Postgres has been updated to version 12.
 
 ### Internal Datastore Only
 . You have taken a backup of the 2.19 instance.

--- a/jekyll/_cci2/server-3-install-migration.adoc
+++ b/jekyll/_cci2/server-3-install-migration.adoc
@@ -23,13 +23,22 @@ installation to the data stores you were using for your 2.19 instance.
 toc::[]
 
 ## Prerequisites
+
 . Your current CircleCI Server installation is 2.19.
 . You have taken a backup of the 2.19 instance.  If you are using external datastores, they will need to be backed up separately.
-. You have a running CircleCI Server 3.0 xref:server-3-install.adoc[installation].
+. You have a new CircleCI Server 3.0 xref:server-3-install.adoc[installation]
 . You have successfully run https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[reality check] with contexts prior to starting.
 . The migration script must be run from a machine with
 - `kubectl` configured for the server 3.x instance
 - `ssh` access to the 2.19 services box
+
+### External Datastores Only
+. Backups have been taken of all external data stores
+. Postgres has been updated to version 12
+
+### Internal Datastore Only
+. You have taken a backup of the 2.19 instance.
+. You have successfully run https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[reality check] on the new server 3.x instance with contexts prior to starting
 
 ## Migration
 


### PR DESCRIPTION
# Description
When to upgrade postgres to 12 when migrating from 2.19 to 3.1.

Do it before the migration.  Reality check runs on 2.19 with postgres 12 so the risk is low.  Also requesting a backup be taken to further reduce risk.

# Reasons
https://circleci.atlassian.net/browse/SERVER-1274

Thanks @soulchips for doing all the work on this one!