### PR TITLE
CVE-2021-41098: Update nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rake'
 gem 'dotenv'
 gem "kramdown-parser-gfm"
 gem "liquid-c"
+gem 'nokogiri', '~> 1.12', '>= 1.12.5'
 
 group :jekyll_plugins do
   gem 'jekyll-algolia', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    nokogiri (1.12.3)
+    nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     nokogumbo (2.0.5)
@@ -136,7 +136,7 @@ GEM
     public_suffix (4.0.6)
     pygments.rb (1.1.2)
       multi_json (>= 1.0.0)
-    racc (1.5.2)
+    racc (1.6.0)
     rainbow (3.0.0)
     rake (13.0.3)
     rb-fsevent (0.11.0)
@@ -179,13 +179,14 @@ DEPENDENCIES
   jekyll-toc
   kramdown-parser-gfm
   liquid-c
+  nokogiri (~> 1.12, >= 1.12.5)
   pronto
   pronto-markdownlint
   pygments.rb (~> 1.1.2)
   rake
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.4p191
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
# Description
- Updated `nokogiri` to `1.12.5`

# Reasons
https://snyk.io/vuln/SNYK-RUBY-NOKOGIRI-1726792