### PR TITLE
[RT-328] Rename /runner/tasks routes to /tasks

### DIFF
--- a/jekyll/_cci2/runner-api.adoc
+++ b/jekyll/_cci2/runner-api.adoc
@@ -189,7 +189,7 @@ curl -X GET https://runner.circleci.com/api/v2/runner?namespace=test-namespace \
 ```
 
 
-=== GET /api/v2/runner/tasks
+=== GET /api/v2/tasks
 
 Get the number of unclaimed tasks for a given resource class.
 
@@ -221,7 +221,7 @@ Get the number of unclaimed tasks for a given resource class.
 ==== Examples
 
 ```sh
-curl -X GET https://runner.circleci.com/api/v2/runner/tasks?resource-class=test-namespace/test-resource \
+curl -X GET https://runner.circleci.com/api/v2/tasks?resource-class=test-namespace/test-resource \
     -H 'Circle-Token: secret-token'
 ```
 
@@ -263,7 +263,7 @@ curl -X GET https://runner.circleci.com/api/v2/runner/tasks?resource-class=test-
 }
 ```
 
-=== GET /api/v2/runner/tasks/running
+=== GET /api/v2/tasks/running
 
 Get the number of running tasks for a given resource class.
 
@@ -294,7 +294,7 @@ Get the number of running tasks for a given resource class.
 ==== Examples
 
 ```sh
-curl -X GET https://runner.circleci.com/api/v2/runner/tasks/running?resource-class=test-namespace/test-resource \
+curl -X GET https://runner.circleci.com/api/v2/tasks/running?resource-class=test-namespace/test-resource \
     -H 'Circle-Token: secret-token'
 ```
 

--- a/jekyll/_cci2_ja/runner-api.adoc
+++ b/jekyll/_cci2_ja/runner-api.adoc
@@ -189,7 +189,7 @@ curl -X GET https://runner.circleci.com/api/v2/runner?namespace=test-namespace \
 ```
 
 
-=== GET /api/v2/runner/tasks
+=== GET /api/v2/tasks
 
 指定したリソース クラスで未処理のタスクの数を取得します。
 
@@ -221,7 +221,7 @@ curl -X GET https://runner.circleci.com/api/v2/runner?namespace=test-namespace \
 ==== サンプル
 
 ```sh
-curl -X GET https://runner.circleci.com/api/v2/runner/tasks?resource-class=test-namespace/test-resource \
+curl -X GET https://runner.circleci.com/api/v2/tasks?resource-class=test-namespace/test-resource \
     -H 'Circle-Token: secret-token'
 ```
 

--- a/jekyll/_cci2_ja/runner-api.adoc
+++ b/jekyll/_cci2_ja/runner-api.adoc
@@ -263,7 +263,7 @@ curl -X GET https://runner.circleci.com/api/v2/tasks?resource-class=test-namespa
 }
 ```
 
-=== GET /api/v2/runner/tasks/running
+=== GET /api/v2/tasks/running
 
 Get the number of running tasks for a given resource class.
 
@@ -294,7 +294,7 @@ Get the number of running tasks for a given resource class.
 ==== サンプル
 
 ```sh
-curl -X GET https://runner.circleci.com/api/v2/runner/tasks/running?resource-class=test-namespace/test-resource \
+curl -X GET https://runner.circleci.com/api/v2/tasks/running?resource-class=test-namespace/test-resource \
     -H 'Circle-Token: secret-token'
 ```
 


### PR DESCRIPTION
JIRA: [RT-328]

- To better support future work that might require in flight tasks, we
  are making the tasks listing endpoints generic, as opposed to be
  runner specific

- This is technically a breaking change, but the route is currently only used
  by an internal staff

- The code change: https://github.com/circleci/distributor/pull/1282

[RT-328]: https://circleci.atlassian.net/browse/RT-328