### PR TITLE
Update orb-intro.md

### DIFF
--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -29,8 +29,7 @@ There are two different types of orbs you can use in your configuration, dependi
 {: #private-orbs }
 
 
-**Note:** _Private orbs are available on any of our [paid plans listed on our plans page](https://circleci.com/pricing). Performance plan customers can create
-up to three private orbs, whereas our Scale plan customers can create an unlimited number of private orbs. Please reach out to your sales representative for more information._
+**Note:** _Private orbs are available on any of our [plans listed on our plans page](https://circleci.com/pricing)._
 {: class="alert alert-warning"}
 
 Using a private orb enables you to author an orb while ensuring the following:


### PR DESCRIPTION
Private orb access has been expanded to all plans listed on the pricing page. Any eligible org can create unlimited private orbs.

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.