### PR TITLE
Document ip range reserved by CircleCI

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -253,7 +253,7 @@ jobs:
 The `image` key is not supported on private installations of CircleCI.
 See the [VM Service documentation]({{ site.baseurl }}/2.0/vm-service) for more information.
 
-The IP range `192.168.53.0/24` is reserved by CircleCI for the internal use on machine executor, so please avoid using the range in your jobs.
+The IP range `192.168.53.0/24` is reserved by CircleCI for the internal use on machine executor. This range should not be used in your jobs.
 
 ## Using macOS
 {: #using-macos }


### PR DESCRIPTION
# Description
Document ip range reserved by CircleCI

# Reasons
We use this IP range for dedicated network link on machine executor
