### PR TITLE
Side nav in migrating from teamcity does not scroll preview

### DIFF
--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -53,24 +53,26 @@
 
         {% if page.toc != false %}
         <aside class="full-height">
-          <h5 class="toc-heading">On this page</h5>
-          <div class="toc-indent">
-            {{ content | toc_only }}
-          </div>
-          {% if page.suggested != false %}
-          <div id="related-resources">
-            <h5 class="related-heading">Helpful resources</h5>
-            <div class="related-indent">
-              <ul class="section-nav">
-                {% for item in page.suggested %}
-                <li class="related-entry related-h2">
-                  <a href="{{item.link}}" target="_blank">{{item.title}}</a>
-                </li>
-                {% endfor %}
-              </ul>
+          <div class='full-height-sticky'>
+            <h5 class="toc-heading">On this page</h5>
+            <div class="toc-indent">
+              {{ content | toc_only }}
             </div>
+            {% if page.suggested != false %}
+            <div id="related-resources">
+              <h5 class="related-heading">Helpful resources</h5>
+              <div class="related-indent">
+                <ul class="section-nav">
+                  {% for item in page.suggested %}
+                  <li class="related-entry related-h2">
+                    <a href="{{item.link}}" target="_blank">{{item.title}}</a>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            </div>
+            {% endif %}
           </div>
-          {% endif %}
         </aside>
         {% endif %}
       </div> <!-- .article-toc -->

--- a/jekyll/_sass/_sidebar.scss
+++ b/jekyll/_sass/_sidebar.scss
@@ -181,18 +181,13 @@ $sidebar-spacing-base: 5px;
 }
 
 aside.full-height {
-  position: sticky;
-  right: 0;
-  padding: 32px 32px 112px 12px;
-  background: #ffffff;
-  min-height: 90vh;
-  width: $rightbar-width;
-  overflow-y: auto;
-  // due to the Docs-Devhub merge experiment having a new header nav in treatment, the top property will vary depending on the variation the user is in, the logic is being implemented in the DevHubDocsNav script. The top property will be set here after the conclusion of the experiment depending on which variation we keep.
-  top: 65px; 
-  font-size: 16px;
-  transition: all 0.5s ease-in-out;
-  max-height: 100vh;
+  .full-height-sticky {
+    position: sticky; 
+    max-height: calc(100vh - 140px); 
+    overflow: auto; 
+    padding-left: 5px;
+    top: 83px;
+  }
 
   @media(max-width: $toc-breakpoint) {
     display: none;

--- a/src-js/experiments/DevHubDocsNav.js
+++ b/src-js/experiments/DevHubDocsNav.js
@@ -23,8 +23,8 @@ $(() => {
         );
       });
 
-      // aside.full-height used to adjust the top property for the sidenav while Docs-Devhub merge experiment is running
-      $('aside.full-height').css('top', '111px');
+      // div.full-height-sticky used to adjust the top property for the sidenav while Docs-Devhub merge experiment is running
+      $('div.full-height-sticky').css('top', '130px');
     }
   });
 });


### PR DESCRIPTION
# Description
Similar to the issue in the Config Reference page, the side nav does not scroll with the page as users move down leading to the contents of the side nav being cut off. 

The side nav that we have on the page in production is currently sticking to the top which would make the feature redundant as once you scroll past it on the page you would no longer be able to use it. 

#Impact:
improving the UX by having the side nav scroll with the users so they are able to navigate the page contents easier

# Reasons
[CIRCLE-38605 ](https://circleci.atlassian.net/browse/CIRCLE-38605)

#Before
<img width="422" alt="Screen Shot 2021-10-21 at 1 47 35 PM" src="https://user-images.githubusercontent.com/86666932/138330389-06b0e4d0-5f8d-4b82-80c2-9b7d4f890de5.png">

#After

<img width="1504" alt="Screen Shot 2021-10-21 at 1 48 11 PM" src="https://user-images.githubusercontent.com/86666932/138330439-1d7e0a62-3c70-46a8-83d5-d94a74fbb7e5.png">
<img width="1496" alt="Screen Shot 2021-10-21 at 1 54 39 PM" src="https://user-images.githubusercontent.com/86666932/138331315-13b74523-b802-4b9f-8c79-00eccd56a2f9.png">

Preview link:
https://app.circleci.com/pipelines/github/circleci/circleci-docs/32642/workflows/58752bde-4ed1-414a-a21b-6ef983ac5d9b/jobs/93178