### PR TITLE
[CIRCLE-36399] Update runner docks for  RHEL, docker, and kubernetes to show supported status

### DIFF
--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -51,8 +51,11 @@ With a *Supported* platform, users receive the following:
 *Supported* CircleCI runners are available on the following platforms:
 
 * Ubuntu 18.04 or later (x86_64 or ARM64)
+* RHEL8 (x86_64 or ARM64)
 * Mac OS X 10.15+ (Intel)
 * macOS 11.2+ (Apple M1)
+* Docker (x86_64)
+* Kubernetes (x86_64)
 
 === Preview
 
@@ -68,8 +71,8 @@ With a *Preview* platform, users receive the following:
 *Preview* CircleCI runners are available on the following platforms:
 
 * Additional Linux distributions - RHEL, SUSE, Debian, etc. (x86_64 or ARM64)
-* Docker
-* Kubernetes
+* Docker (ARM64)
+* Kubernetes (ARM64)
 * Windows
 
 NOTE: Given the active development of Preview CircleCI runners, please https://circleci.com/contact/[contact us] if you


### PR DESCRIPTION
# Description
Jira: [CIRCLE-36399](https://circleci.atlassian.net/browse/CIRCLE-36399)

Updates the runner documents to show that RHEL, Docker, and Kubernetes are now out of preview and are supported.

This change affects the `Supported` and `Preview` sections listed [here](https://circleci.com/docs/2.0/runner-overview/#supported)

Screenshot of the change:
![Screen Shot 2021-08-02 at 16 00 12](https://user-images.githubusercontent.com/17708458/127929822-6d8161a0-58a6-4eb6-b2e9-1d2ed9755de6.png)