### PR TITLE
remove space to keep numbered steps inline

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -331,8 +331,7 @@ and the CircleCI project is `https://circleci.com/gh/you/test-repo`.
 1. Create an SSH key pair by following the
    [GitHub instructions](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/).
    When prompted to enter a passphrase, do **not** enter one:
-
-```
+```bash
 ssh-keygen -t ed25519 -C "your_email@example.com"
 ```
 

--- a/jekyll/_cci2/orb-author-validate-publish.md
+++ b/jekyll/_cci2/orb-author-validate-publish.md
@@ -15,12 +15,10 @@ circleci namespace create <my-namespace> github <my-gh-org>
 **Note:** When creating a namespace via the CircleCI CLI, be sure to specify the VCS provider.
 
 1. Create your orb inside your namespace. At this stage no orb content is being generated, but the naming is reserved for when the orb is published.
-
 To create a **[public](https://circleci.com/docs/2.0/orb-intro/#public-orbs)** orb:
 ```sh
 circleci orb create <my-namespace>/<my-orb-name>
 ```
-
 To create a **[private](https://circleci.com/docs/2.0/orb-intro/#private-orbs)** orb:
 ```sh
 circleci orb create <my-namespace>/<my-orb-name> --private

--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -44,12 +44,10 @@ The name of your repository is not critical, but we recommend something similar 
     When complete, you will be brought to a page confirming your new repository and you should see the generated git URL. Note down the git URL, you will need it in step 4. You can select SSH or HTTPS, which ever you can authenticate with. ![Orb Registry]({{site.baseurl}}/assets/img/docs/github_new_quick_setup.png)
 
 1. **Open a terminal and initialize your new orb project using the `orb init` CLI command.**
-
 To initialize a **[public](https://circleci.com/docs/2.0/orb-intro/#public-orbs)** orb:
 ```bash
 circleci orb init /path/to/myProject-orb
 ```
-
 To initialize a **[private](https://circleci.com/docs/2.0/orb-intro/#private-orbs)** orb:
 ```bash
 circleci orb init /path/to/myProject-orb --private


### PR DESCRIPTION
With these spaces left in the docs the numbered steps restart from one after the space.