### PR TITLE
Fix regexp to list test packages in parallel tests tutorial.

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -205,7 +205,7 @@ Using this example, here is a quick example of how you can accomplish test split
       cat circleci_test_files.txt
       TESTFILES=$(circleci tests split --split-by=timings circleci_test_files.txt)
       # massage filepaths into format manage.py test accepts
-      TESTFILES=$(echo $TESTFILES | tr "/" "." | sed 's/.py//g')
+      TESTFILES=$(echo $TESTFILES | tr "/" "." | sed 's/\.py$//g')
       echo $TESTFILES
       pipenv run python manage.py test --verbosity=2 $TESTFILES  
 ```


### PR DESCRIPTION
# Description
Current command could remove unwanted characters

# Reasons
`/.py/` is not precise enough (files that contain a letter followed by `py`). It might match parts of a dir name + `.` is a catch all etc. Changed to `/\.py$/` (files that end with `.py`)

# Link
https://circleci.com/docs/2.0/parallelism-faster-jobs/#using-test-splitting-with-python-django-tests
