### PR TITLE
all tabbed content to ref server v2.19

### DIFF
--- a/jekyll/_cci2/getting-started.md
+++ b/jekyll/_cci2/getting-started.md
@@ -274,7 +274,7 @@ comment %} TODO: Job {% endcomment %}build with the SSH enabled option.
 {:.tab.switcher.Cloud}
 ![Rebuild With SSH]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH_newui.png)
 
-{:.tab.switcher.Server-v2.19.x}
+{:.tab.switcher.Server-v2}
 ![Rebuild With SSH]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH.png)
 
 

--- a/jekyll/_cci2/getting-started.md
+++ b/jekyll/_cci2/getting-started.md
@@ -274,7 +274,7 @@ comment %} TODO: Job {% endcomment %}build with the SSH enabled option.
 {:.tab.switcher.Cloud}
 ![Rebuild With SSH]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH_newui.png)
 
-{:.tab.switcher.Server v2.19.x}
+{:.tab.switcher.Server-v2.19.x}
 ![Rebuild With SSH]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH.png)
 
 

--- a/jekyll/_cci2/getting-started.md
+++ b/jekyll/_cci2/getting-started.md
@@ -274,7 +274,7 @@ comment %} TODO: Job {% endcomment %}build with the SSH enabled option.
 {:.tab.switcher.Cloud}
 ![Rebuild With SSH]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH_newui.png)
 
-{:.tab.switcher.Server}
+{:.tab.switcher.Server v2.19.x}
 ![Rebuild With SSH]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH.png)
 
 

--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -142,7 +142,7 @@ In the top left, you will find the Org switcher.
 {:.tab.switcher.Cloud}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui_newui.png)
 
-{:.tab.switcher.Serverv2}
+{:.tab.switcher.Server-v2}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui.png)
 
 If you do not see your project and it is not currently building on CircleCI, check your org in the top left corner of the CircleCI application.  For example, if the top left shows your user `my-user`, only GitHub projects belonging to `my-user` will be available under `Add Projects`.  If you want to build the GitHub project `your-org/project`, you must select `your-org` on the application Switch Organization menu.

--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -142,7 +142,7 @@ In the top left, you will find the Org switcher.
 {:.tab.switcher.Cloud}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui_newui.png)
 
-{:.tab.switcher.Server}
+{:.tab.switcher.Server v2.19}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui.png)
 
 If you do not see your project and it is not currently building on CircleCI, check your org in the top left corner of the CircleCI application.  For example, if the top left shows your user `my-user`, only GitHub projects belonging to `my-user` will be available under `Add Projects`.  If you want to build the GitHub project `your-org/project`, you must select `your-org` on the application Switch Organization menu.

--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -142,7 +142,7 @@ In the top left, you will find the Org switcher.
 {:.tab.switcher.Cloud}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui_newui.png)
 
-{:.tab.switcher.Server v2.19}
+{:.tab.switcher.Serverv2}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui.png)
 
 If you do not see your project and it is not currently building on CircleCI, check your org in the top left corner of the CircleCI application.  For example, if the top left shows your user `my-user`, only GitHub projects belonging to `my-user` will be available under `Add Projects`.  If you want to build the GitHub project `your-org/project`, you must select `your-org` on the application Switch Organization menu.

--- a/jekyll/_cci2/project-build.md
+++ b/jekyll/_cci2/project-build.md
@@ -50,7 +50,7 @@ If you do not see your project and it is not currently building on CircleCI, che
 {:.tab.switcher.Cloud}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui_newui.png)
 
-{:.tab.switcher.Server}
+{:.tab.switcher.Server v2.19.x}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui.png)
 
 ## Viewing and navigating pipelines

--- a/jekyll/_cci2/project-build.md
+++ b/jekyll/_cci2/project-build.md
@@ -50,7 +50,7 @@ If you do not see your project and it is not currently building on CircleCI, che
 {:.tab.switcher.Cloud}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui_newui.png)
 
-{:.tab.switcher.Server v2.19.x}
+{:.tab.switcher.Server-v2}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui.png)
 
 ## Viewing and navigating pipelines

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -229,7 +229,7 @@ The following screenshot demonstrates a workflow on hold.
 {:.tab.switcher.Cloud}
 ![Approved Jobs in On Hold Workflow]({{ site.baseurl }}/assets/img/docs/approval_job_cloud.png)
 
-{:.tab.switcher.Server v2.19.x}
+{:.tab.switcher.Server-v2}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/approval_job.png)
 
 

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -229,7 +229,7 @@ The following screenshot demonstrates a workflow on hold.
 {:.tab.switcher.Cloud}
 ![Approved Jobs in On Hold Workflow]({{ site.baseurl }}/assets/img/docs/approval_job_cloud.png)
 
-{:.tab.switcher.Server}
+{:.tab.switcher.Server v2.19.x}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/approval_job.png)
 
 

--- a/jekyll/_cci2_ja/getting-started.md
+++ b/jekyll/_cci2_ja/getting-started.md
@@ -216,7 +216,7 @@ SSH 公開鍵を GitHub アカウントに登録する必要があることに�
 {:.tab.switcher.Cloud}
 ![SSH でのリビルド]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH_newui.png)
 
-{:.tab.switcher.Server}
+{:.tab.switcher.Server v2.19.x}
 ![SSH でのリビルド]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH.png)
 
 

--- a/jekyll/_cci2_ja/getting-started.md
+++ b/jekyll/_cci2_ja/getting-started.md
@@ -216,7 +216,7 @@ SSH 公開鍵を GitHub アカウントに登録する必要があることに�
 {:.tab.switcher.Cloud}
 ![SSH でのリビルド]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH_newui.png)
 
-{:.tab.switcher.Server v2.19.x}
+{:.tab.switcher.Server-v2}
 ![SSH でのリビルド]( {{ site.baseurl }}/assets/img/docs/rebuild-with-SSH.png)
 
 

--- a/jekyll/_cci2_ja/hello-world.md
+++ b/jekyll/_cci2_ja/hello-world.md
@@ -139,7 +139,7 @@ CircleCI アプリケーションの左上で組織を切り替えられます�
 {:.tab.switcher.Cloud}
 ![SWITCH ORGANIZATION メニュー]({{ site.baseurl }}/assets/img/docs/org-centric-ui_newui.png)
 
-{:.tab.switcher.Server v2.19.x}
+{:.tab.switcher.Server-v2}
 ![SWITCH ORGANIZATION メニュー]({{ site.baseurl }}/assets/img/docs/org-centric-ui.png)
 
 表示したいプロジェクトが表示されておらず、現在 CircleCI 上でビルドしているものではない場合は、CircleCI アプリケーションの左上隅で組織を確認してください。  たとえば、左上にユーザー `my-user` と表示されているなら、`my-user` に属する GitHub プロジェクトのみが `Add Projects` の下に表示されます。  `your-org/project` の GitHub プロジェクトをビルドするには、CircleCI アプリケーションの [Switch Organization (組織の切り替え)] メニューで `your-org` を選択する必要があります。

--- a/jekyll/_cci2_ja/hello-world.md
+++ b/jekyll/_cci2_ja/hello-world.md
@@ -139,7 +139,7 @@ CircleCI アプリケーションの左上で組織を切り替えられます�
 {:.tab.switcher.Cloud}
 ![SWITCH ORGANIZATION メニュー]({{ site.baseurl }}/assets/img/docs/org-centric-ui_newui.png)
 
-{:.tab.switcher.Server}
+{:.tab.switcher.Server v2.19.x}
 ![SWITCH ORGANIZATION メニュー]({{ site.baseurl }}/assets/img/docs/org-centric-ui.png)
 
 表示したいプロジェクトが表示されておらず、現在 CircleCI 上でビルドしているものではない場合は、CircleCI アプリケーションの左上隅で組織を確認してください。  たとえば、左上にユーザー `my-user` と表示されているなら、`my-user` に属する GitHub プロジェクトのみが `Add Projects` の下に表示されます。  `your-org/project` の GitHub プロジェクトをビルドするには、CircleCI アプリケーションの [Switch Organization (組織の切り替え)] メニューで `your-org` を選択する必要があります。

--- a/jekyll/_cci2_ja/project-build.md
+++ b/jekyll/_cci2_ja/project-build.md
@@ -46,7 +46,7 @@ If you do not see your project and it is not currently building on CircleCI, che
 {:.tab.switcher.Cloud}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui_newui.png)
 
-{:.tab.switcher.Server v2.19.x}
+{:.tab.switcher.Server-v2}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui.png)
 
 ## Viewing and navigating pipelines

--- a/jekyll/_cci2_ja/project-build.md
+++ b/jekyll/_cci2_ja/project-build.md
@@ -46,7 +46,7 @@ If you do not see your project and it is not currently building on CircleCI, che
 {:.tab.switcher.Cloud}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui_newui.png)
 
-{:.tab.switcher.Server}
+{:.tab.switcher.Server v2.19.x}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/org-centric-ui.png)
 
 ## Viewing and navigating pipelines

--- a/jekyll/_cci2_ja/workflows.md
+++ b/jekyll/_cci2_ja/workflows.md
@@ -242,7 +242,7 @@ workflows:
 {:.tab.switcher.Cloud}
 ![[Switch Organization (組織の切り替え)] メニュー]({{ site.baseurl }}/assets/img/docs/approval_job_cloud.png)
 
-{:.tab.switcher.Server}
+{:.tab.switcher.Server v2.19.x}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/approval_job.png)
 
 

--- a/jekyll/_cci2_ja/workflows.md
+++ b/jekyll/_cci2_ja/workflows.md
@@ -242,7 +242,7 @@ workflows:
 {:.tab.switcher.Cloud}
 ![[Switch Organization (組織の切り替え)] メニュー]({{ site.baseurl }}/assets/img/docs/approval_job_cloud.png)
 
-{:.tab.switcher.Server v2.19.x}
+{:.tab.switcher.Server-v2}
 ![Switch Organization Menu]({{ site.baseurl }}/assets/img/docs/approval_job.png)
 
 


### PR DESCRIPTION
Tabbed content was created to show difference between v2.19.x and Cloud but they were just labelled "Server". Now Server 3 is close to parity with Cloud we need to update the tab labels to be more specific :-)

https://circleci.atlassian.net/browse/DOCS-9?atlOrigin=eyJpIjoiOGQxNDhkNWI2ZDI2NDRjOGFiZDI0NzM3MjhmODc5NTEiLCJwIjoiaiJ9