### PR TITLE
[WEB-374] Update CTA Button in Docs Navbar per Latest Designs

### DIFF
--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -1,15 +1,18 @@
 // Values from outer project variables
 ///////////////////////////////////////////////////////////////////////////////
 
-$zindex-navbar-fixed:      1030;
-$green: #04AA51;
-$blue-darker: #337ab7;
+$zindex-navbar-fixed: 1030;
 $white: #FFFFFF;
 $gray: #D8D8D8;
 $black: #161616;
 $transition-duration-medium: 400ms;
 $padding-large-vertical: 11px;
-
+$btn-outer-green: #049B4A;
+$btn-hover-green: #048C43;
+$btn-selected-green: #00701B;
+$btn-outer-blue: #0078CA;
+$btn-hover-blue: #0062B0;
+$btn-selected-blue: #004A95;
 
 // Copy of outer blog-nav, renmaed to global-nav
 ///////////////////////////////////////////////////////////////////////////////
@@ -186,12 +189,12 @@ $padding-large-vertical: 11px;
   }
 
   --link-color: #{$black};
-  --link-color-hover: #{$green};
+  --link-color-hover: #{$btn-hover-green};
 
   &:hover,
   &:focus {
     text-decoration: none;
-    color: $green;
+    color: $btn-selected-green;
   }
 
   &.active {
@@ -207,7 +210,7 @@ $padding-large-vertical: 11px;
   }
 
   --link-color: #{$gray-dark};
-  --link-color-hover: #{$blue-darker};
+  --link-color-hover: #{$btn-hover-blue};
 
   display: flex;
   align-items: center;
@@ -220,7 +223,7 @@ $padding-large-vertical: 11px;
   }
 
   &:hover {
-    color: $blue-darker;
+    color: $btn-hover-blue;
   }
   .external-icon {
     margin-left: 4px;
@@ -360,15 +363,15 @@ body.global-nav-open .global-nav--search-button {
     transition: background-color 300ms;
     flex: auto 0 0;
     color: #ffffff;
-    background-color: #049b4a;
+    background-color: $btn-outer-green;
     min-width: 7rem;
 
     @media (max-width: $screen-xs-max) {
     }
-  }
 
-  .btn-primary:hover {
-    background-color: #048c43;
+    &:hover {
+      background-color: $btn-hover-green;
+    }
   }
 
   // Replacement for .molecule-search


### PR DESCRIPTION
Ticket: [WEB-374](https://circleci.atlassian.net/browse/WEB-372)
[Preview link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/WEB-374-update-cta-button-in-docs-preview/?force-all)

# Description
Update the ‘Sign up / Go To Application' CTA button per the latest designs here: WEB-373: Buttons: primary, alternate, secondary color changeNEW 

The entire /assets/css/buttons.css can probably be removed, with fresh styles placed in the jekyll/_sass/_global-nav.scss file.

# Changes
- Remove `assets/css/buttons.css`
- Update colour hex codes

# Reasons
To keep styles consistent throughout all applications.