### PR TITLE
Add: template file with analytics code to api v2.

### DIFF
--- a/scripts/build_api_docs.sh
+++ b/scripts/build_api_docs.sh
@@ -18,9 +18,9 @@ build_api_v1() {
 
 # We build our API v2 documentation from an openAPI spec. After fetching the spec we:
 # a) augment the spec using "snippet-enricher-cli" to add code-samples to the spec.
-# b) TODO: merge in any custom code samples we need to alter, using jq.
-# b) run the spec through redoc-cli, outputting a single html file.
-# c) move the file into our temporary workspace, created in .circleci/config.yml
+# b) merge in any custom code samples we need to alter, using jq.
+# c) run the spec through redoc-cli, outputting a single html file.
+# d) move the file into our temporary workspace, created in .circleci/config.yml
 build_api_v2() {
     echo "Building API v2 documentation with Redoc"
     cd src-api;
@@ -31,20 +31,10 @@ build_api_v2() {
     echo "Merging in JSON patches to correct and augment the OpenAPI spec."
     jq -s '.[0] * .[1]' openapi-with-examples.json openapi-patch.json > openapi-final.json
     echo "Bundling with redoc cli."
-    ./node_modules/.bin/redoc-cli bundle openapi-final.json
+    ./node_modules/.bin/redoc-cli bundle openapi-final.json --template "../src-api/v2/template.hbs"
     echo "Moving build redoc file to api/v2"
     mv redoc-static.html index.html
     cp index.html /tmp/workspace/api/v2
-}
-
-# build the Config Reference from slate.
-build_crg() {
-    echo "Building Configuration Reference with Slate "
-    cd src-crg;
-    bundle exec middleman build --clean --verbose
-    echo "CRG bundle built."
-    cp -R build/* /tmp/workspace/crg
-    echo "CRG Output build moved to /tmp/workspace/crg"
 }
 
 
@@ -54,9 +44,6 @@ then
 elif [ "$1" == "-v2" ]
 then
 	build_api_v2
-elif [ "$1" == "-crg" ]
-then
-	build_crg
 else
 	echo "Invalid command"
 fi

--- a/src-api/v2/template.hbs
+++ b/src-api/v2/template.hbs
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf8" />
+  <title>{{title}}</title>
+  <!-- needed for adaptive design -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      padding: 0;
+      margin: 0;
+    }
+  </style>
+  {{{redocHead}}}
+  {{#unless disableGoogleFont}}<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">{{/unless}}
+
+  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-W9HDVK" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-W9HDVK');</script>
+</head>
+
+<body>
+  {{{redocHTML}}}
+</body>
+
+</html>


### PR DESCRIPTION
The redoc-cli enables the use of a custom handlebar template;
using this we are able to attach our analytics snippet to the head of
the document before it is rendered.

Fixes [CIRCLE-38397](https://circleci.atlassian.net/browse/CIRCLE-38397)