### PR TITLE
Fix: Remove jekyll-minibundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,4 @@ COPY Gemfile Gemfile.lock ./
 RUN gem install bundler && bundle install
 RUN bundle exec jekyll clean
 
-ENV JEKYLL_MINIBUNDLE_MODE=development
-
 CMD ["bundle", "exec", "jekyll", "serve", "-s", "jekyll", "--incremental", "--host=0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :jekyll_plugins do
   gem 'jekyll-target-blank'
   gem 'jekyll-toc'
   gem 'jekyll-asciidoc'
-  gem 'jekyll-minibundle'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,6 @@ GEM
       jekyll (>= 3.0.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-minibundle (3.0.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
@@ -173,7 +172,6 @@ DEPENDENCIES
   jekyll-algolia (~> 1.0)
   jekyll-asciidoc
   jekyll-include-cache
-  jekyll-minibundle
   jekyll-sitemap
   jekyll-target-blank
   jekyll-toc

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -20,7 +20,6 @@ plugins:
   - jekyll-asciidoc
   - jekyll-target-blank
   - jekyll-toc
-  - jekyll/minibundle
 
 algolia:
   application_id: U0RXNGRK45

--- a/jekyll/_includes/js-assets.html
+++ b/jekyll/_includes/js-assets.html
@@ -1,8 +1,8 @@
 <div>
-  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/vendor.bundle.js assets/vendor.bundle.js %}"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/assets/js/vendor.bundle.js"></script>
   {% include_cached rollbar.html site=site %}
-  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/app.bundle.js assets/app.bundle.js %}"></script>
-  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/shared/components/subnav.js assets/shared/components/subnav.js %}"></script>
-  <script type="text/javascript" src="{{ site.baseurl }}/{% ministamp assets/js/shared/analytics-recursive-tracking.js assets/shared/analytics-recursive-tracking.js %}"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/assets/js/app.bundle.js"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/assets/js/shared/components/subnav.js"></script>
+  <script type="text/javascript" src="{{ site.baseurl }}/assets/js/shared/analytics-recursive-tracking.js"></script>
   <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
 </div>

--- a/jekyll/_includes/mobile-sidebar.html
+++ b/jekyll/_includes/mobile-sidebar.html
@@ -11,7 +11,7 @@
           <li class="main-nav-item closed" data-section="{{ section_slug }}">
             <div class="list-wrap">
               {% if main-item.icon %}
-                <img class="icon" src="{{ site.baseurl }}/{% ministamp { source_path: 'assets/img/{{ main-item.icon }}', destination_path: 'assets/{{ main-item.icon }}' } %}">
+                <img class="icon" src="{{ site.baseurl }}/assets/img/{{ main-item.icon }}">
               {% endif %}
 
               {% if main-item.i18n_name %}
@@ -31,7 +31,7 @@
               {% endif %}
 
               {% if main-item.children %}
-                <img class="arrow" crossorigin="anonymous" src="{{ site.baseurl }}/{% ministamp assets/img/docs/arrow-right.svg assets/docs/arrow-right.svg %}">
+                <img class="arrow" crossorigin="anonymous" src="{{ site.baseurl }}/assets/img/docs/arrow-right.svg">
               {% endif %}
             </div>
 

--- a/jekyll/_includes/sidebar.html
+++ b/jekyll/_includes/sidebar.html
@@ -11,7 +11,7 @@
           <!-- "main items" (Getting Started, Configuration etc.) -->
           <div class="list-wrap">
             {% if main-item.icon %}
-              <img class="icon" src="{{ site.baseurl }}/{% ministamp { source_path: 'assets/img/{{ main-item.icon }}', destination_path: 'assets/{{ main-item.icon }}' } %}">
+              <img class="icon" src="{{ site.baseurl }}/assets/img/{{ main-item.icon }}">
             {% endif %}
 
             {% if main-item.i18n_name %}
@@ -31,7 +31,7 @@
             {% endif %}
 
             {% if main-item.children %}
-              <img class="arrow" crossorigin="anonymous" src="{{ site.baseurl }}/{% ministamp assets/img/docs/arrow-right.svg assets/docs/arrow-right.svg %}">
+              <img class="arrow" crossorigin="anonymous" src="{{ site.baseurl }}/assets/img/docs/arrow-right.svg">
             {% endif %}
           </div>
 


### PR DESCRIPTION
# Description
- Remove dependency to `jekyll-minibundle` in Gemfile & jekyll `config.yml`.
- Update includes to not use `jekyll-minibundle` (called `ministamp`) anymore.

# Reasons
@teesloane and I are unsure at this point why/if `jekyll-minibundle` is useful. It is causing a bunch of problems in dev because it is [incompatible](jekyll-minibundle) with `--incremental`. Some of the examples includes: broken icons in the sidebar and JS files not found.

Currently, it is only used to md5 fingerprint some assets (not all) in prod and it doesn't seem like other non-fingerprinted assets are giving us any trouble? I'm suggesting that we try this for a while and monitor datadog/rollbar to look for any issues.