### PR TITLE
"characters" misspell bug fix

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -42,7 +42,7 @@ Secrets Masking is applied to environment variables set within Project Settings 
 
 The value of the environment variable will not be masked in the build output if:
 
-* the value of the environment variable is less than 4 characaters
+* the value of the environment variable is less than 4 characters
 * the value of the environment variable is equal to one of `true`, `True`, `false` or `False`
 
 **Note:** Secrets Masking will only prevent the value of the environment variable from appearing in your build output. If your secrets appear elsewhere, such as test results or artifacts, they will not be masked. In addition, the value of the environment variable is still accessible to users [debugging builds with SSH]({{ site.baseurl }}/2.0/ssh-access-jobs).


### PR DESCRIPTION
characaters => characters

# Description
A misspelled word 'characaters' was changed for correct 'characters'

# Reasons
A grammar mistake fixed