### PR TITLE
SERVER-1426 |  VM service can accept more than on subnet

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -328,7 +328,7 @@ Key used by VM Service differs from the policy used by Object Storage in the pre
 
 . *AWS Region* (required): This is the region the application is in.
 . *AWS Windows AMI ID* (optional): If you require Windows builders, you can supply an AMI ID for them here.
-. *Subnets* (required): Choose subnets (public or private) where the VMs should be deployed. Note that all subnets must be in the same aviailability zone.
+. *Subnets* (required): Choose subnets (public or private) where the VMs should be deployed. Note that all subnets must be in the same availability zone.
 . *Security Group ID* (required): This is the security group that will be attached to the VMs. It must be created manually.
 
 The recommended security group configuration can be found in the xref:server-3-install-hardening-your-cluster.adoc#external-vms[Hardening Your Cluster] section. Additionally, the below commands can be run to create the necessary security groups in AWS or GCP.

--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -328,7 +328,7 @@ Key used by VM Service differs from the policy used by Object Storage in the pre
 
 . *AWS Region* (required): This is the region the application is in.
 . *AWS Windows AMI ID* (optional): If you require Windows builders, you can supply an AMI ID for them here.
-. *Subnet ID* (required): Choose a subnet (public or private) where the VMs should be deployed.
+. *Subnets* (required): Choose subnets (public or private) where the VMs should be deployed. Note that all subnets must be in the same aviailability zone.
 . *Security Group ID* (required): This is the security group that will be attached to the VMs. It must be created manually.
 
 The recommended security group configuration can be found in the xref:server-3-install-hardening-your-cluster.adoc#external-vms[Hardening Your Cluster] section. Additionally, the below commands can be run to create the necessary security groups in AWS or GCP.

--- a/jekyll/_cci2/server-3-operator-vm-service.adoc
+++ b/jekyll/_cci2/server-3-operator-vm-service.adoc
@@ -25,7 +25,7 @@ Key used by VM Service differs from the policy used by object storage in the pre
 
 . *AWS Region* (required): This is the region the application is in.
 . *AWS Windows AMI ID* (optional): If you require Windows builders, you can supply an AMI ID for them here.
-. *Subnets* (required): Choose subnets (public or private) where the VMs should be deployed. Note that all subnets must be in the same aviailability zone.
+. *Subnets* (required): Choose subnets (public or private) where the VMs should be deployed. Note that all subnets must be in the same availability zone.
 . *Security Group ID* (required): This is the security group that will be attached to the VMs.
 
 The recommended security group configuration can be found in the https://circleci.com/docs/2.0/server-3-install-hardening-your-cluster[Hardening Your Cluster] section.

--- a/jekyll/_cci2/server-3-operator-vm-service.adoc
+++ b/jekyll/_cci2/server-3-operator-vm-service.adoc
@@ -25,7 +25,7 @@ Key used by VM Service differs from the policy used by object storage in the pre
 
 . *AWS Region* (required): This is the region the application is in.
 . *AWS Windows AMI ID* (optional): If you require Windows builders, you can supply an AMI ID for them here.
-. *Subnet ID* (required): Choose a subnet (public or private) where the VMs should be deployed.
+. *Subnets* (required): Choose subnets (public or private) where the VMs should be deployed. Note that all subnets must be in the same aviailability zone.
 . *Security Group ID* (required): This is the security group that will be attached to the VMs.
 
 The recommended security group configuration can be found in the https://circleci.com/docs/2.0/server-3-install-hardening-your-cluster[Hardening Your Cluster] section.


### PR DESCRIPTION
# Description

VM service accepts more than one subnet now in AWS. Modified docs to note this and added the limitation that they must be in the same AZ.

# Reasons
SERVER-1426
