### PR TITLE
[SERVER-1305] removing references to http proxy vars in 3.1

### DIFF
--- a/jekyll/_cci2/_ops-guide.adoc
+++ b/jekyll/_cci2/_ops-guide.adoc
@@ -25,8 +25,6 @@ include::monitoring.adoc[]
 
 include::nomad-metrics.adoc[]
 
-include::proxy.adoc[]
-
 include::authentication.adoc[]
 
 include::vm-service.adoc[]

--- a/jekyll/_cci2/aws.adoc
+++ b/jekyll/_cci2/aws.adoc
@@ -37,7 +37,6 @@ NOTE: The `builder_instance_type` is only used for CircleCI 1.0 and is disabled 
 
 . In section 3 you can:
 .. choose to use 1.0 Builders if your project requires it (by changing the count to `1`)
-.. enter proxy details, and enter a prefix if there will be multiple installations within your AWS region – the Services and Nomad client instances will be displayed with this prefix in the AWS console.
 
 .Example tfvars
 
@@ -69,10 +68,6 @@ nomad_client_instance_type = "m4.2xlarge"
 # Set this to `1` or higher to enable CircleCI 1.0 builders
 desired_builders_count = "0"
 
-# Provide proxy address if your network configuration requires it
-http_proxy = ""
-https_proxy = ""
-no_proxy = ""
 
 # Use this var if you have multiple installation within one AWS region
 prefix = "..."

--- a/jekyll/_cci2/customizations.adoc
+++ b/jekyll/_cci2/customizations.adoc
@@ -68,19 +68,7 @@ NOTE: Every property should be in the format `export ENV_VAR="value"`
 | Use container specific settings when possible (see files above)
 |===
 
-=== Other Properties and Env Vars
 
-[.table.table-striped]
-[cols=3*, options="header", stripes=even]
-|===
-| Property
-| Impact
-| More info
-
-| HTTP_PROXY, NO_PROXY
-| Proxy for replicated and other services outside CircleCI containers to use
-|
-|===
 
 <<<
 

--- a/jekyll/_cci2/nomad-metrics.adoc
+++ b/jekyll/_cci2/nomad-metrics.adoc
@@ -66,9 +66,6 @@ NOTE: Before proceeding, you should be logged into the EC2 Service section of th
 
 set -exu
 
-export http_proxy=""
-export https_proxy=""
-export no_proxy=""
 export aws_instance_metadata_url="http://169.254.169.254"
 export PUBLIC_IP="$(curl $aws_instance_metadata_url/latest/meta-data/public-ipv4)"
 export PRIVATE_IP="$(curl $aws_instance_metadata_url/latest/meta-data/local-ipv4)"
@@ -125,9 +122,6 @@ tmp=$(mktemp)
 cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
 jq '.["userns-remap"]="default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
 
-sudo echo 'export http_proxy="${http_proxy}"' >> /etc/default/docker
-sudo echo 'export https_proxy="${https_proxy}"' >> /etc/default/docker
-sudo echo 'export no_proxy="${no_proxy}"' >> /etc/default/docker
 sudo service docker restart
 sleep 5
 

--- a/jekyll/_cci2/update-nomad-clients.adoc
+++ b/jekyll/_cci2/update-nomad-clients.adoc
@@ -113,9 +113,6 @@ ec2ccc9d  us-east-1  i-0895ee505ec7e692c  linux-64bit  false  eligible     down
 
 set -exu
 
-export http_proxy=""
-export https_proxy=""
-export no_proxy=""
 export aws_instance_metadata_url="http://169.254.169.254"
 export PUBLIC_IP="$(curl $aws_instance_metadata_url/latest/meta-data/public-ipv4)"
 export PRIVATE_IP="$(curl $aws_instance_metadata_url/latest/meta-data/local-ipv4)"
@@ -168,9 +165,6 @@ tmp=$(mktemp)
 cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
 jq '.["userns-remap"]="default"' /etc/docker/daemon.json > "$tmp" && mv "$tmp" /etc/docker/daemon.json
 
-sudo echo 'export http_proxy="${http_proxy}"' >> /etc/default/docker
-sudo echo 'export https_proxy="${https_proxy}"' >> /etc/default/docker
-sudo echo 'export no_proxy="${no_proxy}"' >> /etc/default/docker
 sudo service docker restart
 sleep 5
 


### PR DESCRIPTION
# Description
http proxy settings do not work currently in 3.x
We are removing this feature for now and will return to this feature later on the road map

# Reasons
https://circleci.atlassian.net/browse/SERVER-1305