### PR TITLE
Fix: wrong import name for highlightJSBadge

### DIFF
--- a/src/js/experiments/index.js
+++ b/src/js/experiments/index.js
@@ -1,5 +1,5 @@
 import forceAll from './forceAll';
-import highlightjsBadge from 'highlightjs-badge';
+import highlightjsBadge from './highlightJSBadge';
 import relatedResources from './relatedResources';
 import surfaceFullExampleConfig from './surfaceFullExampleConfig';
 import videoTutorials from './videoTutorials';


### PR DESCRIPTION
# Description
- Fix wrong import name for `highlightJSBadge`

# Reasons
PR https://github.com/circleci/circleci-docs/pull/5966 broke the copy code button because of a wrong import name. This PR fixes that. 