### PR TITLE
Update/persist to workspace

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1338,6 +1338,30 @@ Jobs can add files into the workspace using the `persist_to_workspace` step and 
 The workspace is additive only, jobs may add files to the workspace but cannot delete files from the workspace. Each job can only see content added to the workspace by the jobs that are upstream of it.
 When attaching a workspace the "layer" from each upstream job is applied in the order the upstream jobs appear in the workflow graph. When two jobs run concurrently the order in which their layers are applied is undefined. If multiple concurrent jobs persist the same filename then attaching the workspace will error.
 
+**Note:** In order for the `attach_to_workspace` step to successfully download assets from a previous job, the `requires` step in the workflow must be set to the name of the previous job that you want assets to persist from. For example:
+
+``` YAML
+      - job1:
+          context: my-context
+          filters:
+            branches:
+              only: my-dev-branch
+      - approve-job1:
+          filters:
+            branches:
+              only: my-dev-branch
+          type: approval
+      - job2:
+          context: my-context
+          filters:
+            branches:
+              only: my-dev-branch
+          requires:
+            - job1
+            - approve-job1
+ ```
+
+
 If a workflow is re-run it inherits the same workspace as the original workflow. When re-running failed jobs only the re-run jobs will see the same workspace content as the jobs in the original workflow.
 
 Note the following distinctions between Artifacts, Workspaces, and Caches:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1341,24 +1341,24 @@ When attaching a workspace the "layer" from each upstream job is applied in the 
 **Note:** In order for the `attach_to_workspace` step to successfully download assets from a previous job, the `requires` step in the workflow must be set to the name of the previous job that you want assets to persist from. For example:
 
 ``` YAML
-      - job1:
-          context: my-context
-          filters:
-            branches:
-              only: my-dev-branch
-      - approve-job1:
-          filters:
-            branches:
-              only: my-dev-branch
-          type: approval
-      - job2:
-          context: my-context
-          filters:
-            branches:
-              only: my-dev-branch
-          requires:
-            - job1
-            - approve-job1
+- job1:
+    context: my-context
+    filters:
+      branches:
+        only: my-dev-branch
+- approve-job1:
+    filters:
+      branches:
+        only: my-dev-branch
+    type: approval
+- job2:
+    context: my-context
+    filters:
+      branches:
+        only: my-dev-branch
+    requires:
+      - job1
+      - approve-job1
  ```
 
 


### PR DESCRIPTION
# Description
Added note and example of required workflow step needed to persist assets from one job to the next.

# Reasons
I spent several days trying to figure out why assets were being successfully persisted from my first job in the persist step, but then the `attach_workspace` step in my second job was constantly erroring and downloading 0B of assets. Hopefully this note in the documentaion will help others know that this is required in order for `attach_workspace` to work correctly.