### PR TITLE
Update tag from Cloud to Server

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -220,7 +220,7 @@ jobs:
 
 ```
 
-{:.tab.windowsblockfour.Cloud}
+{:.tab.windowsblockfour.Server}
 ```YAML
 version: 2.0
 


### PR DESCRIPTION
# Description

I think the example config connecting to this change is for Server (i.e., where `version: 2.0`) and so this is a fix on a minor typo.
<img width="745" alt="Screen Shot 2021-10-01 at 13 49 41" src="https://user-images.githubusercontent.com/2164346/135566892-e405c931-6d23-4547-a4a6-81ada0992c39.png">

Ref: https://circleci.com/docs/2.0/hello-world-windows/

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.