### PR TITLE
Update circleci-images.md

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -163,7 +163,6 @@ cimg/python@sha256:bdabda041f88d40d194c65f6a9e2a2e69ac5632db8ece657b15269700b018
 CircleCI's convenience images fall into two categories: **language** images and
 **service** images. All images add a `circleci` user as a system user. The sections below will walk through the available next-generation and legacy images.
 
-
 ### Next-gen language images
 {: #next-gen-language-images }
 {:.no_toc}
@@ -201,7 +200,6 @@ next-gen images be sure to check each image listing for information on each
 variant. The `-browsers` variant for next-gen images is still in progress. See
 each image listing on the [Developer Hub](https://circleci.com/developer/images/)
 for details on which variants it supports.
-
 
 ### Legacy language images
 {: #legacy-language-images }
@@ -331,7 +329,6 @@ The following packages are installed via `curl` or other means.
    language, we suggest installing it via [an orb](https://circleci.com/orbs/)
    or a custom Docker image instead.
 
-
 ## Latest image tags by language
 {: #latest-image-tags-by-language }
 
@@ -343,7 +340,6 @@ For a list of the latest next-gen convenience images and
 details about the content of each image, visit
 the <a href="https://circleci.com/developer/">Developer Hub.</a>
 </div>
-
 
 **Note:** Excluding [language image variants](#language-image-variants) and [the
 service image variant](#service-image-variant), **for legacy images** CircleCI

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -305,8 +305,6 @@ directory for the Linux distribution/version installed in that variant's base
 image. The legacy CircleCI convenience images are [Debian Jessie](https://packages.debian.org/jessie/)-
 or [Stretch](https://packages.debian.org/stretch/)-based images,
 however the next-gen images, `cimg`, extend the official [Ubuntu](https://packages.ubuntu.com) image.
-For details on individual variants of legacy CircleCI images, see the
-[circleci-dockerfiles](https://github.com/circleci-public/circleci-dockerfiles) repository.
 For details on the next-gen images, see the [Developer Hub](https://circleci.com/developer/images/). Each image is tracked in its own repository.
 
 The following packages are installed via `curl` or other means.
@@ -338,9 +336,6 @@ The following packages are installed via `curl` or other means.
 {: #latest-image-tags-by-language }
 
 Below is a list of the latest **legacy** convenience images, sorted by language.
-For details about the contents of each image,
-refer to the [corresponding Dockerfiles](https://github.com/circleci-public/circleci-dockerfiles).
-
 
 <div class="alert alert-warning" role="alert">
 It is recommended to use next-generation images when possible.
@@ -366,7 +361,6 @@ images!
 **Resources:**
 
 - [DockerHub](https://hub.docker.com/r/circleci/{{ image[0] }}) - where this image is hosted as well as some useful instructions.
-- [Dockerfiles](https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/{{ image[0] }}/images) - the Dockerfiles this image was built from.
 
 **Usage:** Add the following under `docker:` in your config.yml:
 


### PR DESCRIPTION
removed links to legacy dockerfiles that are now obsolete. This fixes #5574 .

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.