### PR TITLE
Help users find examples by linking to them from where they are referenced

### DIFF
--- a/jekyll/_cci2/pipeline-variables.md
+++ b/jekyll/_cci2/pipeline-variables.md
@@ -189,7 +189,7 @@ Pipeline parameters which are defined in configuration are always in scope, with
 ## Conditional workflows
 {: #conditional-workflows }
 
-Use the `when` clause (or the inverse clause `unless`) under a workflow declaration, with a truthy or falsy value, to decide whether or not to run that workflow. Truthy/falsy values can be booleans, numbers, and strings. Falsy would be any of: false, 0, empty string, null, and NaN. Everything else would be truthy.
+Use the [`when` clause](https://circleci.com/docs/2.0/configuration-reference/#using-when-in-workflows) (or the inverse clause `unless`) under a workflow declaration, along with a [logic statement](https://circleci.com/docs/2.0/configuration-reference/#logic-statements), to decide whether or not to run that workflow. Logic statements in a `when` or `unless` clause should evaluate to a truthy or falsy value.
 
 The most common use of this construct is to use a pipeline parameter as the value, allowing an API trigger to pass that parameter to determine which workflows to run.
 


### PR DESCRIPTION
# Description
This PR simply adds a few links to examples and detailed documentation where they are referenced, so users can get a complete picture of how to use pipeline variables. I also de-duplicated a bit of the truthy/falsy explanation since it's more thoroughly covered in the linked-to section.

# Reasons
It's difficult to find the reference documentation for `when`/`unless` clauses and logic statements/expressions when you're digging through the documentation. If you are immensely familiar with the documentation, you know to look in the configuration reference page for this information, but users don't have that knowledge.