### PR TITLE
[CIRCLE-38483]: Side Nav in Configuring CircleCI Does Not Scroll

### DIFF
--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -53,13 +53,13 @@
 
         {% if page.toc != false %}
         <aside class="full-height">
-          <h6 class="toc-heading">On this page</h6>
+          <h5 class="toc-heading">On this page</h5>
           <div class="toc-indent">
             {{ content | toc_only }}
           </div>
           {% if page.suggested != false %}
           <div id="related-resources">
-            <h6 class="related-heading">Helpful resources</h6>
+            <h5 class="related-heading">Helpful resources</h5>
             <div class="related-indent">
               <ul class="section-nav">
                 {% for item in page.suggested %}

--- a/jekyll/_sass/_sidebar.scss
+++ b/jekyll/_sass/_sidebar.scss
@@ -183,16 +183,15 @@ $sidebar-spacing-base: 5px;
 aside.full-height {
   position: sticky;
   right: 0;
-  padding: 50px 32px 112px 12px;
+  padding: 32px 32px 112px 12px;
   background: #ffffff;
   min-height: 90vh;
   width: $rightbar-width;
   overflow-y: auto;
-  top: 64px;
+  top: 111px;
   font-size: 16px;
   transition: all 0.5s ease-in-out;
   max-height: 100vh;
-  margin-top: 22px;
 
   @media(max-width: $toc-breakpoint) {
     display: none;


### PR DESCRIPTION
**Ticket:** [CIRCLE-38483](https://circleci.atlassian.net/browse/CIRCLE-38483)

# Changes

- update class name to `full-height`
- add `fixed` position and `max-height` to allow sidenav to scroll with page 

# Rationale
The side nav that we have on the page in production is currently sticking to the top which would make the feature redundant as once you scroll past it on the page you would no longer be able to use it. As the Configuring CircleCI page is rather long, having the side nav scroll with the page as users move down would allow them to click to certain sections thus improving the overall experience. 

# Screen Shots

**Before:**

https://user-images.githubusercontent.com/57234605/137387277-a82da1f7-9da6-44f8-a4b7-84ba48297c7e.mp4

**After:**

https://user-images.githubusercontent.com/57234605/137385782-cb4241b1-22fd-42c7-8d99-c9d53638275e.mp4


