### PR TITLE
Fix: remove globing to prevent tests from spilling into the app.bundle.js

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2,23 +2,19 @@
 
 import * as Cookie from 'js-cookie';
 import * as highlightjsBadge from 'highlightjs-badge';
-// site files
-import OptimizelyClient from './services/optimizely.js';
-import AnalyticsClient from './services/analytics.js';
-import * as rum from './services/rum.js';
-import * as search from './services/instantsearch.js';
-import * as lang from './services/lang.js';
-import * as Site from './site';
+
+import services from './services';
+import site from './site';
 import '../styles/main.scss';
 
 // imports all experiments
-import * as Experiments from './experiments';
+import experiments from './experiments';
 
-search.init();
-lang.init();
-rum.init();
+services.instantsearch.init();
+services.lang.init();
+services.rum.init();
 
 // adding "Clients" to the window object so they can be accessed by other js inside Jekyll
 window.Cookie = Cookie;
-window.AnalyticsClient = AnalyticsClient; // because it only has static methods, AnalyticsClient is not instantiated
-window.OptimizelyClient = new OptimizelyClient();
+window.AnalyticsClient = services.AnalyticsClient; // because it only has static methods, AnalyticsClient is not instantiated
+window.OptimizelyClient = new services.OptimizelyClient();

--- a/src/js/experiments/index.js
+++ b/src/js/experiments/index.js
@@ -1,0 +1,15 @@
+import DevHubDocsNav from './DevhubDocsNav';
+import forceAll from './forceAll';
+import highlightjsBadge from 'highlightjs-badge';
+import relatedResources from './relatedResources';
+import surfaceFullExampleConfig from './surfaceFullExampleConfig';
+import videoTutorials from './videoTutorials';
+
+export default {
+  DevHubDocsNav,
+  forceAll,
+  highlightjsBadge,
+  relatedResources,
+  surfaceFullExampleConfig,
+  videoTutorials,
+};

--- a/src/js/experiments/index.js
+++ b/src/js/experiments/index.js
@@ -1,4 +1,3 @@
-import DevHubDocsNav from './DevhubDocsNav';
 import forceAll from './forceAll';
 import highlightjsBadge from 'highlightjs-badge';
 import relatedResources from './relatedResources';
@@ -6,7 +5,6 @@ import surfaceFullExampleConfig from './surfaceFullExampleConfig';
 import videoTutorials from './videoTutorials';
 
 export default {
-  DevHubDocsNav,
   forceAll,
   highlightjsBadge,
   relatedResources,

--- a/src/js/services/analytics.test.js
+++ b/src/js/services/analytics.test.js
@@ -1,7 +1,6 @@
 import AnalyticsClient from './analytics.js';
 import { default as CookieOrginal } from 'js-cookie';
 import glob from '../../../jest/global';
-import { describe } from 'jest-circus';
 
 jest.mock('js-cookie');
 const Cookie = CookieOrginal;

--- a/src/js/services/index.js
+++ b/src/js/services/index.js
@@ -1,0 +1,7 @@
+import AnalyticsClient from './analytics';
+import * as instantsearch from './instantsearch';
+import * as lang from './lang';
+import OptimizelyClient from './optimizely';
+import * as rum from './rum';
+
+export default { AnalyticsClient, instantsearch, lang, OptimizelyClient, rum };

--- a/src/js/site/index.js
+++ b/src/js/site/index.js
@@ -1,0 +1,6 @@
+import * as main from './main';
+import * as nav from './nav';
+import * as sidebar from './sidebar';
+import * as user from './user';
+
+export default { main, nav, sidebar, user };


### PR DESCRIPTION
Preview: [link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/rs/fix/remove-globing-to-avoid-tests-in-bundle-preview/?force-all)

# Description
- Use an `import/export` pattern in each directory to precisely bring in the build what is needed 

# Reasons
While working on [DD-181](https://circleci.atlassian.net/browse/DD-181), @teesloane and I realized that with the current setup, tests were spilling into the bundle and were creating problems in production. This PR ensures that only the files we actually need make it to the bundle.

# Considerations
Please thoroughly test the [preview build](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/rs/fix/remove-globing-to-avoid-tests-in-bundle-preview/?force-all) as we changed the way everything is imported. Thank you 🙏 