### PR TITLE
[CIRCLE-38203] Add metadata to video experiment analytics

### DIFF
--- a/jekyll/_includes/youtube-grid.html
+++ b/jekyll/_includes/youtube-grid.html
@@ -1,9 +1,10 @@
 <div class="video-grid">
   {% for item in include.videos %}
+  {% assign title_slug = item.title | slugify %}
   <div class="video-card">
     <div class="video-thumbnail">
-      <a href="https://www.youtube.com/watch?v={{item.youtubeId}}" target="_blank" rel="noopener noreferrer"
-        class="no-external-icon ">
+      <a href="https://www.youtube.com/watch?v={{item.youtubeId}}" id="thumbnail-{{title_slug}}" target="_blank"
+        rel="noopener noreferrer" class="no-external-icon ">
         <div class="play-button"></div>
         {% if item.maxresdefault == false %}
         <img src="https://img.youtube.com/vi/{{item.youtubeId}}/mqdefault.jpg" alt="Youtube cover for {{item.title}}" />
@@ -13,8 +14,8 @@
         {% endif %}
       </a>
     </div>
-    <a href="https://www.youtube.com/watch?v={{item.youtubeId}}" target="_blank" rel="noopener noreferrer"
-      class="no-external-icon video-title">{{item.title}}</a>
+    <a href="https://www.youtube.com/watch?v={{item.youtubeId}}" id="title-{{title_slug}}" target="_blank"
+      rel="noopener noreferrer" class="no-external-icon video-title">{{item.title}}</a>
   </div>
   {% endfor %}
 </div>

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -605,6 +605,7 @@ Fixing styling for the code example tables in the "Migrating From..." pages
  font-size: 16px;
  max-width: 45%;
  min-width: 45%;
+ text-decoration: none;
 }
 
 /* this is the play "icon" (white circle) */

--- a/src-js/experiments/videoTutorials.js
+++ b/src-js/experiments/videoTutorials.js
@@ -19,6 +19,13 @@ $(() => {
             'docs-video-tutorials-video-clicked',
             {
               link: $(this).attr('href'),
+              title: $(this)
+                .attr('id')
+                .replace(/^(thumbnail|title)-/i, ''),
+              element:
+                $(this).attr('id').indexOf('title') === 0
+                  ? 'title'
+                  : 'thumbnail',
             },
           );
         });


### PR DESCRIPTION
Ticket: https://circleci.atlassian.net/browse/CIRCLE-38203

# Description
- Add video `title` metadata to `docs-video-tutorials-video-clicked` event
- Add video `element` metadata to `docs-video-tutorials-video-clicked` event
- Fix anchor element underline when link is visited

# Reasons
We want to add more metadata to the `docs-video-tutorials-video-clicked` event so we can more accurately tell which video was clicked and from where it was clicked:

![Screen Shot 2021-11-01 at 5 29 47 PM](https://user-images.githubusercontent.com/1449325/139762261-a291c728-0874-4570-8e90-08e4db24c11b.png)

![Screen Shot 2021-11-01 at 5 29 54 PM](https://user-images.githubusercontent.com/1449325/139762285-b4fee214-b2c7-4820-a847-aaaeb17f52cc.png)
