### PR TITLE
Added clarification around the definition of certified orbs

### DIFF
--- a/jekyll/_cci2/orbs-faq.md
+++ b/jekyll/_cci2/orbs-faq.md
@@ -47,7 +47,7 @@ This document describes various questions and technical issues that you may find
 
 * **Answer:** To enable usage of _uncertified_ orbs, go to your organization's settings page, and click the _Security_ tab. Then, click yes to enable _Allow Uncertified Orbs_.
 
-**Note:** _Uncertified orbs are not tested or verified by CircleCI. Currently, only orbs created by CircleCI are considered certified. So any other orbs, including partner orbs, and not certified._
+**Note:** _Uncertified orbs are not tested or verified by CircleCI. Currently, only orbs created by CircleCI are considered certified. Any other orbs, including partner orbs, and not certified._
 
 ## How to use the latest version of an orb
 {: #how-to-use-the-latest-version-of-an-orb }

--- a/jekyll/_cci2/orbs-faq.md
+++ b/jekyll/_cci2/orbs-faq.md
@@ -47,7 +47,7 @@ This document describes various questions and technical issues that you may find
 
 * **Answer:** To enable usage of _uncertified_ orbs, go to your organization's settings page, and click the _Security_ tab. Then, click yes to enable _Allow Uncertified Orbs_.
 
-**Note:** _Uncertified orbs are not tested or verified by CircleCI._
+**Note:** _Uncertified orbs are not tested or verified by CircleCI. Currently, only orbs created by CircleCI are considered certified. So any other orbs, including partner orbs, and not certified._
 
 ## How to use the latest version of an orb
 {: #how-to-use-the-latest-version-of-an-orb }

--- a/jekyll/_cci2_ja/orbs-faq.md
+++ b/jekyll/_cci2_ja/orbs-faq.md
@@ -47,7 +47,7 @@ version:
 
 * **Answer:** To enable usage of _uncertified_ orbs, go to your organization's settings page, and click the _Security_ tab. Then, click yes to enable _Allow Uncertified Orbs_.
 
-**Note:** _Uncertified orbs are not tested or verified by CircleCI. Currently, only orbs created by CircleCI are considered certified. So any other orbs, including partner orbs, and not certified._
+**Note:** _Uncertified orbs are not tested or verified by CircleCI. Currently, only orbs created by CircleCI are considered certified. Any other orbs, including partner orbs, and not certified._
 
 ## How to use the latest version of an orb
 {: #how-to-use-the-latest-version-of-an-orb }

--- a/jekyll/_cci2_ja/orbs-faq.md
+++ b/jekyll/_cci2_ja/orbs-faq.md
@@ -47,7 +47,7 @@ version:
 
 * **Answer:** To enable usage of _uncertified_ orbs, go to your organization's settings page, and click the _Security_ tab. Then, click yes to enable _Allow Uncertified Orbs_.
 
-**Note:** _Uncertified orbs are not tested or verified by CircleCI._
+**Note:** _Uncertified orbs are not tested or verified by CircleCI. Currently, only orbs created by CircleCI are considered certified. So any other orbs, including partner orbs, and not certified._
 
 ## How to use the latest version of an orb
 {: #how-to-use-the-latest-version-of-an-orb }


### PR DESCRIPTION
# Description
Added some extra clarification around what certified orbs are. 

# Reasons
Received a customer question about what kind of security testing (if any) uncertified orbs receive, which then prompted the question around what is considered an uncertified/certified orb. 