### PR TITLE
[CIRCLE-38683]: Add Property to Amplitude event to see what sections are being shared

### DIFF
--- a/src-js/site/main.js
+++ b/src-js/site/main.js
@@ -293,6 +293,7 @@ $(document).ready(function () {
         });
       },
       copy(event) {
+        let url = event.target.href;
         event.preventDefault();
         navigator?.clipboard
           .writeText(event.target.href)
@@ -316,7 +317,7 @@ $(document).ready(function () {
             window.AnalyticsClient.trackAction('docs-share-button-click', {
               page: location.pathname,
               success: true,
-              section: event.target.href,
+              section: url.substring(url.indexOf('#')),
             });
           })
           .catch((error) =>

--- a/src-js/site/main.js
+++ b/src-js/site/main.js
@@ -260,7 +260,7 @@ $(document).ready(function () {
       var isMainTitle = $(this).prop('nodeName') === 'H1';
       $(this).append(
         (isMainTitle ? ' <a href="#' : '<a href="#' + $(this).attr('id')) +
-          '"><i class="fa fa-link"></i></a>',
+        '"><i class="fa fa-link"></i></a>',
       );
       if (isMainTitle) {
         $(this).find('i').toggle();
@@ -316,6 +316,7 @@ $(document).ready(function () {
             window.AnalyticsClient.trackAction('docs-share-button-click', {
               page: location.pathname,
               success: true,
+              section: event.target.href,
             });
           })
           .catch((error) =>

--- a/src-js/site/main.js
+++ b/src-js/site/main.js
@@ -294,6 +294,11 @@ $(document).ready(function () {
       },
       copy(event) {
         let url = event.target.href;
+        // to account for if section copied and shared is the page title
+        let section =
+          url.charAt(url.length - 1) === '#'
+            ? url
+            : url.substring(url.indexOf('#'));
         event.preventDefault();
         navigator?.clipboard
           .writeText(event.target.href)
@@ -317,7 +322,7 @@ $(document).ready(function () {
             window.AnalyticsClient.trackAction('docs-share-button-click', {
               page: location.pathname,
               success: true,
-              section: url.substring(url.indexOf('#')),
+              section: section,
             });
           })
           .catch((error) =>

--- a/src-js/site/main.js
+++ b/src-js/site/main.js
@@ -260,7 +260,7 @@ $(document).ready(function () {
       var isMainTitle = $(this).prop('nodeName') === 'H1';
       $(this).append(
         (isMainTitle ? ' <a href="#' : '<a href="#' + $(this).attr('id')) +
-        '"><i class="fa fa-link"></i></a>',
+          '"><i class="fa fa-link"></i></a>',
       );
       if (isMainTitle) {
         $(this).find('i').toggle();

--- a/src-js/site/main.js
+++ b/src-js/site/main.js
@@ -297,7 +297,7 @@ $(document).ready(function () {
         // to account for if section copied and shared is the page title
         let section =
           url.charAt(url.length - 1) === '#'
-            ? url
+            ? 'Page Title'
             : url.substring(url.indexOf('#'));
         event.preventDefault();
         navigator?.clipboard

--- a/src-js/site/main.js
+++ b/src-js/site/main.js
@@ -322,7 +322,7 @@ $(document).ready(function () {
             window.AnalyticsClient.trackAction('docs-share-button-click', {
               page: location.pathname,
               success: true,
-              section: section,
+              section,
             });
           })
           .catch((error) =>


### PR DESCRIPTION
**Ticket:** [CIRCLE-38683](https://circleci.atlassian.net/browse/CIRCLE-38683)

# Changes

- add new `section` property to `trackAction` for  tracking analytics to know explicitly 

# Reasons

- Adding new metadata property to our tracking analytics in amplitude for the share section button to explicitly know which sections users are sharing so we can prioritize those to update and kept up to date.  

# Screenshot

<img width="588" alt="Screen Shot 2021-11-01 at 2 04 12 PM" src="https://user-images.githubusercontent.com/57234605/139741934-2fb8ac38-9d7f-4e88-b082-5b1a5d99a0a2.png">

