### PR TITLE
Add URL query key to enable experiments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,4 +325,4 @@ jobs:
           command: aws s3 sync generated-site/_site/${JEKYLL_BASENAME} s3://circleci-doc-preview/${JEKYLL_BASENAME}/ --delete
       - run:
           name: Preview deployment URL
-          command: echo "Preview is deployed at http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/${JEKYLL_BASENAME}"
+          command: echo "Preview is deployed at http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/${JEKYLL_BASENAME}?force-all"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,4 +325,4 @@ jobs:
           command: aws s3 sync generated-site/_site/${JEKYLL_BASENAME} s3://circleci-doc-preview/${JEKYLL_BASENAME}/ --delete
       - run:
           name: Preview deployment URL
-          command: echo "Preview is deployed at http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/${JEKYLL_BASENAME}?force-all"
+          command: echo "Preview is deployed at http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/${JEKYLL_BASENAME}/?force-all"

--- a/src-js/experiments/forceAll.js
+++ b/src-js/experiments/forceAll.js
@@ -2,7 +2,10 @@ const FORCE_QUERY_KEY = 'force-all';
 const FORCE_STORAGE_KEY = 'growth-experiments-force-all';
 const PREVIEW_DOMAIN = 'circleci-doc-preview.s3-website-us-east-1.amazonaws.com';
 
-getJekyllBaseName = () => window.location.href.replace(`${PREVIEW_DOMAIN}/`, '');
+getJekyllBaseName = () => {
+  const match = location.href.match(`${PREVIEW_DOMAIN}\/.*-preview\/`);
+  return match.length ? match[0] : null;
+}
 
 forceAll = () => {
   let force = false;

--- a/src-js/experiments/forceAll.js
+++ b/src-js/experiments/forceAll.js
@@ -2,12 +2,6 @@ const FORCE_QUERY_KEY = 'force-all';
 const FORCE_STORAGE_KEY = 'growth-experiments-force-all';
 const PREVIEW_DOMAIN = 'circleci-doc-preview.s3-website-us-east-1.amazonaws.com';
 
-const currentPage = window.location;
-if (currentPage.host === PREVIEW_DOMAIN &&
-    (new RegExp(`[\?&]${FORCE_QUERY_KEY}`)).test(currentPage.href ?? "")) {
-      localStorage.setItem(FORCE_STORAGE_KEY, getJekyllBaseName());
-}
-
 getJekyllBaseName = () => window.location.href.replace(`${PREVIEW_DOMAIN}/`, '');
 
 forceAll = () => {
@@ -22,4 +16,10 @@ forceAll = () => {
   }
 
   return force;
+}
+
+const currentPage = window.location;
+if (currentPage.host === PREVIEW_DOMAIN &&
+    (new RegExp(`[\?&]${FORCE_QUERY_KEY}`)).test(currentPage.href ?? "")) {
+      localStorage.setItem(FORCE_STORAGE_KEY, getJekyllBaseName());
 }

--- a/src-js/experiments/forceAll.js
+++ b/src-js/experiments/forceAll.js
@@ -1,6 +1,6 @@
 const FORCE_QUERY_KEY = 'force-all';
 const FORCE_STORAGE_KEY = 'growth-experiments-force-all';
-const PREVIEW_DOMAIN = 'circleci-doc-preview.s3-website-us-east-1.amazonaws.com/';
+const PREVIEW_DOMAIN = 'circleci-doc-preview.s3-website-us-east-1.amazonaws.com';
 
 const currentPage = window.location;
 if (currentPage.host === PREVIEW_DOMAIN &&
@@ -8,7 +8,7 @@ if (currentPage.host === PREVIEW_DOMAIN &&
       localStorage.setItem(FORCE_STORAGE_KEY, getJekyllBaseName());
 }
 
-getJekyllBaseName = () => window.location.href.replace(PREVIEW_DOMAIN, '');
+getJekyllBaseName = () => window.location.href.replace(`${PREVIEW_DOMAIN}/`, '');
 
 forceAll = () => {
   let force = false;

--- a/src-js/experiments/forceAll.js
+++ b/src-js/experiments/forceAll.js
@@ -6,5 +6,5 @@ const currentPage = window.location;
 
 if (currentPage.host === PREVIEW_DOMAIN &&
     (new RegExp(`[\?&]${FORCE_QUERY_KEY}`)).test(currentPage.href ?? "")) {
-      localStorage.setItem(FORCE_STORAGE_KEY, JSON.stringify(true));
+      localStorage.setItem(FORCE_STORAGE_KEY, "1");
 }

--- a/src-js/experiments/forceAll.js
+++ b/src-js/experiments/forceAll.js
@@ -1,10 +1,25 @@
 const FORCE_QUERY_KEY = 'force-all';
 const FORCE_STORAGE_KEY = 'growth-experiments-force-all';
-const PREVIEW_DOMAIN = 'circleci-doc-preview.s3-website-us-east-1.amazonaws.com';
+const PREVIEW_DOMAIN = 'circleci-doc-preview.s3-website-us-east-1.amazonaws.com/';
 
 const currentPage = window.location;
-
 if (currentPage.host === PREVIEW_DOMAIN &&
     (new RegExp(`[\?&]${FORCE_QUERY_KEY}`)).test(currentPage.href ?? "")) {
-      localStorage.setItem(FORCE_STORAGE_KEY, "1");
+      localStorage.setItem(FORCE_STORAGE_KEY, getJekyllBaseName());
+}
+
+getJekyllBaseName = () => window.location.href.replace(PREVIEW_DOMAIN, '');
+
+forceAll = () => {
+  let force = false;
+
+  if (window.location.host === PREVIEW_DOMAIN) {
+    const jekyllBaseName = getJekyllBaseName();
+    force = (localStorage.getItem(FORCE_STORAGE_KEY) ?? "") === jekyllBaseName;
+  }
+  if (!force) {
+    localStorage.removeItem(FORCE_STORAGE_KEY);
+  }
+
+  return force;
 }

--- a/src-js/experiments/forceAll.js
+++ b/src-js/experiments/forceAll.js
@@ -1,0 +1,10 @@
+const FORCE_QUERY_KEY = 'force-all';
+const FORCE_STORAGE_KEY = 'growth-experiments-force-all';
+const PREVIEW_DOMAIN = 'circleci-doc-preview.s3-website-us-east-1.amazonaws.com';
+
+const currentPage = window.location;
+
+if (currentPage.host === PREVIEW_DOMAIN &&
+    (new RegExp(`[\?&]${FORCE_QUERY_KEY}`)).test(currentPage.href ?? "")) {
+      localStorage.setItem(FORCE_STORAGE_KEY, JSON.stringify(true));
+}

--- a/src-js/optimizely.js
+++ b/src-js/optimizely.js
@@ -36,7 +36,7 @@ class OptimizelyClient {
   // - User is in the exclusion group
   getVariationName(options) {
     return new Promise((resolve, reject) => {
-      if (localStorage.getItem(FORCE_STORAGE_KEY)) {
+      if (forceAll()) {
         return resolve("treatment");
       }
 

--- a/src-js/optimizely.js
+++ b/src-js/optimizely.js
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 const COOKIE_KEY = 'cci-org-analytics-id';
 const STORAGE_KEY = 'growth-experiments-participated';
+const FORCE_STORAGE_KEY = 'growth-experiments-force-all';
 
 class OptimizelyClient {
   constructor() {
@@ -35,6 +36,10 @@ class OptimizelyClient {
   // - User is in the exclusion group
   getVariationName(options) {
     return new Promise((resolve, reject) => {
+      if (localStorage.getItem(FORCE_STORAGE_KEY)) {
+        return resolve("treatment");
+      }
+
       // First we check that the required options are provided
       if (!options || !options.experimentKey || !options.groupExperimentName) {
         return reject({error: "Missing required options"});


### PR DESCRIPTION
# Description
- Add a `force-all` query key to enable all experiments by default

# Reasons
We have a preview system but when sharing these links with stakeholders the experiments are not able to resolve. This URL query key helps short-circuiting the optimizely client  