### PR TITLE
Fix a sample config of the dynamic configuration

### DIFF
--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -625,7 +625,7 @@ In the above configuration, we:
     - Continues running the pipeline based on what configuration is provided to the required `configuration_path`.
 - Lastly, we call the `setup` job defined above as a part of our `workflow`
 
-Note: You can only use one workflow per `config.yml` when using CircleCI's dynamic configuration feature
+**Note:** You can only use one workflow per `config.yml` when using CircleCI's dynamic configuration feature
 You can only run a single workflow as part of the pipeline's setup stage. This setup-workflow has access to a one-time-use token to create more workflows. The setup process does not cascade, so subsequent workflows in the pipeline cannot launch their own continuations.
 
 For a more in-depth explanation of what the `continuation` orb does, review the orb's source code in the
@@ -659,6 +659,7 @@ For example, consider a monorepo structure like the example shown below:
 An example implementation of CircleCI's dynamic configuration for the above use case can be found in the following `config.yml` and `continue_config.yml`:
 
 #### config.yml
+{: #configyml }
 
 ```yaml
 version: 2.1
@@ -694,6 +695,7 @@ workflows:
 ```
 
 #### continue_config.yml
+{: #continueconfigyml }
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -645,7 +645,8 @@ For example, consider a monorepo structure like the example shown below:
 ```shell
 .
 ├── .circleci
-│   └── config.yml
+│   ├── config.yml
+│   └── continue_config.yml
 ├── service1
 │   ├── Service1.java
 ├── service2
@@ -654,7 +655,9 @@ For example, consider a monorepo structure like the example shown below:
 │   ├── IntegrationTests.java
 ```
 
-An example implementation of CircleCI's dynamic configuration for the above use case can be found in the following `config.yml`:
+An example implementation of CircleCI's dynamic configuration for the above use case can be found in the following `config.yml` and `continue_config.yml`:
+
+#### config.yml
 
 ```yaml
 version: 2.1
@@ -663,10 +666,40 @@ version: 2.1
 setup: true
 
 # the path-filtering orb is required to continue a pipeline based on
-# the path of an updated fileset the maven orb is also used, as an
-# example on using dynamic configuration to build a Java project.
+# the path of an updated fileset
 orbs:
   path-filtering: circleci/path-filtering@0.0.2
+
+workflows:
+  # the always-run workflow is always triggered, regardless of the pipeline parameters.
+  always-run:
+    jobs:
+      # the path-filtering/filter job determines which pipeline
+      # parameters to update.
+      - path-filtering/filter:
+          name: check-updated-files
+          # 3-column, whitespace-delimited mapping. One mapping per
+          # line:
+          # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
+          mapping: |
+            service1/.* run-build-service-1-job true
+            service2/.* run-build-service-2-job true
+          base-revision: master
+          # this is the path of the configuration we should trigger once
+          # path filtering and pipeline parameter value updates are
+          # complete. In this case, we are using the parent dynamic
+          # configuration itself.
+          config-path: .circleci/continue_config.yml
+```
+
+#### continue_config.yml
+
+```yaml
+version: 2.1
+
+# the path-filtering orb is required to continue a pipeline based on
+# the path of an updated fileset
+orbs:
   maven: circleci/maven@1.2.0
 
 # the default pipeline parameters, which will be updated according to
@@ -679,29 +712,6 @@ parameters:
     type: boolean
     default: false
 
-# our defined jobs
-jobs:
-  # the build-service-1 job uses the maven orb to build and install
-  # service1 artifacts into the maven repository (it does not run
-  # tests).
-  build-service-1:
-    - maven/test:
-        command: 'install -DskipTests'
-        app_src_directory: 'service1'
-  # the build-service-2 job uses the maven orb to build and install
-  # service2 artifacts into the maven repository (it does not run
-  # tests).
-  build-service-2:
-    - maven/test:
-        command: 'install -DskipTests'
-        app_src_directory: 'service2'
-  # the run-integration-tests job will run any tests defined in the
-  # tests directory.
-  run-integration-tests:
-    - maven/test:
-        command: '-X verify'
-        app_src_directory: 'tests'
-
 # here we specify our workflows, most of which are conditionally
 # executed based upon pipeline parameter values. Each workflow calls a
 # specific job defined above, in the jobs section.
@@ -711,13 +721,19 @@ workflows:
   service-1:
     when: << pipeline.parameters.run-build-service-1-job >>
     jobs:
-      - build-service-1
+      - maven/test:
+          name: build-service-1
+          command: 'install -DskipTests'
+          app_src_directory: 'service1'
   # when pipeline parameter, run-build-service-2-job is true, the
   # build-service-2 job is triggered.
   service-2:
     when: << pipeline.parameters.run-build-service-2-job >>
     jobs:
-      - build-service-2
+      - maven/test:
+          name: build-service-2
+          command: 'install -DskipTests'
+          app_src_directory: 'service2'
   # when pipeline parameter, run-build-service-1-job OR
   # run-build-service-2-job is true, run-integration-tests job is
   # triggered. see:
@@ -727,26 +743,10 @@ workflows:
     when:
       or: [<< pipeline.parameters.run-build-service-1-job >>, << pipeline.parameters.run-build-service-2-job >>]
     jobs:
-      - run-integration-tests
-  # the check-updated-files job is always triggered, regardless of
-  # pipeline parameters.
-  always-run:
-    jobs:
-      # the path-filtering/filter job determines which pipeline
-      # parameters to update.
-      - path-filtering/filter:
-          # 3-column, whitespace-delimited mapping. One mapping per
-          # line:
-          # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
-          mapping: |
-            service1/.* run-build-service-1-job true
-            service2/.* run-build-service-2-job true
-          base-revision: master
-          # this is the path of the configuration we should trigger once
-          # path filtering and pipeline parameter value updates are
-          # complete. In this case, we are using the parent dynamic
-          # configuration itself.
-          config-path: .circleci/config.yml
+      - maven/test:
+          name: run-integration-tests
+          command: '-X verify'
+          app_src_directory: 'tests'
 ```
 
 In the above configuration, we:

--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -626,7 +626,7 @@ In the above configuration, we:
 - Lastly, we call the `setup` job defined above as a part of our `workflow`
 
 Note: You can only use one workflow per `config.yml` when using CircleCI's dynamic configuration feature
-Note: You can't call CircleCI's dynamic configuration feature several times in the same pipeline. It means you can't make the another workflow with `setup: true` by the CircleCI's dynamic configuration feature.
+You can only run a single workflow as part of the pipeline's setup stage. This setup-workflow has access to a one-time-use token to create more workflows. The setup process does not cascade, so subsequent workflows in the pipeline cannot launch their own continuations.
 
 For a more in-depth explanation of what the `continuation` orb does, review the orb's source code in the
 [CircleCI Developer Hub](https://circleci.com/developer/orbs/orb/circleci/continuation?version=0.1.2) or review the

--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -626,6 +626,7 @@ In the above configuration, we:
 - Lastly, we call the `setup` job defined above as a part of our `workflow`
 
 Note: You can only use one workflow per `config.yml` when using CircleCI's dynamic configuration feature
+Note: You can't call CircleCI's dynamic configuration feature several times in the same pipeline. It means you can't make the another workflow with `setup: true` by the CircleCI's dynamic configuration feature.
 
 For a more in-depth explanation of what the `continuation` orb does, review the orb's source code in the
 [CircleCI Developer Hub](https://circleci.com/developer/orbs/orb/circleci/continuation?version=0.1.2) or review the


### PR DESCRIPTION
# Description
Fix a sample config of the dynamic configuration, the current configuration is completely broken, so split the config to `config.yml` and `continue_config.yml`, and fix some small issues.

Also, add a note for the dynamic configuration. Currently, CircleCI doesn't allow to call the dynamic configuration feature more than once, and that's why I split the config.yml to `config.yml` and `continue_config.yml`.

This is an example of the failed build by using the dynamic configuration twice.
> https://app.circleci.com/pipelines/github/cheekit/circleci-setup-workflow/85/workflows/b724ba84-96e5-4852-b6fe-964cf23defde/jobs/78

# Reasons

CircleCI user pointed out about this issue.