### PR TITLE
Fix: src-api yarn lock path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,12 +186,12 @@ jobs:
       - ruby-deps:
           dir: src-api
       - restore_cache:
-          key: circleci-docs-v2-{{ .Branch }}-{{ checksum "yarn.lock"}}
+          key: circleci-docs-v2-{{ .Branch }}-{{ checksum "src-api/yarn.lock"}}
       - run:
           name: Install Node dependencies
           command: cd src-api; yarn install
       - save_cache:
-          key: circleci-docs-v2-{{ .Branch }}-{{ checksum "yarn.lock"}}
+          key: circleci-docs-v2-{{ .Branch }}-{{ checksum "src-api/yarn.lock"}}
           paths:
             - src-api/node_modules
       - run:


### PR DESCRIPTION
# Description
Bug fixing the `.circleci/config.yml` where the path for the `src-api` cache points at the main directory `yarn.lock` instead of the `src-api/yarn.lock`