### PR TITLE
Default Fedora ssh client configuration fails to work

### DIFF
--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -130,7 +130,7 @@ debug1: Authentication succeeded (publickey).
 This sequence indicates that the key /Users/me/.ssh/id_rsa_github is the one which
 GitHub accepted.
 
-Next, run the SSH command for your CircleCI build, but add the -v flag.
+Next, run the SSH command for your CircleCI build, but add the `-v` flag.
 In the output, look for one or more lines like this:
 
 ```
@@ -144,8 +144,18 @@ If it was not offered, you can specify it via the `-i` command-line
 argument to SSH. For example:
 
 ```
-$ ssh -i /Users/me/.ssh/id_rsa_github -p 64784 ubuntu@54.224.97.243
+$ ssh -v -i /Users/me/.ssh/id_rsa_github -p 64784 ubuntu@54.224.97.243
 ```
+
+If it was offered but rejected with
+
+```
+debug1: send_pubkey_test: no mutual signature algorithm
+```
+
+it is possible that your ssh client configuration is hardened while CircleCI
+requires weaker algorithms. Try to add `-o 'PubkeyAcceptedKeyTypes ssh-rsa'`
+option to select the algorithms supported by CircleCI.
 
 ## See also
 {: #see-also }


### PR DESCRIPTION

# Description
Default Fedora ssh client configuration fails to work

# Reasons
It is necessary to downgrade the selected signature algorithms to log in to the CircleCI job via ssh from Fedora. Using `-o 'PubkeyAcceptedKeyTypes ssh-rsa'` worked for me. Maybe it will save time to others who'd be struggling with `Permission denied (publickey).` even if using the right key.