### PR TITLE
update runner image extension docs to use sudo

### DIFF
--- a/jekyll/_cci2/runner-installation-docker.adoc
+++ b/jekyll/_cci2/runner-installation-docker.adoc
@@ -30,8 +30,8 @@ In this example, Python 3 is installed on top of the base image.
 
 ```
 FROM circleci/runner:launch-agent
-RUN apt-get update; \
-    apt-get install --no-install-recommends -y \
+RUN sudo apt-get update; \
+    sudo apt-get install --no-install-recommends -y \
         python3
 ```
 


### PR DESCRIPTION
# Description
A change to the runner docker image requires sudo to be used for some commands that require admin privileges. This change updates our extension docs to note that. 

# Reasons
Keep docs up to date with the current state of the runner docker image. 