### PR TITLE
Fixes forked repo PRs with missing Datadog keys

### DIFF
--- a/scripts/datadog-synthetics-ci.sh
+++ b/scripts/datadog-synthetics-ci.sh
@@ -20,6 +20,7 @@ while read l1 ;do
    elif [[ $l1 =~ "failed" ]] && [[ $l1 =~ "passed," ]]; then 
       exit 1
    elif [[ $l1 =~ "Missing" ]] && [[ $l1 =~ "in your environment." ]]; then
-      exit 1
+      echo "WARNING: Missing Datadog API key or Datadog App Key. Skipping Datadog Synthetics…"
+      exit 0
    fi
 done < <(yarn datadog-synthetics-ci)


### PR DESCRIPTION
# Description
Forked PRs are failing on the new Datadog Synthetics CI step because the key is not available to forks.

Example: https://app.circleci.com/pipelines/github/circleci/circleci-docs/33379/workflows/d4e67abe-b00a-46be-b811-4ff2ba826833/jobs/95984

This exits with status code 0 if there is no such key.

# Reasons
We want to allow for open contributions.