### PR TITLE
[DD-6] Overflow issue on side nav

### DIFF
--- a/src/styles/_sidebar.scss
+++ b/src/styles/_sidebar.scss
@@ -187,6 +187,7 @@ aside.full-height {
     overflow: auto; 
     padding-left: 5px;
     top: 83px;
+    max-width: 400px;
   }
 
   @media(max-width: $toc-breakpoint) {


### PR DESCRIPTION
Jira ticket: [DD-6](https://circleci.atlassian.net/browse/DD-6)
Preview [link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-6-max-width-side-nav-preview/?force-all)

# Description
Devin Beliveau Reported an issue in slack about the nav width not having a max in circleci-docs https://circleci.slack.com/archives/C021NCSEM44/p1637336044022100

This will cause issues for titles that are very long.

Example page where it fails
https://circleci.com/docs/2.0/runner-upgrading-on-server/

# Screen shots
# Before
<img width="1427" alt="Screen Shot 2021-11-22 at 3 44 28 PM" src="https://user-images.githubusercontent.com/86666932/142932649-cc7ce12d-77f3-4d23-b087-b095c4590848.png">

#After
<img width="1401" alt="Screen Shot 2021-11-22 at 3 43 49 PM" src="https://user-images.githubusercontent.com/86666932/142932541-60602dc0-30b0-44f6-abc4-09755c90f44f.png">
554384d.png">