### PR TITLE
[WEB-390] Allow recursive event tracking when `a` tag includes another element

### DIFF
--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang }}">
+<html lang="{{ page.lang }}">
 {% include_cached head.html site=site page=page %}
 <body class="{% if page.page-type == "index" or page.page-type == "homepage" %}homepage{% endif %}">
 {% if jekyll.environment == "production" %}

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -32,6 +32,12 @@ a {
 		color: $link-hover-color;
 		text-decoration: none;
 	}
+
+	& > * {
+		// to prevent the child elements inside a tag from registering
+		// as the target in event listeners (for analytics tracking)
+		pointer-events: none;
+	}
 }
 
 .container-semi-fluid {


### PR DESCRIPTION
Ticket: [WEB-390](https://circleci.atlassian.net/browse/WEB-390)

# Description
Currently, if you click a link with child elements inside (like svg/span/img/etc), the child element triggers the click and become the target element causing our analytics tracking code to skip it over. 

# Changes
- Used CSS to make the child elements inside an `a` tag have no pointer events so they stop registering as the target element in event listeners.
