### PR TITLE
Fix: Change `cci-customer` expiration from 10 years to 1 year

### DIFF
--- a/src/js/site/user.js
+++ b/src/js/site/user.js
@@ -19,14 +19,14 @@ function setUserData(userData) {
 
 function setLoggedIn(userData) {
   $(document.body).addClass('loggedin');
-  Cookies.set('cci-customer', 'true', { expires: 3650 });
+  Cookies.set('cci-customer', 'true', { expires: 365 });
 
   setUserData(userData);
 }
 
 function setLoggedOut() {
   $(document.body).removeClass('loggedin');
-  Cookies.set('cci-customer', 'false', { expires: 3650 });
+  Cookies.set('cci-customer', 'false', { expires: 365 });
 
   setUserData({});
 }


### PR DESCRIPTION
# Description
- Change `cci-customer` expiration from 10 years to 1 year

# Reasons
Cookies lifetime were not GDPR compliant