### PR TITLE
Add link to orb publishing steps from orb-dev-kit

### DIFF
--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -60,6 +60,8 @@ The `circleci orb init` command is called, followed by a path that will be creat
   ▸ Yes, walk me through the process.
     No, I'll handle everything myself.
 ```
+When choosing the manual option, see [Manual Orb Authoring Process](https://circleci.com/docs/2.0/orb-author-validate-publish/) for instructions on how to publish your orb.
+
 When choosing the fully automated option, the [Orb-Project-Template](https://github.com/CircleCI-Public/Orb-Project-Template) will be downloaded and automatically modified with your customized settings. The project will be followed on CircleCI with an automated CI/CD pipeline included. <br/><br/>
 For more information on the included CI/CD pipeline, see the [Orb Publishing Process]({{site.baseurl}}/2.0/creating-orbs/) documentation.
 Alternatively, if you would simply like a convenient way of downloading the [Orb-Project-Template](https://github.com/CircleCI-Public/Orb-Project-Template) you can opt to handle everything yourself.


### PR DESCRIPTION
From orb-development-kit page, there could be better indication of the next steps if opting not to do the automated setup.

# Description
Added a section to account for those who don't choose the fully automated option but still need to publish their orb.

# Reasons
The current state of the documentation didn't make it very clear that the `init` command was not what I needed to actually publish the orb, and a link from the edited page would help users who end up in that same part of the docs but don't want the fully automated setup.