### PR TITLE
Update instructions on configuring launch-agent via env vars [RT-13]

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -489,7 +489,7 @@ runner:
   name: RUNNER_NAME
 ```
 
-NOTE: The launch agent can also be configured via environment variables by supplying the `--env` flag to the launch agent command.
+NOTE: The launch agent can also be configured via environment variables. These will be prioritized over the YAML file, if set.
 
 === runner.name
 `$LAUNCH_AGENT_RUNNER_NAME`


### PR DESCRIPTION
# Description
The launch agent will prioritise env vars for configuration, and can be using with config file settings. This updates the docs with this new usage.

# Reasons
https://circleci.atlassian.net/browse/RT-13