### PR TITLE
Fix k8s namespace name to circleci-server

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -167,7 +167,7 @@ Create a DNS entry for your Traefik load balancer, i.e. circleci.your.domain.com
 You will need the IP address of the Traefik load balancer. You can find it with the following terminal command:
 
 ----
-kubectl get service circleci-server-traefik --namespace=nfish-circleci-server
+kubectl get service circleci-server-traefik --namespace=circleci-server
 ----
 
 For more information on adding a new DNS record, see the following documentation:


### PR DESCRIPTION
Since all other document of CircleCI server 3.x use `circleci-server` as k8s namespace

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.