### PR TITLE
Add @circleci/translations to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,9 @@
 # See GitHub docs for more:
 # https://help.github.com/articles/about-codeowners/
 
-*.md @circleci/docs
-*.adoc @circleci/docs
-*.pdf @circleci/docs
+*.md @circleci/docs @circleci/translations
+*.adoc @circleci/docs @circleci/translations
+*.pdf @circleci/docs @circleci/translations
 
 /src-js/** @circleci/docs-disco
 ./package*.json @circleci/docs-disco


### PR DESCRIPTION
# Description
- Add `@circleci/translations` to CODEOWNERS.

# Reasons
Translation team needs to be able to review their own changes of content. https://circleci.slack.com/archives/C021NCSEM44/p1634519740491500