### PR TITLE
[DD-256] Make sure content always fills available space

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -204,6 +204,7 @@ div.article-container{
     @media (max-width: $screen-sm) {
       width: 100%;
     }
+    min-height: calc(100vh - 68px); // make sure content always fill available space (68px is header size)
 }
 
 article{

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -204,7 +204,7 @@ div.article-container{
     @media (max-width: $screen-sm) {
       width: 100%;
     }
-    min-height: calc(100vh - 68px); // make sure content always fill available space (68px is header size)
+    min-height: calc(100vh - 68px); // make sure content always fills available space (68px is header size)
 }
 
 article{


### PR DESCRIPTION
Ticket: [DD-256](https://circleci.atlassian.net/browse/DD-256)

# Description
- Add a `min-height` to the main content to ensure it always fills the available space and doesn't show background from the sidebar

# Reasons
When content is too short, a grey box is shown at the end because the content is not filling up the whole available space. This PR adds a `min-height: calc(100vh - header size)` to fix that. Depending on your monitor size, you can experience the issue for yourself here: https://circleci.com/docs/2.0/server-3-faq/

# Screenshots

## Before

![Screen Shot 2021-11-29 at 6 08 15 PM](https://user-images.githubusercontent.com/1449325/143973291-ee108b81-1233-49c0-ac6b-a7715ec0da9e.png)


## After

![Screen Shot 2021-11-29 at 6 08 03 PM](https://user-images.githubusercontent.com/1449325/143973319-d8810bf5-bdfe-44c3-94dc-c14bea7e87d0.png)
