### PR TITLE
[No Jira] Apostrophes are an invalid character for descriptions

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -347,7 +347,7 @@ AWS
 ```bash
 $ aws ec2 create-security-group \
     --vpc-id "<<VPC ID>>" \
-    --description "CircleCI's VM Service security group" \
+    --description "CircleCI VM Service security group" \
     --group-name "circleci-vm-service-sg"
 $ aws ec2 authorize-security-group-ingress \
     --group-id "<< SG ID from create-security-group >>" \


### PR DESCRIPTION
Apostrophes are an invalid character for descriptions. The command will fail if an apostrophe is present.