### PR TITLE
[WEB-610] Update long cookie expirations

### DIFF
--- a/src/js/site/user.js
+++ b/src/js/site/user.js
@@ -1,4 +1,5 @@
 import Cookies from 'js-cookie';
+import { updateCookieExpiration } from '../utils';
 
 function setUserData(userData) {
   window.userData = userData;
@@ -19,19 +20,22 @@ function setUserData(userData) {
 
 function setLoggedIn(userData) {
   $(document.body).addClass('loggedin');
-  Cookies.set('cci-customer', 'true', { expires: 3650 });
+  Cookies.set('cci-customer', 'true', { expires: 365 * 2 });
 
   setUserData(userData);
 }
 
 function setLoggedOut() {
   $(document.body).removeClass('loggedin');
-  Cookies.set('cci-customer', 'false', { expires: 3650 });
+  Cookies.set('cci-customer', 'false', { expires: 365 * 2 });
 
   setUserData({});
 }
 
 $(function () {
+  // Update cookie expiry (migrating from 10 years to 2 years)
+  updateCookieExpiration('cci-customer', 365 * 2);
+
   if (Cookies.get('cci-customer') === 'true') {
     $(document.body).addClass('loggedin');
   }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,3 +1,5 @@
+import Cookies from 'js-cookie';
+
 export function isProduction() {
   return window.location.origin === 'https://circleci.com';
 }
@@ -31,4 +33,24 @@ export function isElementInViewport(el) {
       (window.innerHeight || document.documentElement.clientHeight) &&
     rect.right <= (window.innerWidth || document.documentElement.clientWidth)
   );
+}
+
+// Refreshes a given cookie (if set) with a new expiration date. If cookie is
+// not already set, no action will be taken.
+export function updateCookieExpiration(cookieName, newExpiration) {
+  // Ensure cookie name is a non-empty string. If no cookie name is given,
+  // js-cookie will return ALL cookies on the subsequent `get()` call.
+  if (typeof cookieName !== 'string' || cookieName.length < 1) {
+    return;
+  }
+
+  var existingValue = Cookies.get(cookieName);
+
+  // Return early if cookie is not set
+  if (existingValue === undefined) {
+    return;
+  }
+
+  // Re-set cookie with same values and new expiration date
+  Cookies.set(cookieName, existingValue, { expires: newExpiration });
 }


### PR DESCRIPTION
**Ticket:** [WEB-610](https://circleci.atlassian.net/browse/WEB-610)

NOTE: I was unable to test this locally, due to a problem installing the `liquid-c` gem I was unable to resolve in reasonable time. Someone should give this a try in a dev or staging environment before merging.

## Description

The goal of this ticket is to reduce our long (10-year) expirations on various cookies to 2 years. This commit changes the expiry that we write when creating cookies.

In addition, since cookie setting is conditional, we can't count on those being re-created with the current expiry date on each visit. So we add and call a function to update the expiration date on an existing cookie (but won't set the cookie if it doesn't already exist).

See also: [WEB-611]

## How to test

There are two paths to test:

#### Pre-existing cookies

A pre-existing cookie has its expiry shortened by loading a page with this new code. So load a preview page, e.g. http://static-preview.circleci.com/master/ and see that your `cci-customer` cookie has a far-future expiration date (10 years, 2031).

Then load a page from this branch, e.g. http://static-preview.circleci.com/cookie-expiry-update/, and verify your `cci-customer` cookie has the new shorter expiry date (2 years, 2023).

I did notice that in Firefox, it seemed to cache the value for this on the "Storage" tab of the dev tools, and only showed the new one when I closed and reopened the tab.

#### New cookies

This one is easier. Just delete your `cci-customer` cookie for the preview domain (or clear all cookies), load the new page, and check for the desired 2-year date.


[WEB-611]: https://circleci.atlassian.net/browse/WEB-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ