### PR TITLE
[CIRCLE-36663] Add documentation for enabling rerun with SSH on runner

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -541,6 +541,23 @@ Draining can end in one of two ways:
 * The task has been in the draining state for longer than the configured `max_run_time`.
 * An additional TERM signal is received by the Launch Agent during "draining".
 
+==== runner.ssh.advertise_addr
+
+This parameter enables the 'Rerun job with SSH' feature. Before enabling this feature, there are xref:runner-installation.adoc#considerations-before-enabling-ssh-debugging[*important considerations that should be made*].
+
+The address is of the form `*host:port*` and is displayed in the 'Enable SSH' and 'Wait for SSH' sections for a job that is rerun.
+
+NOTE: While the presence of the `runner.ssh.advertise_addr` variable enables the 'Rerun job with SSH' feature, the value it holds is for publishing purposes only in the web UI. The address does not need to match the actual host and port of the machine that the runner is installed on and can be a proxy configuration.
+
+===== Considerations before enabling SSH debugging
+
+Task agent runs an embedded SSH server and agent on a dedicated port when the 'Rerun job with SSH' option is activated. This feature will not affect any other SSH servers or agents on the system that the runner is installed on.
+
+* The host port used by the SSH server is currently fixed to `*54782*`. Ensure this port is unblocked and available for SSH connections. A port conflict can occur if multiple launch agents are installed on the same host.
+* The SSH server will inherit the same user privileges and associated access authorizations as task agent as defined by the xref:runner-installation.adoc#runner-command_prefix[runner.command_prefix parameter].
+* The SSH server is configured for public key authentication. Anyone with permission to initiate a job can rerun it with SSH, but only the user who initiated the rerun will have their SSH public keys added to the server for the duration of the SSH session.
+* Rerunning a job with SSH will hold the job open for *two hours* if a connection is made to the SSH server, or *ten minutes* if no connection is made, unless cancelled. While in this state, the job is counted against an organization’s concurrency limit, and the task agent will be unavailable to handle other jobs. Therefore, it is recommended to cancel an SSH rerun job explicitly (through the web UI or CLI) when finished debugging.
+
 == Runner for Server Compatibility
 _CircleCI Runner is available from server v3.1.0_
 

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -99,6 +99,12 @@ The runner consists of two components: the launch agent and the task agent.
 
 The system has been designed to allow administrators to configure the task-agent to run with a lower level of privileges than the launch-agent. Any user who is able to execute a job will be able to gain the same privileges as task-agent. The instructions below are the recommended deployment which follows this approach (launch agent will run as root, but task agent will run as circleci).
 
+== Debugging with SSH
+
+CircleCI runner supports rerunning a job with SSH for debugging purposes. Instructions on using this feature can be found at <<ssh-access-jobs#,Debugging with SSH>>.
+
+NOTE: The 'Rerun job with SSH' feature is disabled by default. To enable this feature, see xref:runner-installation.adoc#runner-ssh-advertise_addr[Installing the CircleCI Runner].
+
 == Public repositories
 
 CircleCI runner is not recommended for use with public projects that have the "Build forked pull requests" setting enabled. In this case, a malicious actor may alter your machine or execute code on it by forking your repository, committing code, and opening a pull request. Untrusted jobs running on your CircleCI runner pose significant security risks for your machine and network environment, especially if your machine persists its environment between jobs. Some of the risks include:
@@ -138,7 +144,6 @@ NOTE: A namespace is a unique identifier claimed by a user or organization. Each
 
 Almost all standard CircleCI features are available for use with runner jobs, but at present a few features are not yet supported. If these features are important for you to make use of runner jobs, please let us know via the relevant canny page.
 
-- https://circleci.canny.io/runner-feature-requests/p/support-rerun-with-ssh-on-runner[Rerun with SSH]
 - https://circleci.canny.io/runner-feature-requests/p/support-test-splitting-on-self-hosted-runners[Test Splitting]
 - https://circleci.canny.io/runner-feature-requests/p/support-addsshkey-on-self-hosted-runners[`add_ssh_keys`]
 


### PR DESCRIPTION
# Description
Adds documentation for enabling rerun with SSH on runner.

![enable-ssh-runner](https://user-images.githubusercontent.com/28056419/131553294-a351feca-340b-4d27-bbf5-ff422d74fc82.png)

JIRA: [CIRCLE-36663](https://circleci.atlassian.net/browse/CIRCLE-36663)