### PR TITLE
[CIRCLE-38540] Add created_at to analytics payload

### DIFF
--- a/jekyll/_includes/segment.html
+++ b/jekyll/_includes/segment.html
@@ -14,7 +14,10 @@
     "description": {{ page["description"] | jsonify }},
     "collection": {{ page["collection"] | jsonify }}
   };
+  window.currentPage = {
+    name: pageName,
+    jekyllProperties: properties
+  }
 
-  analytics.page(pageCategory, pageName, properties);
   }}();
 </script>

--- a/src-js/services/analytics.js
+++ b/src-js/services/analytics.js
@@ -47,7 +47,7 @@ class AnalyticsClient {
     if (isDataDogSynthetics()) return;
 
     properties = properties ?? null;
-    window.analytics && window.analytics.page(name, properties, {
+    window.analytics && window.analytics.page("docs", name, properties, {
       integrations: { Amplitude: { session_id: AnalyticsClient.getSessionId() } },
     });
   }

--- a/src-js/site/user.js
+++ b/src-js/site/user.js
@@ -2,6 +2,13 @@ import Cookies from 'js-cookie';
 
 function setUserData(userData) {
   window.userData = userData;
+  const {name, jekyllProperties} = window.currentPage;
+  if (window.userData.created_at) {
+    AnalyticsClient.trackPage(name, {...jekyllProperties, user_account_created_at: userData.created_at})
+  } else {
+    AnalyticsClient.trackPage(name, jekyllProperties)
+  }
+
   // emit an event to let the system know that userData is ready/has changed
   const userDataReady = new CustomEvent("userDataReady");
   window.dispatchEvent(userDataReady);


### PR DESCRIPTION
Ticket: [CIRCLE-38540](https://circleci.atlassian.net/browse/CIRCLE-38540).

This PR adds the user account's created_at timestamp to `Viewed Doc Page` amplitude event.

**Considerations**

The segment logic is moved out of the segment include so that it can be implemented when the userData object is available (if it is). This, however, requires adding more data to the [window object](https://github.com/circleci/circleci-docs/compare/ts/docs-disco/CIRCLE-38540?expand=1#diff-b758e5c1b8984dfefda48c1b43f78e6809973ef367c1758cd53e45145054c9b3R17-R20) since we can't access jekyll page frontmatter in our src-js files.

**screenshots**

![image](https://user-images.githubusercontent.com/12987958/137934591-98c2a203-5d7a-4633-a9e5-106e55096b63.png)
