### PR TITLE
[WIP] SEO audit link fixing

### DIFF
--- a/jekyll/_archive/ios-builds-on-os-x.md
+++ b/jekyll/_archive/ios-builds-on-os-x.md
@@ -398,7 +398,7 @@ Please try using any of the versions of simulator that are present on the machin
 
 ### Can't Add Project as macOS Build
 
-If you are trying to add an macOS project from the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard, but you don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page, then on the "Build Environment" page you will see the "Build OS X project" option.
+If you are trying to add a macOS project from the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard, but you don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page. Then, on the "Build Environment" page ,you will see the "Build OS X project" option.
 
 ### Ruby Segfaults
 

--- a/jekyll/_archive/ios-builds-on-os-x.md
+++ b/jekyll/_archive/ios-builds-on-os-x.md
@@ -9,8 +9,8 @@ sitemap: false
 ---
 
 CircleCI offers support for building and testing iOS and macOS projects.
-You can select a macOS project you would like to build on the [Add
-Projects page](https://circleci.com/add-projects){:rel="nofollow"}.
+You can select a macOS project you would like to build on the Add
+Projects page.
 
 If you're unable to find your project in the "OS X" tab, it may be listed as a
 "Linux" project. After adding your project as a "Linux" build, you can change

--- a/jekyll/_archive/ios-builds-on-os-x.md
+++ b/jekyll/_archive/ios-builds-on-os-x.md
@@ -398,7 +398,7 @@ Please try using any of the versions of simulator that are present on the machin
 
 ### Can't Add Project as macOS Build
 
-If you are trying to add an macOS project from the ["add-project"](https://circleci.com/add-projects){:rel="nofollow"} page, but you don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page, then on the "Build Environment" page you will see the "Build OS X project" option.
+If you are trying to add an macOS project from the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard, but you don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page, then on the "Build Environment" page you will see the "Build OS X project" option.
 
 ### Ruby Segfaults
 

--- a/jekyll/_archive/shipio-to-circleci-migration.md
+++ b/jekyll/_archive/shipio-to-circleci-migration.md
@@ -12,7 +12,7 @@ Coming from Ship.io? You've come to the right place, we'll help you get started.
 
 For iOS projects, please [contact support](https://support.circleci.com/hc/en-us) with the name of your GitHub user or organization for access to the iOS build system. Once you've been enabled,
 
-1. Add your project on the [Add Projects page](https://circleci.com/add-projects){:rel="nofollow"}.
+1. Add your project on the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard.
 2. Turn on the "Build iOS project" setting through the **Project Settings > Build Settings > Build Environment** page of your your project.
 3. Push a new commit to start a build on the iOS build system.
 
@@ -20,7 +20,7 @@ For iOS projects, please [contact support](https://support.circleci.com/hc/en-us
 
 You can easily migrate your Android projects from Ship.io to CircleCI in a few simple steps.
 
-1. Add your project on the [Add Projects page](https://circleci.com/add-projects){:rel="nofollow"}.
+1. Add your project on the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard.
 2. After adding your project, CircleCI will usually infer your build settings. Sometimes the magic doesn't always work. Please take a look at our [getting started]( {{ site.baseurl }}/1.0/getting-started/) documentation.
 3. Check out the [Testing Android on CircleCI]( {{ site.baseurl }}/1.0/android/) documentation.
 

--- a/jekyll/_cci1/ios-builds-on-os-x.md
+++ b/jekyll/_cci1/ios-builds-on-os-x.md
@@ -397,7 +397,7 @@ Please try using any of the versions of simulator that are present on the machin
 
 ### Can't Add Project as macOS Build
 
-If you are trying to add an macOS project from the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard, but you don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page, then on the "Build Environment" page you will see the "Build OS X project" option.
+If you are trying to add a macOS project from the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard, but don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page. Then, on the "Build Environment" page, you will see the "Build OS X project" option.
 
 ### Ruby Segfaults
 

--- a/jekyll/_cci1/ios-builds-on-os-x.md
+++ b/jekyll/_cci1/ios-builds-on-os-x.md
@@ -9,8 +9,7 @@ sitemap: false
 ---
 
 CircleCI offers support for building and testing iOS and macOS projects.
-You can select a macOS project you would like to build on the [Add
-Projects page](https://circleci.com/add-projects){:rel="nofollow"}.
+You can select a macOS project you would like to build on the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard.
 
 If you're unable to find your project in the "OS X" tab, it may be listed as a
 "Linux" project. After adding your project as a "Linux" build, you can change
@@ -398,7 +397,7 @@ Please try using any of the versions of simulator that are present on the machin
 
 ### Can't Add Project as macOS Build
 
-If you are trying to add an macOS project from the ["add-project"](https://circleci.com/add-projects){:rel="nofollow"} page, but you don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page, then on the "Build Environment" page you will see the "Build OS X project" option.
+If you are trying to add an macOS project from the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard, but you don't see your project under the "OS X" tab, you can first add your project as a "Linux" build — and then switch it to an "OS X" build by going to the "Project Settings" page, then on the "Build Environment" page you will see the "Build OS X project" option.
 
 ### Ruby Segfaults
 

--- a/jekyll/_cci1/shipio-to-circleci-migration.md
+++ b/jekyll/_cci1/shipio-to-circleci-migration.md
@@ -12,7 +12,7 @@ Coming from Ship.io? You've come to the right place, we'll help you get started.
 
 For iOS projects, please [contact support](https://support.circleci.com/hc/en-us) with the name of your GitHub user or organization for access to the iOS build system. Once you've been enabled,
 
-1. Add your project on the [Add Projects page](https://circleci.com/add-projects){:rel="nofollow"}.
+1. Add your project on the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard.
 2. Turn on the "Build iOS project" setting through the **Project Settings > Build Settings > Build Environment** page of your your project.
 3. Push a new commit to start a build on the iOS build system.
 
@@ -20,7 +20,7 @@ For iOS projects, please [contact support](https://support.circleci.com/hc/en-us
 
 You can easily migrate your Android projects from Ship.io to CircleCI in a few simple steps.
 
-1. Add your project on the [Add Projects page](https://circleci.com/add-projects){:rel="nofollow"}.
+1. Add your project on the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard.
 2. After adding your project, CircleCI will usually infer your build settings. Sometimes the magic doesn't always work. Please take a look at our [getting started]( {{ site.baseurl }}/1.0/getting-started/) documentation.
 3. Check out the [Testing Android on CircleCI]( {{ site.baseurl }}/1.0/android/) documentation.
 

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -113,10 +113,10 @@ In other words, you can reduce time spent in a **usage queue** by [purchasing mo
 {:.no_toc}
 In order to keep the system stable for all CircleCI customers, we implement different soft concurrency limits on each of the [resource classes](https://circleci.com/docs/2.0/configuration-reference/#resource_class). If you are experiencing queuing on your builds, it's possible you are hitting these limits. Please [contact CircleCI support](https://support.circleci.com/hc/en-us/requests/new) to request raises on these limits.
 
-### Why can't I find my project on the Add Project page?
-{: #why-cant-i-find-my-project-on-the-add-project-page }
+### Why can't I find my project on the Projects dashboard?
+{: #why-cant-i-find-my-project-on-the-projects-dashboard }
 {:.no_toc}
-If you are not seeing a project you would like to build and it is not currently building on CircleCI, check your org in the top left corner of the CircleCI application.  For instance, if the top left shows your user `my-user`, only GitHub projects belonging to `my-user` will be available under `Add Projects`.  If you want to build the GitHub project `your-org/project`, you must change your org on the application Switch Organization menu to `your-org`.
+If you are not seeing a project you would like to build and it is not currently building on CircleCI, check your org in the top left corner of the CircleCI application.  For instance, if the top left shows your user `my-user`, only GitHub projects belonging to `my-user` will be available under `Projects`.  If you want to build the GitHub project `your-org/project`, you must change your org on the application Switch Organization menu to `your-org`.
 
 ### I got an error saying my “build didn’t run because it needs more containers than your plan allows” but my plan has more than enough. Why is this failing?
 {: #i-got-an-error-saying-my-build-didnt-run-because-it-needs-more-containers-than-your-plan-allows-but-my-plan-has-more-than-enough-why-is-this-failing }

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -116,7 +116,7 @@ In order to keep the system stable for all CircleCI customers, we implement diff
 ### Why can't I find my project on the Projects dashboard?
 {: #why-cant-i-find-my-project-on-the-projects-dashboard }
 {:.no_toc}
-If you are not seeing a project you would like to build and it is not currently building on CircleCI, check your org in the top left corner of the CircleCI application.  For instance, if the top left shows your user `my-user`, only GitHub projects belonging to `my-user` will be available under `Projects`.  If you want to build the GitHub project `your-org/project`, you must change your org on the application Switch Organization menu to `your-org`.
+If you are not seeing a project you would like to build, and it is not currently building on CircleCI, check your org in the top left corner of the CircleCI application.  For instance, if the top left shows your user `my-user`, only GitHub projects belonging to `my-user` will be available under `Projects`.  If you want to build the GitHub project `your-org/project`, you must change your org on the application Switch Organization menu to `your-org`.
 
 ### I got an error saying my “build didn’t run because it needs more containers than your plan allows” but my plan has more than enough. Why is this failing?
 {: #i-got-an-error-saying-my-build-didnt-run-because-it-needs-more-containers-than-your-plan-allows-but-my-plan-has-more-than-enough-why-is-this-failing }

--- a/jekyll/_cci2/jenkins-converter.md
+++ b/jekyll/_cci2/jenkins-converter.md
@@ -41,7 +41,7 @@ Currently, the converter only supports declarative Jenkinsfiles. While the numbe
 ### Executors
 {: #executors }
 
-A static Docker executor, [cimg/base](https://github.com/CircleCI-Public/cimg-base), is inserted as the [executor](https://circleci.com/docs/reference-2-1/#executors) regardless of the one defined within the Jenkinsfile input.
+A static Docker executor, [cimg/base](https://github.com/CircleCI-Public/cimg-base), is inserted as the [executor]({{site.baseurl}}/2.0/configuration-reference/#executors-requires-version-21) regardless of the one defined within the Jenkinsfile input.
 
 Given that `cimg/base` is a very lean image, it's highly likely that your project will require a different image. [CircleCI's convenience images](https://circleci.com/developer/images/) are a good place to find other images. Refer to [custom Docker image](https://circleci.com/docs/2.0/custom-images/) for advanced steps to create your own custom image.
 

--- a/jekyll/_cci2/language-clojure.md
+++ b/jekyll/_cci2/language-clojure.md
@@ -69,9 +69,9 @@ jobs: # basic units of work in a run
 
 The configuration above is from a demo Clojure app, which you can access at [https://github.com/CircleCI-Public/circleci-demo-clojure-luminus](https://github.com/CircleCI-Public/circleci-demo-clojure-luminus).
 
-If you want to step through it yourself, you can fork the project on GitHub and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
+If you want to step through it yourself, you can fork the project on GitHub and download it to your machine. Go to the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard in the CircleCI app and click the **Follow Project** button next to your project. Finally, delete everything in `.circleci/config.yml`.
 
-Now we’re ready to build a `config.yml` from scratch.
+Now we are ready to build a `config.yml` from scratch.
 
 ## Config walkthrough
 {: #config-walkthrough }

--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -129,7 +129,7 @@ We recommend using a CircleCI pre-built image that comes pre-installed with tool
 A good way to start using CircleCI is to build a project yourself. Here's how to build the <a href="https://github.com/CircleCI-Public/circleci-demo-go" target="_blank">Demo Go Project</a> with your own account:
 
 1. Fork the <a href="https://github.com/CircleCI-Public/circleci-demo-go" target="_blank">Demo Go Project on GitHub</a> to your own account
-2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to the project you just forked
+2. Go to the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard in the CircleCI app and click the **Follow Project** button next to the project you just forked.
 3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 If you want to test your changes locally, use [our CLI tool](https://circleci.com/docs/2.0/local-jobs/) and run `circleci build`.

--- a/jekyll/_cci2/language-java.md
+++ b/jekyll/_cci2/language-java.md
@@ -115,7 +115,7 @@ workflows:
 
 The configuration above is from a demo Java app, which you can access at [https://github.com/CircleCI-Public/circleci-demo-java-spring](https://github.com/CircleCI-Public/circleci-demo-java-spring).
 
-If you want to step through it yourself, you can fork the project on GitHub and download it to your machine. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to your project. Finally, delete everything in `.circleci/config.yml`.
+If you want to step through it yourself, you can fork the project on GitHub and download it to your machine. Go to the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard in CircleCI and click the **Follow Project** button next to your project. Finally, delete everything in `.circleci/config.yml`.
 
 Now we are ready to build a `config.yml` from scratch.
 

--- a/jekyll/_cci2/language-php.md
+++ b/jekyll/_cci2/language-php.md
@@ -38,7 +38,7 @@ Database images for use as a secondary 'service' container are also available.
 A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
 
 1. Fork the project on GitHub to your own account
-2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to the project you just forked
+2. Go to the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard in the CircleCI app and click the **Follow Project** button next to the project you just forked.
 3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 ---

--- a/jekyll/_cci2/language-ruby.md
+++ b/jekyll/_cci2/language-ruby.md
@@ -145,7 +145,7 @@ workflows:
 A good way to start using CircleCI is to build a project yourself. Here's how to build the demo project with your own account:
 
 1. [Fork the project][fork-demo-project] on GitHub to your own account.
-2. Go to the [Add Projects](https://circleci.com/add-projects){:rel="nofollow"} page in CircleCI and click the Build Project button next to the project you just forked.
+2. Go to the [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard in the CircleCI app and click the **Follow Project** button next to the project you just forked.
 3. To make changes you can edit the `.circleci/config.yml` file and make a commit. When you push a commit to GitHub, CircleCI will build and test the project.
 
 ## See also

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -208,7 +208,7 @@ jobs:
 ----
 
 2+| Using shared tasks (Actions for Github, orbs for CircleCI). In CircleCI, you declare orbs at the top level +
-and then https://circleci.com/docs/2.0/orbs-user-config/#section=configuration[refer to them by name in config], similar in concept to Python or JavaScript imports.
+and then https://circleci.com/docs/2.0/configuration-reference/#orbs-requires-version-21[refer to them by name in config], similar in concept to Python or JavaScript imports.
 
 a|
 [source, yaml]

--- a/jekyll/_cci2/projects.md
+++ b/jekyll/_cci2/projects.md
@@ -17,8 +17,8 @@ the owner of on your VCS, or, _Follow_ any project in your organization to gain
 access to its pipelines and to subscribe to [email notifications]({{
 site.baseurl }}/2.0/notifications/) for the project's status.
 
-## Add projects page
-{: #add-projects-page }
+## Projects dashboard
+{: #projects-dashboard }
 
 {:.tab.addprojectpage.Cloud}
 ![header]({{ site.baseurl }}/assets/img/docs/CircleCI-2.0-setup-project-circle101_cloud.png)

--- a/jekyll/_cci2_ja/env-vars.md
+++ b/jekyll/_cci2_ja/env-vars.md
@@ -480,7 +480,7 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 }' https://circleci.com/api/v2/project/:project_slug/pipeline
 ```
 
-**重要:** パイプライン パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/ja/glossary/#context)で確認できます。
+**重要:** パイプライン パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/glossary/#context)で確認できます。
 
 詳細については、「[パイプライン変数]({{site.baseurl}}/2.0/pipeline-variables/)」を参照してください。
 
@@ -495,7 +495,7 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 
 環境変数の通常の制限以外には、値自体への制限はなく、単純な文字列として扱われます。 ビルド パラメーターがロードされる順序は**保証されない**ため、ビルド パラメーターに値を挿入して別のビルド パラメーターに渡すことは避けてください。 ベスト プラクティスとして、独立した環境変数から成る順不同のリストとしてビルド パラメーターを設定することをお勧めします。
 
-**重要:** ビルド パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/ja/glossary/#context)で確認できます。
+**重要:** ビルド パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/glossary/#context)で確認できます。
 
 たとえば、以下のパラメーターを渡すとします。
 

--- a/jekyll/_cci2_ja/env-vars.md
+++ b/jekyll/_cci2_ja/env-vars.md
@@ -480,7 +480,7 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 }' https://circleci.com/api/v2/project/:project_slug/pipeline
 ```
 
-**重要:** パイプライン パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/ja/lossary/#context)で確認できます。
+**重要:** パイプライン パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/ja/glossary/#context)で確認できます。
 
 詳細については、「[パイプライン変数]({{site.baseurl}}/2.0/pipeline-variables/)」を参照してください。
 
@@ -495,7 +495,7 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 
 環境変数の通常の制限以外には、値自体への制限はなく、単純な文字列として扱われます。 ビルド パラメーターがロードされる順序は**保証されない**ため、ビルド パラメーターに値を挿入して別のビルド パラメーターに渡すことは避けてください。 ベスト プラクティスとして、独立した環境変数から成る順不同のリストとしてビルド パラメーターを設定することをお勧めします。
 
-**重要:** ビルド パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/ja/lossary/#context)で確認できます。
+**重要:** ビルド パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/ja/glossary/#context)で確認できます。
 
 たとえば、以下のパラメーターを渡すとします。
 

--- a/jekyll/_cci2_ja/faq.md
+++ b/jekyll/_cci2_ja/faq.md
@@ -115,7 +115,7 @@ In other words, you can reduce time spent in a **usage queue** by [purchasing mo
 CircleCI のすべてのお客様がシステムを安定した状態で利用できるよう、[リソース クラス](https://circleci.com/ja/docs/2.0/configuration-reference/#resource_class)ごとに同時処理数のソフト制限が設けられています。 ビルドの待機時間が発生する場合は、この制限に達している可能性が考えられます。 [CircleCI サポート](https://support.circleci.com/hc/ja/requests/new)に制限値の引き上げを依頼してください。
 
 ### [Add Projects (プロジェクトの追加)] ページにプロジェクトが見当たりません。
-{: #why-cant-i-find-my-project-on-the-add-project-page }
+{: #why-cant-i-find-my-project-on-the-projects-dashboard }
 {:.no_toc}
 ビルドしようとしているプロジェクトが表示されておらず、現在 CircleCI 上でビルドしているものではない場合は、CircleCI アプリケーションの左上隅で組織を確認してください。  たとえば、左上に `my-user` と表示されているなら、`my-user` に属する GitHub プロジェクトのみが `Add Projects` の下に表示されます。  `your-org/project` の GitHub プロジェクトをビルドするには、CircleCI アプリケーションの [Switch Organization (組織の切り替え)] メニューで `your-org` を選択する必要があります。
 

--- a/jekyll/_cci2_ja/faq.md
+++ b/jekyll/_cci2_ja/faq.md
@@ -254,7 +254,7 @@ UTC 協定世界時のタイムゾーンに基づいてスケジュールを指�
 ### スケジュールを設定したワークフローは、指定した時間どおりに正確に実行されますか?
 {: #what-do-i-need-to-get-started-building-on-windows }
 {:.no_toc}
-[Performance プラン](https://circleci.com/ja/pricing/usage/)を購入し、プロジェクトの[パイプラインを有効化]({{site.baseurl}}/ja/2.0/build-processing/)する必要があります。 Windows ジョブでは、1 分あたり 40 クレジットが消費されます。
+[Performance プラン](https://circleci.com/ja/pricing/)を購入し、プロジェクトの[パイプラインを有効化]({{site.baseurl}}/ja/2.0/build-processing/)する必要があります。 Windows ジョブでは、1 分あたり 40 クレジットが消費されます。
 
 ### Windows でのビルドを開始するには何が必要ですか?
 {: #what-exact-version-of-windows-are-you-using }

--- a/jekyll/_cci2_ja/jenkins-converter.md
+++ b/jekyll/_cci2_ja/jenkins-converter.md
@@ -42,7 +42,7 @@ Currently, the converter only supports declarative Jenkinsfiles. While the numbe
 ### Executors
 {: #executors }
 
-A static Docker executor, [cimg/base](https://github.com/CircleCI-Public/cimg-base), is inserted as the [executor](https://circleci.com/docs/reference-2-1/#executors) regardless of the one defined within the Jenkinsfile input.
+A static Docker executor, [cimg/base](https://github.com/CircleCI-Public/cimg-base), is inserted as the [executor](https://circleci.com/docs/configuration-reference/#executors-requires-version-21) regardless of the one defined within the Jenkinsfile input.
 
 Given that `cimg/base` is a very lean image, it's highly likely that your project will require a different image. [CircleCI's convenience images](https://circleci.com/developer/images/) are a good place to find other images. Refer to [custom Docker image](https://circleci.com/docs/2.0/custom-images/) for advanced steps to create your own custom image.
 

--- a/jekyll/_cci2_ja/language-clojure.md
+++ b/jekyll/_cci2_ja/language-clojure.md
@@ -67,7 +67,7 @@ jobs: # 1 回の実行の基本作業単位
 
 `lein-2.7.1` タグを指定して [CircleCI 提供の Clojure イメージ](https://circleci.com/ja/docs/2.0/circleci-images/#clojure)を使用します。
 
-ご自身でコード全体を確認する場合は、GitHub でプロジェクトをフォークし、ローカル マシンにダウンロードします。 CircleCI で [[Add Projects (プロジェクトの追加)](https://circleci.com/add-projects){:rel="nofollow"}] ページにアクセスし、プロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。 最後に `.circleci/config.yml` の内容をすべて削除します。
+ご自身でコード全体を確認する場合は、GitHub でプロジェクトをフォークし、ローカル マシンにダウンロードします。 CircleCI で [[Projects dashboard (プロジェクトの追加)](https://app.circleci.com/projects/){:rel="nofollow"}] ページにアクセスし、プロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。 最後に `.circleci/config.yml` の内容をすべて削除します。
 
 他のディレクトリを指定しない限り、以降の `job` ではこのパスがデフォルトの作業ディレクトリとなります。
 

--- a/jekyll/_cci2_ja/language-go.md
+++ b/jekyll/_cci2_ja/language-go.md
@@ -68,7 +68,7 @@ CircleCI のビルド済みイメージを使用することをお勧めしま�
 CircleCI を初めて使用する際は、プロジェクトをご自身でビルドしてみることをお勧めします。 以下に、ユーザー自身のアカウントを使用して <a href="https://github.com/CircleCI-Public/circleci-demo-go" target="_blank">Go デモ プロジェクト</a>をビルドする方法を示します。
 
 1. お使いのアカウントに、GitHub 上の <a href="https://github.com/CircleCI-Public/circleci-demo-go" target="_blank">Go デモ プロジェクト</a>をフォークします。
-2. CircleCI で [[Add Projects (プロジェクトの追加)](https://circleci.com/add-projects){:rel="nofollow"}] ページにアクセスし、フォークしたプロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。
+2. CircleCI で [[Projects dashboard (プロジェクトの追加)](https://app.circleci.com/projects/){:rel="nofollow"}] ページにアクセスし、フォークしたプロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。
 3. 変更を加えるには、`.circleci/config.yml` ファイルを編集してコミットします。 コミットを GitHub にプッシュすると、CircleCI がそのプロジェクトをビルドしてテストします。
 
 さらに、PostgreSQL のイメージを使用し、データベース初期化用の 2 つの環境変数を指定します。

--- a/jekyll/_cci2_ja/language-java-maven.md
+++ b/jekyll/_cci2_ja/language-java-maven.md
@@ -281,7 +281,7 @@ workflows:
 ```
 {% endraw %}
 
-このデモ アプリケーションには、リポジトリの `maven` ブランチである [https://github.com/CircleCI-Public/circleci-demo-java-spring/tree/maven](https://github.com/CircleCI-Public/circleci-demo-java-spring/tree/maven) からアクセスできます。 ご自身でコード全体を確認する場合は、GitHub でプロジェクトをフォークし、ローカル マシンにダウンロードします。 CircleCI の [[Add Projects (プロジェクトの追加)](https://circleci.com/add-projects){:rel="nofollow"}] ページにアクセスし、プロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。 最後に `.circleci/config.yml` の内容をすべて削除します。 Nice! これで、Maven と Spring を使用する Java アプリケーション用に CircleCI を構成できました。
+このデモ アプリケーションには、リポジトリの `maven` ブランチである [https://github.com/CircleCI-Public/circleci-demo-java-spring/tree/maven](https://github.com/CircleCI-Public/circleci-demo-java-spring/tree/maven) からアクセスできます。 ご自身でコード全体を確認する場合は、GitHub でプロジェクトをフォークし、ローカル マシンにダウンロードします。 CircleCI の [[Projects dashboard (プロジェクトの追加)](https://app.circleci.com/projects/){:rel="nofollow"}] ページにアクセスし、プロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。 最後に `.circleci/config.yml` の内容をすべて削除します。 Nice! これで、Maven と Spring を使用する Java アプリケーション用に CircleCI を構成できました。
 
 ## 設定ファイルの詳細
 {: #see-also }

--- a/jekyll/_cci2_ja/language-java.md
+++ b/jekyll/_cci2_ja/language-java.md
@@ -135,7 +135,7 @@ workflows:
 
 このデモ アプリケーションには、<https://github.com/CircleCI-Public/circleci-demo-java-spring> からアクセスできます。
 
-ご自身でコード全体を確認する場合は、GitHub でプロジェクトをフォークし、ローカル マシンにダウンロードします。 CircleCI で [[Add Projects (プロジェクトの追加)](https://circleci.com/add-projects){:rel="nofollow"}] ページにアクセスし、プロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。 最後に `.circleci/config.yml` の内容をすべて削除します。
+ご自身でコード全体を確認する場合は、GitHub でプロジェクトをフォークし、ローカル マシンにダウンロードします。 CircleCI で [[Projects dashboard (プロジェクトの追加)](https://app.circleci.com/projects/){:rel="nofollow"}] ページにアクセスし、プロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。 最後に `.circleci/config.yml` の内容をすべて削除します。
 
 また、`environment` キーを使用して、[OOM エラーを回避](https://circleci.com/blog/how-to-handle-java-oom-errors/)するように JVM と Gradle を構成しています。
 

--- a/jekyll/_cci2_ja/language-javascript.md
+++ b/jekyll/_cci2_ja/language-javascript.md
@@ -32,7 +32,7 @@ We maintain a reference JavaScript project to show how to build a React.js app o
 CircleCI を初めて使用する際は、プロジェクトをご自身でビルドしてみることをお勧めします。 以下に、ユーザー自身のアカウントを使用してデモ プロジェクトをビルドする方法を示します。
 
 1. GitHub 上のプロジェクトをお使いのアカウントにフォークします。
-2. CircleCI で [[Add Projects (プロジェクトの追加)](https://circleci.com/add-projects){:rel="nofollow"}] ページにアクセスし、フォークしたプロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。
+2. CircleCI で [[Projects dashboard (プロジェクトの追加)](https://app.circleci.com/projects/){:rel="nofollow"}] ページにアクセスし、フォークしたプロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。
 3. 変更を加えるには、`.circleci/config.yml` ファイルを編集してコミットします。 コミットを GitHub にプッシュすると、CircleCI がそのプロジェクトをビルドしてテストします。
 
 

--- a/jekyll/_cci2_ja/language-php.md
+++ b/jekyll/_cci2_ja/language-php.md
@@ -39,7 +39,7 @@ CircleCI のビルド済みイメージを使用することをお勧めしま�
 CircleCI を初めて使用する際は、プロジェクトをご自身でビルドしてみることをお勧めします。 以下に、ユーザー自身のアカウントを使用してデモ プロジェクトをビルドする方法を示します。
 
 1. GitHub 上のプロジェクトをお使いのアカウントにフォークします。
-2. CircleCI で [[Add Projects (プロジェクトの追加)](https://circleci.com/add-projects){:rel="nofollow"}] ページにアクセスし、フォークしたプロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。
+2. CircleCI で [[Projects dashboard (プロジェクトの追加)](https://app.circleci.com/projects/)){:rel="nofollow"}] ページにアクセスし、フォークしたプロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。
 3. 変更を加えるには、`.circleci/config.yml` ファイルを編集してコミットします。 コミットを GitHub にプッシュすると、CircleCI がそのプロジェクトをビルドしてテストします。
 
 ---

--- a/jekyll/_cci2_ja/language-ruby.md
+++ b/jekyll/_cci2_ja/language-ruby.md
@@ -158,7 +158,7 @@ workflows:
 CircleCI を初めて使用する際は、プロジェクトをご自身でビルドしてみることをお勧めします。 以下に、ユーザー自身のアカウントを使用してデモ プロジェクトをビルドする方法を示します。
 
 1. お使いのアカウントに、GitHub 上の[プロジェクトをフォーク](https://github.com/CircleCI-Public/circleci-demo-ruby-rails/fork)します。
-2. CircleCI で ［[Add Projects (プロジェクトの追加)](https://circleci.com/add-projects){:rel="nofollow"}] ページにアクセスし、フォークしたプロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。
+2. CircleCI で ［[Projects dashboard (プロジェクトの追加)](https://app.circleci.com/projects/){:rel="nofollow"}] ページにアクセスし、フォークしたプロジェクトの横にある [Build Project (プロジェクトのビルド)] ボタンをクリックします。
 3. 変更を加えるには、`.circleci/config.yml` ファイルを編集してコミットします。 コミットを GitHub にプッシュすると、CircleCI がそのプロジェクトをビルドしてテストします。
 
 ## 設定ファイルの詳細

--- a/jekyll/_cci2_ja/local-cli-getting-started.md
+++ b/jekyll/_cci2_ja/local-cli-getting-started.md
@@ -165,7 +165,7 @@ Success!
 ## リポジトリを CircleCI に接続する
 {: #connect-your-repo-to-circleci }
 
-このステップでは、ターミナルを離れる必要があります。 [[Add Projects (プロジェクトの追加)] ページ](https://circleci.com/add-projects)にアクセスします。 コードをプッシュするたびに CI が実行されるようにプロジェクトをセットアップします。
+このステップでは、ターミナルを離れる必要があります。 [[Projects dashboard (プロジェクトの追加)](https://app.circleci.com/projects/)にアクセスします。 コードをプッシュするたびに CI が実行されるようにプロジェクトをセットアップします。
 
 プロジェクトのリストから目的のプロジェクト ("foo_ci" または GitHub で付けた名前) を見つけ、[Set Up Project (プロジェクトのセットアップ)] をクリックします。 次に、ターミナルに戻り、最新の変更を GitHub にプッシュします (`config.yml` ファイルの追加分)。
 

--- a/jekyll/_cci2_ja/migrating-from-github.adoc
+++ b/jekyll/_cci2_ja/migrating-from-github.adoc
@@ -206,7 +206,7 @@ jobs:
 ----
 
 2+| Using shared tasks (Actions for Github, orbs for CircleCI). In CircleCI, you declare orbs at the top level +
-and then https://circleci.com/docs/2.0/orbs-user-config/#section=configuration[refer to them by name in config], similar in concept to Python or JavaScript imports.
+and then https://circleci.com/docs/2.0/configuration-reference/#orbs-requires-version-21[[refer to them by name in config], similar in concept to Python or JavaScript imports.
 
 a|
 [source, yaml]

--- a/jekyll/_cci2_ja/projects.md
+++ b/jekyll/_cci2_ja/projects.md
@@ -15,8 +15,8 @@ A CircleCI project shares the name of the associated code repository and is visi
 
 On the "Add Projects" page, you can either _Set Up_ any project that you are the owner of on your VCS, or, _Follow_ any project in your organization to gain access to its pipelines and to subscribe to \[email notifications\]({{ site.baseurl }}/2.0/notifications/) for the project's status.
 
-## Add projects page
-{: #add-projects-page }
+## Projects dashboard
+{: #projects-dashboard }
 
 {:.tab.addprojectpage.Cloud}
 ![header]({{ site.baseurl }}/assets/img/docs/CircleCI-2.0-setup-project-circle101_cloud.png)


### PR DESCRIPTION
- [x] fix link to executor link in Jenkins Convertor doc to main config ref
- [x] several dead links to old Add Projects page in app which no longer exists. Docs wide search for "Add Projects" and change over to [**Projects**](https://app.circleci.com/projects/){:rel="nofollow"} dashboard - this will take logged-in users to the app and others to the login page. And when this text is just a descriptor rather than a link use projects dashboard, or "select **Projects** from the side bar"
- [x] fix link to old orbs doc from github migration guide