### PR TITLE
[CIRCLE-37451] Add example payload for workflow-completed and job-completed webhooks

### DIFF
--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -310,6 +310,15 @@ isn't associated with a git commit.
     "id": "cf8c4fdd-0587-4da1-b4ca-4846e9640af9",
     "name": "Sample Webhook"
   },
+  "project": {
+    "id": "84996744-a854-4f5e-aea3-04e2851dc1d2",
+    "name": "webhook-service",
+    "slug": "github/circleci/webhook-service"
+  },
+  "organization": {
+    "id": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
+    "name": "circleci"
+  }
   "workflow": {
     "id": "fda08377-fe7e-46b1-8992-3a7aaecac9c3",
     "name": "build-test-deploy",
@@ -347,15 +356,6 @@ isn't associated with a git commit.
       "branch": "main"
     }
   },
-  "project": {
-    "id": "84996744-a854-4f5e-aea3-04e2851dc1d2",
-    "name": "webhook-service",
-    "slug": "github/circleci/webhook-service"
-  },
-  "organization": {
-    "id": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
-    "name": "circleci"
-  }
 }
 ```
 

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -331,8 +331,8 @@ isn't associated with a git commit.
       "target_repository_url": "https://github.com/circleci/webhook-service",
       "revision": "1dc6aa69429bff4806ad6afe58d3d8f57e25973e",
       "commit": {
-        "subject": "Trigger CI",
-        "body": "",
+        "subject": "Description of change",
+        "body": "More details about the change",
         "author": {
           "name": "Author Name",
           "email": "author.email@example.com"
@@ -392,8 +392,8 @@ isn't associated with a git commit.
       "target_repository_url": "https://github.com/circleci/webhook-service",
       "revision": "1dc6aa69429bff4806ad6afe58d3d8f57e25973e",
       "commit": {
-        "subject": "Trigger CI",
-        "body": "",
+        "subject": "Description of change",
+        "body": "More details about the change",
         "author": {
           "name": "Author Name",
           "email": "author.email@example.com"

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -368,7 +368,7 @@ isn't associated with a git commit.
   "happened_at": "2021-09-01T22:49:34.279Z",
   "webhook": {
     "id": "cf8c4fdd-0587-4da1-b4ca-4846e9640af9",
-    "name": "alex testing jobs"
+    "name": "Sample Webhook"
   },
   "project": {
     "id": "84996744-a854-4f5e-aea3-04e2851dc1d2",

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -298,8 +298,10 @@ isn't associated with a git commit.
 
 
 ## Sample webhook payloads
+{: #sample-webhook-payloads }
 
 ### workflow-completed
+{: #workflow-completed }
 
 ```json
 {
@@ -360,6 +362,7 @@ isn't associated with a git commit.
 ```
 
 ### job-completed
+{: #job-completed }
 
 ```json
 {

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -295,3 +295,133 @@ isn't associated with a git commit.
 | branch                 | no              | Branch being built                                                                                                 |
 | tag                    | no              | Tag being built (mutually exclusive with "branch")                                                                 |
 {: class="table table-striped"}
+
+
+## Sample webhook payloads
+
+### workflow-completed
+
+```json
+{
+  "id": "3888f21b-eaa7-38e3-8f3d-75a63bba8895",
+  "type": "workflow-completed",
+  "happened_at": "2021-09-01T22:49:34.317Z",
+  "webhook": {
+    "id": "cf8c4fdd-0587-4da1-b4ca-4846e9640af9",
+    "name": "Sample Webhook"
+  },
+  "workflow": {
+    "id": "fda08377-fe7e-46b1-8992-3a7aaecac9c3",
+    "name": "build-test-deploy",
+    "created_at": "2021-09-01T22:49:03.616Z",
+    "stopped_at": "2021-09-01T22:49:34.170Z",
+    "url": "https://app.circleci.com/pipelines/github/circleci/webhook-service/130/workflows/fda08377-fe7e-46b1-8992-3a7aaecac9c3",
+    "status": "success"
+  },
+  "pipeline": {
+    "id": "1285fe1d-d3a6-44fc-8886-8979558254c4",
+    "number": 130,
+    "created_at": "2021-09-01T22:49:03.544Z",
+    "trigger": {
+      "type": "webhook"
+    },
+    "vcs": {
+      "provider_name": "github",
+      "origin_repository_url": "https://github.com/circleci/webhook-service",
+      "target_repository_url": "https://github.com/circleci/webhook-service",
+      "revision": "1dc6aa69429bff4806ad6afe58d3d8f57e25973e",
+      "commit": {
+        "subject": "Trigger CI",
+        "body": "",
+        "author": {
+          "name": "Author Name",
+          "email": "author.email@example.com"
+        },
+        "authored_at": "2021-09-01T22:48:53Z",
+        "committer": {
+          "name": "Committer Name",
+          "email": "committer.email@example.com"
+        },
+        "committed_at": "2021-09-01T22:48:53Z"
+      },
+      "branch": "main"
+    }
+  },
+  "project": {
+    "id": "84996744-a854-4f5e-aea3-04e2851dc1d2",
+    "name": "webhook-service",
+    "slug": "github/circleci/webhook-service"
+  },
+  "organization": {
+    "id": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
+    "name": "circleci"
+  }
+}
+```
+
+### job-completed
+
+```json
+{
+  "id": "8bd71c28-4969-3677-8940-3e3a61c46660",
+  "type": "job-completed",
+  "happened_at": "2021-09-01T22:49:34.279Z",
+  "webhook": {
+    "id": "cf8c4fdd-0587-4da1-b4ca-4846e9640af9",
+    "name": "alex testing jobs"
+  },
+  "project": {
+    "id": "84996744-a854-4f5e-aea3-04e2851dc1d2",
+    "name": "webhook-service",
+    "slug": "github/circleci/webhook-service"
+  },
+  "organization": {
+    "id": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
+    "name": "circleci"
+  },
+  "pipeline": {
+    "id": "1285fe1d-d3a6-44fc-8886-8979558254c4",
+    "number": 130,
+    "created_at": "2021-09-01T22:49:03.544Z",
+    "trigger": {
+      "type": "webhook"
+    },
+    "vcs": {
+      "provider_name": "github",
+      "origin_repository_url": "https://github.com/circleci/webhook-service",
+      "target_repository_url": "https://github.com/circleci/webhook-service",
+      "revision": "1dc6aa69429bff4806ad6afe58d3d8f57e25973e",
+      "commit": {
+        "subject": "Trigger CI",
+        "body": "",
+        "author": {
+          "name": "Author Name",
+          "email": "author.email@example.com"
+        },
+        "authored_at": "2021-09-01T22:48:53Z",
+        "committer": {
+          "name": "Committer Name",
+          "email": "committer.email@example.com"
+        },
+        "committed_at": "2021-09-01T22:48:53Z"
+      },
+      "branch": "main"
+    }
+  },
+  "workflow": {
+    "id": "fda08377-fe7e-46b1-8992-3a7aaecac9c3",
+    "name": "welcome",
+    "created_at": "2021-09-01T22:49:03.616Z",
+    "stopped_at": "2021-09-01T22:49:34.170Z",
+    "url": "https://app.circleci.com/pipelines/github/circleci/webhook-service/130/workflows/fda08377-fe7e-46b1-8992-3a7aaecac9c3"
+  },
+  "job": {
+    "id": "8b91f9a8-7975-4e60-916c-f0152ccbc937",
+    "name": "test",
+    "started_at": "2021-09-01T22:49:28.841Z",
+    "stopped_at": "2021-09-01T22:49:34.170Z",
+    "status": "success",
+    "number": 136
+  }
+}
+```


### PR DESCRIPTION
# Description

Since webhook "test pings" are a subset of the data that an actual webhook will receive, we need a full example payload somewhere for developers to use for testing & debugging. I'm adding two sample payloads at the end of the webhooks document.