### PR TITLE
[CIRCLE-37827] Add documentation for `runner.mode`

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -516,6 +516,17 @@ This directory allows you to control the default working directory used by each 
 
 This directory enables you to control the working directory cleanup after each job. The default value is `false`.
 
+==== runner.mode
+
+This parameter allows you to specify whether you want to terminate this runner instance upon completion of a job (single-task) or to continuously poll for new available jobs.
+
+The possible values are:
+
+* continuous
+* single-task
+
+NOTE: The default value is continuous.
+
 ==== runner.max_run_time
 
 This value can be used to override the default maximum duration the task agent will run each job. Note that the value is a string with the following unit identifiers `h`, `m` or `s` for hour minute and seconds respectively:


### PR DESCRIPTION
# Description
Jira: [CIRCLE-37827](https://circleci.atlassian.net/browse/CIRCLE-37827)

Adds documentation info for `runner.mode`

# Reasons
This is already enabled and being used for Windows runner installs. Making this public for other use cases as well (docker, runner auto scaling)


Screenshot:

![Screen Shot 2021-09-22 at 17 26 08](https://user-images.githubusercontent.com/17708458/134512819-7bc8bc72-4224-4387-9f36-db9e90aab708.png)