### PR TITLE
Change full config ref to v2.1 and update to pipeline value

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1951,7 +1951,7 @@ workflows:
 
 {% raw %}
 ```yaml
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -2019,7 +2019,7 @@ jobs:
       - run: |
           set -xu
           mkdir -p /tmp/artifacts
-          create_jars.sh ${CIRCLE_BUILD_NUM}
+          create_jars.sh << pipeline.number >>
           cp *.jar /tmp/artifacts
 
       - save_cache:


### PR DESCRIPTION
# Description
The full config ref example is still valid, but some minor updates are needed:
- update to version 2.1
- environment variables are being phased out in favor of pipeline values (${CIRCLE_BUILD_NUM} to << pipeline.number >>

# Reasons
We are beginning the process of going over the config ref page to make sure all code snippets are up to date and valid. 