### PR TITLE
Add instructions for non-admin and admin requests

### DIFF
--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -268,11 +268,22 @@ consider contacting your VCS provider to communicate your concerns.
 This section describes how to re-enable CircleCI after enabling third-party
 application restrictions for a GitHub organization. Go to
 [GitHub Settings](https://github.com/settings/connections/applications/78a2ba87f071c28e65bb)
-and in the "Organization access" section either:
+and in the "Organization access" you will have the option to request accesss if you are not an admin, or grant access if you are an admin.
 
-- "Request access" if you are not an admin for the organization in question (an
-  admin will have to approve the request) or
-- "Grant access" if you are an admin
+#### Member workflow
+{:.no_toc}
+
+- If you are a Member of a GitHub org (not an admin), click the “Request” button and a message will be sent to an Admin of your organization. An admin will have to approve the request.
+- Click “Request approval from owners” to send an email to your organization’s owners.
+- While waiting for their approval, you’ll see “Access request pending” next to your company organization’s name.
+- If CircleCI has been approved by your organization, you’ll see a checkmark next to your organization’s name.
+
+#### Owner workflow
+{:.no_toc}
+
+- If you are an Owner of your organization, you may grant access to CircleCI by clicking on the “Grant” button.
+- You may be asked to confirm your password in order to authorize our app.
+- Once you’ve approved CircleCI, you’ll see a checkmark next to your organization’s name.
 
 After access is granted, CircleCI should behave normally again.
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -271,7 +271,7 @@ application restrictions for a GitHub organization. Go to
 and in the "Organization access" you will have the option to request accesss if you are not an admin, or grant access if you are an admin.
 
 #### Non-admin member workflow
-{: #member-workflow }
+{: #non-admin-member-workflow }
 {:.no_toc}
 
 - If you are member of a GitHub org (not an admin), click the “Request” button and a message will be sent to an admin of your organization. An admin will have to approve the request.
@@ -280,7 +280,7 @@ and in the "Organization access" you will have the option to request accesss if 
 - If CircleCI has been approved by your organization, you will see a checkmark next to your organization’s name.
 
 #### Admin owner workflow
-{: #owner-workflow }
+{: #admin-owner-workflow }
 {:.no_toc}
 
 - If you are an owner of your organization (an admin), you may grant access to CircleCI by clicking on the “Grant” button.

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -270,22 +270,22 @@ application restrictions for a GitHub organization. Go to
 [GitHub Settings](https://github.com/settings/connections/applications/78a2ba87f071c28e65bb)
 and in the "Organization access" you will have the option to request accesss if you are not an admin, or grant access if you are an admin.
 
-#### Member workflow
+#### Non-admin member workflow
 {: #member-workflow }
 {:.no_toc}
 
 - If you are member of a GitHub org (not an admin), click the “Request” button and a message will be sent to an admin of your organization. An admin will have to approve the request.
 - Click “Request approval from owners” to send an email to your organization’s owners.
-- While waiting for approval, you’ll see “Access request pending” next to your company organization’s name.
-- If CircleCI has been approved by your organization, you’ll see a checkmark next to your organization’s name.
+- While waiting for approval, you will see “Access request pending” next to your company organization’s name.
+- If CircleCI has been approved by your organization, you will see a checkmark next to your organization’s name.
 
-#### Owner workflow
+#### Admin owner workflow
 {: #owner-workflow }
 {:.no_toc}
 
-- If you are an owner of your organization, you may grant access to CircleCI by clicking on the “Grant” button.
+- If you are an owner of your organization (an admin), you may grant access to CircleCI by clicking on the “Grant” button.
 - You may be asked to confirm your password in order to authorize our app.
-- Once you’ve approved CircleCI, you’ll see a checkmark next to your organization’s name.
+- Once you’ve approved CircleCI, you will see a checkmark next to your organization’s name.
 
 After access is granted, CircleCI should behave normally again.
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -274,16 +274,16 @@ and in the "Organization access" you will have the option to request accesss if 
 {: #member-workflow }
 {:.no_toc}
 
-- If you are a Member of a GitHub org (not an admin), click the “Request” button and a message will be sent to an Admin of your organization. An admin will have to approve the request.
+- If you are member of a GitHub org (not an admin), click the “Request” button and a message will be sent to an admin of your organization. An admin will have to approve the request.
 - Click “Request approval from owners” to send an email to your organization’s owners.
-- While waiting for their approval, you’ll see “Access request pending” next to your company organization’s name.
+- While waiting for approval, you’ll see “Access request pending” next to your company organization’s name.
 - If CircleCI has been approved by your organization, you’ll see a checkmark next to your organization’s name.
 
 #### Owner workflow
 {: #owner-workflow }
 {:.no_toc}
 
-- If you are an Owner of your organization, you may grant access to CircleCI by clicking on the “Grant” button.
+- If you are an owner of your organization, you may grant access to CircleCI by clicking on the “Grant” button.
 - You may be asked to confirm your password in order to authorize our app.
 - Once you’ve approved CircleCI, you’ll see a checkmark next to your organization’s name.
 

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -271,6 +271,7 @@ application restrictions for a GitHub organization. Go to
 and in the "Organization access" you will have the option to request accesss if you are not an admin, or grant access if you are an admin.
 
 #### Member workflow
+{: #member-workflow }
 {:.no_toc}
 
 - If you are a Member of a GitHub org (not an admin), click the “Request” button and a message will be sent to an Admin of your organization. An admin will have to approve the request.
@@ -279,6 +280,7 @@ and in the "Organization access" you will have the option to request accesss if 
 - If CircleCI has been approved by your organization, you’ll see a checkmark next to your organization’s name.
 
 #### Owner workflow
+{: #owner-workflow }
 {:.no_toc}
 
 - If you are an Owner of your organization, you may grant access to CircleCI by clicking on the “Grant” button.


### PR DESCRIPTION
# Description
Further clarification of instructions for both non-admin and admin users to authorize GitHub organizations to CircleCI.

# Reasons
Further clarification was needed for these instructions as the whole process wasn't documented.
[Jira Ticket](https://circleci.atlassian.net/jira/software/projects/DOCSTEAM/boards/412?selectedIssue=DOCSTEAM-43)