### PR TITLE
Add a note about runner `launch-agent` environment on Linux [RT-97]

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -237,6 +237,8 @@ TimeoutStopSec=18300
 WantedBy = multi-user.target
 ```
 
+NOTE: Unlike the task agent, which uses the environment of the `circleci` user, the launch agent will need to have any required environment variables (e.g., proxy settings) explicitly defined in the unit configuration file. These can be set by `Environment=` or `EnvironmentFile=`. https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment[Please visit the `systemd` documentation for more information].
+
 You can now enable the service:
 
 ```bash


### PR DESCRIPTION
# Description
Adds a note clarifying specifying the environment for `launch-agent` on Linux.

![systemd-env-caveat](https://user-images.githubusercontent.com/28056419/137505281-638d6e79-cf64-41a0-b7bc-39ab49d4263e.png)

# Reasons
https://circleci.atlassian.net/browse/RT-97
