### PR TITLE
Server 3.2.1 supports k8s < 1.21

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -78,8 +78,8 @@ Supported Kubernetes versions:
 | CircleCI Version
 | Kubernetes Version
 
-| 3.0.0 - 3.2.x
-| < 1.22
+| 3.0.0 - 3.2.1
+| < 1.21
 
 | 3.3.x+
 | >= 1.16


### PR DESCRIPTION
We found a problem with k8s 1.21 in server 3.2.1. We're going to fix this in 3.2.2.