### PR TITLE
Make container names consistent across machines

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3"
 services:
   jekyll:
+    container_name: jekyll
     working_dir: /root
     build: .
     volumes:
@@ -9,6 +10,7 @@ services:
       - 127.0.0.1:4000:4000
       - 127.0.0.1:35729:35729
   https:
+    container_name: https
     image: "caddy:2"
     ports:
       - '127.0.0.1:443:443'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "git config blame.ignoreRevsFile .git-blame-ignore-revs && git submodule update --init",
     "dev": "yarn webpack-dev && docker-compose up",
     "start": "./scripts/start.sh",
-    "clean": "docker exec -it circleci-docs_jekyll_1 bundle exec jekyll clean",
+    "clean": "docker exec -it jekyll bundle exec jekyll clean",
     "stop": "docker-compose down",
     "prod": "yarn webpack-prod && docker-compose up",
     "webpack-dev": "webpack --mode=development",


### PR DESCRIPTION
# Description
- Use `container_name` in `docker-compose.yml` to force  containers name.

# Reasons
A bit of a TIL for me but @devinmarieb @ccgeller and I realized that default docker containers might not have a consistent name across machines until you expressively name them. This resulted in breaking the `yarn clean` command because it was expecting a specific name. 