### PR TITLE
Update private orb access information

### DIFF
--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -29,7 +29,7 @@ There are two different types of orbs you can use in your configuration, dependi
 {: #private-orbs }
 
 
-**Note:** _Private orbs are available on any of our paid [plans](https://circleci.com/pricing). Performance plan customers can create
+**Note:** _Private orbs are available on any of our [paid plans listed on our plans page](https://circleci.com/pricing). Performance plan customers can create
 up to three private orbs, whereas our Scale plan customers can create an unlimited number of private orbs. Please reach out to your sales representative for more information._
 {: class="alert alert-warning"}
 


### PR DESCRIPTION
# Description
This PR will adjust our language to note that private orbs are only available to paid plans listed on our plans page, as legacy plans, even if paid, do not currently have access.

# Reasons
This came about from a discussion with a customer, so updating to make sure it's clearer. 