### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,5 @@
 *.pdf @circleci/docs
 
 /src-js/** @circleci/docs-disco
+./packages*.json @circleci/docs-disco
+./Gemfile* @circleci/docs-disco


### PR DESCRIPTION
# Description
- Add `CODEOWNERS` file to hook up teams with GH notifications and reviews