### PR TITLE
Update branch used in example for branch filtering to "main"

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -486,11 +486,11 @@ jobs:
   build:
     branches:
       only:
-        - master
+        - main
         - /rc-.*/
 ```
 
-In this case, only "master" branch and branches matching regex "rc-.*" will be executed.
+In this case, only "main" branch and branches matching regex "rc-.*" will be executed.
 
 ``` YAML
 jobs:


### PR DESCRIPTION
# Description
updated branch used in example for branch filtering to support more inclusive language. Changed "master" to "main"

# Reasons
To support more inclusive language. 