### PR TITLE
Remove "actor" field from webhook trigger object

### DIFF
--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -268,7 +268,6 @@ can also be triggered manually through the API.
 | Field    | Always present? | Description                                                         |
 |----------|-----------------|---------------------------------------------------------------------|
 | type     | yes             | How this pipeline was triggered (e.g. "webhook", "api", "schedule") |
-| actor.id | No              | The user who triggered the pipeline, if there is one                |
 {: class="table table-striped"}
 
 


### PR DESCRIPTION
While preparing https://github.com/circleci/circleci-docs/pull/5652, I noticed a discrepancy between our webhook docs and reality: the `pipeline.trigger.actor.id` nested field is never populated.

This was proposed as part of the alpha implementation, but never implemented. I'd like to remove this field for clarity until we properly add that in.