### PR TITLE
Add vpc ID for vm-service SG command

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -346,6 +346,7 @@ The recommended security group configuration can be found in the xref:server-3-i
 AWS
 ```bash
 $ aws ec2 create-security-group \
+    --vpc-id "<<VPC ID>>" \
     --description "CircleCI's VM Service security group" \
     --group-name "circleci-vm-service-sg"
 $ aws ec2 authorize-security-group-ingress \


### PR DESCRIPTION
# Description
If no VPC ID is given, AWS will use the default VPC. We cannot assume that the user is using the default VPC.

# Reasons
SERVER-1331