### PR TITLE
move arm64 docker runners out of preview

### DIFF
--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -54,7 +54,7 @@ With a *Supported* platform, users receive the following:
 * RHEL8 (x86_64 or ARM64)
 * Mac OS X 10.15+ (Intel)
 * macOS 11.2+ (Apple M1)
-* Docker (x86_64)
+* Docker (x86_64 or ARM64)
 * Kubernetes (x86_64)
 * Windows Server 2019, 2016 (x86_64)
 
@@ -72,7 +72,6 @@ With a *Preview* platform, users receive the following:
 *Preview* CircleCI runners are available on the following platforms:
 
 * Additional Linux distributions - RHEL, SUSE, Debian, etc. (x86_64 or ARM64)
-* Docker (ARM64)
 * Kubernetes (ARM64)
 
 NOTE: Given the active development of Preview CircleCI runners, please https://circleci.com/contact/[contact us] if you


### PR DESCRIPTION
# Description
A PR to move ARM64 based runners to supported

# Reasons
Our runner docker image now supports ARM64 fully. 