### PR TITLE
potential mistake in who gets access to windows executors?

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -22,8 +22,8 @@ This document describes how to get started with continuous integration on **Wind
 To follow along with this document you will need:
 
 * An [account](https://circleci.com/signup/) on CircleCI.
-* Either the Free plan (default) or a [performance plan](https://circleci.com/pricing/usage/). If you are running CircleCI Server there are alternative code examples below.
-* For the cloud version, pipelines must be [enabled]({{site.baseurl}}/2.0/build-processing/) for your project to use Windows.
+* Either the Free, Performance, or Scale [plan](https://circleci.com/pricing/usage/). If you are running CircleCI Server there are alternative code examples below.
+* For the Cloud version, pipelines must be [enabled]({{site.baseurl}}/2.0/build-processing/) for your project to use Windows.
 
 # Overview of the Windows executor
 {: #overview-of-the-windows-executor }

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -22,7 +22,7 @@ This document describes how to get started with continuous integration on **Wind
 To follow along with this document you will need:
 
 * An [account](https://circleci.com/signup/) on CircleCI.
-* Either the Free, Performance, or Scale [plan](https://circleci.com/pricing/usage/). If you are running CircleCI Server there are alternative code examples below.
+* Either the Free, Performance, or Scale [plan](https://circleci.com/pricing/usage/). If you are running CircleCI server there are alternative code examples below.
 * For the Cloud version, pipelines must be [enabled]({{site.baseurl}}/2.0/build-processing/) for your project to use Windows.
 
 # Overview of the Windows executor


### PR DESCRIPTION
I think Scale plan customers can also use Windows based on our pricing page

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.