### PR TITLE
Update Ruby switching and simulator pre-boot to use macOS Orb

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -232,6 +232,7 @@ If you want to run steps with a version of Ruby that is listed as "available to 
 **Note:** Installing Gems with the system Ruby is not advised due to the restrictive permissions enforced on the system directories. As a general rule, we advise using one of the alternative Rubies provided by Chruby for all jobs.
 
 ### Switching Rubies with the macOS Orb (Recommended)
+{: #switching-rubies-with-the-macos-orb-recommended }
 
 Using the official macOS Orb (version `2.0.0` and above) is the easiest way to switch Rubies in your jobs. It automatically uses the correct switching command, regardless of which Xcode image is in use.
 


### PR DESCRIPTION
# Description
Update Ruby switching and simulator pre-boot to use macOS Orb

# Reasons
Pre-booting the simulator in Xcode 13 images and higher requires a set of fairly complicated commands which I have now wrapped into nice commands in the macOS orb.

Additionally a new Ruby switching command has been added.

In both cases these are much more user friendly and are compatible across all our images, meaning a single command and easier configs.