### PR TITLE
Add note about needing setup key of true for dynamic configs to start

### DIFF
--- a/jekyll/_cci2/dynamic-config.md
+++ b/jekyll/_cci2/dynamic-config.md
@@ -50,6 +50,8 @@ To get started with Dynamic Config in CircleCI:
 
 Now, your project has the ability to dynamically generate and update configuration.
 
+Note: While the above will make the feature available, your static `config.yml` will continue to work as normal. This feature won't start to be utilized until you add the key `setup` with a value of `true` to that `config.yml`.
+
 When using dynamic configuration, at the end of the `setup workflow`, a `continue` job from the [`continuation`](https://circleci.com/developer/orbs/orb/circleci/continuation)
 [`orb`]({{ site.baseurl }}/2.0/orb-intro/) must be called (**NOTE:** this does not apply if you desire to conditionally execute
 workflows or steps based on updates to specified files, as described in the [Configuration Cookbook]({{ site.baseurl }}/2.0/configuration-cookbook/?section=examples-and-guides#execute-specific-workflows-or-steps-based-on-which-files-are-modified) example).

--- a/jekyll/_cci2/dynamic-config.md
+++ b/jekyll/_cci2/dynamic-config.md
@@ -50,7 +50,7 @@ To get started with Dynamic Config in CircleCI:
 
 Now, your project has the ability to dynamically generate and update configuration.
 
-Note: While the above will make the feature available, your static `config.yml` will continue to work as normal. This feature won't start to be utilized until you add the key `setup` with a value of `true` to that `config.yml`.
+Note: While the steps above will make the feature available, your static `config.yml` will continue to work as normal. This feature will not be used until you add the key `setup` with a value of `true` to that `config.yml`.
 
 When using dynamic configuration, at the end of the `setup workflow`, a `continue` job from the [`continuation`](https://circleci.com/developer/orbs/orb/circleci/continuation)
 [`orb`]({{ site.baseurl }}/2.0/orb-intro/) must be called (**NOTE:** this does not apply if you desire to conditionally execute


### PR DESCRIPTION
# Description
This PR will add a note to the documentation that without adding `setup: true` to your config.yml that your CircleCI pipelines will continue to operate as normal.

# Reasons
We had a customer who had some concerns over enabling this feature and it causing issues with their existing setup. I can understand the concern there so this update is to ensure customers know that just enabling the feature doesn't do anything out of the box. It only comes into play after you add in `setup: true` to your config. 