### PR TITLE
Don't specify a UID for the `circleci` user on Linux runner [RT-151]

### DIFF
--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -51,7 +51,7 @@ These will be used when executing the task agent. These commands must be run as 
 === Ubuntu/Debian
 
 ```bash
-id -u circleci &>/dev/null || sudo adduser --uid 1500 --disabled-password --gecos GECOS circleci
+id -u circleci &>/dev/null || sudo adduser --disabled-password --gecos GECOS circleci
 
 sudo mkdir -p /opt/circleci/workdir
 sudo chown -R circleci /opt/circleci/workdir
@@ -60,7 +60,7 @@ sudo chown -R circleci /opt/circleci/workdir
 === CentOS/RHEL
 
 ```bash
-id -u circleci &>/dev/null || sudo adduser --uid 1500 -c GECOS circleci
+id -u circleci &>/dev/null || sudo adduser -c GECOS circleci
 
 sudo mkdir -p /opt/circleci/workdir
 sudo chown -R circleci /opt/circleci/workdir


### PR DESCRIPTION
# Description
Remove specifying a UID (i.e., 1500) for the `circleci` user in the runner installation docs for Linux.

# Reasons
`adduser` will default to the next available UID defined by the range in `/etc/adduser.conf`, and specifying an arbitrary UID could have a conflict if it's already in use. The `launch-agent` and `task-agent` also don't care about the UID.

Jira: https://circleci.atlassian.net/browse/RT-151?focusedCommentId=165890

Some discussion around the UID for the `circleci` user in the launch agent Docker image: https://github.com/CircleCI-Public/circleci-runner-docker/pull/13#discussion_r741754265