### PR TITLE
[RT-159] Add Server 3.2 launch-agent version

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -599,6 +599,9 @@ depending on your version of server:
 
 | 3.1            
 | 1.0.11147-881b608
+
+| 3.2
+| 1.0.19813-e9e1cd9
 |===
 
 


### PR DESCRIPTION
Jira: [RT-159](https://circleci.atlassian.net/browse/RT-159)

# Description
Adds a new entry in the table for the supported version of Runner for Server 3.2 (launch-agent version 1.0.19813-e9e1cd9)

---

![Screen Shot 2021-10-22 at 11 23 43](https://user-images.githubusercontent.com/17708458/138481760-4f93856a-59ff-42d9-a23c-644fadfe38cf.png)