### PR TITLE
[CIRCLE-38681]: Add property to Amplitude event to see which snippets are copied (Docs)

### DIFF
--- a/src-js/experiments/highlightJSBadge.js
+++ b/src-js/experiments/highlightJSBadge.js
@@ -34,6 +34,7 @@ window.onload = () => {
         onBeforeCodeCopied: function (text) {
           window.AnalyticsClient.trackAction('docs-copy-code-clicked', {
             page: location.pathname,
+            code: text,
           });
           return text;
         },

--- a/src-js/experiments/highlightJSBadge.js
+++ b/src-js/experiments/highlightJSBadge.js
@@ -31,10 +31,11 @@ window.onload = () => {
         // function called before code is placed on clipboard that allows you inspect and modify
         // the text that goes onto the clipboard. Passes text and code root element (hljs).
         // Example:  function(text, codeElement) { return text + " $$$"; }
-        onBeforeCodeCopied: function (text) {
+        onBeforeCodeCopied: function (text, codeElement) {
+          const codeSnippets = [...document.getElementsByClassName('hljs')];
           window.AnalyticsClient.trackAction('docs-copy-code-clicked', {
             page: location.pathname,
-            code: text,
+            codeSnippetPosition: codeSnippets.indexOf(codeElement) + 1,
           });
           return text;
         },


### PR DESCRIPTION
**Ticket:** [CIRCLE-38681](https://circleci.atlassian.net/browse/CIRCLE-38681)

# Changes

- add `codeSnippetPosition` property as `trackAction` metadata 

# Reasons

- we want to add more metadata to our tracking analytics, in this case to let use know explicitly what code snippets are being copied so that we may better prioritize them for updates and upkeep