### PR TITLE
Remove links to the legacy Dockerfiles from circleci-images

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -360,7 +360,7 @@ images!
 
 **Resources:**
 
-- [DockerHub](https://hub.docker.com/r/circleci/{{ image[0] }}) - where this image is hosted as well as some useful instructions.
+- [Docker Hub](https://hub.docker.com/r/circleci/{{ image[0] }}) - where this image is hosted as well as some useful instructions.
 
 **Usage:** Add the following under `docker:` in your config.yml:
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Remove links to the legacy `Dockerfile`s from [/docs/2.0/circleci-images/](https://circleci.com/docs/2.0/circleci-images/).

# Reasons
https://github.com/CircleCI-Public/circleci-dockerfiles was archived in 2021-04 and there is no replacement for it in public repos the CircleCI users can access.