### PR TITLE
Add audit log events for schedules

### DIFF
--- a/jekyll/_cci2/security.md
+++ b/jekyll/_cci2/security.md
@@ -89,6 +89,9 @@ Following are the system events that are logged. See `action` in the Field secti
 - project.settings.update
 - project.ssh_key.create
 - project.ssh_key.delete
+- schedule.create
+- schedule.update
+- schedule.delete
 - user.create
 - user.logged_in
 - user.logged_out


### PR DESCRIPTION
# Description
The new Scheduled Pipelines feature will emit new events to the `audit-log-service`.
These new events are added to the public docs via this PR.

# Reasons
See above
Upstream PR in `audit-log-service`:
https://github.com/circleci/audit-log-service/pull/177