### PR TITLE
Add note about orb kit working with Bitbucket

### DIFF
--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -32,6 +32,8 @@ The orb development kit refers to a suite of tools that work together to simplif
 ### Getting started
 {: #getting-started }
 
+Note: While the outlined process below only mentions GitHub, the development kit also works with Bitbucket repositories.
+
 To begin creating your new orb with the orb development kit, follow these steps. The starting point is creating a new repository on [GitHub.com](https://github.com).
 
 Ensure the organization on GitHub is the owner for the [namespace]({{site.baseurl}}/2.0/orb-concepts/#namespaces) for which you are developing your orb. If this is your own personal organization and namespace, you need not worry.


### PR DESCRIPTION
# Description
This document outlines the process for creating an Orb with the development kit utilizing GitHub as your VCS. However, the kit also works with Bitbucket repos, so I added a note to clarify that it's possible.

# Reasons
This was brought to my attention from a ticket I was working on with a customer. While this note will help clarify the situation, as a bigger project, we may want to split this document into two sections. One outlining the process for GitHub and one outlining the process for Bitbucket.