### PR TITLE
The username does not seem to matter

### DIFF
--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -144,7 +144,7 @@ If it was not offered, you can specify it via the `-i` command-line
 argument to SSH. For example:
 
 ```
-$ ssh -i /Users/me/.ssh/id_rsa_github -p 64784 ubuntu@54.224.97.243
+$ ssh -i /Users/me/.ssh/id_rsa_github -p 64784 54.224.97.243
 ```
 
 ## See also


### PR DESCRIPTION
# Description
The username does not seem to matter

# Reasons
It seems the CircleCI does not care which username the ssh access is attempted as.