### PR TITLE
small typo

### DIFF
--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -87,7 +87,7 @@ This will return something similar to the following:
 ...
 }
 +
-Then, using the VPCID you just found, run the following command to get the CIDR Block for your cluster. For AWS, the DNS Server is the third IP in your CIDR block (`serviceIpv4Cidr`), for example your CIDR block might be `10.100.0.0/16` so the third IP would be `10.100.0.2`.
+Then, using the VPCID you just found, run the following command to get the CIDR Block for your cluster. For AWS, the DNS Server is the third IP in your CIDR block (`CidrBlock`), for example your CIDR block might be `10.100.0.0/16` so the third IP would be `10.100.0.2`.
 +
 ```bash
 aws ec2 describe-vpcs --filters Name=vpc-id,Values=<YOUR_VPCID>


### PR DESCRIPTION
# Description
A mistake in referencing the CIDR block field for VPC may confuse customers on install. This PR addresses this

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.