### PR TITLE
[CIRCLE-37763]: Include a section for Orbs on the landing page of Docs

### DIFF
--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -19,7 +19,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/getting-started/">Your First Green Build</a></li>
       <li><a href="{{ site.baseurl }}/2.0/hello-world/">Hello World</a></li>
       <li><a href="{{ site.baseurl }}/2.0/faq/">FAQ</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/orb-intro/">Orbs</a></li>
+      <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/orb-intro/">Orbs</a></li>
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">
@@ -30,7 +30,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
         <li><a href="{{ site.baseurl }}/2.0/postgres-config/">Database Config Examples</a></li>
         <li><a href="{{ site.baseurl }}/2.0/sample-config/">Sample config.yml Files</a></li>
         <li><a href="{{ site.baseurl }}/2.0/tutorials/">Tutorials and Sample Apps</a></li>
-        <li><a href="{{ site.baseurl }}/2.0/using-orbs/">Using Orbs</a></li>
+        <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/using-orbs/">Using Orbs</a></li>
       </ul>
   </div>
   <div class="col-xs-12">
@@ -54,7 +54,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/workflows/#workflows-configuration-examples">Example Configs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#scheduling-a-workflow">Scheduling a Workflow</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and Filtering in Your Workflows</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/creating-orbs/">Creating Orbs</a></li>
+      <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Creating Orbs</a></li>
     </ul>
   </div>
    <div class="col-xs-12">
@@ -66,6 +66,17 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
     <ul>
       <li><a href="{{ site.baseurl }}/2.0/optimization-cookbook/">Discover ways to optimize your pipelines</a></li>
       <li><a href="{{ site.baseurl }}/2.0/configuration-cookbook">Explore best practices for a range of use cases</a></li>
+    </ul>
+  </div>
+    <div id="orb-section" class="col-xs-12 col-sm-6">
+    <h2>Orbs</h2>
+    <p>Simplify your builds with reuseable configurations.</p>
+    <ul>
+      <li><a href="{{ site.baseurl }}/2.0/orb-intro/">Getting started with orbs</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/using-orbs/">Core concepts</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/creating-orbs/">Publishing your orb</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/orbs-faq/">Orbs FAQ</a>
+      </li>
     </ul>
   </div>
 </div>

--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -53,7 +53,8 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/workflows/">Using Workflows to Schedule Jobs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#workflows-configuration-examples">Example Configs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#scheduling-a-workflow">Scheduling a Workflow</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and Filtering in Your Workflows</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-
+      workflows">Using Contexts and Filtering in Your Workflows</a></li>
       <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Creating Orbs</a></li>
     </ul>
   </div>
@@ -72,11 +73,10 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
     <h2>Orbs</h2>
     <p>Simplify your builds with reuseable configurations.</p>
     <ul>
-      <li><a href="{{ site.baseurl }}/2.0/orb-intro/">Getting started with orbs</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/using-orbs/">Core concepts</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/creating-orbs/">Publishing your orb</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/orbs-faq/">Orbs FAQ</a>
-      </li>
+      <li id="orb-intro"><a href="{{ site.baseurl }}/2.0/orb-intro/">Getting Started with Orbs</a></li>
+      <li id="orb-concepts"><a href="{{ site.baseurl }}/2.0/using-orbs/">Core Concepts</a></li>
+      <li id="orb-publish"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Publishing Your Orb</a></li>
+      <li id="orb-faq"><a href="{{ site.baseurl }}/2.0/orbs-faq/">Orbs FAQ</a></li>
     </ul>
   </div>
 </div>

--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -30,7 +30,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
         <li><a href="{{ site.baseurl }}/2.0/postgres-config/">Database Config Examples</a></li>
         <li><a href="{{ site.baseurl }}/2.0/sample-config/">Sample config.yml Files</a></li>
         <li><a href="{{ site.baseurl }}/2.0/tutorials/">Tutorials and Sample Apps</a></li>
-        <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/using-orbs/">Using Orbs</a></li>
+      <li><a id="orb-content-swap" href="{{ site.baseurl }}/2.0/using-orbs/">Using Orbs</a></li>
       </ul>
   </div>
   <div class="col-xs-12">
@@ -71,11 +71,15 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
   </div>
     <div id="orb-section" class="col-xs-12 col-sm-6">
     <h2>Orbs</h2>
-    <p>Simplify your builds with reuseable configurations.</p>
+    <p>Automate common tasks with reusable, shareable config packages.</p>
     <ul>
-      <li id="orb-intro"><a href="{{ site.baseurl }}/2.0/orb-intro/">Getting Started with Orbs</a></li>
-      <li id="orb-concepts"><a href="{{ site.baseurl }}/2.0/using-orbs/">Core Concepts</a></li>
-      <li id="orb-publish"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Publishing Your Orb</a></li>
+      <li id="orb-intro"><a href="{{ site.baseurl }}/2.0/orb-intro/">Get started with orbs</a></li>
+      <li id="using-orbs"><a href="{{ site.baseurl }}/2.0/using-orbs/">How orbs work</a></li>
+      <li id="orb-author-intro"><a href="{{ site.baseurl }}/2.0/orb-author-intro/">Create a reusable config package</a>
+      </li>
+      <li id="orb-registry"><a
+          href="https://circleci.com/developer/orbs?filterBy=popular&query=&page=1&pageSize=15">Public
+          registry</a></li>
       <li id="orb-faq"><a href="{{ site.baseurl }}/2.0/orbs-faq/">Orbs FAQ</a></li>
     </ul>
   </div>

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -517,3 +517,4 @@ h6{
 #orb-section {
 	display: none
 }
+

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -513,3 +513,7 @@ h6{
 .code-badge-language {
 	display: none
 }
+
+#orb-section {
+	display: none
+}

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -60,7 +60,6 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-
         workflows">Using Contexts and Filtering in Your Workflows</a></li>
       <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Creating Orbs</a></li>
-
     </ul>
   </div>
   <div class="col-xs-12">
@@ -86,3 +85,4 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
     </ul>
   </div>
 </div>
+

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -57,8 +57,8 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/workflows/">Using Workflows to Schedule Jobs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#workflows-configuration-examples">Example Configs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#scheduling-a-workflow">Scheduling a Workflow</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">
-        Using Contexts and Filtering in Your Workflows</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-
+        workflows">Using Contexts and Filtering in Your Workflows</a></li>
       <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Creating Orbs</a></li>
 
     </ul>

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -22,6 +22,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/getting-started/">Your First Green Build</a></li>
       <li><a href="{{ site.baseurl }}/2.0/hello-world/">Hello World</a></li>
       <li><a href="{{ site.baseurl }}/2.0/faq/">FAQ</a></li>
+      <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/orb-intro/">Orbs</a></li>
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">
@@ -32,6 +33,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/postgres-config/">Database Config Examples</a></li>
       <li><a href="{{ site.baseurl }}/2.0/sample-config/">Sample config.yml Files</a></li>
       <li><a href="{{ site.baseurl }}/2.0/tutorials/">Tutorials and Sample Apps</a></li>
+      <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/using-orbs/">Using Orbs</a></li>
     </ul>
   </div>
   <div class="col-xs-12">
@@ -57,6 +59,8 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/workflows/#scheduling-a-workflow">Scheduling a Workflow</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and
           Filtering in Your Workflows</a></li>
+      <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Creating Orbs</a></li>
+
     </ul>
   </div>
   <div class="col-xs-12">
@@ -71,7 +75,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       </li>
     </ul>
   </div>
-  <div class="col-xs-12 col-sm-6">
+  <div id="orb-section" class="col-xs-12 col-sm-6">
     <h2>Orbs</h2>
     <p>Simplify your builds with reuseable configurations.</p>
     <ul>

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -22,19 +22,17 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/getting-started/">Your First Green Build</a></li>
       <li><a href="{{ site.baseurl }}/2.0/hello-world/">Hello World</a></li>
       <li><a href="{{ site.baseurl }}/2.0/faq/">FAQ</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/orb-intro/">Orbs</a></li>
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">
     <h2>Examples</h2>
     <p>Check out some of our popular examples.</p>
     <ul>
-        <li><a href="{{ site.baseurl }}/2.0/example-configs/">Open Source Projects that use CircleCI</a></li>
-        <li><a href="{{ site.baseurl }}/2.0/postgres-config/">Database Config Examples</a></li>
-        <li><a href="{{ site.baseurl }}/2.0/sample-config/">Sample config.yml Files</a></li>
-        <li><a href="{{ site.baseurl }}/2.0/tutorials/">Tutorials and Sample Apps</a></li>
-        <li><a href="{{ site.baseurl }}/2.0/using-orbs/">Using Orbs</a></li>
-      </ul>
+      <li><a href="{{ site.baseurl }}/2.0/example-configs/">Open Source Projects that use CircleCI</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/postgres-config/">Database Config Examples</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/sample-config/">Sample config.yml Files</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/tutorials/">Tutorials and Sample Apps</a></li>
+    </ul>
   </div>
   <div class="col-xs-12">
     <hr />
@@ -57,19 +55,31 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/workflows/">Using Workflows to Schedule Jobs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#workflows-configuration-examples">Example Configs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#scheduling-a-workflow">Scheduling a Workflow</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and Filtering in Your Workflows</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/creating-orbs/">Creating Orbs</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and
+          Filtering in Your Workflows</a></li>
     </ul>
   </div>
   <div class="col-xs-12">
     <hr />
   </div>
-   <div class="col-xs-12 col-sm-6">
+  <div class="col-xs-12 col-sm-6">
     <h2>Cookbooks</h2>
     <p>Recipes to assist and inspire your pipeline config.</p>
     <ul>
       <li><a href="{{ site.baseurl }}/2.0/optimization-cookbook/">Discover ways to optimize your pipelines</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/configuration-cookbook">Explore best practices for a range of use cases</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/configuration-cookbook">Explore best practices for a range of use cases</a>
+      </li>
+    </ul>
+  </div>
+  <div class="col-xs-12 col-sm-6">
+    <h2>Orbs</h2>
+    <p>Simplify your builds with reuseable configurations.</p>
+    <ul>
+      <li><a href="{{ site.baseurl }}/2.0/orb-intro/">Getting started with orbs</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/using-orbs/">Core concepts</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/creating-orbs/">Publishing your orb</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/orbs-faq/">Orbs FAQ</a>
+      </li>
     </ul>
   </div>
 </div>

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -57,8 +57,8 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/workflows/">Using Workflows to Schedule Jobs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#workflows-configuration-examples">Example Configs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#scheduling-a-workflow">Scheduling a Workflow</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and
-          Filtering in Your Workflows</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">
+        Using Contexts and Filtering in Your Workflows</a></li>
       <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Creating Orbs</a></li>
 
     </ul>
@@ -79,11 +79,10 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
     <h2>Orbs</h2>
     <p>Simplify your builds with reuseable configurations.</p>
     <ul>
-      <li><a href="{{ site.baseurl }}/2.0/orb-intro/">Getting started with orbs</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/using-orbs/">Core concepts</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/creating-orbs/">Publishing your orb</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/orbs-faq/">Orbs FAQ</a>
-      </li>
+      <li id="orb-intro"><a href="{{ site.baseurl }}/2.0/orb-intro/">Getting Started with Orbs</a></li>
+      <li id="orb-concepts"><a href="{{ site.baseurl }}/2.0/using-orbs/">Core Concepts</a></li>
+      <li id="orb-publish"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Publishing Your Orb</a></li>
+      <li id="orb-faq"><a href="{{ site.baseurl }}/2.0/orbs-faq/">Orbs FAQ</a></li>
     </ul>
   </div>
 </div>

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -33,7 +33,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/postgres-config/">Database Config Examples</a></li>
       <li><a href="{{ site.baseurl }}/2.0/sample-config/">Sample config.yml Files</a></li>
       <li><a href="{{ site.baseurl }}/2.0/tutorials/">Tutorials and Sample Apps</a></li>
-      <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/using-orbs/">Using Orbs</a></li>
+      <li><a id="orb-content-swap" href="{{ site.baseurl }}/2.0/using-orbs/">Using Orbs</a></li>
     </ul>
   </div>
   <div class="col-xs-12">
@@ -76,13 +76,16 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
   </div>
   <div id="orb-section" class="col-xs-12 col-sm-6">
     <h2>Orbs</h2>
-    <p>Simplify your builds with reuseable configurations.</p>
+    <p>Automate common tasks with reusable, shareable config packages.</p>
     <ul>
-      <li id="orb-intro"><a href="{{ site.baseurl }}/2.0/orb-intro/">Getting Started with Orbs</a></li>
-      <li id="orb-concepts"><a href="{{ site.baseurl }}/2.0/using-orbs/">Core Concepts</a></li>
-      <li id="orb-publish"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Publishing Your Orb</a></li>
+      <li id="orb-intro"><a href="{{ site.baseurl }}/2.0/orb-intro/">Get started with orbs</a></li>
+      <li id="using-orbs"><a href="{{ site.baseurl }}/2.0/using-orbs/">How orbs work</a></li>
+      <li id="orb-author-intro"><a href="{{ site.baseurl }}/2.0/orb-author-intro/">Create a reusable config package</a>
+      </li>
+      <li id="orb-registry"><a
+          href="https://circleci.com/developer/orbs?filterBy=popular&query=&page=1&pageSize=15">Public
+          registry</a></li>
       <li id="orb-faq"><a href="{{ site.baseurl }}/2.0/orbs-faq/">Orbs FAQ</a></li>
     </ul>
   </div>
 </div>
-

--- a/src-js/addOrbSection.js
+++ b/src-js/addOrbSection.js
@@ -7,8 +7,6 @@ $(() => {
   }).then(variation => {
     if (variation === "treatment") {
       $(".orb-bullet").css('visibility', 'hidden');
-      // $(".orb-bullet").hide();
-
       $("#orb-section").show();
 
       $("#orb-intro, #orb-concepts, #orb-publish, #orb-faq").click(function () {

--- a/src-js/addOrbSection.js
+++ b/src-js/addOrbSection.js
@@ -1,14 +1,26 @@
 
 $(() => {
-    // https://app.optimizely.com/v2/projects/16812830475/experiments/20598037463/variations
-    window.OptimizelyClient.getVariationName({
-        experimentKey: 'dd_add_orb_section_to_docs_landing_page_test',
-        groupExperimentName: 'q3_fy22_docs_disco_experiment_group_test'
-    }).then(variation => {
-        console.log('current variation group >>> ', variation)
-        if (variation === "treatment") {
-            $(".orb-bullet").hide();
-            $("#orb-section").show();
-        }
-    })
+  // https://app.optimizely.com/v2/projects/16812830475/experiments/20598037463/variations
+  window.OptimizelyClient.getVariationName({
+    experimentKey: 'dd_add_orb_section_to_docs_landing_page_test',
+    groupExperimentName: 'q3_fy22_docs_disco_experiment_group_test'
+  }).then(variation => {
+    if (variation === "treatment") {
+      $(".orb-bullet").hide();
+      $("#orb-section").show();
+
+      $("#orb-intro").click(function () {
+        window.AnalyticsClient.trackAction('docs-orb-bullet', { link: "Getting Started with Orbs" });
+      })
+      $("#orb-concepts").click(function () {
+        window.AnalyticsClient.trackAction('docs-orb-bullet', { link: "Core Concepts" });
+      })
+      $("#orb-publish").click(function () {
+        window.AnalyticsClient.trackAction('docs-orb-bullet', { link: "Publishing Your Orb" });
+      })
+      $("#orb-faq").click(function () {
+        window.AnalyticsClient.trackAction('docs-orb-bullet', { link: "Orbs FAQ" });
+      })
+    }
+  })
 })

--- a/src-js/addOrbSection.js
+++ b/src-js/addOrbSection.js
@@ -9,18 +9,9 @@ $(() => {
       $(".orb-bullet").hide();
       $("#orb-section").show();
 
-      $("#orb-intro").click(function () {
-        window.AnalyticsClient.trackAction('docs-orb-bullet', { link: "Getting Started with Orbs" });
-      })
-      $("#orb-concepts").click(function () {
-        window.AnalyticsClient.trackAction('docs-orb-bullet', { link: "Core Concepts" });
-      })
-      $("#orb-publish").click(function () {
-        window.AnalyticsClient.trackAction('docs-orb-bullet', { link: "Publishing Your Orb" });
-      })
-      $("#orb-faq").click(function () {
-        window.AnalyticsClient.trackAction('docs-orb-bullet', { link: "Orbs FAQ" });
-      })
+      $("#orb-intro, #orb-concepts, #orb-publish, #orb-faq").click(function () {
+        window.AnalyticsClient.trackAction('docs-orb-bullet', { link: this.id });
+      });
     }
   })
 })

--- a/src-js/addOrbSection.js
+++ b/src-js/addOrbSection.js
@@ -6,7 +6,9 @@ $(() => {
     groupExperimentName: 'q3_fy22_docs_disco_experiment_group_test'
   }).then(variation => {
     if (variation === "treatment") {
-      $(".orb-bullet").hide();
+      $(".orb-bullet").css('visibility', 'hidden');
+      // $(".orb-bullet").hide();
+
       $("#orb-section").show();
 
       $("#orb-intro, #orb-concepts, #orb-publish, #orb-faq").click(function () {

--- a/src-js/addOrbSection.js
+++ b/src-js/addOrbSection.js
@@ -1,0 +1,14 @@
+
+$(() => {
+    // https://app.optimizely.com/v2/projects/16812830475/experiments/20598037463/variations
+    window.OptimizelyClient.getVariationName({
+        experimentKey: 'dd_add_orb_section_to_docs_landing_page_test',
+        groupExperimentName: 'q3_fy22_docs_disco_experiment_group_test'
+    }).then(variation => {
+        console.log('current variation group >>> ', variation)
+        if (variation === "treatment") {
+            $(".orb-bullet").hide();
+            $("#orb-section").show();
+        }
+    })
+})

--- a/src-js/addOrbSection.js
+++ b/src-js/addOrbSection.js
@@ -8,8 +8,9 @@ $(() => {
     if (variation === "treatment") {
       $(".orb-bullet").css('visibility', 'hidden');
       $("#orb-section").show();
+      $("#orb-content-swap").replaceWith("<a id=orb-kit href=https://circleci.com/docs/2.0/creating-orbs/#orb-development-kit>" + "Orb Development Kit" + "</a>")
 
-      $("#orb-intro, #orb-concepts, #orb-publish, #orb-faq").click(function () {
+      $("#orb-intro, #orb-concepts, #orb-publish, #orb-faq, #orb-kit").click(function () {
         window.AnalyticsClient.trackAction('docs-orb-bullet', { link: this.id });
       });
     }

--- a/src-js/app.js
+++ b/src-js/app.js
@@ -3,8 +3,9 @@ import * as search from './instantsearch.js';
 import * as lang from './lang.js'
 import OptimizelyClient from './optimizely.js';
 import AnalyticsClient from "./analytics.js";
-
- // imported but not used just so webpack picks it up and add it to the `app.bundle.js`
+// importing for add orbs section experiment: https://app.optimizely.com/v2/projects/16812830475/experiments/20598037463/variations
+import addOrbSection from "./addOrbSection.js";
+// imported but not used just so webpack picks it up and add it to the `app.bundle.js`
 import * as highlightJSBadge from 'highlightjs-badge';
 
 search.init();


### PR DESCRIPTION
**Ticket**: [CIRCLE-37763](https://circleci.atlassian.net/browse/CIRCLE-37771)

# Changes

- hide `Orbs`, `Using Orbs`, and `Creating Orbs` links from other sections when in control 
- add in section for orbs with associated links for docs and docs 2.0
- add `id` and `class` attributes to display specific links and sections for treatment and control variations
- add `window.AnalyticsClient.trackAction` for each link in orbs section

# Rationale
In an effort to try and help surface the orbs feature more and building engagement to developer resources, we decided that it would be helpful to include a section for orbs on the landing page of Docs with the appropriate links. 

# Considerations
Current links and copy is still a WIP. Some possible link candidates could be [Orbs Intro](https://circleci.com/docs/2.0/orb-intro/), [Orbs Concepts](https://circleci.com/docs/2.0/orb-concepts/), [Publishing Orbs](https://circleci.com/docs/2.0/creating-orbs/) and [Orbs FAQ](https://circleci.com/docs/2.0/orbs-faq/). Copy for title, subheading and links should be approved by a UX writer before merging. 

# Analytic Events

- `docs-orb-bullet`

# Screenshots 

**Before/Control:**

![Screen Shot 2021-09-13 at 12 17 41 PM](https://user-images.githubusercontent.com/57234605/133143381-3f036bce-114f-4688-9eec-d2d1d395cfd1.png)

**After/Treatment:**

![Screen Shot 2021-09-13 at 12 18 46 PM](https://user-images.githubusercontent.com/57234605/133143535-5fc14a3a-3636-45d4-801c-597a4743e5e5.png)
