### PR TITLE
Use Ruby 2.7 image (buster) instead of 2.3 (jessie)

### DIFF
--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -49,12 +49,12 @@ The `config-translation` endpoint can help you quickly get started with converti
 5. Add the language and version you want to run the primary container to your configuration using either the `docker:` and `- image:` keys in the example or by setting `machine: true` or by using `macos`. If your configuration includes language and version as shown for `ruby:` below, replace it as shown.
      ```
        ruby:
-         version: 2.3
+         version: 2.7
      ```
      Replace with the following lines:
      ```
          docker:
-           - image: circleci/ruby:2.3-jessie
+           - image: circleci/ruby:2.7
              auth:
                username: mydockerhub-user
                password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/packagecloud.md
+++ b/jekyll/_cci2/packagecloud.md
@@ -64,7 +64,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/ruby:2.3-jessie
+    - image: circleci/ruby:2.7
       auth:
         username: mydockerhub-user
         password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Use Ruby 2.7 image (buster) instead of 2.3 (jessie). cf. #5553 for ja docs.

# Reasons
Ruby 2.3 has reached EOL in 2018, so force users to use the stable. Ruby 3.0 has some incompatibility so using 2.7 instead.