### PR TITLE
Add new remote Docker version

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -128,6 +128,7 @@ To specify the Docker version, you can set it as a `version` attribute:
 
 CircleCI supports multiple versions of Docker. The following are the available versions:
 
+- `20.10.11`
 - `20.10.7`
 - `20.10.6`
 - `20.10.2`


### PR DESCRIPTION
This was available as of a couple of weeks ago. The version is all scaled up now and available.