### PR TITLE
Update Node.js orb and use next-gen image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1 # Set the CI version.
 # Learn more about orbs: https://circleci.com/orbs/
 orbs:
   ruby: circleci/ruby@1.1.4
-  node: circleci/node@1.1.6
+  node: circleci/node@4.7.0
   md-proofer: hubci/md-proofer@0.1
 
 
@@ -128,16 +128,13 @@ jobs:
   js_build: # this job is responsible for building Javascript assets and making them available for the "build" job
     executor: # we specify our executor to use the node orb.
       name: node/default
-      tag: '8.11.1'
+      tag: '14.1'
     steps:
       - *attach_workspace
       - checkout # get the code from GitHub
       - install-shared-assets
-      - node/with-cache: # An orb command for steps to run in-between restoring and saving a cache.
-          cache-key: "package-lock.json"
-          cache-version: &npm-cache-version v9 # Gets cache version from project environment variable (E.g v1)
-          steps:
-            - run: npm install
+      - node/install-packages:
+          cache-version: &npm-cache-version v1 # Gets cache version from project environment variable (E.g v1)
       - run:
           name: "Prepare JS assets" # Compile our final, production-ready JavaScript.
           command: npm run webpack-prod
@@ -227,11 +224,8 @@ jobs:
             sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install cmake pkg-config
       - ruby-deps
-      - node/with-cache: # An orb command for steps to run in-between restoring and saving a cache.
-          cache-key: "package-lock.json"
+      - node/install-packages:
           cache-version: *npm-cache-version # Gets cache version from project environment variable (E.g v1)
-          steps:
-            - run: npm install
       - run:
           name: Run markdownlint with pronto
           command: bundle exec pronto run -f github_pr -c origin/master


### PR DESCRIPTION
This PR is mainly to swap the Node.js image. The legacy image, which is currently used, is deprecated. This switches over to the next-gen Noide.js image.

The orb is updated too because 1) why not and 2) we needed a newer version of the orb in order to use the next-gen image.

One thing to pay attention to here, this updates the Node.js version by a lot. From v8 all the way to v14. The pipeline passed successfully so that's good but we'll want to make sure there isn't any other unintended changes.