### PR TITLE
Fix Ruby dev step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ commands:
             if [[ "<< parameters.dir >>" != "" ]]; then
               cd << parameters.dir >>
             fi
+            #cmake is needed fo rugged, a gem dependency
+            sudo apt-get update && sudo apt-get install -y cmake
             bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
       - save_cache:
           key: circleci-docs-v1-{{ .Branch }}-<< parameters.dir >>-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
The [reindex-search job failed](https://app.circleci.com/pipelines/github/circleci/circleci-docs/30936/workflows/1bfe5d5d-b4f6-4f53-892f-ebdcc05c2e77/jobs/87463) after the Ruby changes. The next-gen Ruby image doesn't have cmake installed so we need to install it manually.

I didn't catch this in the other PR because the `reindex-search` job doesn't run for PRs.