### PR TITLE
remove reference to default resource class

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -188,7 +188,7 @@ job. In Docker, the following resources classes are available:
 Class                 | vCPUs | RAM
 ----------------------|-------|-----
 small                 | 1     | 2GB
-medium (default)      | 2     | 4GB
+medium                | 2     | 4GB
 medium+               | 3     | 6GB
 large                 | 4     | 8GB
 xlarge                | 8     | 16GB


### PR DESCRIPTION
Motivation for removing references to default resource class in this feature brief: https://circleci.atlassian.net/wiki/spaces/PROD/pages/6266060873/Fleets+-+July+2021+-+Changing+Resource+Class+Default+DRAFT+Mini-Feature+Brief