### PR TITLE
[CIRCLE-38381] Update: site url for in local dev jekyll config

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -5,7 +5,7 @@ description: > # this means to ignore newlines until "baseurl:"
   The documentation site for CircleCI, the fastest testing platform on the
   Internet.
 
-url: "http://localhost:4040" # the base hostname & protocol for your site
+url: "https://ui.circleci.com" # the base hostname & protocol for your site
 baseurl: "/docs" # the subpath of your site, e.g. /blog
 gh_url: "https://github.com/circleci/circleci-docs"
 devhub_base_url: "https://circleci.com/developer"


### PR DESCRIPTION
# Description
Change {{ site.url }} from `localhost:4000` to `https://ui.circleci.com` in local jekyll config. Production jekyll config is already `https://circleci.com`.

# Reasons
[CIRCLE-38381](https://circleci.atlassian.net/browse/CIRCLE-38381)