### PR TITLE
docs: add notes on using personal access tokens from Docker Hub

### DIFF
--- a/jekyll/_cci2/private-images.adoc
+++ b/jekyll/_cci2/private-images.adoc
@@ -51,6 +51,17 @@ jobs:
           password: $DOCKERHUB_PASSWORD  # or project environment variable reference
 ----
 
+If you have https://docs.docker.com/docker-hub/2fa/[two-factor authentication set up on Docker Hub], you can simply use https://docs.docker.com/docker-hub/access-tokens/[your personal access token] for the `password` key instead.
+For example:
+
+[source,yaml]
+----
+- image: acme-private/private-image:321
+  auth:
+    username: mydockerhub-user
+    password: $DOCKERHUB_ACCESS_TOKEN
+----
+
 You can also use images from a private repository like https://cloud.google.com/container-registry[gcr.io] or
 https://quay.io[quay.io]. Make sure to supply the full registry/image URL for the `image` key, and use the appropriate
 username/password for the `auth` key. For example:


### PR DESCRIPTION
# Description

I have updated our https://circleci.com/docs/2.0/private-images/ page to include notes on how to use personal access tokens in-place of passwords from Docker Hub.

# Reasons

Based on a customer's feedback, and having resolved their issue around how to use personal access tokens from Docker Hub, I am updating our docs to make it easier for others in the future.