### PR TITLE
Add Datadog integration to partnerships

### DIFF
--- a/jekyll/_cci2/insights-partnerships.md
+++ b/jekyll/_cci2/insights-partnerships.md
@@ -12,13 +12,12 @@ version:
 
 {:toc}
 
-This document describes how you can connect Insights data with third party
-providers.
+This document describes how you can connect Insights data with third party providers. Currently we support integrations with [Datadog](https://www.datadoghq.com/) and [Sumo Logic](https://www.sumologic.com/).
 
-### Datadog integration
+## Datadog integration
 {: #datadog-integration }
 
-Use webhooks to send data to [Datadog](https://www.datadoghq.com/) through the CircleCI integration.
+You can send data to Datadog through the use of webhooks with CircleCI.
 
 1. In the [CircleCI App](https://app.circleci.com/), click on the ellipsis menu for each project, and then click **Project Settings** > **Webhooks**.
   - **Webhook URL**: `https://webhook-intake.datadoghq.com/api/v2/webhook/?dd-api-key=<API_KEY>` where `<API_KEY>` is your [Datadog API key](https://app.datadoghq.com/account/login).
@@ -28,20 +27,20 @@ Use webhooks to send data to [Datadog](https://www.datadoghq.com/) through the C
 
 1. Click **Add Webhook** to save the new webhook.
 
-#### Visualize pipeline data in Datadog
+### Visualize pipeline data in Datadog
 {: #visualize-pipeline-data-in-datadog }
 
 Sign in to [Datadog](https://app.datadoghq.com/account/login) and visit the Pipelines and Pipeline Executions pages to see data populate after workflows finish.
 
 **Note**: The Pipelines page will only show data for the default branch of each repository.
 
-### Sumo Logic integration
+## Sumo Logic integration
 {: #sumo-logic-integration }
 
-The CircleCI app for [Sumo Logic](https://www.sumologic.com/) provides advanced views to track the performance and health of your continuous integration and deployment pipelines.
+The CircleCI app for Sumo Logic provides advanced views to track the performance and health of your continuous integration and deployment pipelines.
 
 
-#### The CircleCI dashboard for Sumo Logic
+### The CircleCI dashboard for Sumo Logic
 {: #the-circleci-dashboard-for-sumo-logic }
 
 Use this dashboard to:
@@ -70,25 +69,25 @@ Install the CircleCI dashboard by using the App Catalog from the dashboard home 
 
 This dashboard receives data through the CircleCI Sumo Logic orb which must be included in your projects to be tracked.
 
-## Set up Sumo Logic metrics using CircleCI webhooks
+### Set up Sumo Logic metrics using CircleCI webhooks
 {: #set-up-sumo-logic-metrics-using-circleci-webhooks }
 
 To begin collecting and visualizing data with Sumo Logic, first configure CircleCI webhooks to send metrics data to Sumo Logic.
-### Configure Webhooks
+#### Configure Webhooks
 {: #configure-webhooks }
-#### **Step 1. Configure Hosted Collector**
+##### **Step 1. Configure Hosted Collector**
 {: #step-1-configure-hosted-collector }
 
 Follow the Sumo Logic documentation for [Configuring a Hosted Collector](https://help.sumologic.com/03Send-Data/Hosted-Collectors/Configure-a-Hosted-Collector).
 
-#### **Step 2. Add an HTTP Source**
+##### **Step 2. Add an HTTP Source**
 {: #step-2-add-an-http-source }
 
 To get the URL where the CircleCI Webhooks will be sent, and then recorded to the collector, we must [add an HTTP Source](https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source).
 
 When complete, copy the generated “HTTP Source Address”. You can always get this link from Sumo Logic again in the future. This is the URL that will need to be entered in the CircleCI Webhooks UI in the next step.
 
-#### **Step 3. Configure Project Webhooks**
+##### **Step 3. Configure Project Webhooks**
 {: #step-3-configure-project-webhooks }
 
 For each project on CircleCI you wish to track, configure a webhook directed at the HTTP Source Address.
@@ -96,12 +95,12 @@ Follow the [CircleCI docs for configuring webhooks]({{ site.baseurl }}/2.0/webho
 
 When configuring the webooks, ensure to include both the “workflow-completed”, and “job-completed” events.
 
-## Install the CircleCI App for Sumo Logic
+### Install the CircleCI App for Sumo Logic
 {: #install-the-circleci-app-for-sumo-logic }
 
 Now that you have set up collection, install the Sumo Logic App for CircleCI to use the preconfigured searches and Dashboards that provide insight into your CI Pipeline.
 
-##### To install the CircleCI app for Sumo Logic:
+#### To install the CircleCI app for Sumo Logic:
 {: #to-install-the-circleci-app-for-sumo-logic }
 
 1. Locate and install the CircleCI app from the App Catalog. If you want to see a preview of the dashboards included with the app before installing, click **Preview Dashboards**.


### PR DESCRIPTION
# Description
 Add the Datadog integration to our docs and restructure the headings of the page.

# Reasons
Datadog will officially release their integration at the end of October. 