### PR TITLE
[CIRCLE-38657] Adding H5 and H6 Headings to Side Nav in Docs

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -50,7 +50,7 @@ algolia:
 
 toc:
   min_level: 1
-  max_level: 4
+  max_level: 6
 
 sass:
   sass_dir: _sass


### PR DESCRIPTION
Ticket: [CIRCLE-38657](https://circleci.atlassian.net/jira/software/c/projects/CIRCLE/boards/376?modal=detail&selectedIssue=CIRCLE-38657)

Reviewed with @rosieyohannan 

# Changes
 - Changed 'jekyll/_config.yml' file to go form H1 to H6. Jekyll-toc docs found [here](https://github.com/toshimaru/jekyll-toc)
 - Missing tags are a result of specified command `{:.no_toc}` any tags hidden by the command must be manually 

# Reasons
- trying to drive engagement for the content we currently have in docs 
- improving the overall experience for users by giving them an easier time to find what they need

# Description
Based on a discussion with Rosie, there are lower level sub headings that we should add to the side nav in the Config Reference page in addition to the current h2 - h4 tags that are there. 

As the Config Reference page is frequently visited by users, we want to include the low level h5 and h6 headings as well to make it easier for users to get to directly what they are looking for. Additionally if there are any h4 sub headings that are not included, please add them to the side nav as well. 

# Before
<img width="1429" alt="Screen Shot 2021-11-04 at 10 12 15 AM" src="https://user-images.githubusercontent.com/86666932/140329152-f4e7c839-0102-45a6-9fdf-a93cbe98d254.png">

# After
<img width="1432" alt="Screen Shot 2021-11-04 at 10 12 33 AM" src="https://user-images.githubusercontent.com/86666932/140329220-9bb4d36a-5d75-4ca5-b139-25c934e06bea.png">

# Preview
http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/CIRCLE-38657-Adding-H5-and-H6-Heading-to-Side-Nav-in-Docs-preview