### PR TITLE
Fix: attach trackEvent to window

### DIFF
--- a/src-js/services/analytics.js
+++ b/src-js/services/analytics.js
@@ -61,7 +61,16 @@ export default AnalyticsClient;
 // legacy tracking code:
 // This is still used in the src-shared/*.js.
 // analytics.track wrapper
-var trackEvent = function (name, properties, options, callback) {
+
+const setCookieMinutes = (name, value, path, expiration) => {
+  // expiration is set in minutes
+  const date = new Date();
+  date.setMinutes(date.getMinutes() + expiration);
+  date = date.toUTCString();
+  document.cookie = name + "=" + value + "; path=" + path + "; expires=" + date;
+};
+
+const trackEvent = (name, properties, options, callback) => {
   if (!window.analytics) {
     return;
   }

--- a/src-js/site/main.js
+++ b/src-js/site/main.js
@@ -35,14 +35,6 @@ var getSessionId = function () {
   return amplitude.getSessionId();
 };
 
-var setCookieMinutes = function (name, value, path, expiration) {
-  // expiration is set in minutes
-  var date = new Date();
-  date.setMinutes(date.getMinutes() + expiration);
-  date = date.toUTCString();
-
-  document.cookie = name + "=" + value + "; path=" + path + "; expires=" + date;
-};
 
 
 // analytics tracking for CTA button clicks


### PR DESCRIPTION
Footer links are broken; this PR attaches the trackEvent to the window so the call to it in the footer doesn't fail.

Ticket: https://circleci.atlassian.net/browse/CIRCLE-38477