### PR TITLE
[CIRCLE-38726] Migrate Scheduled Workflows to Scheduled Pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,15 @@ orbs:
   node: circleci/node@4.7.0
   md-proofer: hubci/md-proofer@0.1
 
+# This is using the new Scheduled Pipeline feature.
+# Right now (10/2021) there is no UI to configure it, so if you need to
+# change it's behavior, you'll have to do it manualy:
+# https://circleci.atlassian.net/wiki/spaces/CD/pages/6301483319/Schedule+Pipelines+Migration#Other-methods
+# See the "GET", "DELETE" or "PATCH" section.
+parameters:
+  run-schedule:
+    type: boolean
+    default: false
 
 # Yaml References enable us to DRY out our config by sharing variables across multiple jobs.
 # In this case, we are commonly using the "workspaces" feature to share
@@ -75,6 +84,8 @@ commands:
 workflows:
 
   build-deploy:
+    when: 
+      not: << pipeline.parameters.run-schedule >>
     jobs:
       - js_build
       - build_server_pdfs:
@@ -107,13 +118,9 @@ workflows:
               only: master
   # We run a nightly build for running build/maintenance tasks
   # such as pulling in docker image tags or automating our api documentation
+  # Triggered every day at 08:00 AM on master branch
   nightly-build:
-    triggers:
-      - schedule:
-          cron: "0 8 * * *"
-          filters:
-            branches:
-              only: master
+    when: << pipeline.parameters.run-schedule >>
     jobs:
       - js_build
       - build_api_docs
@@ -125,6 +132,25 @@ workflows:
           requires:
             - build
 
+
+
+curl --location --request POST 'https://circleci.com/api/v2/project/github/circleci/circleci-docs/schedule' \
+--header 'circle-token: <your-cci-token>' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "name": "nightly-build",
+    "description": "Nightly build for running build/maintenance tasks such as pulling in docker image tags or automating our api documentation",
+    "attribution-actor": "system",
+    "parameters": {
+      "branch": "master",
+      "run-schedule": true
+    },
+    "timetable": {
+        "per-hour": 1,
+        "hours-of-day": [8],
+        "days-of-week": [“MON", “TUE", “WED", “THU", “FRI", "SAT", “SUN"]
+    }
+}'
 
 jobs:
   js_build: # this job is responsible for building Javascript assets and making them available for the "build" job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,26 +132,6 @@ workflows:
           requires:
             - build
 
-
-
-curl --location --request POST 'https://circleci.com/api/v2/project/github/circleci/circleci-docs/schedule' \
---header 'circle-token: <your-cci-token>' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "name": "nightly-build",
-    "description": "Nightly build for running build/maintenance tasks such as pulling in docker image tags or automating our api documentation",
-    "attribution-actor": "system",
-    "parameters": {
-      "branch": "master",
-      "run-schedule": true
-    },
-    "timetable": {
-        "per-hour": 1,
-        "hours-of-day": [8],
-        "days-of-week": [“MON", “TUE", “WED", “THU", “FRI", "SAT", “SUN"]
-    }
-}'
-
 jobs:
   js_build: # this job is responsible for building Javascript assets and making them available for the "build" job
     executor: # we specify our executor to use the node orb.


### PR DESCRIPTION
Ticket: [CIRCLE-38726](https://circleci.atlassian.net/browse/CIRCLE-38726)

# Description
- Replace the old scheduled trigger with the new Scheduled pipeline

# Reasons

The pipeline team has asked us to migrate to this new way of handling scheduled workflow. You can see the process in [their documentation](https://circleci.atlassian.net/wiki/spaces/CD/pages/6301483319/Schedule+Pipelines+Migration).

Here's the curl command to check the schedule pipeline: 

```
❯ curl --location --request GET 'https://circleci.com/api/v2/project/github/circleci/circleci-docs/schedule' \
--header 'circle-token: <your token>'

[ {
  "description" : "Nightly build for running build/maintenance tasks such as pulling in docker image tags or automating our api documentation",
  "name" : "nightly-build",
  "id" : "<redacted>",
  "project_slug" : "gh/circleci/circleci-docs",
  "created_at" : "2021-10-30T01:14:06.991Z",
  "parameters" : {
    "branch" : "master",
    "run_schedule" : true
  },
  "actor" : {
    "login" : "system-actor",
    "name" : "Scheduled",
    "id" : "<redacted>"
  },
  "timetable" : {
    "per_hour" : 1,
    "hours_of_day" : [ 8 ],
    "days_of_week" : [ "MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN" ]
  }
} ]
```