### PR TITLE
Add a class for env vars to prevent wrapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   jekyll:
-    command: bash -c "apt-get update -y && apt-get install -y cmake pkg-config && bundle install && bundle exec jekyll clean && JEKYLL_MINIBUNDLE_MODE=development bundle exec jekyll serve -s jekyll --incremental --host=0.0.0.0"
+    command: bash scripts/docker_command.sh
     working_dir: /root
     image: ruby:2.7.2
     volumes:

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -565,34 +565,34 @@ to export the new environment variables using `BASH_ENV`.
 
 For more details, see [Setting an Environment Variable in a Shell Command](#setting-an-environment-variable-in-a-shell-command).
 
-Variable                    | Type    | Value
-----------------------------|---------|-----------------------------------------------
-`CI`                        | Boolean | `true` (represents whether the current environment is a CI environment)
-`CIRCLECI`                  | Boolean | `true` (represents whether the current environment is a CircleCI environment)
-`CIRCLE_BRANCH`             | String  | The name of the Git branch currently being built.
-`CIRCLE_BUILD_NUM`          | Integer | The number of the current job. Job numbers are unique for each job.
-`CIRCLE_BUILD_URL`          | String  | The URL for the current job on CircleCI.
-`CIRCLE_JOB`                | String  | The name of the current job.
-`CIRCLE_NODE_INDEX`         | Integer | For jobs that run with parallelism enabled, this is the index of the current parallel run. The value ranges from 0 to (`CIRCLE_NODE_TOTAL` - 1)
-`CIRCLE_NODE_TOTAL`         | Integer | For jobs that run with parallelism enabled, this is the number of parallel runs. This is equivielnt to the value of `parallelism` in your config file.
-`CIRCLE_PR_NUMBER`          | Integer | The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
-`CIRCLE_PR_REPONAME`        | String  | The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
-`CIRCLE_PR_USERNAME`        | String  | The GitHub or Bitbucket username of the user who created the pull request. Only available on forked PRs.
-`CIRCLE_PREVIOUS_BUILD_NUM` | Integer | The number of previous builds on the current branch.
-`CIRCLE_PROJECT_REPONAME`   | String  | The name of the repository of the current project.
-`CIRCLE_PROJECT_USERNAME`   | String  | The GitHub or Bitbucket username of the current project.
-`CIRCLE_PULL_REQUEST`       | String  | The URL of the associated pull request. If there are multiple associated pull requests, one URL is randomly chosen.
-`CIRCLE_PULL_REQUESTS`      | List    | Comma-separated list of URLs of the current build's associated pull requests.
-`CIRCLE_REPOSITORY_URL`     | String  | The URL of your GitHub or Bitbucket repository.
-`CIRCLE_SHA1`               | String  | The SHA1 hash of the last commit of the current build.
-`CIRCLE_TAG`                | String  | The name of the git tag, if the current build is tagged. For more information, see the [Git Tag Job Execution]({{ site.baseurl }}/2.0/workflows/#executing-workflows-for-a-git-tag).
-`CIRCLE_USERNAME`           | String  | The GitHub or Bitbucket username of the user who triggered the pipeline.
-`CIRCLE_WORKFLOW_ID`        | String  | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
-`CIRCLE_WORKING_DIRECTORY`  | String  | The value of the `working_directory` key of the current job.
-`CIRCLE_INTERNAL_TASK_DATA` | String  | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.
-`CIRCLE_COMPARE_URL`        | String  | **Deprecated**. The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{ site.baseurl }}/2.0/pipeline-variables/) as an alternative.
-`CI_PULL_REQUEST`           | String  | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUEST` instead.
-`CI_PULL_REQUESTS`          | List    | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUESTS` instead.
+Variable                               | Type    | Value
+---------------------------------------|---------|-----------------------------------------------
+`CI`{:.env_var}                        | Boolean | `true` (represents whether the current environment is a CI environment)
+`CIRCLECI`{:.env_var}                  | Boolean | `true` (represents whether the current environment is a CircleCI environment)
+`CIRCLE_BRANCH`{:.env_var}             | String  | The name of the Git branch currently being built.
+`CIRCLE_BUILD_NUM`{:.env_var}          | Integer | The number of the current job. Job numbers are unique for each job.
+`CIRCLE_BUILD_URL`{:.env_var}          | String  | The URL for the current job on CircleCI.
+`CIRCLE_JOB`{:.env_var}                | String  | The name of the current job.
+`CIRCLE_NODE_INDEX`{:.env_var}         | Integer | For jobs that run with parallelism enabled, this is the index of the current parallel run. The value ranges from 0 to (`CIRCLE_NODE_TOTAL` - 1)
+`CIRCLE_NODE_TOTAL`{:.env_var}         | Integer | For jobs that run with parallelism enabled, this is the number of parallel runs. This is equivielnt to the value of `parallelism` in your config file.
+`CIRCLE_PR_NUMBER`{:.env_var}          | Integer | The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
+`CIRCLE_PR_REPONAME`{:.env_var}        | String  | The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
+`CIRCLE_PR_USERNAME`{:.env_var}        | String  | The GitHub or Bitbucket username of the user who created the pull request. Only available on forked PRs.
+`CIRCLE_PREVIOUS_BUILD_NUM`{:.env_var} | Integer | The number of previous builds on the current branch.
+`CIRCLE_PROJECT_REPONAME`{:.env_var}   | String  | The name of the repository of the current project.
+`CIRCLE_PROJECT_USERNAME`{:.env_var}   | String  | The GitHub or Bitbucket username of the current project.
+`CIRCLE_PULL_REQUEST`{:.env_var}       | String  | The URL of the associated pull request. If there are multiple associated pull requests, one URL is randomly chosen.
+`CIRCLE_PULL_REQUESTS`{:.env_var}      | List    | Comma-separated list of URLs of the current build's associated pull requests.
+`CIRCLE_REPOSITORY_URL`{:.env_var}     | String  | The URL of your GitHub or Bitbucket repository.
+`CIRCLE_SHA1`{:.env_var}               | String  | The SHA1 hash of the last commit of the current build.
+`CIRCLE_TAG`{:.env_var}                | String  | The name of the git tag, if the current build is tagged. For more information, see the [Git Tag Job Execution]({{ site.baseurl }}/2.0/workflows/#executing-workflows-for-a-git-tag).
+`CIRCLE_USERNAME`{:.env_var}           | String  | The GitHub or Bitbucket username of the user who triggered the pipeline.
+`CIRCLE_WORKFLOW_ID`{:.env_var}        | String  | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
+`CIRCLE_WORKING_DIRECTORY`{:.env_var}  | String  | The value of the `working_directory` key of the current job.
+`CIRCLE_INTERNAL_TASK_DATA`{:.env_var} | String  | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.
+`CIRCLE_COMPARE_URL`{:.env_var}        | String  | **Deprecated**. The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{ site.baseurl }}/2.0/pipeline-variables/) as an alternative.
+`CI_PULL_REQUEST`{:.env_var}           | String  | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUEST` instead.
+`CI_PULL_REQUESTS`{:.env_var}          | List    | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUESTS` instead.
 {:class="table table-striped"}
 
 **Note:** For a list of pipeline values and parameters, refer to the [Pipeline Variables]({{ site.baseurl }}/2.0/pipeline-variables/#pipeline-values) page.

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -321,6 +321,12 @@ code {
   word-wrap: anywhere;
 }
 
+code.env_var {
+  white-space: nowrap !important;
+}
+
+
+
 /***** Widgets ****************************************************************/
 //
 //*****************************************************************************/
@@ -428,7 +434,7 @@ pre {
 }
 
 .serveronly {
-	color: #4e9eb3; 
+	color: #4e9eb3;
 }
 
 .server-version-badge {

--- a/scripts/docker_command.sh
+++ b/scripts/docker_command.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+# This file is intended to be used to launch the Jekyll container when running
+# locally using docker-compose.
+
+export JEKYLL_MINIBUNDLE_MODE="development"
+
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+source $NVM_DIR/nvm.sh
+
+nvm install 14.1
+npm install
+npm run webpack-prod
+
+apt-get update -y
+apt-get install -y cmake pkg-config
+
+bundle install
+bundle exec jekyll clean
+bundle exec jekyll serve -s jekyll --incremental --host=0.0.0.0 --trace


### PR DESCRIPTION
The table of environment variable was wrapping them. This change adds a
new CSS class for environment variables that can be used to prevent
wrapping.

I also needed to fix the docker-compose setup to get it working locally.
