### PR TITLE
Add legacy images deprecation banner

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -11,8 +11,7 @@ version:
 ---
 
 <div class="alert alert-warning" role="alert">
-<strong>As of Dec 31, 2021,</strong> legacy convenience images (images with the prefix "circleci/") <strong>will be deprecated.</strong>
-Please refer to the image <a href="https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034">deprecation timeline</a> and <a href="https://circleci.com/docs/2.0/next-gen-migration-guide/">migration guide</a> for more information on how to upgrade your projects to <a href="https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/">next-generation convenience images</a>.
+  <strong>Legacy images with the prefix "circleci/" will be <a href="https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034">deprecated</a></strong> on December 31, 2021. For faster builds, upgrade your projects with <a href="https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/">next-generation convenience images</a>.
 </div>
 
 This document provides information about pre-built CircleCI images and a listing by language, service type, and tags in the following sections:

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -19,8 +19,7 @@ CircleCI offers several build environments. We call these **executors**. An **ex
 {: #docker }
 
 <div class="alert alert-warning" role="alert">
-<strong>As of Dec 31, 2021,</strong> legacy convenience images (images with the prefix "circleci/") <strong>will be deprecated.</strong>
-Please refer to the image <a href="https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034">deprecation timeline</a> and <a href="https://circleci.com/docs/2.0/next-gen-migration-guide/">migration guide</a> for more information on how to upgrade your projects to <a href="https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/">next-generation convenience images</a>.
+  <strong>Legacy images with the prefix "circleci/" will be <a href="https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034">deprecated</a></strong> on December 31, 2021. For faster builds, upgrade your projects with <a href="https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/">next-generation convenience images</a>.
 </div>
 
 ```

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -23,8 +23,7 @@ This document describes the available executor types (`docker`, `machine`, `wind
 {:.no_toc}
 
 <div class="alert alert-warning" role="alert">
-<strong>As of Dec 31, 2021,</strong> legacy convenience images (images with the prefix "circleci/") <strong>will be deprecated.</strong>
-Please refer to the image <a href="https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034">deprecation timeline</a> and <a href="https://circleci.com/docs/2.0/next-gen-migration-guide/">migration guide</a> for more information on how to upgrade your projects to <a href="https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/">next-generation convenience images</a>.
+  <strong>Legacy images with the prefix "circleci/" will be <a href="https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034">deprecated</a></strong> on December 31, 2021. For faster builds, upgrade your projects with <a href="https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/">next-generation convenience images</a>.
 </div>
 
 An *executor type* defines the underlying technology or environment in which to run a job. CircleCI enables you to run jobs in one of four environments:


### PR DESCRIPTION
# Description
Addition of banner to the following pages:
- https://circleci.com/docs/2.0/circleci-images/
- https://circleci.com/docs/2.0/executor-intro/#docker
- https://circleci.com/docs/2.0/executor-types/#overview

# Reasons
We are trying to encourage users to migrate to next-gen convenience images, as support for legacy images will end on Dec. 31. The banner text includes links to a [deprecation timeline + migration guide](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034), as well as an [announcement blog post](https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/).