### PR TITLE
Update SG commands to use group-id instead of group-name

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -350,27 +350,27 @@ $ aws ec2 create-security-group \
     --description "CircleCI's VM Service security group" \
     --group-name "circleci-vm-service-sg"
 $ aws ec2 authorize-security-group-ingress \
-    --group-name "circleci-vm-service-sg" \
+    --group-id "<< SG ID from create-security-group >>" \
     --protocol tcp \
     --port 22 \
     --cidr "<<CIDR of Nomad clients>>"
 $ aws ec2 authorize-security-group-ingress \
-    --group-name "circleci-vm-service-sg" \
+    --group-id "<< SG ID from create-security-group >>" \
     --protocol tcp \
     --port 22 \
     --cidr "<<CIDR of Kubernetes nodes>>"
 $ aws ec2 authorize-security-group-ingress \
-    --group-name "circleci-vm-service-sg" \
+    --group-id "<< SG ID from create-security-group >>" \
     --protocol tcp \
     --port 2376 \
     --cidr "<<CIDR of Nomad clients>>"
 $ aws ec2 authorize-security-group-ingress \
-    --group-name "circleci-vm-service-sg" \
+    --group-id "<< SG ID from create-security-group >>" \
     --protocol tcp \
     --port 2376 \
     --cidr "<<CIDR of Kubernetes nodes>>"
 $ aws ec2 authorize-security-group-ingress \
-    --group-name "circleci-vm-service-sg" \
+    --group-id "<< SG ID from create-security-group >>" \
     --protocol tcp \
     --port 54782
 ```


### PR DESCRIPTION
On Friday we realized these commands don't actually work as-is because of how a named security group can exist in multiple regions. Using the ID prevents any confusion or mistakes.