### PR TITLE
Update circleci/node images to latest

### DIFF
--- a/jekyll/_cci2/adv-config.md
+++ b/jekyll/_cci2/adv-config.md
@@ -60,7 +60,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node-jessie-browsers
+      - image: circleci/node:buster-browsers
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/browser-testing.md
+++ b/jekyll/_cci2/browser-testing.md
@@ -41,7 +41,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:jessie-browsers
+      - image: circleci/node:buster-browsers
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/code-coverage.md
+++ b/jekyll/_cci2/code-coverage.md
@@ -282,7 +282,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.0-browsers
+      - image: circleci/node:14.17-browsers
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -209,7 +209,7 @@ jobs:
             CC_TEST_REPORTER_ID: code_climate_id_here
             NODE_ENV: development
         docker:
-            - image: circleci/node:8
+            - image: circleci/node:14
               auth:
                 username: mydockerhub-user
                 password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/config-intro.md
+++ b/jekyll/_cci2/config-intro.md
@@ -114,7 +114,7 @@ jobs:
   build:
     # pre-built images: https://circleci.com/docs/2.0/circleci-images/
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:14-browsers
     steps:
       - checkout
       - run:
@@ -179,7 +179,7 @@ jobs:
             echo '^^^That should look familiar^^^'
   Run-With-Node:
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:14-browsers
     steps:
       - run:
           name: Running In A Container With Node

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -318,7 +318,7 @@ It is possible to reuse [declared commands]({{ site.baseurl }}/2.0/reusing-confi
 jobs:
   myjob:
     docker:
-      - image: "circleci/node:9.6.1"
+      - image: circleci/node:14.17.3
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -46,7 +46,7 @@ jobs:
   build:
     docker:
       # DLC does nothing here, its caching depends on commonality of the image layers.
-      - image: circleci/node:9.8.0-stretch-browsers
+      - image: circleci/node:14.17.3-buster-browsers
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -219,7 +219,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:9.8.0-stretch-browsers
+      - image: circleci/node:14.17.3-buster-browsers
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -95,7 +95,7 @@ jobs: # basic units of work in a run
   build:
     docker: # use the Docker executor
       # CircleCI node images available at: https://hub.docker.com/r/circleci/node/
-      - image: circleci/node:10.0-browsers
+      - image: circleci/node:14.17-browsers
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/examples-intro.md
+++ b/jekyll/_cci2/examples-intro.md
@@ -25,7 +25,7 @@ jobs:
     working_directory: ~/mern-starter
     # The primary container is an instance of the first image listed. The job's commands run in this container.
     docker:
-      - image: circleci/node:4.8.2-jessie
+      - image: circleci/node:14.17.3-buster
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -96,7 +96,7 @@ Docker Images may be specified in three ways, by the image name and version tag 
 {: #public-convenience-images-on-docker-hub }
 {:.no_toc}
   - `name:tag`
-    - `circleci/node:7.10-jessie-browsers`
+    - `circleci/node:14.17-buster-browsers`
   - `name@digest`
     - `redis@sha256:34057dd7e135ca41...`
 

--- a/jekyll/_cci2/migrating-from-travis.md
+++ b/jekyll/_cci2/migrating-from-travis.md
@@ -100,7 +100,7 @@ jobs:
   build:
     working_directory: ~/mern-starter
     docker:
-      - image: circleci/node:4.8.2 # Primary execution image
+      - image: circleci/node:14.17.3 # Primary execution image
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -178,7 +178,7 @@ version: 2
 jobs:
  build:
     docker:
-      - image: circleci/node:9.8.0-stretch-browsers # DLC does nothing here, its caching depends on commonality of the image layers.
+      - image: circleci/node:14.17.3-buster-browsers # DLC does nothing here, its caching depends on commonality of the image layers.
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/packagecloud.md
+++ b/jekyll/_cci2/packagecloud.md
@@ -179,7 +179,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.9.1
+    - image: circleci/node:14.17.3
       auth:
         username: mydockerhub-user
         password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -381,7 +381,7 @@ jobs:
     working_directory: ~/mern-starter
     # The primary container is an instance of the first image listed. The job's commands run in this container.
     docker:
-      - image: circleci/node:4.8.2-jessie
+      - image: circleci/node:14.17.3-buster
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -406,7 +406,7 @@ jobs:
             - node_modules
   test:
     docker:
-      - image: circleci/node:4.8.2-jessie
+      - image: circleci/node:14.17.3-buster
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/jekyll/_cci2/triggers.md
+++ b/jekyll/_cci2/triggers.md
@@ -83,7 +83,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.0-browsers # < an arbitrarily chosen docker image.
+      - image: circleci/node:14.17-browsers # < an arbitrarily chosen docker image.
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Updates the versions of `circleci/node` image on Docker Hub, keeping the minor/revision specifications.

# Reasons
Node.js 4.x, 7.x, 8.x, 9.x, and 10.x got EOL'ed, so we need to use 14.x LTS or 16 stable. Also `jessie` reached EOL, so these should be updated to the latest `buster`. `stretch` is still stable, but these can be updated now.