### PR TITLE
[WEB-555] Remove jenkins-converter pages from sitemap.xml

### DIFF
--- a/jekyll/_cci2/jenkins-converter.md
+++ b/jekyll/_cci2/jenkins-converter.md
@@ -6,6 +6,7 @@ description: "Starting point for how to use the Jenkins Converter"
 categories: [getting-started]
 order: 1
 noindex: true
+sitemap: false
 ---
 
 The CircleCI [Jenkins Converter](https://circleci.com/developer/tools/jenkins-converter) is a web tool that allows you to easily convert a Jenkinsfile to a CircleCI config.yml, helping you to get started building on CircleCI quickly and easily.

--- a/jekyll/_cci2_ja/jenkins-converter.md
+++ b/jekyll/_cci2_ja/jenkins-converter.md
@@ -7,6 +7,7 @@ categories:
   - getting-started
 order: 1
 noindex: true
+sitemap: false
 ---
 
 The CircleCI [Jenkins Converter](https://circleci.com/developer/tools/jenkins-converter) is a web tool that allows you to easily convert a Jenkinsfile to a CircleCI config.yml, helping you to get started building on CircleCI quickly and easily.


### PR DESCRIPTION
Ticket: [WEB-555](https://circleci.atlassian.net/browse/WEB-555)

# Description
- Add `sitemap: false` to the two JC pages 

# Reasons
The two pages are already in `noindex` for robots and so they need to be removed from the `sitemap.xml`

# Screenshots

before:
![Screen Shot 2021-11-22 at 6 43 34 PM](https://user-images.githubusercontent.com/1449325/142964293-c239b1a8-2bff-488d-8937-3557d18d4212.png)
![Screen Shot 2021-11-22 at 6 44 12 PM](https://user-images.githubusercontent.com/1449325/142964303-81c17711-57c2-46a7-bfaf-e99e17423e6c.png)

after:
![Screen Shot 2021-11-22 at 6 44 06 PM](https://user-images.githubusercontent.com/1449325/142964334-09ce40c1-9afd-46b7-b60b-126b2e9222fd.png)
