### PR TITLE
Fix: Remove repeated code block in `_cci2_ja/collect-test-data.md`

### DIFF
--- a/jekyll/_cci2_ja/collect-test-data.md
+++ b/jekyll/_cci2_ja/collect-test-data.md
@@ -448,9 +448,6 @@ Use [trx2junit](https://github.com/gfoidl/trx2junit) to convert Visual Studio / 
 A working `.circleci/config.yml` section might look like this:
 
 ```yaml
-    A working `.circleci/config.yml` section might look like this:
-
-```yaml
     steps:
       - checkout
       - run: dotnet build


### PR DESCRIPTION
# Description
- remove the unwanted extra ` ```yaml` code block

# Reasons
While looking at some doc, I stumbled upon this sentence that was repeated twice by mistake:
```
yaml
    A working `.circleci/config.yml` section might look like this:
```

https://circleci.com/docs/ja/2.0/collect-test-data/#trx2junit-for-visual-studio-net-core-tests

![Screen Shot 2021-11-17 at 6 38 31 PM](https://user-images.githubusercontent.com/1449325/142341502-dc2b30e9-6966-4a7d-a083-c779a96162a1.png)
