### PR TITLE
Fix broken markdown introduced in #5499

### DIFF
--- a/jekyll/_cci2_ja/caching.md
+++ b/jekyll/_cci2_ja/caching.md
@@ -99,7 +99,7 @@ If your project is open source/available to be forked and receive PRs from contr
 
 CircleCI では、`restore_cache` ステップにリストされているキーの順番でキャッシュが復元されます。 各キャッシュ キーはプロジェクトの名前空間にあり、プレフィックスが一致すると取得されます。 最初に一致したキーのキャッシュが復元されます。 複数の一致がある場合は、最も新しく生成されたキャッシュが使用されます。
 
-{% raw %}```yaml
+次の例では、2 つのキーが指定されています:
 
 {% raw %}
 ```yaml


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Fixes a broken markdown, introduced in #5499, in [キャッシュの復元](https://circleci.com/docs/ja/2.0/caching/#restoring-cache).

# Reasons
![circleci com_docs_ja_2 0_caching_](https://user-images.githubusercontent.com/10229505/126859036-32a69360-4184-4fef-9cd6-4f25e49a6a00.png)
