### PR TITLE
SERVER-1250 | Document Arm executors for Server 3

### DIFF
--- a/jekyll/_cci2/arm-resources.md
+++ b/jekyll/_cci2/arm-resources.md
@@ -5,6 +5,7 @@ short-title: "Using Arm resources on CircleCI"
 description: "Using Arm resources on CircleCI"
 version:
 - Cloud
+- Server v3.x
 ---
 
 # Overview

--- a/jekyll/_cci2/arm-resources.md
+++ b/jekyll/_cci2/arm-resources.md
@@ -11,8 +11,7 @@ version:
 {: #overview }
 
 This document will walk you through the setup steps required to use an Arm
-resource on CircleCI. Arm resources are not available on CircleCI Server 1.x or
-2.x.
+resource on CircleCI. Arm resources are available on cloud and server 3.x.
 
 CircleCI offers multiple kinds of environments for you to run jobs in. In your
 CircleCI `config.yml` file you can choose the right environment for your job using the
@@ -42,16 +41,12 @@ The following Arm resource class is available to all CircleCI customers:
 
 For pricing and availability check out our [Pricing](https://circleci.com/pricing/) page.
 
-At this moment, Arm resources are only available on our cloud offering. If you
-are a CircleCI Server customer and are looking to try Arm resources, consider
-creating a CircleCI Cloud account, or contact your Customer Success Manager to
-request Arm on Server.
-
 ## Using Arm resources
 {: #using-arm-resources }
 
 Update your `.circleci/config.yml` file to use Arm resources. Consider the example config:
 
+{:.tab.armblock.Cloud}
 ```yaml
 # .circleci/config.yml
 version: 2.1
@@ -68,6 +63,34 @@ jobs:
   build-large:
     machine:
       image: ubuntu-2004:202101-01
+    resource_class: arm.large
+    steps:
+      - run: uname -a
+      - run: echo "Hello, Arm!"
+
+workflows:
+  build:
+    jobs:
+      - build-medium
+      - build-large
+```
+{:.tab.armblock.Server}
+```yaml
+# .circleci/config.yml
+version: 2.1
+
+jobs:
+  build-medium:
+    machine:
+      image: arm-default
+    resource_class: arm.medium
+    steps:
+      - run: uname -a
+      - run: echo "Hello, Arm!"
+
+  build-large:
+    machine:
+      image: arm-default
     resource_class: arm.large
     steps:
       - run: uname -a
@@ -96,6 +119,9 @@ configuration (and even the same workflow).
 * If there is software you require that is not available in the image, please
   [open an issue](https://github.com/CircleCI-Public/arm-preview-docs/issues) to
   let us know.
+* In server 3.x, Arm resources are only available when using the EC2 provider
+  for VM service. This is because there are no Arm instances available in GCP.
+
 
 ## Learn More
 {: #learn-more }

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -8,6 +8,7 @@ order: 1
 version:
 - Cloud
 - Server v2.x
+- Server v3.x
 ---
 
 CircleCI offers several build environments. We call these **executors**. An **executor** defines the underlying technology or environment in which to run a job. Set up your jobs to run in the `docker`, `machine`, `macos` or  `windows` executor and specify an image with the tools and packages you need.


### PR DESCRIPTION
# Description

Server 3.2 will support Arm executors. This work updates the Arm resources docs to call out the differences on server and note that server 3 is supported

# Reasons

[SERVER-1250](https://circleci.atlassian.net/browse/SERVER-1250)