### PR TITLE
[WEB-549] Add alternate hreflang to all pages

### DIFF
--- a/jekyll/_includes/head.html
+++ b/jekyll/_includes/head.html
@@ -6,10 +6,14 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 	{% if page.redirect %}<meta http-equiv="refresh" content="0; url={{ page.redirect }}">{% endif %}
-  {% assign current_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
+  	{% assign current_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
 	<link rel="canonical" href="{{current_url}}">
-  <link rel="alternate" hreflang="{{page.lang}}" href="{{current_url}}" />
-  {% if page.lang == "en" %}<link rel="alternate" hreflang="ja" href="{{ current_url | replace: '/docs/','/docs/ja/' }}" />{% elsif page.lang == "ja" %}<link rel="alternate" hreflang="en" href="{{ current_url | replace: '/docs/ja/','/docs/' }}" />{% endif %}
+  	<link rel="alternate" hreflang="{{page.lang}}" href="{{current_url}}" />
+  	{% if page.lang == "en" %}
+	  <link rel="alternate" hreflang="ja" href="{{ current_url | replace: '/docs/','/docs/ja/' }}" />
+	{% elsif page.lang == "ja" %}
+	  <link rel="alternate" hreflang="en" href="{{ current_url | replace: '/docs/ja/','/docs/' }}" />
+	{% endif %}
 	<link href="{{ "/assets/img/icons/favicon.png" | prepend: site.baseurl }}" rel="icon" type="image/png" />
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" />
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />

--- a/jekyll/_includes/head.html
+++ b/jekyll/_includes/head.html
@@ -6,7 +6,10 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 	{% if page.redirect %}<meta http-equiv="refresh" content="0; url={{ page.redirect }}">{% endif %}
-	<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+  {% assign current_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
+	<link rel="canonical" href="{{current_url}}">
+  <link rel="alternate" hreflang="{{page.lang}}" href="{{current_url}}" />
+  {% if page.lang == "en" %}<link rel="alternate" hreflang="ja" href="{{ current_url | replace: '/docs/','/docs/ja/' }}" />{% elsif page.lang == "ja" %}<link rel="alternate" hreflang="en" href="{{ current_url | replace: '/docs/ja/','/docs/' }}" />{% endif %}
 	<link href="{{ "/assets/img/icons/favicon.png" | prepend: site.baseurl }}" rel="icon" type="image/png" />
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" />
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />


### PR DESCRIPTION
Ticket: [WEB-549](https://circleci.atlassian.net/browse/WEB-549)

# Description
- Add `hreflang` tags in the `head.html` include so they are are used across all pages

# Reasons
If you have multiple versions of a page for different languages or regions, telling Google about these different variations is highly recommended. Doing so will help Google Search point users to the most appropriate version of our page depending on the language or region. More info: https://developers.google.com/search/docs/advanced/crawling/localized-versions

# Demo

On an `en` page:
![Screen Shot 2021-11-09 at 8 04 50 PM](https://user-images.githubusercontent.com/1449325/141047796-913b3632-f75f-4cf6-b4c5-5793102cef7c.png)

Same page but for `ja`:
![Screen Shot 2021-11-09 at 8 04 32 PM](https://user-images.githubusercontent.com/1449325/141047829-728f8b35-a3e6-4d10-b41b-406700c9d229.png)


