### PR TITLE
Add: webhooks documentation

### DIFF
--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -180,8 +180,9 @@ can also be triggered manually through the API.
 ### VCS
 {: #vcs}
 
-VCS map
-Note: The "vcs" map or its contents may not always be provided in cases where the information doesn't apply, such as future scenarios in which a pipeline isn't associated with a git commit.
+Note: The vcs map or its contents may not always be provided in cases where
+the information doesn't apply, such as future scenarios in which a pipeline
+isn't associated with a git commit.
 
 | Field                  | Always present? | Description                                                                                                        |
 |------------------------|-----------------|--------------------------------------------------------------------------------------------------------------------|

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -27,13 +27,12 @@ shape of events that will be sent to your webhook destination.
 
 Webhooks can be leveraged for various purposes. Some possible examples might include:
 
-- Building custom a dashboard to visualize/analyze workflow/job events.
+- Building a custom dashboard to visualize or analyze workflow/job events.
 - Sending data to incident management tools (such as Pagerduty).
 - Send events to communication apps, such as Slack.
-- Use webhooks to be alerted when a workflow is cancelled then use the API to rerun the workflow.
+- Use webhooks to be alerted when a workflow is cancelled, then use the API to rerun the workflow.
 - Trigger internal notification systems to alert people when workflows/jobs complete.
 - Build your own automation plugins and tools.
-- Connect CircleCI with tools such as airtable, to aggregate data on completed workflows or jobs (see example).
 
 ## Setting up a hook
 {: #setting-up-a-hook}

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -23,6 +23,19 @@ shape of events that will be sent to your webhook destination.
 
 **Note:** The Webhooks feature on CircleCI is currently in preview; documentation and features may change or be added to.
 
+## Use cases
+{: #use-cases}
+
+Webhooks can be leveraged for various purposes. Some possible examples might include:
+
+- Building custom a dashboard to visualize/analyze workflow/job events.
+- Sending data to incident management tools (such as Pagerduty).
+- Send events to communication apps, such as Slack.
+- Use webhooks to be alerted when a workflow is cancelled then use the API to rerun the workflow.
+- Trigger internal notification systems to alert people when workflows/jobs complete.
+- Build your own automation plugins and tools.
+- Connect CircleCI with tools such as airtable, to aggregate data on completed workflows or jobs (see example).
+
 ## Setting up a hook
 {: #setting-up-a-hook}
 Webhooks are set up on a per-project basis. To get started:
@@ -105,7 +118,7 @@ Data about the organization associated with the webhook event.
 | id    | yes             | Unique ID of the organization              |
 | name  | yes             | Name of the organization (e.g. "circleci") |
 {: class="table table-striped"}
- 
+
 ### Job
 {: #job}
 

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -1,0 +1,94 @@
+---
+layout: classic-docs
+title: "Webhooks"
+short-title: "Using Webhooks to subscribe to CircleCI events"
+description: "Using Webhooks to subscribe to CircleCI events"
+version:
+- Cloud
+---
+
+# Overview
+{: #overview}
+
+A webhook, sometimes referred to as a _reverse API_, allows you to connect a
+platform you manage (either an API you create yourself, or with a third party
+service) to a stream of _future events_ (or, _real-time information_).
+
+Setting up a Webhook on CircleCI enables you to receive information (referred to
+as _events_) from CircleCI, as they happen. This can help you avoid polling the
+API, or manually checking the CircleCI web application for desired information.
+
+The rest of this document will detail how to set up a webhook as well as the
+shape of events that will be sent to your webhook destination.
+
+* TOC 
+{:toc}
+
+# Setting up a hook
+{: #setting-up-a-hook}
+
+Webhooks are set up on a per-project basis. To get started:
+
+- Visit a specific project you have setup on CircleCI
+- Click on **Project Settings**
+- In the sidebar of your Project Settings, click on **Webhooks**
+- Click **Add Webhook**
+- Fill out the Webhook form (the table below describes the fields and their intent):
+
+| Field                  | Required? | Intent                                                               |
+|------------------------|-----------|----------------------------------------------------------------------|
+| Webhook name           | Y         | The name of your webhook                                             |
+| URL                    | Y         | The URL the webhook will make POST requests to.                      |
+| Certificate Validation | Y         |                                                                      |
+| Secret token           | Y         | Used by your API/platform to validate incoming data is from CircleCI |
+| Select an event        | Y         | You must select at least one event that will trigger a webhook       |
+
+
+# Event Specifications
+{: #event-specifications}
+
+CircleCI currently offers webhooks for the following events:
+
+- Ping
+- Workflow Completed
+- Job Completed
+
+
+## Common top level keys
+
+Each Webhook will have some common data as part of the event:
+
+| Field         | Description                                                                                        | Type   |
+|---------------|----------------------------------------------------------------------------------------------------|--------|
+| `id`          | ID used to uniquely identify each event from the system (the client can use this to dedupe events) | String |
+| `happened_at` | ISO 8601 timestamp representing when the event happened                                            | String |
+| `webhook`     | A map of metadata representing the webhook that was triggered                                      | Map    |
+
+**Note:** The event payloads are open maps, meaning new fields may be added to
+maps in the webhook payload without considering it a breaking change.
+
+## Ping
+{: #ping}
+
+Once you set up your Webhook, you can _ping_ your API to test that it is
+working. Let's look at the _shape_ of the _event_ (referred to as a **payload**)
+that will be sent to your API:
+
+```
+{
+  "type": "ping",
+  "id": "198c5ba2-8713-44fa-b91d-d80e5119df5d",
+  "happened_at": "2021-02-03T23:49:03Z",
+  "webhook": {
+    "id": "32869f4e-ad1e-45c4-be08-693865dad4f5",
+    "name": "My Webhook"
+  }
+}
+```
+
+
+## Workflow completed
+{: #workflow-completed}
+
+## Job completed
+{: #job-completed}

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -12,7 +12,7 @@ version:
 
 A webhook, sometimes referred to as a _reverse API_, allows you to connect a
 platform you manage (either an API you create yourself, or a third party
-service) to a stream of _future events_ (or, _real-time information_).
+service) to a stream of future _events_.
 
 Setting up a Webhook on CircleCI enables you to receive information (referred to
 as _events_) from CircleCI, as they happen. This can help you avoid polling the
@@ -33,14 +33,16 @@ Webhooks are set up on a per-project basis. To get started:
 1. Click **Add Webhook**.
 1. Fill out the Webhook form (the table below describes the fields and their intent):
 
-| Field                  | Required? | Intent                                                               |
-|------------------------|-----------|----------------------------------------------------------------------|
-| Webhook name           | Y         | The name of your webhook                                             |
-| URL                    | Y         | The URL the webhook will make POST requests to.                      |
-| Certificate Validation | Y         |                                                                      |
-| Secret token           | Y         | Used by your API/platform to validate incoming data is from CircleCI |
-| Select an event        | Y         | You must select at least one event that will trigger a webhook       |
+| Field                  | Required? | Intent                                                                                      |
+|------------------------|-----------|---------------------------------------------------------------------------------------------|
+| Webhook name           | Y         | The name of your webhook                                                                    |
+| URL                    | Y         | The URL the webhook will make POST requests to.                                             |
+| Certificate Validation | Y         | Ensure the receiving host has a valid SSL certificate before sending an event <sup>1</sup>. |
+| Secret token           | Y         | Used by your API/platform to validate incoming data is from CircleCI.                       |
+| Select an event        | Y         | You must select at least one event that will trigger a webhook.                             |
 {: class="table table-striped"}
+
+<sup>1</sup>Only leave this unchecked for testing purposes.
 
 ## Event Specifications
 {: #event-specifications}
@@ -49,7 +51,6 @@ CircleCI currently offers webhooks for the following events:
 
 | Event type         | Description                                              | Potential statuses                                       | Included sub-entities                          |
 |--------------------|----------------------------------------------------------|----------------------------------------------------------|------------------------------------------------|
-| ping               | Test ping event when the webhook is initially configured |                                                          | project, organization                          |
 | workflow-completed | A workflow has reached a terminal state                  | "success", "failed", "error", "canceled", "unauthorized" | project, organization, workflow, pipeline      |
 | job-completed      | A job has reached a terminal state                       | "success", "failed", "canceled", "unauthorized"          | project, organization, workflow, pipeline, job |
 {: class="table table-striped"}
@@ -77,8 +78,8 @@ The next sections describe the payloads of different events offered with
 CircleCI webhooks. The schema of these webhook events will share often share
 data with other webhooks - we refer to these as common maps of data as
 "sub-entities". For example, when you receive an event payload for the
-`job-completed` webhook, it will contains maps of data for your a *project,
-organization, workflow and pipeline*.
+`job-completed` webhook, it will contains maps of data for your *project,
+organization, job, workflow and pipeline*.
 
 Let's look at some of the common sub-entities that will appear across various webhooks:
 
@@ -104,7 +105,7 @@ Data about the organization associated with the webhook event.
 | id    | yes             | Unique ID of the organization              |
 | name  | yes             | Name of the organization (e.g. "circleci") |
 {: class="table table-striped"}
-    
+ 
 ### Job
 {: #job}
 
@@ -143,15 +144,6 @@ the CircleCI configuration (but typically one will be triggered).
 Pipelines are the most high-level unit of work, and contain zero or
 more workflows. A single git-push always triggers up to one pipeline. Pipelines
 can also be triggered manually through the API.
-
-A pipeline's overall status doesn't change after it is created, so there are no
-exclusively-pipeline-related events.
-
-Re-running a workflow (either via "Re-run from failed" or "Re-run from
-beginning") creates a new, distinct workflow in the same pipeline.
-
-A pipeline may have parameters supplied during a manual invocation, that affect
-the behavior of its workflows and jobs.
 
 | Field       | Always present? | Description                                                                       |
 |-------------|-----------------|-----------------------------------------------------------------------------------|
@@ -196,3 +188,7 @@ Note: The "vcs" map or its contents may not always be provided in cases where th
 {: class="table table-striped"}
 
 
+### Test your webhook
+{: #test-your-webhook}
+
+You can use a "ping" event to test out the webhook.

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -21,6 +21,8 @@ API or manually checking the CircleCI web application for desired information.
 The rest of this document will detail how to set up a webhook as well as the
 shape of events that will be sent to your webhook destination.
 
+**Note:** The Webhooks feature on CircleCI is currently in preview; documentation and features may change or be added to.
+
 ## Setting up a hook
 {: #setting-up-a-hook}
 Webhooks are set up on a per-project basis. To get started:

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -37,6 +37,7 @@ Webhooks can be leveraged for various purposes. Some possible examples might inc
 
 ## Setting up a hook
 {: #setting-up-a-hook}
+
 Webhooks are set up on a per-project basis. To get started:
 
 1. Visit a specific project you have setup on CircleCI.
@@ -44,6 +45,7 @@ Webhooks are set up on a per-project basis. To get started:
 1. In the sidebar of your Project Settings, click on **Webhooks**.
 1. Click **Add Webhook**.
 1. Fill out the Webhook form (the table below describes the fields and their intent):
+1. Provided your receiving API or third party service is set up, click **Test Ping Event** to dispatch a test event.
 
 | Field                  | Required? | Intent                                                                                      |
 |------------------------|-----------|---------------------------------------------------------------------------------------------|
@@ -198,9 +200,3 @@ Note: The "vcs" map or its contents may not always be provided in cases where th
 | branch                 | no              | Branch being built                                                                                                 |
 | tag                    | no              | Tag being built (mutually exclusive with "branch")                                                                 |
 {: class="table table-striped"}
-
-
-### Test your webhook
-{: #test-your-webhook}
-
-You can use a "ping" event to test out the webhook.

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -10,9 +10,8 @@ version:
 ## Overview
 {: #overview}
 
-A webhook, sometimes referred to as a _reverse API_, allows you to connect a
-platform you manage (either an API you create yourself, or a third party
-service) to a stream of future _events_.
+A webhook allows you to connect a platform you manage (either an API you create
+yourself, or a third party service) to a stream of future _events_.
 
 Setting up a Webhook on CircleCI enables you to receive information (referred to
 as _events_) from CircleCI, as they happen. This can help you avoid polling the


### PR DESCRIPTION
- Adds documentation on new webhook functionality
- [Preview link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/feat-webhooks-preview/2.0/webhooks/)

Notes / Todo
- [ ] Add documentation for parternships in separate docs, and then link to it?
- [ ] Eventually, remove note about open preview
- [x] Address technical comments/questions in PR review .