### PR TITLE
Use Ruby 2.7 image (buster) instead of 2.3 (jessie) (ja)

### DIFF
--- a/jekyll/_cci2_ja/migrating-from-1-2.md
+++ b/jekyll/_cci2_ja/migrating-from-1-2.md
@@ -50,12 +50,12 @@ CircleCI では、[`.circleci/config.yml`]({{ site.baseurl }}/ja/2.0/configurati
 5. `docker:` キーと `- image:` キーを記述するか、`machine: true` を設定するか、`macos` を指定して、プライマリ コンテナを実行するときの言語とバージョンを追加します。 以下の `ruby:` の例のように、構成に言語とバージョンが含まれている場合は、修正が必要です。
      ```
        ruby:
-         version: 2.3
+         version: 2.7
      ```
      上記を以下の 2 行に置き換えます。
      ```
          docker:
-           - image: circleci/ruby:2.3-jessie
+           - image: circleci/ruby:2.7
      ```
      最初に記述したイメージのインスタンスがプライマリ コンテナになります。 ジョブのコマンドはこのコンテナ内で実行されます。 ジョブごとにコマンドを宣言します。 Docker コンテナを初めて使用する場合は、「[Docker 入門](https://docs.docker.com/get-started/#docker-concepts)」を参照してください。
      ```yaml

--- a/jekyll/_cci2_ja/packagecloud.md
+++ b/jekyll/_cci2_ja/packagecloud.md
@@ -65,7 +65,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/ruby:2.3-jessie
+    - image: circleci/ruby:2.7
       auth:
         username: mydockerhub-user
         password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Use Ruby 2.7 image (buster) instead of 2.3 (jessie) in ja docs. cf. #5552 for the original (en) docs.

# Reasons
Ruby 2.3 has reached EOL in 2018, so force users to use the stable. Ruby 3.0 has some incompatibility so using 2.7 instead.