### PR TITLE
Update typo inside CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,5 @@
 *.pdf @circleci/docs
 
 /src-js/** @circleci/docs-disco
-./packages*.json @circleci/docs-disco
+./package*.json @circleci/docs-disco
 ./Gemfile* @circleci/docs-disco


### PR DESCRIPTION
# Description
- `packages*.json` -> `package*.json`

# Reasons
Plural is not used for `package.json` & `package-lock.json`