### PR TITLE
Update context docs to match existing docs about secret masking

### DIFF
--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -430,7 +430,7 @@ The value of the context will not be masked in the build output if:
 * the value is less than 4 characters
 * the value is equal to one of `true`, `True`, `false` or `False`
 
-**Note:** secret masking will only prevent the secret value from appearing in your build output. The value is still accessible to code executed within your builds and users [debugging builds with SSH]({{ site.baseurl }}/2.0/ssh-access-jobs).
+**Note:** Secrets Masking will only prevent the value of the environment variable from appearing in your build output. If your secrets appear elsewhere, such as test results or artifacts, they will not be masked. In addition, the value of the environment variable is still accessible to users [debugging builds with SSH]({{ site.baseurl }}/2.0/ssh-access-jobs).
 
 ## See also
 {: #see-also }


### PR DESCRIPTION
# Description
This update will add some clarification around the scope of secret masking.

# Reasons
This information is listed twice in the docs in different parts, this is updating the context section to match the previously updated section: https://github.com/circleci/circleci-docs/pull/5738