### PR TITLE
Document `runner.idle_timeout` parameter [RT-100]

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -520,7 +520,7 @@ This directory enables you to control the working directory cleanup after each j
 
 This value can be used to override the default maximum duration the task agent will run each job. Note that the value is a string with the following unit identifiers `h`, `m` or `s` for hour minute and seconds respectively:
 
-Here are few valid examples:
+Here are a few valid examples:
 
 * `72h` - 3 days
 * `1h30m` - 1 hour 30 minutes
@@ -540,6 +540,12 @@ Draining can end in one of two ways:
 
 * The task has been in the draining state for longer than the configured `max_run_time`.
 * An additional TERM signal is received by the Launch Agent during "draining".
+
+==== runner.idle_timeout
+
+This timeout will enable a launch agent to terminate if no task has been claimed within the given time period. The value is a string with the following unit identifiers: `h`, `m` or `s` for hours, minutes and seconds, respectively (e.g., `5m` is 5 minutes).
+
+NOTE: The default behaviour is to never time out due to inactivity.
 
 ==== runner.ssh.advertise_addr
 


### PR DESCRIPTION
# Description
Add documentation for the optional runner parameter, `runner.idle_timeout`. This parameter will cause the polling loop in the launch agent to terminate if no tasks are claimed within the timeout period. This will help to support autoscaling in the event that too many runners are scaled up.

![runner idle_timeout](https://user-images.githubusercontent.com/28056419/134940187-18e00359-3f9c-4f25-9b85-62ef9d88d0c6.png)

# Reasons
Jira ticket: https://circleci.atlassian.net/browse/RT-100 (https://circleci.atlassian.net/browse/CIRCLE-36413)