### PR TITLE
Improve ja env var page

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -301,7 +301,7 @@ to be accessible in more than one step, export the value [using `BASH_ENV`](#usi
 ## Setting an environment variable in a job
 {: #setting-an-environment-variable-in-a-job }
 
-To set an environment variable in a job, use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
+To set an environment variable in a job, use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#lessjobnamegreater).
 
 ```yaml
 version: 2.1
@@ -326,7 +326,7 @@ jobs:
 
     ![Contexts]({{ site.baseurl }}/assets/img/docs/org-settings-contexts-v2.png)
 
-2. Select the Context you want to associate your envorinment variable with, or create a new one by clicking the Create Context button.
+2. Select the Context you want to associate your environment variable with, or create a new one by clicking the Create Context button.
 3. Click Add Environment Variable and enter a name and value.
 4. Use your new environment variable in your `.circleci/config.yml` once the context is added under the workflows key, as follows:
 
@@ -596,7 +596,7 @@ Variable                                   | Type    | Value
 `CIRCLE_TAG`{:.env_var}                    | String  | The name of the git tag, if the current build is tagged. For more information, see the [Git Tag Job Execution]({{ site.baseurl }}/2.0/workflows/#executing-workflows-for-a-git-tag).
 `CIRCLE_USERNAME`{:.env_var}               | String  | The GitHub or Bitbucket username of the user who triggered the pipeline.
 `CIRCLE_WORKFLOW_ID`{:.env_var}            | String  | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
-`CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var}  | String  | An identifier for the [workspace](https://circleci.com/docs/2.0/glossary/#workspace) of the current job. This identifier is the same for every job in a given workspace.
+`CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var}  | String  | An identifier for the [workspace]({{ site.baseurl }}/2.0/glossary/#workspace) of the current job. This identifier is the same for every job in a given workspace.
 `CIRCLE_WORKING_DIRECTORY`{:.env_var}      | String  | The value of the `working_directory` key of the current job.
 `CIRCLE_INTERNAL_TASK_DATA`{:.env_var}     | String  | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.
 `CIRCLE_COMPARE_URL`{:.env_var}            | String  | **Deprecated**. The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{ site.baseurl }}/2.0/pipeline-variables/) as an alternative.

--- a/jekyll/_cci2_ja/env-vars.md
+++ b/jekyll/_cci2_ja/env-vars.md
@@ -2,20 +2,18 @@
 layout: classic-docs
 title: "環境変数の使用"
 short-title: "環境変数の使用"
-description: "CircleCI 2.0 でサポートされている環境変数の一覧"
+description: "CircleCI でサポートされている環境変数の一覧"
 order: 40
 version:
-  - Cloud
-  - Server v2.x
+- Cloud
+- Server v3.x
+- Server v2.x
 suggested:
-  - 
-    title: Keep environment variables private
+  - title: Keep environment variables private
     link: https://circleci.com/blog/keep-environment-variables-private-with-secret-masking/
-  - 
-    title: Troubleshoot env vars settings
+  - title: Troubleshoot env vars settings
     link: https://discuss.circleci.com/t/somehow-i-just-cannot-get-the-enviroment-variable-from-enviroment-variable-setting-an-context-in-organization-menu/40342
-  - 
-    title: Insert files as environment variables
+  - title: Insert files as environment variables
     link: https://support.circleci.com/hc/en-us/articles/360003540393?input_string=how+to+i+inject+an+environment+variable+using+the+api%3F
 ---
 
@@ -28,13 +26,13 @@ suggested:
 {: #overview }
 {:.no_toc}
 
-CircleCI では、スコープや認証レベルに幅を持たせるために、環境変数の使用方法を複数提供しています。 環境変数は、その設定方法によって[優先順位](#%E5%84%AA%E5%85%88%E9%A0%86%E4%BD%8D)に基づいて使用され、構成において各レベルで制御することができます。
+CircleCI では、スコープや認可レベルに幅を持たせるために、環境変数の使用方法を複数提供しています。 環境変数は、その設定方法によって[優先順位](#order-of-precedence)に基づいて使用され、構成において各レベルで制御することができます。
 
-プライベート プロジェクト全体で使用する**プライベート キー**または**シークレット環境変数**を追加するには、CircleCI アプリケーションで [[Project Settings (プロジェクト設定)] の [Environment Variables (環境変数)] ページ](#%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%A7%E3%81%AE%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%81%AE%E8%A8%AD%E5%AE%9A)に移動します。 設定された後の変数の値は、アプリで読み取ることも編集することもできません。 環境変数の値を変更するには、現在の変数を削除し、新しい値を設定して再度追加します。
+プライベート プロジェクト全体で使用する**プライベート キー**または**シークレット環境変数**を追加するには、CircleCI アプリケーションで [[Project Settings (プロジェクト設定)] の [Environment Variables (環境変数)] ページ](#setting-an-environment-variable-in-a-project)に移動します。 設定された後の変数の値は、アプリで読み取ることも編集することもできません。 環境変数の値を変更するには、現在の変数を削除し、新しい値を設定して再度追加します。
 
-プライベート環境変数を使用すると、プロジェクトがパブリックの場合でもシークレットを安全に格納できます。 関連する設定情報については、「[オープンソース プロジェクトの構築]({{ site.baseurl }}/2.0/oss/)」ページを参照してください。
+プライベート環境変数を使用すると、プロジェクトがパブリックの場合でもシークレットを安全に格納できます。 関連する設定情報については、「[オープンソース プロジェクトの構築]({{ site.baseurl }}/ja/2.0/oss/)」ページを参照してください。
 
-Use Contexts to [further restrict access to environment variables](#setting-an-environment-variable-in-a-context). CircleCI アプリケーションの [Organization Settings (組織設定)] で設定します。 For more information about controlling access to env vars with Contexts, refer to the [Restricting a Context]({{ site.baseurl }}/2.0/contexts/#restricting-a-context) documentation.
+[環境変数へのアクセスをさらに制限する](#setting-an-environment-variable-in-a-context)には、コンテキストを使用してください。コンテキストは CircleCI アプリケーションの [Organization Settings (組織設定)] で設定します。コンテキストを使用した環境変数へのアクセス制御について詳しく知りたい場合は「[コンテキストの制限]({{ site.baseurl }}/ja/2.0/contexts/#restricting-a-context)」ページを参照してください.
 
 ## シークレットのマスキング
 {: #secrets-masking }
@@ -48,7 +46,7 @@ _シークレットのマスキングは、オンプレミス版である Circle
 * 環境変数の値が 4 文字未満
 * 環境変数の値が `true`、`True`、`false`、`False` のいずれか
 
-**注:** シークレットのマスキングは、ビルドの出力で環境変数の値が表示されないようにするだけの機能です。 If your secrets appear elsewhere, such as test results or artifacts, they will not be masked. In addition, the value of the environment variable is still accessible to users [debugging builds with SSH]({{ site.baseurl }}/2.0/ssh-access-jobs).
+**注:** シークレットのマスキングは、ビルドの出力で環境変数の値が表示されないようにするだけの機能です。テスト結果やアーティファクト内など、ビルド出力以外の場所で値が使用されている場合はマスキングされません。さらに、ユーザーは[SSH を使用したデバッグ]({{ site.baseurl }}/ja/2.0/ssh-access-jobs)で環境変数の値を確認することができます。
 
 ## 組織とリポジトリの名前変更
 {: #renaming-orgs-and-repositories }
@@ -73,24 +71,24 @@ CircleCI は Bash を使用しますが、ここでは POSIX 命名規則に従�
 
 環境変数は、以下に示す優先順位に従って使用されます。
 
-1. `FOO=bar make install` など、`run` ステップの[シェル コマンド](#%E3%82%B7%E3%82%A7%E3%83%AB-%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E3%81%A7%E3%81%AE%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%81%AE%E8%A8%AD%E5%AE%9A)で宣言された環境変数
-2. [`run` ステップ](#%E3%82%B9%E3%83%86%E3%83%83%E3%83%97%E3%81%A7%E3%81%AE%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%81%AE%E8%A8%AD%E5%AE%9A)で `environment` キーを使用して宣言された環境変数
-3. [ジョブ](#%E3%82%B8%E3%83%A7%E3%83%96%E3%81%A7%E3%81%AE%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%81%AE%E8%A8%AD%E5%AE%9A)で `environment` キーを使用して設定された環境変数
-4. このドキュメントの「[CircleCI 定義済み環境変数](#%E5%AE%9A%E7%BE%A9%E6%B8%88%E3%81%BF%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0)」セクションで解説されている特別な CircleCI 環境変数
-5. コンテキスト環境変数 (ユーザーがコンテキストへのアクセス権を持つ場合)。 手順については、[コンテキストに関するドキュメント]({{ site.baseurl }}/2.0/contexts)を参照してください。
-6. [Project Settings (プロジェクト設定)] ページで設定された[プロジェクトレベルの環境変数](#%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%A7%E3%81%AE%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%81%AE%E8%A8%AD%E5%AE%9A)
+1. `FOO=bar make install` など、`run` ステップの[シェル コマンド](#setting-an-environment-variable-in-a-shell-command)で宣言された環境変数
+2. [`run` ステップ](#setting-an-environment-variable-in-a-step)で `environment` キーを使用して宣言された環境変数
+3. [ジョブ](#setting-an-environment-variable-in-a-job)で `environment` キーを使用して設定された環境変数
+4. このドキュメントの「[CircleCI 定義済み環境変数](#built-in-environment-variables)」セクションで解説されている特別な CircleCI 環境変数
+5. コンテキスト環境変数 (ユーザーがコンテキストへのアクセス権を持つ場合)。 手順については、[コンテキストに関するドキュメント]({{ site.baseurl }}/ja/2.0/contexts)を参照してください。
+6. [Project Settings (プロジェクト設定)] ページで設定された[プロジェクトレベルの環境変数](#setting-an-environment-variable-in-a-project)
 
 `FOO=bar make install` のように、`run` ステップのシェル コマンドで宣言された環境変数は、`environment` キーおよび `contexts` キーを使用して宣言された環境変数よりも優先されます。 [Contexts (コンテキスト)] ページで追加された環境変数は、[Project Settings (プロジェクト設定)] ページで追加された変数よりも優先されます。
 
-![Env Var Order]({{ site.baseurl }}/assets/img/docs/env-var-order.png)
+![環境変数の優先順位]({{ site.baseurl }}/assets/img/docs/env-var-order.png)
 
 #### セキュリティに関する注意事項
 {: #notes-on-security }
 {:.no_toc}
 
-`.circleci/config.yml` ファイル内にシークレットやキーを追加しないでください。 CircleCI 上のプロジェクトにアクセスできる開発者には、`config.yml` の全文が表示されます。 シークレットやキーは、CircleCI アプリケーションの[プロジェクト設定](#%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%A7%E3%81%AE%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%81%AE%E8%A8%AD%E5%AE%9A)または[コンテキスト設定](#%E3%82%B3%E3%83%B3%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E3%81%A7%E3%81%AE%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0%E3%81%AE%E8%A8%AD%E5%AE%9A)に格納してください。 詳細については、セキュリティに関するドキュメントの「[暗号化]({{ site.baseurl }}/ja/2.0/security/#%E6%9A%97%E5%8F%B7%E5%8C%96)」セクションを参照してください。
+`.circleci/config.yml` ファイル内にシークレットやキーを追加しないでください。 CircleCI 上のプロジェクトにアクセスできる開発者には、`config.yml` の全文が表示されます。 シークレットやキーは、CircleCI アプリケーションの[プロジェクト設定](#setting-an-environment-variable-in-a-project)または[コンテキスト設定](#setting-an-environment-variable-in-a-context)に格納してください。 詳細については、セキュリティに関するドキュメントの「[暗号化]({{ site.baseurl }}/ja/2.0/security/#encryption)」セクションを参照してください。
 
-構成内でスクリプトを実行すると、シークレット環境変数が公開される場合があります。 安全なスクリプトのベスト プラクティスについては、「[シェル スクリプトの使用]({{ site.baseurl }}/ja/2.0/using-shell-scripts/#%E3%82%B7%E3%82%A7%E3%83%AB-%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88%E3%81%AE%E3%83%99%E3%82%B9%E3%83%88-%E3%83%97%E3%83%A9%E3%82%AF%E3%83%86%E3%82%A3%E3%82%B9)」を参照してください。
+構成内でスクリプトを実行すると、シークレット環境変数が公開される場合があります。 安全なスクリプトのベスト プラクティスについては、「[シェル スクリプトの使用]({{ site.baseurl }}/ja/2.0/using-shell-scripts/#shell-script-best-practices)」を参照してください。
 
 ### 環境変数の構成例
 {: #example-configuration-of-environment-variables }
@@ -101,26 +99,26 @@ CircleCI は Bash を使用しますが、ここでは POSIX 命名規則に従�
 ```yaml
 version: 2.1
 
-jobs: # basic units of work in a run
+jobs: # 実行時の基本的な作業単位を定義
   build:
-    docker: # use the Docker executor
-      # CircleCI node images available at: https://hub.docker.com/r/circleci/node/
+    docker: # Docker Executor を使用
+      # CircleCI の Node.js イメージはこちらで確認できます: https://hub.docker.com/r/circleci/node/
       - image: circleci/node:10.0-browsers
         auth:
           username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-    steps: # steps that comprise the `build` job
-      - checkout # check out source code to working directory
-      # Run a step to setup an environment variable
-      # Redirect MY_ENV_VAR into $BASH_ENV
+          password: $DOCKERHUB_PASSWORD  # コンテキストまたはプロジェクトの画面で設定した環境変数を参照
+    steps: # `build` ジョブを構成するステップを定義
+      - checkout # 作業用ディレクトリにソースコードをチェックアウト
+      # 環境変数をセットアップするステップを実行
+      # MY_ENV_VAR を $BASH_ENV にリダイレクト
       - run:
           name: "Setup custom environment variables"
           command: echo 'export MY_ENV_VAR="FOO"' >> $BASH_ENV
-      - run: # print the name of the branch we're on
+      - run: # 現在のブランチ名を print
           name: "What branch am I on?"
           command: echo ${CIRCLE_BRANCH}
-      # Run another step, the same as above; note that you can
-      # invoke environment variable without curly braces.
+      # 上記のステップと同じことをするステップを実行
+      # 環境変数を参照する際には波括弧をつけなくても大丈夫です
       - run:
           name: "What branch am I on now?"
           command: echo $CIRCLE_BRANCH
@@ -134,7 +132,7 @@ jobs: # basic units of work in a run
           name: "Print an env var stored in a Context"
           command: echo ${CONTEXT_ENV_VAR}
 
-workflows: # a single workflow with a single job called build
+workflows: # build という名前のジョブを実行するだけのワークフロー
   build:
     jobs:
       - build:
@@ -160,7 +158,7 @@ workflows: # a single workflow with a single job called build
 
 原則として、CircleCI はビルド構成への環境変数の挿入をサポートしていません。 使用する値はリテラルとして扱われます。 そのため、`working_directory` を定義するときや、`PATH` を変更するとき、複数の `run` ステップで変数を共有するときに、問題が発生する可能性があります。
 
-ただし、[プライベート イメージ]({{ site.baseurl }}/2.0/private-images/)をサポートするため、Docker イメージ セクションは例外となっています。
+ただし、[プライベート イメージ]({{ site.baseurl }}/ja/2.0/private-images/)をサポートするため、Docker イメージ セクションは例外となっています。
 
 以下の例では、`$ORGNAME` と `$REPONAME` に挿入は行われません。
 
@@ -205,7 +203,7 @@ workflows:
 
 ```
 
-詳細については、「[parameters 宣言の使用]({{ site.baseurl }}/ja/2.0/reusing-config/#parameters-%E5%AE%A3%E8%A8%80%E3%81%AE%E4%BD%BF%E7%94%A8)」を参照してください。
+詳細については、「[parameters 宣言の使用]({{ site.baseurl }}/ja/2.0/reusing-config/#using-the-parameters-declaration)」を参照してください。
 
 設定ファイルに値を挿入する方法として、以下のように、`run` ステップを使用して環境変数を `BASH_ENV` にエクスポートすることもできます。
 
@@ -226,9 +224,9 @@ steps:
 {: #alpine-linux }
 {:.no_toc}
 
-下の例では、上記の設定ファイルの例で説明したパラメーターを使用して、パイプラインをトリガーしています (注: API からパイプラインをトリガーするときにパラメーターを渡すには、設定ファイルでパラメーターを宣言している必要があります)。
+[Alpine Linux](https://alpinelinux.org/)ベースのイメージ([docker](https://hub.docker.com/_/docker)もそうですね)は `ash` シェルを使用しています。
 
-1 つのジョブで環境変数を設定するには、[`environment` キー]({{ site.baseurl }}/2.0/configuration-reference/#job_name)を使用します。
+次のように2つのパラメータをジョブに追加するだけで `bash` で環境変数を使用することができます。
 
 ```yaml
 version: 2.1
@@ -244,7 +242,7 @@ jobs:
 ## シェル コマンドでの環境変数の設定
 {: #setting-an-environment-variable-in-a-shell-command }
 
-CircleCI は環境変数の設定時の挿入をサポートしませんが、[`BASH_ENV` を使用](#%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF%E3%83%BC%E3%81%A8-bash-%E7%92%B0%E5%A2%83%E3%81%AE%E4%BD%BF%E7%94%A8)して、現在のシェルに変数を設定することは可能です。 これは、`PATH` を変更するときや、他の変数を参照する環境変数を設定するときに便利です。
+CircleCI は環境変数の設定時の挿入をサポートしませんが、[`BASH_ENV` を使用](#using-parameters-and-bash-environment)して、現在のシェルに変数を設定することは可能です。 これは、`PATH` を変更するときや、他の変数を参照する環境変数を設定するときに便利です。
 
 ```yaml
 version: 2.1 
@@ -268,12 +266,12 @@ jobs:
 
 **注:** シェルによっては、`~/.tcshrc` や `~/.zshrc` などのシェル スタートアップ ファイルに新しい変数を付加しなければならない場合があります。
 
-[Contexts]({{ site.baseurl }}/2.0/contexts/) [Keep environment variables private with secret masking](https://circleci.com/blog/keep-environment-variables-private-with-secret-masking/)
+環境変数の設定についての詳細は、ご使用のシェルのドキュメントを確認してください。
 
 ## ステップでの環境変数の設定
 {: #setting-an-environment-variable-in-a-step }
 
-1 つのステップで環境変数を設定するには、[`environment` キー]({{ site.baseurl }}/2.0/configuration-reference/#run)を使用します。
+ステップで環境変数を設定するには、[`environment` キー]({{ site.baseurl }}/ja/2.0/configuration-reference/#run)を使用します。
 
 ```yaml
 version: 2.1
@@ -296,12 +294,12 @@ jobs:
             DATABASE_URL: postgres://conductor:@localhost:5432/conductor_test
 ```
 
-**注:** 各 `run` ステップは新しいシェルなので、環境変数はステップ間で共有されません。 複数のステップで環境変数にアクセスできるようにする必要がある場合は、[`BASH_ENV` を使用](#%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF%E3%83%BC%E3%81%A8-bash-%E7%92%B0%E5%A2%83%E3%81%AE%E4%BD%BF%E7%94%A8)して値をエクスポートします。
+**注:** 各 `run` ステップは新しいシェルなので、環境変数はステップ間で共有されません。 複数のステップで環境変数にアクセスできるようにする必要がある場合は、[`BASH_ENV` を使用](#using-parameters-and-bash-environment)して値をエクスポートします。
 
 ## ジョブでの環境変数の設定
 {: #setting-an-environment-variable-in-a-job }
 
-[Contexts]({{ site.baseurl }}/ja/2.0/contexts/) [Keep environment variables private with secret masking](https://circleci.com/blog/keep-environment-variables-private-with-secret-masking/)
+ジョブで環境変数を設定するには、[`environment` キー]({{ site.baseurl }}/ja/2.0/configuration-reference/#lessjobnamegreater)を使用します。
 
 ```yaml
 version: 2.1
@@ -357,7 +355,7 @@ jobs:
             echo $MY_ENV_VAR
 ```
 
-コンテキストを作成すると、複数のプロジェクト間で環境変数を共有すると共に、アクセス可能なユーザーを制御できるようになります。 詳細については、[コンテキストに関するドキュメント]({{ site.baseurl }}/2.0/contexts/)を参照してください。
+コンテキストを作成すると、複数のプロジェクト間で環境変数を共有すると共に、アクセス可能なユーザーを制御できるようになります。 詳細については、[コンテキストに関するドキュメント]({{ site.baseurl }}/ja/2.0/contexts/)を参照してください。
 
 ## プロジェクトでの環境変数の設定
 {: #setting-an-environment-variable-in-a-project }
@@ -400,9 +398,9 @@ jobs:
 ## コンテナでの環境変数の設定
 {: #setting-an-environment-variable-in-a-container }
 
-環境変数は Docker コンテナにも設定することができます。 設定するには、[`environment` キー]({{ site.baseurl }}/2.0/configuration-reference/#docker)を使用します。
+環境変数は Docker コンテナにも設定することができます。 設定するには、[`environment` キー]({{ site.baseurl }}/ja/2.0/configuration-reference/#docker)を使用します。
 
-**注:**: この方法で設定する環境変数は、コンテナ内で実行される*ステップ*では使用できません。 これらを使用できるのは、コンテナ*によって*実行されるエントリポイントとコマンドのみです。 CircleCI のデフォルトでは、ジョブのプライマリ コンテナのエントリポイントは無視されます。 プライマリ コンテナの環境変数を利用可能にするには、エントリポイントを保持する必要があります。 For more information, see the [_adding an entrypoint_ section of the Custom Images guide]({{ site.baseurl }}/2.0/custom-images/#adding-an-entrypoint).
+**注:**: この方法で設定する環境変数は、コンテナ内で実行される*ステップ*では使用できません。 これらを使用できるのは、コンテナ*によって*実行されるエントリポイントとコマンドのみです。 CircleCI のデフォルトでは、ジョブのプライマリ コンテナのエントリポイントは無視されます。 プライマリ コンテナの環境変数を利用可能にするには、エントリポイントを保持する必要があります。詳細については、[カスタム ビルドの Docker イメージの使用ページの*エントリポイントの追加*セクション]({{ site.baseurl }}/ja/2.0/custom-images/#adding-an-entrypoint)を参照してください。
 
 ```yaml
 version: 2.1
@@ -450,35 +448,35 @@ jobs:
 {: #encoding-multi-line-environment-variables }
 {:.no_toc}
 
-結果の値を CircleCI 環境変数に格納します。
+もし、複数行の環境変数を追加したくて困っている場合は `base64` を使用してエンコードしてください。
 
 ```bash
 $ echo "foobar" | base64 --wrap=0
 Zm9vYmFyCg==
 ```
 
-その変数を使用するコマンド内で変数をデコードします。
+結果の値を CircleCI の環境変数に格納します。
 
 ```bash
 $ echo $MYVAR
 Zm9vYmFyCg==
 ```
 
-**注:** すべてのコマンド ライン プログラムが `docker` と同じ方法で認証情報を受け取るわけではありません。
+その変数を使用するコマンド内でデコードします。
 
 ```bash
 $ echo $MYVAR | base64 --decode | docker login -u my_docker_user --password-stdin
 Login Succeeded
 ```
 
-**Note:** Not all command-line programs take credentials in the same way that `docker` does.
+**注:** すべてのコマンド ライン プログラムが `docker` と同じ方法で認証情報を受け取るわけではありません。
 
 ## API v2 を使用した環境変数の挿入
 {: #injecting-environment-variables-with-api-v2 }
 
 CircleCI API v2 を使用すると、パイプライン パラメーターから変数を渡すことができます。
 
-[パイプラインをトリガーする]({{site.baseurl}}/api/v2/#operation/getPipelineConfigById) API v2`` エンドポイントを使用すると、特定のパラメーターの値でパイプラインをトリガーすることができます。 これを実行するには、`POST` 本体の JSON パケット内で `parameters` キーを渡します。
+[パイプラインをトリガーする]({{site.baseurl}}/api/v2/#operation/getPipelineConfigById) API v2 エンドポイントを使用すると、特定のパラメーターの値でパイプラインをトリガーすることができます。 これを実行するには、`POST` 本体の JSON パケット内で `parameters` キーを渡します。
 
 下の例では、上記の設定ファイルの例で説明したパラメーターを使用して、パイプラインをトリガーしています (注: API からパイプラインをトリガーするときにパラメーターを渡すには、設定ファイルでパラメーターを宣言している必要があります)。
 
@@ -491,9 +489,9 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 }' https://circleci.com/api/v2/project/:project_slug/pipeline
 ```
 
-**重要:** パイプライン パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/ja/lossary/#context)で確認できます。
+**重要:** パイプライン パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/ja/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/ja/2.0/glossary/#context)で確認できます。
 
-詳細については、「[パイプライン変数]({{site.baseurl}}/2.0/pipeline-variables/)」を参照してください。
+詳細については、「[パイプライン変数]({{site.baseurl}}/ja/2.0/pipeline-variables/)」を参照してください。
 
 ## API v1 を使用した環境変数の挿入
 {: #injecting-environment-variables-with-api-v1 }
@@ -506,9 +504,9 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 
 環境変数の通常の制限以外には、値自体への制限はなく、単純な文字列として扱われます。 ビルド パラメーターがロードされる順序は**保証されない**ため、ビルド パラメーターに値を挿入して別のビルド パラメーターに渡すことは避けてください。 ベスト プラクティスとして、独立した環境変数から成る順不同のリストとしてビルド パラメーターを設定することをお勧めします。
 
-**重要:** ビルド パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/2.0/ja/lossary/#context)で確認できます。
+**重要:** ビルド パラメーターは機密データとして扱われないため、機密の値 (シークレット) には使用しないでください。 シークレットは、[プロジェクト設定ページ]({{site.baseurl}}/ja/2.0/settings/)と[コンテキスト ページ]({{site.baseurl}}/ja/2.0/glossary/#context)で確認できます。
 
-このビルドは、以下の環境変数を受け取ります。
+例えば、次のようなパラメーターを渡した場合は
 
 ```sh
 {
@@ -521,7 +519,7 @@ curl -u ${CIRCLECI_TOKEN}: -X POST --header "Content-Type: application/json" -d 
 }
 ```
 
-以下の環境変数はビルドごとにエクスポートされ、より複雑なテストやデプロイに使用できます。
+このビルドは、以下の環境変数を受け取ります。
 
 ```sh
 export foo="bar"
@@ -543,7 +541,7 @@ export list="[\"a\", \"list\", \"of\", \"strings\"]"
 }
 ```
 
-上の例の `$CIRCLE_TOKEN` は[パーソナル API トークン]({{ site.baseurl }}/ja/2.0/managing-api-tokens/#%E3%83%91%E3%83%BC%E3%82%BD%E3%83%8A%E3%83%AB-api-%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%81%AE%E4%BD%9C%E6%88%90)です。
+例えば `curl` を使用する場合
 
 ```sh
 curl \
@@ -554,7 +552,7 @@ curl \
   https://circleci.com/api/v1.1/project/github/circleci/mongofinil/tree/master
 ```
 
-このビルドは、以下の環境変数を受け取ります。
+上の例の `$CIRCLE_TOKEN` は[パーソナル API トークン]({{ site.baseurl }}/ja/2.0/managing-api-tokens/#creating-a-personal-api-token)です。
 
 このビルドは、以下の環境変数を受け取ります。
 
@@ -568,11 +566,11 @@ POST API 呼び出しを使用して実行を開始します。 詳細につい�
 ## 定義済み環境変数
 {: #built-in-environment-variables }
 
-The following environment variables are exported in each build and can be used for more complex testing or deployment.
+以下の環境変数はビルドごとにエクスポートされているので、より複雑なテストやデプロイに使用することができます。
 
 **注:** 定義済み環境変数を使用して別の環境変数を定義することはできません。 代わりに、`run` ステップを使用して、新しい環境変数を `BASH_ENV` でエクスポートする必要があります。
 
-詳細については、シェルのドキュメントで環境変数の設定方法を参照してください。
+詳細については、[シェル コマンドでの環境変数の設定](#setting-an-environment-variable-in-a-shell-command)を参照してください。
 
 | 変数                                     | タイプ  | 値                                                                                                                                                                                                                                                                                         |
 | -------------------------------------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -582,8 +580,8 @@ The following environment variables are exported in each build and can be used f
 | `CIRCLE_BUILD_NUM`{:.env_var}          | 整数   | 現在のジョブの番号。 この番号はジョブごとに一意です。                                                                                                                                                                                                                                                               |
 | `CIRCLE_BUILD_URL`{:.env_var}          | 文字列  | CircleCI での現在のジョブの URL                                                                                                                                                                                                                                                                    |
 | `CIRCLE_JOB`{:.env_var}                | 文字列  | 現在のジョブの名前                                                                                                                                                                                                                                                                                 |
-| `CIRCLE_NODE_INDEX`{:.env_var}         | 整数   | (並列処理を有効化してジョブを実行する場合) 現在の並列実行の総数であり、 設定ファイルの `parallelism` の値と等しくなります。 0 から "`CIRCLE_NODE_TOTAL` - 1" までの値を取ります。                                                                                                                                                                         |
-| `CIRCLE_NODE_TOTAL`{:.env_var}         | 整数   | For jobs that run with parallelism enabled, this is the number of parallel runs. This is equivielnt to the value of `parallelism` in your config file.                                                                                                                                    |
+| `CIRCLE_NODE_INDEX`{:.env_var}         | 整数   | (並列処理を有効化してジョブを実行する場合) 並列実行の現在のインデックスであり、 0 から "`CIRCLE_NODE_TOTAL` - 1" までの値を取ります。                                                                                                                                                                         |
+| `CIRCLE_NODE_TOTAL`{:.env_var}         | 整数   | (並列処理を有効化してジョブを実行する場合) 並列実行の総数であり、 設定ファイルの `parallelism` の値と等しくなります。                                                                                                                               |
 | `CIRCLE_PR_NUMBER`{:.env_var}          | 整数   | 関連付けられた GitHub または Bitbucket プル リクエストの番号。 フォークされた PR でのみ使用できます。                                                                                                                                                                                                                           |
 | `CIRCLE_PR_REPONAME`{:.env_var}        | 文字列  | プル リクエストが作成された GitHub または Bitbucket リポジトリの名前。 フォークされた PR でのみ使用できます。                                                                                                                                                                                                                       |
 | `CIRCLE_PR_USERNAME`{:.env_var}        | 文字列  | プル リクエストを作成したユーザーの GitHub または Bitbucket ユーザー名。 フォークされた PR でのみ使用できます。                                                                                                                                                                                                                      |
@@ -594,17 +592,18 @@ The following environment variables are exported in each build and can be used f
 | `CIRCLE_PULL_REQUESTS`{:.env_var}      | リスト  | 現在のビルドに関連付けられたプル リクエストの URL の一覧 (カンマ区切り)                                                                                                                                                                                                                                                  |
 | `CIRCLE_REPOSITORY_URL`{:.env_var}     | 文字列  | GitHub または Bitbucket リポジトリ URL                                                                                                                                                                                                                                                            |
 | `CIRCLE_SHA1`{:.env_var}               | 文字列  | 現在のビルドの前回のコミットの SHA1 ハッシュ                                                                                                                                                                                                                                                                 |
-| `CIRCLE_TAG`{:.env_var}                | 文字列  | git タグの名前 (現在のビルドがタグ付けされている場合)。 詳細については、「[Git タグに対応するワークフローを実行する]({{ site.baseurl }}/ja/2.0/workflows/#git-%E3%82%BF%E3%82%B0%E3%81%AB%E5%AF%BE%E5%BF%9C%E3%81%99%E3%82%8B%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E3%82%92%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B)」を参照してください。 |
+| `CIRCLE_TAG`{:.env_var}                | 文字列  | git タグの名前 (現在のビルドがタグ付けされている場合)。 詳細については、「[Git タグに対応するワークフローを実行する]({{ site.baseurl }}/ja/2.0/workflows/#executing-workflows-for-a-git-tag)」を参照してください。 |
 | `CIRCLE_USERNAME`{:.env_var}           | 文字列  | パイプラインをトリガーしたユーザーの GitHub または Bitbucket ユーザー名                                                                                                                                                                                                                                             |
 | `CIRCLE_WORKFLOW_ID`{:.env_var}        | 文字列  | 現在のジョブのワークフロー インスタンスの一意の識別子。 この識別子は、特定のワークフロー インスタンス内のすべてのジョブで同じです。                                                                                                                                                                                                                       |
+| `CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var}  | 文字列  | 現在のジョブの[workspace]({{ site.baseurl }}/ja/2.0/glossary/#workspace)の識別子。この識別子は、特定のワークスペース内のすべてのジョブで同じです。 |
 | `CIRCLE_WORKING_DIRECTORY`{:.env_var}  | 文字列  | 現在のジョブの `working_directory` キーの値                                                                                                                                                                                                                                                          |
 | `CIRCLE_INTERNAL_TASK_DATA`{:.env_var} | 文字列  | **内部用**。 ジョブ関連の内部データが格納されるディレクトリ。 データ スキーマは変更される可能性があるため、このディレクトリのコンテンツは文書化されていません。                                                                                                                                                                                                       |
-| `CIRCLE_COMPARE_URL`{:.env_var}        | 文字列  | **非推奨**。 同じビルドのコミットどうしを比較するための GitHub または Bitbucket URL。 v2 以下の設定ファイルで使用可能です。 v2.1 では、この変数に代わり "[パイプライン値]({{ site.baseurl }}/2.0/pipeline-variables/)" が導入されています。                                                                                                                         |
+| `CIRCLE_COMPARE_URL`{:.env_var}        | 文字列  | **非推奨**。 同じビルドのコミットどうしを比較するための GitHub または Bitbucket URL。 v2 以下の設定ファイルで使用可能です。 v2.1 では、この変数に代わり "[パイプライン値]({{ site.baseurl }}/ja/2.0/pipeline-variables/)" が導入されています。                                                                                                                         |
 | `CI_PULL_REQUEST`{:.env_var}           | 文字列  | **非推奨**。 CircleCI 1.0 との下位互換性を確保するために残されています。 `CIRCLE_PULL_REQUEST` の使用が推奨されます。                                                                                                                                                                                                           |
 | `CI_PULL_REQUESTS`{:.env_var}          | リスト  | **非推奨**。 CircleCI 1.0 との下位互換性を確保するために残されています。 `CIRCLE_PULL_REQUESTS` の使用が推奨されます。                                                                                                                                                                                                          |
 {:class="table table-striped"}
 
-**注:** パイプライン値とパラメーターの一覧については、「[パイプライン変数]({{ site.baseurl }}/ja/2.0/pipeline-variables/#%E3%83%91%E3%82%A4%E3%83%97%E3%83%A9%E3%82%A4%E3%83%B3%E5%80%A4)」を参照してください。
+**注:** パイプライン値とパラメーターの一覧については、「[パイプライン変数]({{ site.baseurl }}/ja/2.0/pipeline-variables/#pipeline-values)」を参照してください。
 
 ## 関連項目
 {: #see-also }


### PR DESCRIPTION
# Description

Improved Japanese translation and added small fixes for English version I found.

En

* Fixed typo
* Fixed links

Ja

* Fixed header
* Fixed links
* Added translation to the untranslated sentences
* Fixed wrong translations which seems to translate different parts

# Reasons

I read the Japanese page and found there were several small things which can be improved.