### PR TITLE
Add altered version of billing to faq page

### DIFF
--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -329,7 +329,7 @@ You can choose to pay for premium features per active user, compute, and optiona
 {: #how-do-I-calculate-my-monthly-costs }
 {:.no_toc}
 
-Calculate your monthly costs by finding your Storage and Network usage on the [CircleCI app](https://app.circleci.com/) by navigating to Plan > Plan Usage. 
+Calculate your monthly costs by finding your Storage and Network usage on the [CircleCI app](https://app.circleci.com/) by navigating to Plan > Plan Usage.
 
 ##### Storage
 {: #storage }

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -325,6 +325,30 @@ You can choose to pay for premium features per active user, compute, and optiona
 - Docker Layer Caching (DLC) is paid for with credits per usage, similar to
   compute credits.
 
+#### How do I calculate my monthly costs?
+{: #how-do-I-calculate-my-monthly-costs }
+{:.no_toc}
+
+Calculate your monthly costs by finding your Storage and Network usage on the [CircleCI app](https://app.circleci.com/) by navigating to Plan > Plan Usage. 
+
+##### Storage
+{: #storage }
+{:.no_toc}
+
+To calculate monthly storage costs from your daily usage, click on the Storage tab to see if your organization has accrued any overages beyond the GB-monthly allotment (your network egress). Your overage GB-Months can be mutliplied by 420 credits to estimate the total montly costs.
+
+![storage-usage-overage]( {{ site.baseurl }}/assets/img/docs/storage-usage-overage.png)
+
+##### Network
+{: #network }
+{:.no_toc}
+
+To calculate monthly network costs from your usage, click on the Objects tab to see if your organization has accrued any overages (your network egress). Your overage GB can be mutliplied by 420 credits to estimate the total montly costs.
+
+The GB allotment only applies to outbound traffic from CircleCI. Traffic within CircleCI is unlimited.
+
+![network-usage-overage]( {{ site.baseurl }}/assets/img/docs/network-usage-overage.png)
+
 
 #### Why does CircleCI have per-active-user pricing?
 {: #why-does-circleci-have-per-active-user-pricing }


### PR DESCRIPTION
# Description
A slightly shorter version of the added changes to the Persisting Data page about how to calculate monthly billing. 

# Reasons
There is a billing section in the FAQ page, so it make sense to include it here as well. 