### PR TITLE
[CIRCLE-38503] Fix z-index for tooltip popover

### DIFF
--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -456,6 +456,7 @@ pre {
     padding: 5px 10px;
     border-radius: 4px;
     font-size: 13px;
+    z-index: 1;
 }
 
 .server-version-wrapper {


### PR DESCRIPTION
# Description

"Noticed that when a section title is immediately above a code snippet, the tool tip for 'copy link/copied!' is drawn under the code snippet block:

To repro, 

go to this page https://circleci.com/docs/2.0/configuration-reference/#example-full-configuration 

hover over the link icon next to ‘Example full Configuration’

note that the tool tip renders ‘underneath’ the code block (see attached screenshot)"

![image](https://user-images.githubusercontent.com/42252054/137362433-0de98de3-65b2-4ea1-9172-12a8ed675d31.png)

# Reasons
[CIRCLE-38503](https://circleci.atlassian.net/browse/CIRCLE-38503?atlOrigin=eyJpIjoiYzFhYmFhY2U1YzdiNDc1Yjk5YmVmMDQ3NmNlZWYwOGEiLCJwIjoiaiJ9)