### PR TITLE
Use jekyll-minibundle in place of jekyll-assets to solve docker issues while editing files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,10 @@ ruby '2.7.2'
 
 gem "jekyll", '~> 4.2.0', github: "jekyll/jekyll"
 gem 'html-proofer'
-gem "rack", ">= 2.0.6"
 gem 'asciidoctor'
 gem 'pygments.rb', '~> 1.1.2'
 gem 'rake'
 gem 'dotenv'
-gem "sprockets"
 gem "kramdown-parser-gfm"
 gem "liquid-c"
 
@@ -17,14 +15,10 @@ group :jekyll_plugins do
   gem 'jekyll-algolia', '~> 1.0'
   gem 'jekyll-sitemap'
   gem 'jekyll-include-cache'
-  gem 'jekyll-assets', git: "https://github.com/envygeeks/jekyll-assets"
   gem 'jekyll-target-blank'
   gem 'jekyll-toc'
-  # jekyll-assets depends on sprockets, which depends on rack, which has two
-  # security vulnerabilities prior to 2.0.6.
-  # https://nvd.nist.gov/vuln/detail/CVE-2018-16471
-  # https://nvd.nist.gov/vuln/detail/CVE-2018-16470
   gem 'jekyll-asciidoc'
+  gem 'jekyll-minibundle'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,4 @@
 GIT
-  remote: https://github.com/envygeeks/jekyll-assets
-  revision: 056d2c88719ef3b1f90967a606dd1441581dd832
-  specs:
-    jekyll-assets (4.0.0.alpha)
-      activesupport (>= 5, < 7)
-      execjs (~> 2.7)
-      extras (~> 0.2)
-      fastimage (~> 2.0, >= 1.8)
-      jekyll (>= 3.5, < 5.0)
-      jekyll-sanity (~> 1.2)
-      liquid-tag-parser (>= 1, < 3)
-      nokogiri (~> 1.10)
-      pathutil (~> 0.16)
-      sassc (>= 1.11, < 3.0)
-      sprockets (~> 4.0.beta7)
-
-GIT
   remote: https://github.com/jekyll/jekyll.git
   revision: 76517175e700d80706c9139989053f1c53d9b956
   specs:
@@ -39,12 +22,6 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     algolia_html_extractor (2.6.4)
@@ -63,15 +40,11 @@ GEM
     ethon (0.14.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    execjs (2.7.0)
-    extras (0.3.0)
-      forwardable-extended (~> 2.5)
     faraday (1.3.0)
       faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
-    fastimage (2.2.3)
     ffi (1.15.3)
     filesize (0.2.0)
     forwardable-extended (2.6.0)
@@ -107,9 +80,7 @@ GEM
       jekyll (>= 3.0.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-sanity (1.6.0)
-      jekyll (>= 3.1, < 5.0)
-      pathutil (~> 0.16)
+    jekyll-minibundle (3.0.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
@@ -130,9 +101,6 @@ GEM
     liquid (4.0.3)
     liquid-c (4.0.0)
       liquid (>= 3.0.0)
-    liquid-tag-parser (2.0.2)
-      extras (~> 0.3)
-      liquid (>= 3.0, < 5.0)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -141,7 +109,6 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
     mini_portile2 (2.6.1)
-    minitest (5.14.4)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -170,7 +137,6 @@ GEM
     pygments.rb (1.1.2)
       multi_json (>= 1.0.0)
     racc (1.5.2)
-    rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.3)
     rb-fsevent (0.11.0)
@@ -186,21 +152,15 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    sprockets (4.0.2)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
     terminal-table (3.0.1)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.1.0)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
     verbal_expressions (0.1.5)
     webrick (1.7.0)
     yell (2.2.2)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -212,8 +172,8 @@ DEPENDENCIES
   jekyll (~> 4.2.0)!
   jekyll-algolia (~> 1.0)
   jekyll-asciidoc
-  jekyll-assets!
   jekyll-include-cache
+  jekyll-minibundle
   jekyll-sitemap
   jekyll-target-blank
   jekyll-toc
@@ -222,9 +182,7 @@ DEPENDENCIES
   pronto
   pronto-markdownlint
   pygments.rb (~> 1.1.2)
-  rack (>= 2.0.6)
   rake
-  sprockets
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   jekyll:
-    command: bash -c "apt-get update -y && apt-get install -y cmake pkg-config && bundle install && bundle exec jekyll serve -s jekyll --incremental --livereload --host=0.0.0.0"
+    command: bash -c "apt-get update -y && apt-get install -y cmake pkg-config && bundle install && JEKYLL_MINIBUNDLE_MODE=development bundle exec jekyll serve -s jekyll --incremental --host=0.0.0.0"
     working_dir: /root
     image: ruby:2.7.2
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   jekyll:
-    command: bash -c "apt-get update -y && apt-get install -y cmake pkg-config && bundle install && JEKYLL_MINIBUNDLE_MODE=development bundle exec jekyll serve -s jekyll --incremental --host=0.0.0.0"
+    command: bash -c "apt-get update -y && apt-get install -y cmake pkg-config && bundle install && bundle exec jekyll clean && JEKYLL_MINIBUNDLE_MODE=development bundle exec jekyll serve -s jekyll --incremental --host=0.0.0.0"
     working_dir: /root
     image: ruby:2.7.2
     volumes:

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -20,6 +20,7 @@ plugins:
   - jekyll-asciidoc
   - jekyll-target-blank
   - jekyll-toc
+  - jekyll/minibundle
 
 algolia:
   application_id: U0RXNGRK45

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -15,7 +15,6 @@ exclude:
 
 plugins:
   - jekyll-include-cache
-  - jekyll-assets
   - jekyll-sitemap
   - jekyll-asciidoc
   - jekyll-target-blank

--- a/jekyll/_includes/js-assets.html
+++ b/jekyll/_includes/js-assets.html
@@ -1,13 +1,13 @@
 <div>
-  {% asset vendor.min.js %}
-  <script src="https://unpkg.com/@popperjs/core@2.4.4/dist/umd/popper.min.js"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/vendor.min.js assets/vendor.min.js %}"></script>
+  <script type="text/javascript" src="https://unpkg.com/@popperjs/core@2.4.4/dist/umd/popper.min.js"></script>
   {% include_cached rollbar.html site=site %}
-  {% asset app.bundle.js %}
-  {% asset site.min.js %}
-  {% asset jquery.cookie.min.js %}
-  {% asset main.js %}
-  {% asset nav.js %}
-  {% asset shared/components/subnav.js %}
-  {% asset shared/analytics-recursive-tracking.js %}
+  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/app.bundle.js assets/app.bundle.js %}"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/site.min.js assets/site.min.js %}"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/jquery.cookie.min.js assets/jquery.cookie.min.js %}"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/main.js assets/main.js %}"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/nav.js assets/nav.js %}"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/shared/components/subnav.js assets/shared/components/subnav.js %}"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/shared/analytics-recursive-tracking.js assets/shared/analytics-recursive-tracking.js %}"></script>
   <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
 </div>

--- a/jekyll/_includes/js-assets.html
+++ b/jekyll/_includes/js-assets.html
@@ -5,6 +5,7 @@
   <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/app.bundle.js assets/app.bundle.js %}"></script>
   <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/site.min.js assets/site.min.js %}"></script>
   <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/jquery.cookie.min.js assets/jquery.cookie.min.js %}"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/sidebar.js assets/sidebar.js %}"></script>
   <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/main.js assets/main.js %}"></script>
   <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/nav.js assets/nav.js %}"></script>
   <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/shared/components/subnav.js assets/shared/components/subnav.js %}"></script>

--- a/jekyll/_includes/mobile-sidebar.html
+++ b/jekyll/_includes/mobile-sidebar.html
@@ -9,7 +9,7 @@
           <li class="main-nav-item closed" data-section="{{ main-item.name | slugify }}">
             <div class="list-wrap">
               {% if main-item.icon %}
-                {% asset '{{ main-item.icon }}' class=icon %}
+                <img class="icon" src="{{ site.baseurl }}/{% ministamp { source_path: 'assets/img/{{ main-item.icon }}', destination_path: 'assets/{{ main-item.icon }}' } %}">
               {% endif %}
 
               {% if main-item.i18n_name %}
@@ -27,7 +27,7 @@
               {% endif %}
 
               {% if main-item.children %}
-              {% asset docs/arrow-right.svg class=arrow %}
+                <img class="arrow" crossorigin="anonymous" src="{{ site.baseurl }}/{% ministamp assets/img/docs/arrow-right.svg assets/docs/arrow-right.svg %}">
               {% endif %}
             </div>
 

--- a/jekyll/_includes/sidebar.html
+++ b/jekyll/_includes/sidebar.html
@@ -8,7 +8,7 @@
           <!-- "main items" (Getting Started, Configuration etc.) -->
           <div class="list-wrap">
             {% if main-item.icon %}
-              {% asset '{{ main-item.icon }}' class=icon %}
+              <img class="icon" src="{{ site.baseurl }}/{% ministamp { source_path: 'assets/img/{{ main-item.icon }}', destination_path: 'assets/{{ main-item.icon }}' } %}">
             {% endif %}
 
             {% if main-item.i18n_name %}
@@ -26,7 +26,7 @@
             {% endif %}
 
             {% if main-item.children %}
-              {% asset docs/arrow-right.svg class=arrow %}
+              <img class="arrow" crossorigin="anonymous" src="{{ site.baseurl }}/{% ministamp assets/img/docs/arrow-right.svg assets/docs/arrow-right.svg %}">
             {% endif %}
           </div>
 

--- a/jekyll/assets/js/main.js
+++ b/jekyll/assets/js/main.js
@@ -1,5 +1,3 @@
-//= require sidebar.js
-
 // compiles an object of parameters relevant for analytics event tracking.
 // takes an optional DOM element and uses additional information if present.
 window.analyticsTrackProps = function (el) {


### PR DESCRIPTION
# Changes

- Replace `jekyll-assets` to `jekyll-minibundle` 
- Use  `JEKYLL_MINIBUNDLE_MODE` env variable to disable asset fingerprinting in dev

# Reasons

With https://github.com/circleci/circleci-docs/pull/5601 landing, developers working on that repo are pretty much required to use Docker if they want to mimic a true-to-life experience (e.g. being able to call the circleci API) and jekyll being pretty slow to build, sometimes up to 10 minutes, we needed to make the developer experience a little better. With the help of the `--incremental` jekyll [option](https://jekyllrb.com/docs/configuration/incremental-regeneration/), we are able to only regenerate the content that changes and thus shorting the wait time. 

Something I discovered while working on this PR is that our `jekyll-assets` plugin was not compatible with [Incremental regeneration](https://jekyllrb.com/docs/configuration/incremental-regeneration/) since it came out after the latest release. `jekyll-assets` hasn't been updated since [November 2018](https://github.com/envygeeks/jekyll-assets/releases/tag/v3.0.12) and Jekyll 4 was released in the [Summer 2019](https://jekyllrb.com/news/2019/08/20/jekyll-4-0-0-released/). On top of that, it sounds that the project might even be dead? https://github.com/envygeeks/jekyll-assets/issues/627

This PR is replacing `jekyll-assets` to `jekyll-minibundle` which supports an option to disable assets [fingerprinting](https://github.com/tkareine/jekyll-minibundle#asset-fingerprinting) and allows the site to work correctly once regenerated and the browser refreshed.

Prior to this PR, every single change to the codebase was breaking the build and a full restart of the Docker container was needed to see an update (~10 minutes). With this PR, the wait times are entirely dependent on the `--incremental` performances and for a single JS change can take between one and ten seconds in my experience.
