### PR TITLE
Fix: try using --allow-releaseinfo-change to build docs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
       - run:
           name: Install dependecies for pronto gem
           command: |
-            sudo apt-get update
+            sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install cmake pkg-config
       - ruby-deps
       - node/with-cache: # An orb command for steps to run in-between restoring and saving a cache.


### PR DESCRIPTION
Our builds are failing based on a debian release change. The flag I am adding is described as such:

```
--allow-releaseinfo-change

Allow the update command to continue downloading data from a repository which changed its information of the release contained in the repository indicating e.g a new major release. APT will fail at the update command for such repositories until the change is confirmed to ensure the user is prepared for the change. See also apt-secure(8) for details on the concept and configuration.
Specialist options (--allow-releaseinfo-change-field) exist to allow changes only for certain fields like origin, label, codename, suite, version and defaultpin. See also apt_preferences(5). Configuration Item: Acquire::AllowReleaseInfoChange.
```

The error we are getting:
```
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```

I do not know for how long this flag is required, or if there are security implications. I haven't seen any based on my research but am tagging @taxonomic-blackfish on this because they have contributed to our security docs and they may know about this.