### PR TITLE
Fix typo in "Setting Up Certificates"

### DIFF
--- a/jekyll/_cci2/certificates.adoc
+++ b/jekyll/_cci2/certificates.adoc
@@ -185,7 +185,7 @@ Once you have a valid certificate and key file in `.pem` format, you must upload
 
 . To do so, navigate to `hostname:8800/console/settings`
 
-. Under "Privacy" section, check the box for "SSL only (Recommened)"
+. Under "Privacy" section, check the box for "SSL only (Recommended)"
 
 . Upload your newly generated certificate and key
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Fix a typo in "[Setting Up Certificates](https://circleci.com/docs/2.0/certificates/#adding-the-certificate-to-circleci-server)".