### PR TITLE
[CIRCLE-37998]: Surfacing Full Example Config on Docs Home Page

### DIFF
--- a/jekyll/_cci2/index.md
+++ b/jekyll/_cci2/index.md
@@ -44,7 +44,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/writing-yaml/">Writing YAML</a></li>
       <li><a href="{{ site.baseurl }}/2.0/env-vars/">Using Environment Variables</a></li>
       <li><a href="{{ site.baseurl }}/2.0/ssh-access-jobs/">Debugging with SSH</a></li>
-      <li id="full-config-example"><a href="{{ site.baseurl }}/2.0/configuration-reference/#example-full-configuration">Full config example</a></li>
+      <li id="full-config-example"><a href="{{ site.baseurl }}/2.0/configuration-reference/#example-full-configuration">Full Config Example</a></li>
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -544,6 +544,3 @@ Fixing styling for the code example tables in the "Migrating From..." pages
 #full-config-example {
 	visibility: hidden
 }
-// #full-config-example {
-// 	display: none
-// }

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -48,7 +48,7 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/env-vars/">Using Environment Variables</a></li>
       <li><a href="{{ site.baseurl }}/2.0/ssh-access-jobs/">Debugging with SSH</a></li>
       <li><a href="{{ site.baseurl }}/2.0/reusing-config/">Reusing Config</a></li>
-      <li id="full-config-example"><a href="{{ site.baseurl }}/2.0/configuration-reference/#example-full-configuration">Full config example</a></li>
+      <li id="full-config-example"><a href="{{ site.baseurl }}/2.0/configuration-reference/#example-full-configuration">Full Config Example</a></li>
     </ul>
   </div>
   <div class="col-xs-12 col-sm-6">
@@ -58,7 +58,8 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
       <li><a href="{{ site.baseurl }}/2.0/workflows/">Using Workflows to Schedule Jobs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#workflows-configuration-examples">Example Configs</a></li>
       <li><a href="{{ site.baseurl }}/2.0/workflows/#scheduling-a-workflow">Scheduling a Workflow</a></li>
-      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and Filtering in Your Workflows</a></li>
+      <li><a href="{{ site.baseurl }}/2.0/workflows/#using-contexts-and-filtering-in-your-workflows">Using Contexts and
+          Filtering in Your Workflows</a></li>
       <li class="orb-bullet"><a href="{{ site.baseurl }}/2.0/creating-orbs/">Creating Orbs</a></li>
     </ul>
   </div>
@@ -79,7 +80,8 @@ Use the tutorials, samples, how-to, and reference documentation to learn CircleC
     <ul>
       <li id="orb-intro"><a href="{{ site.baseurl }}/2.0/orb-intro/">Get started with orbs</a></li>
       <li id="using-orbs"><a href="{{ site.baseurl }}/2.0/using-orbs/">How orbs work</a></li>
-      <li id="orb-author-intro"><a href="{{ site.baseurl }}/2.0/orb-author-intro/">Create a reusable config package</a></li>
+      <li id="orb-author-intro"><a href="{{ site.baseurl }}/2.0/orb-author-intro/">Create a reusable config package</a>
+      </li>
       <li id="orb-registry"><a href="https://circleci.com/developer/orbs?filterBy=popular&query=&page=1&pageSize=15">Public registry</a></li>
       <li id="orb-faq"><a href="{{ site.baseurl }}/2.0/orbs-faq/">Orbs FAQ</a></li>
     </ul>

--- a/src-js/experiments/surfaceFullExampleConfig.js
+++ b/src-js/experiments/surfaceFullExampleConfig.js
@@ -8,7 +8,7 @@ $(() => {
     if (variation === 'treatment') {
       $("#full-config-example").css('visibility', 'visible');
       $("#full-config-example").click(function () {
-        window.AnalyticsClient.trackAction('full-config-example-link', { link: this.id });
+        window.AnalyticsClient.trackAction('docs-full-config-example-link', { link: this.id });
       });
     }
   })


### PR DESCRIPTION
**Ticket:** [CIRCLE-37998](https://circleci.atlassian.net/browse/CIRCLE-37998)

# Changes

- add experiment logic to segment users into treatment or control variations in the `src-js/experiments` directory
- add new bullet to display full config example on landing page under config section for both docs and docs 2.0
- add css to full config example bullet to display bullet if user is in treatment

# Rationale
Based on Joanna Jablonski's [report](https://docs.google.com/document/d/1gil5qiUCLv9vzuNL7wgUjoButPozne5vFNsgfAlJSck/edit#heading=h.eihg9k5tagz7) we decided it would be beneficial to surface the example full config on the docs home page by providing a direct link to the config since it has been heavily trafficked. 

# Analytic Events

- `docs-full-config-example-link`

# Optimizely

- `dd_surfacing_full_example_config_experiment_test` [Link](https://app.optimizely.com/v2/projects/16812830475/experiments/20742690126/variations) 

# Screen Shots

**Before/Control:**

<img width="887" alt="Screen Shot 2021-10-12 at 10 34 30 PM" src="https://user-images.githubusercontent.com/57234605/137073178-a815aa82-a08c-4ac7-be8f-4a672ea8f0d0.png">


**After/Treatment:**

<img width="887" alt="Screen Shot 2021-10-13 at 9 42 07 AM" src="https://user-images.githubusercontent.com/57234605/137177019-477f24eb-92ca-4515-92c1-dab2ac2f48e5.png">


