### PR TITLE
[CIRCLE-37785] Consistent link behavior

### DIFF
--- a/jekyll/assets/css/asciidoc.css
+++ b/jekyll/assets/css/asciidoc.css
@@ -51,5 +51,3 @@ span.icon>.fa {
 .green{
   color: #43C78A;
 }
-
-

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -171,6 +171,23 @@ div.article-container{
       padding: 0 16px 0 16px;
       width: 100%;
   }
+
+  .tag-wrapper{
+	  display: inline-block;
+  }
+
+  .external-link-icon {
+	align-self: center;
+	margin: 0 0 0 5px;
+	background-size: 16px 16px;
+	height: 16px;
+	width: 16px;
+  }
+
+  .external-link-anchor {
+	display: flex;
+  }
+
   padding: 0 48px;
   width: calc(100% - #{$rightbar-width});
   max-width: 60em; // increase readability on large screens.

--- a/src-js/site/main.js
+++ b/src-js/site/main.js
@@ -372,3 +372,16 @@ $( document ).ready(function() {
   // 	analytics.identify(userData['analytics_id']);
   // });
 });
+
+$( document ).ready(function() {
+  $("#main a").not('.license-notice *').each(function () {
+    $(this).wrap("<div class='tag-wrapper'></div>")
+    var inlineSVG = '<svg class="external-link-icon" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="css-bleycz"><path viewBox="0 0 24 24" fill-rule="evenodd" d="M17,19 L5,19 L5,7 L10,7 L10,5.00083798 L4.44085883,5.00083798 C4.05495161,4.9876138 3.68075435,5.13139282 3.4077085,5.39780868 C3.13466265,5.66422454 2.98730555,6.02933568 3.00085883,6.40587245 L3.00085883,19.5941275 C2.98730555,19.9706643 3.13466265,20.3357755 3.4077085,20.6021913 C3.68075435,20.8686072 4.05495161,21.0123862 4.44085883,20.999162 L17.56,20.999162 C18.35529,20.999162 19,20.3701067 19,19.5941275 L19,14 L17,14 L17,19 Z M17.5857864,5 L14,5 C13.4477153,5 13,4.55228475 13,4 C13,3.44771525 13.4477153,3 14,3 L20,3 C20.5522847,3 21,3.44771525 21,4 L21,10 C21,10.5522847 20.5522847,11 20,11 C19.4477153,11 19,10.5522847 19,10 L19,6.41421356 L14.8786797,10.5355339 C14.4881554,10.9260582 13.8549904,10.9260582 13.4644661,10.5355339 C13.0739418,10.1450096 13.0739418,9.51184464 13.4644661,9.12132034 L17.5857864,5 Z"></path></svg>'
+    if(!this.origin.includes(window.location.origin)) {
+      $(this).removeClass().addClass("external-link-anchor")
+      $(inlineSVG).appendTo(this);
+      $(this).attr('target', '_blank')
+      $(this).attr('rel', 'noopener noreferrer')
+    }
+  });
+});


### PR DESCRIPTION
**Ticket:** [CIRCLE-37785](https://circleci.atlassian.net/browse/CIRCLE-37785)
co-auther: @teesloane 

Changes
=======

- Add in open up to new tab for external links
- Add in icon to external indicator

Rationale
=========
Docs
Inconsistent - some links open in same tab/window, others open in new tab
Example: Pipeline Variables - CircleCI 
Links that open in new tab (external) should have an icon to indicate behavior

Questions for Design/PM:
- What is the desired behavior of docs links? (for example, should all internal links open in same tab, all external open in new tab?)

Acceptance Criteria:
- Update Docs links to follow our decisions on desired behavior
- External docs link have an icon beside them indicated they’re external.

Considerations
==============
- Some sites go /docs but they direct to an external site
- No links on header, footer, side bar or liecence agreement


Analytics Events Used
=================

- N/A

Optimizely Experiment Key
============

- N/A

Screenshots
============
<h4>Before</h4>
<img width="620" alt="Screen Shot 2021-10-07 at 12 30 46 AM" src="https://user-images.githubusercontent.com/86666932/136320637-651a5d48-daef-40d8-8211-1d3663feb8dc.png">

<img width="1116" alt="Screen Shot 2021-10-13 at 10 28 41 AM" src="https://user-images.githubusercontent.com/86666932/137153384-5a92916c-4699-4da3-aff0-47727d2040c5.png">

<h4>After</h4>
<img width="620" alt="Screen Shot 2021-10-07 at 12 30 14 AM" src="https://user-images.githubusercontent.com/86666932/136320619-8863f57d-9e73-4687-9fc3-97a68277a4a6.png">

<img width="1114" alt="Screen Shot 2021-10-13 at 10 50 46 AM" src="https://user-images.githubusercontent.com/86666932/137157788-a0c4452e-2feb-468f-8a41-b3a8cbd0c988.png">

