### PR TITLE
[CIRCLE-38589] Ignore default export warnings for `app.js`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,4 +33,7 @@ module.exports = {
       },
     ],
   },
+  // Ignore warnings about default exports because some of our legacy
+  // code are not modules: src-js/site/main.js & src-js/site/user.js
+  ignoreWarnings: [/export 'default'/],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,13 @@ module.exports = {
     ],
   },
   // Ignore warnings about default exports because some of our legacy
-  // code are not modules: src-js/site/main.js & src-js/site/user.js
-  ignoreWarnings: [/export 'default'/],
+  // code inported in app.js are not modules:
+  // - src-js/site/main.js
+  // - src-js/site/user.js
+  ignoreWarnings: [
+    {
+      module: /src-js\/app\.js/,
+      message: /export 'default'/,
+    },
+  ],
 };


### PR DESCRIPTION
Ticket: [CIRCLE-38589](https://circleci.atlassian.net/browse/CIRCLE-38589)

# Description
- Use `ignoreWarnings` config key to tell webpack to ignore this specific warning

# Reasons
Some of our legacy code that is imported in `app.js` are not modules and so we want to silence that warning until we eventually refactor that code. 