### PR TITLE
[FIX]: Conditionally set top value for sidenav based on Docs-Devhub merge variation

### DIFF
--- a/jekyll/_sass/_sidebar.scss
+++ b/jekyll/_sass/_sidebar.scss
@@ -188,8 +188,8 @@ aside.full-height {
   min-height: 90vh;
   width: $rightbar-width;
   overflow-y: auto;
-  // due to the Docs Devhub merge experiment and the new header nav in treatment, the top property will vary depending on the variation the user is in, the logic is being implemented in the DevHubDocsNav script. The top property will be set here after the conclusion of the experiment depending on which variation we keep.
-  // top: 111px;
+  // due to the Docs-Devhub merge experiment having a new header nav in treatment, the top property will vary depending on the variation the user is in, the logic is being implemented in the DevHubDocsNav script. The top property will be set here after the conclusion of the experiment depending on which variation we keep.
+  top: 65px; 
   font-size: 16px;
   transition: all 0.5s ease-in-out;
   max-height: 100vh;

--- a/src-js/experiments/DevHubDocsNav.js
+++ b/src-js/experiments/DevHubDocsNav.js
@@ -23,8 +23,6 @@ $(() => {
 
       // aside.full-height used to adjust the top property for the sidenav while Docs-Devhub merge experiment is running
       $("aside.full-height").css('top', '111px');
-    } else {
-      $("aside.full-height").css('top', '65px');
     }
   })
 });


### PR DESCRIPTION
**Associated Ticket:** [CIRCLE-38483](https://circleci.atlassian.net/browse/CIRCLE-38483)


# Changes

- conditionally set `top` value in `DevHubDocsNav` based on experiment variation

# Rationale
Accounting for the different header navbars (control vs. treatment) for the Docs-Devhub merge experiment and how it affects the sidenav positioning when scrolling down the page. 
