### PR TITLE
update running runner tasks API response code snippet

### DIFF
--- a/jekyll/_cci2/runner-api.adoc
+++ b/jekyll/_cci2/runner-api.adoc
@@ -331,7 +331,7 @@ curl -X GET https://runner.circleci.com/api/v2/runner/tasks/running?resource-cla
 
 ```json
 {
-    "unclairunning_runner_tasksmed_task_count": 42
+    "running_runner_tasks": 42
 }
 ```
 


### PR DESCRIPTION
# Description
Update example API response

# Reasons
The example API response for the `/api/v2/runner/tasks/running` request was malformed. Updated to make this more accurate.