### PR TITLE
Remove on hold job for orbs.

### DIFF
--- a/jekyll/_cci2/creating-orbs.md
+++ b/jekyll/_cci2/creating-orbs.md
@@ -85,10 +85,7 @@ A development version of the orb is created in the [orb-tools/publish-dev](https
 The workflow runs as follows:
 
 * Tests that do not require special access to the Personal Access Token are run, this stage can run from open source pull requests.
-* The workflow is placed [on-hold](https://github.com/CircleCI-Public/Orb-Project-Template/blob/0354adde8405564ee7fc77e21335090a080daebf/.circleci/config.yml#L54) for [manual approval]({{site.baseurl}}/2.0/workflows/#holding-a-workflow-for-a-manual-approval). ![Manually approve publishing development orbs]({{site.baseurl}}/assets/img/docs/orb-publish-approval.png)
-    The workflow will wait for a button click, via an alert prompt in the CircleCI app, before continuing.
-* Once the manual approval is authorized, subsequent jobs will be automatically authorized and may access the Restricted Context. This is especially useful when we want to allow open-source pull requests to build against our orb but gives us a chance to ensure there is no malicious code.
-* After the workflow has been approved, the [orb-tools/publish-dev](https://github.com/CircleCI-Public/Orb-Project-Template/blob/0354adde8405564ee7fc77e21335090a080daebf/.circleci/config.yml#L62) job will publish a development version of your orb twice:
+* The [orb-tools/publish-dev](https://github.com/CircleCI-Public/Orb-Project-Template/blob/0354adde8405564ee7fc77e21335090a080daebf/.circleci/config.yml#L62) job will publish a development version of your orb twice:
 
     | Published Development Tag | Description|
     | ----------| -----------|


### PR DESCRIPTION
This was removed from the starter kit a while back since it
does not behave as expected in regards to permissions.

https://github.com/CircleCI-Public/Orb-Project-Template/commit/a4f0c89b05dbf06a4b3e08fa54cbe4da06c9a4e1