### PR TITLE
Adjust known time limits on approval jobs

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -212,8 +212,9 @@ workflows:
 The outcome of the above example is that the `deploy:` job will not run until
 you click the `hold` job in the Workflows page of the CircleCI app and then
 click Approve. In this example the purpose of the `hold` job is to wait for
-approval to begin deployment. A job can be approved for up to 15 days after
-being issued.
+approval to begin deployment. A job can be approved for up to 90 days after
+being issued. However, workspaces expire after 15 days, so if the jobs after
+the hold job utilize workspaces, the effective approval time-limit is 15 days.
 
 Some things to keep in mind when using manual approval in a workflow:
 


### PR DESCRIPTION
# Description
This PR will update our documentation to match the current time limits for approval jobs.

# Reasons
This stemmed from a conversation with a customer, and testing/working with engineering confirmed these time limits.