### PR TITLE
redefine on which branches server PDFs are built

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
       - build_server_pdfs:
           filters:
             branches:
-              only: /server\/.*/
+              only: /.*/server/
       - build_api_docs
       - build:
           requires:


### PR DESCRIPTION
Previously, the server PDF build script: /scripts/build_pdfs_asciidoc.sh was run for any branch starting with `server/*`. This needs to change to `*/server` so that we can start branch names with the jira ticket reference. 

I am not sure I've done it right though! 😬 