### PR TITLE
Fixing incorrect indentation in overview example

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -26,7 +26,7 @@ jobs:
       # ... steps for building/testing app ...
 
       - setup_remote_docker:
-        version: 19.03.13
+          version: 19.03.13
 ```
 
 When `setup_remote_docker` executes, a remote environment will be created, and your current [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) will be configured to use it. Then, any docker-related commands you use will be safely executed in this new environment.


### PR DESCRIPTION
# Description
Added missing indentation in the configuration example [under the "Overview" section](https://circleci.com/docs/2.0/building-docker-images/#overview).

# Reasons
The `version` key needs to be indented by two characters to the right.

The documentation currently shows:

```
- setup_remote_docker:
  version: 19.03.13
```

when it should be:

```
- setup_remote_docker:
    version: 19.03.13
```
