### PR TITLE
Fix: Add a `experimentContainer` to accurately track `Experiment Viewed` events

### DIFF
--- a/src/js/experiments/DevHubDocsNav.js
+++ b/src/js/experiments/DevHubDocsNav.js
@@ -3,6 +3,7 @@ $(() => {
   window.OptimizelyClient.getVariationName({
     experimentKey: 'dd_merge_devhub_docs_experiment_test',
     groupExperimentName: 'q3_fy22_docs_disco_experiment_group_test',
+    experimentContainer: '.dd-global-nav--links',
     attributes: {
       // https://app.optimizely.com/v2/projects/16812830475/audiences/20678820396/#modal
       windowWidth: window.innerWidth ?? 0,

--- a/src/js/experiments/highlightJSBadge.js
+++ b/src/js/experiments/highlightJSBadge.js
@@ -4,6 +4,7 @@ window.onload = () => {
   window.OptimizelyClient.getVariationName({
     experimentKey: 'dd_add_copy_code_button_to_docs',
     groupExperimentName: 'q3_fy22_docs_disco_experiment_group_test',
+    experimentContainer: '.hljs',
   }).then(function (variation) {
     if (variation === 'treatment') {
       var options = {

--- a/src/js/experiments/relatedResources.js
+++ b/src/js/experiments/relatedResources.js
@@ -3,6 +3,7 @@ $(() => {
   window.OptimizelyClient.getVariationName({
     experimentKey: 'dd_docs_related_resources_mvp_test',
     groupExperimentName: 'q3_fy22_docs_disco_experiment_group_test',
+    experimentContainer: '#related-resources',
     attributes: {
       // https://app.optimizely.com/v2/projects/16812830475/audiences/20680670160
       windowWidth: window.innerWidth ?? 0,

--- a/src/js/experiments/surfaceFullExampleConfig.js
+++ b/src/js/experiments/surfaceFullExampleConfig.js
@@ -3,6 +3,7 @@ $(() => {
   window.OptimizelyClient.getVariationName({
     experimentKey: 'dd_surfacing_full_example_config_experiment_test',
     groupExperimentName: 'q3_fy22_docs_disco_experiment_group_test',
+    experimentContainer: '#full-config-example',
   }).then((variation) => {
     if (variation === 'treatment') {
       $('#full-config-example').css('visibility', 'visible');

--- a/src/js/experiments/videoTutorials.js
+++ b/src/js/experiments/videoTutorials.js
@@ -3,6 +3,7 @@ $(() => {
   window.OptimizelyClient.getVariationName({
     experimentKey: 'dd_add_video_tab_to_docs_test',
     groupExperimentName: 'q4_fy22_docs_disco_experiment_group_test',
+    experimentContainer: '.main-nav-item[data-section=video-tutorials]',
   }).then((variation) => {
     if (variation === 'treatment') {
       $('.main-nav-item[data-section=video-tutorials]').show();

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -49,7 +49,12 @@ class OptimizelyClient {
       }
 
       // First we check that the required options are provided
-      if (!options || !options.experimentKey || !options.groupExperimentName) {
+      if (
+        !options ||
+        !options.experimentKey ||
+        !options.groupExperimentName ||
+        !options.experimentContainer
+      ) {
         return reject({ error: 'Missing required options' });
       }
 
@@ -117,6 +122,7 @@ class OptimizelyClient {
               trackExperimentViewed(
                 orgId,
                 options.experimentKey,
+                options.experimentContainer,
                 experimentId,
                 variationName,
                 variationId,
@@ -146,10 +152,16 @@ const trackExperimentViewed = (
   orgId,
   experimentKey,
   experimentId,
+  experimentContainer,
   variationName,
   variationId,
   userId,
 ) => {
+  // don't track user if the experiment is not present in the current page
+  if (!$(experimentContainer).length) {
+    return;
+  }
+
   if (!isExperimentAlreadyViewed(orgId, experimentKey)) {
     const properties = {
       id: uuidv4(),


### PR DESCRIPTION
# Description
- Change `getVariationName()` definition to require a `experimentContainer` attribute
- Return early when tracking `Experiment Viewed` if the `experimentContainer` is not in the DOM
- Update all experiments to provide an `experimentContainer` attribute

# Reasons
We realized that we track an experiment as viewed as soon as we get a resolution from optimizely (`control` or `treatment`). This works well for experiments that are globally seen across the entire site (like the `Doc/DevHub merge` exp) but produces bogus results for experiments that are only focusing on a subset of pages (like the `Recomended Resources` exp).

By providing an `experimentContainer` we can make sure that the experiment is in the DOM before tracking a view. 