### PR TITLE
updating runner k8 docs to reference circleci-runner-k8 readme [RT-210]

### DIFF
--- a/jekyll/_cci2/runner-on-kubernetes.adoc
+++ b/jekyll/_cci2/runner-on-kubernetes.adoc
@@ -57,7 +57,7 @@ $ helm install "circleci-runner" ./ \
 ....
 +
 
-Further information about configing the helm chart see the https://github.com/CircleCI-Public/circleci-runner-k8s#setup[readme] 
+For further information about configuring the helm chart see the https://github.com/CircleCI-Public/circleci-runner-k8s#setup[readme] 
 
 . Verify your pods are up and running by checking their status and following the logs. You should see output like the following:
 +

--- a/jekyll/_cci2/runner-on-kubernetes.adoc
+++ b/jekyll/_cci2/runner-on-kubernetes.adoc
@@ -56,6 +56,9 @@ $ helm install "circleci-runner" ./ \
   --namespace your-namespace
 ....
 +
+
+Further information about configing the helm chart see the https://github.com/CircleCI-Public/circleci-runner-k8s#setup[readme] 
+
 . Verify your pods are up and running by checking their status and following the logs. You should see output like the following:
 +
 ....


### PR DESCRIPTION
# Description
updating runner k8 installation to reference circleci-runner-k8
![Screenshot 2021-11-18 at 16 26 15](https://user-images.githubusercontent.com/1072268/142455948-3298c93c-2da8-415e-91e7-cada2b263f40.png)

# Reasons
circleci-runner-k8 readme was updated to include additional configuration options, updating the docs here to reference circleci-runner-k8 readme to ensure the latest options are shown
https://circleci.atlassian.net/browse/RT-210