### PR TITLE
[DD-72] Add unit test optimizely client

### DIFF
--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -2,8 +2,10 @@ import * as optimizelySDK from '@optimizely/optimizely-sdk';
 import { v4 as uuidv4 } from 'uuid';
 import { isProduction } from '../utils';
 import Cookies from 'js-cookie';
+// testing not working unless add this
+import { forceAll } from '../experiments/forceAll';
 
-const COOKIE_KEY = 'cci-org-analytics-id';
+export const COOKIE_KEY = 'cci-org-analytics-id';
 export const STORAGE_KEY = 'growth-experiments-participated';
 const optimizelyLogLevel = isProduction() ? 'error' : 'info';
 optimizelySDK.setLogLevel(optimizelyLogLevel);
@@ -64,6 +66,7 @@ class OptimizelyClient {
       // it means the current user is not ready to see an experiment and so
       // getVariationName() will resolve to "null"
       const orgId = Cookies.get(COOKIE_KEY) ?? null;
+
       if (!orgId) {
         return resolve(null);
       }

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -148,7 +148,7 @@ class OptimizelyClient {
 // trackExperimentViewed checks if we alredy have sent the Experiment Viewed
 // event to segment/amplitude by looking into the localstorage.
 // If not, it builds the properties needed and call trackAction with it
-export function trackExperimentViewed(
+export const trackExperimentViewed = (
   orgId,
   experimentKey,
   experimentContainer,
@@ -156,7 +156,7 @@ export function trackExperimentViewed(
   variationName,
   variationId,
   userId,
-) {
+) => {
   // don't track user if the experiment is not present in the current page
   if (!$(experimentContainer).length) {
     return;
@@ -182,11 +182,11 @@ export function trackExperimentViewed(
     // store experiment participation in localstorage
     storeExperimentParticipation(orgId, experimentKey, variationName);
   }
-}
+};
 
 // isExperimentAlreadyViewed checks in the localstorage if we already
 // marked the experiment as viewed
-export function isExperimentAlreadyViewed(orgId, experimentKey) {
+export const isExperimentAlreadyViewed = (orgId, experimentKey) => {
   try {
     const experiments = JSON.parse(localStorage.getItem(STORAGE_KEY));
     return (
@@ -199,15 +199,15 @@ export function isExperimentAlreadyViewed(orgId, experimentKey) {
     // Uglify /w browserlist force us to do catch (_)
     return false;
   }
-}
+};
 
 // storeExperimentParticipation stores the experiment variationName in the
 // localstorage
-export function storeExperimentParticipation(
+export const storeExperimentParticipation = (
   orgId,
   experimentKey,
   variationName,
-) {
+) => {
   if (!orgId || !experimentKey || !variationName) {
     return;
   }
@@ -243,6 +243,6 @@ export function storeExperimentParticipation(
     // We're deliberately ignoring it so that it doesn't break the app. It'll mean a few extra
     // events are emitted, but I think that's the lesser issue.
   }
-}
+};
 
 export default OptimizelyClient;

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -147,7 +147,7 @@ class OptimizelyClient {
 // trackExperimentViewed checks if we alredy have sent the Experiment Viewed
 // event to segment/amplitude by looking into the localstorage.
 // If not, it builds the properties needed and call trackAction with it
-export function trackExperimentViewed (
+export function trackExperimentViewed(
   orgId,
   experimentKey,
   experimentContainer,
@@ -181,14 +181,13 @@ export function trackExperimentViewed (
     // store experiment participation in localstorage
     storeExperimentParticipation(orgId, experimentKey, variationName);
   }
-};
+}
 
 // isExperimentAlreadyViewed checks in the localstorage if we already
 // marked the experiment as viewed
 export function isExperimentAlreadyViewed(orgId, experimentKey) {
   try {
     const experiments = JSON.parse(localStorage.getItem(STORAGE_KEY));
-
     return (
       experiments &&
       Object.prototype.hasOwnProperty.call(experiments, orgId) &&
@@ -199,11 +198,15 @@ export function isExperimentAlreadyViewed(orgId, experimentKey) {
     // Uglify /w browserlist force us to do catch (_)
     return false;
   }
-};
+}
 
 // storeExperimentParticipation stores the experiment variationName in the
 // localstorage
-export function storeExperimentParticipation(orgId, experimentKey, variationName) {
+export function storeExperimentParticipation(
+  orgId,
+  experimentKey,
+  variationName,
+) {
   if (!orgId || !experimentKey || !variationName) {
     return;
   }
@@ -239,6 +242,6 @@ export function storeExperimentParticipation(orgId, experimentKey, variationName
     // We're deliberately ignoring it so that it doesn't break the app. It'll mean a few extra
     // events are emitted, but I think that's the lesser issue.
   }
-};
+}
 
 export default OptimizelyClient;

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -4,7 +4,7 @@ import { isProduction } from '../utils';
 import Cookies from 'js-cookie';
 
 const COOKIE_KEY = 'cci-org-analytics-id';
-const STORAGE_KEY = 'growth-experiments-participated';
+export const STORAGE_KEY = 'growth-experiments-participated';
 const optimizelyLogLevel = isProduction() ? 'error' : 'info';
 optimizelySDK.setLogLevel(optimizelyLogLevel);
 
@@ -147,7 +147,7 @@ class OptimizelyClient {
 // trackExperimentViewed checks if we alredy have sent the Experiment Viewed
 // event to segment/amplitude by looking into the localstorage.
 // If not, it builds the properties needed and call trackAction with it
-const trackExperimentViewed = (
+export function trackExperimentViewed (
   orgId,
   experimentKey,
   experimentContainer,
@@ -155,7 +155,7 @@ const trackExperimentViewed = (
   variationName,
   variationId,
   userId,
-) => {
+) {
   // don't track user if the experiment is not present in the current page
   if (!$(experimentContainer).length) {
     return;
@@ -185,7 +185,7 @@ const trackExperimentViewed = (
 
 // isExperimentAlreadyViewed checks in the localstorage if we already
 // marked the experiment as viewed
-const isExperimentAlreadyViewed = (orgId, experimentKey) => {
+export function isExperimentAlreadyViewed(orgId, experimentKey) {
   try {
     const experiments = JSON.parse(localStorage.getItem(STORAGE_KEY));
 
@@ -203,7 +203,7 @@ const isExperimentAlreadyViewed = (orgId, experimentKey) => {
 
 // storeExperimentParticipation stores the experiment variationName in the
 // localstorage
-const storeExperimentParticipation = (orgId, experimentKey, variationName) => {
+export function storeExperimentParticipation(orgId, experimentKey, variationName) {
   if (!orgId || !experimentKey || !variationName) {
     return;
   }

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -64,7 +64,6 @@ class OptimizelyClient {
       // it means the current user is not ready to see an experiment and so
       // getVariationName() will resolve to "null"
       const orgId = Cookies.get(COOKIE_KEY) ?? null;
-
       if (!orgId) {
         return resolve(null);
       }

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -190,9 +190,7 @@ export const isExperimentAlreadyViewed = (orgId, experimentKey) => {
   try {
     const experiments = JSON.parse(localStorage.getItem(STORAGE_KEY));
     return (
-      experiments &&
       Object.prototype.hasOwnProperty.call(experiments, orgId) &&
-      experiments[orgId] &&
       Object.prototype.hasOwnProperty.call(experiments[orgId], experimentKey)
     );
   } catch (_) {

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -2,8 +2,6 @@ import * as optimizelySDK from '@optimizely/optimizely-sdk';
 import { v4 as uuidv4 } from 'uuid';
 import { isProduction } from '../utils';
 import Cookies from 'js-cookie';
-// testing not working unless add this
-import { forceAll } from '../experiments/forceAll';
 
 export const COOKIE_KEY = 'cci-org-analytics-id';
 export const STORAGE_KEY = 'growth-experiments-participated';

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -1,0 +1,16 @@
+// import OptimizelyClient from './optimizely';
+// import * as optimizelySDK from '@optimizely/optimizely-sdk';
+// import { default as CookieOrginal } from 'js-cookie';
+// import glob from '../../../jest/global';
+
+jest.mock('js-cookie');
+// const Cookie = CookieOrginal;
+
+describe('Optimizely Service', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+  it('true is true', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -1,16 +1,14 @@
-import { optimize } from 'webpack';
-import OptimizelyClient from './optimizely';
+// import { optimize } from 'webpack';
+// import OptimizelyClient from './optimizely';
 // import * as optimizelySDK from '@optimizely/optimizely-sdk';
 // import { default as CookieOrginal } from 'js-cookie';
 // import glob from '../../../jest/global';
 
-
-/*Todo:
+/*Todo: MOCK FILES
 Setup mock file for promise async
-Figure out localstorage syntax
+Figure out localstorage syntax (maybe glob)
+validate parameters
 */
-
-
 
 jest.mock('js-cookie');
 // const Cookie = CookieOrginal;
@@ -27,15 +25,14 @@ describe('Optimizely Service', () => {
     //***Need to create a mock file for async promise
 
     it('test if userData already exists', () => {
-    
+      expect(true).toBe(true);
     });
 
     it('test waiting for userData to populate', () => {
-    
+      expect(true).toBe(true);
     });
 
     //Should we add a no userData test?
-
   });
 
   //Function used in TrackExperimentViewed
@@ -44,6 +41,7 @@ describe('Optimizely Service', () => {
       //jest.spyOn(localStorage, "getItem");
       //localStorage.getItem = jest.fn();
       //expect(localStorage.getItem).toHaveBeenCalled();
+      expect(true).toBe(true);
     });
   });
 
@@ -53,55 +51,54 @@ describe('Optimizely Service', () => {
       //jest.spyOn(localStorage, "getItem");
       //localStorage.getItem = jest.fn();
       //expect(localStorage.getItem).toHaveBeenCalled();
+      expect(true).toBe(true);
     });
 
     it('test experiments value', () => {
-
+      expect(true).toBe(true);
     });
 
     it('test set localStorage key', () => {
-
+      expect(true).toBe(true);
     });
-
   });
 
   //Function used in getVariationName
   describe('trackExperimentViewed()', () => {
     it('check experimentContainer', () => {
-
+      expect(true).toBe(true);
     });
 
     it('check isExperimentAlreadyViewed on experimentKey', () => {
-
+      expect(true).toBe(true);
     });
 
     it('set trackAction Experiment Viewed properties', () => {
-
+      expect(true).toBe(true);
     });
 
     it('store ExperimentParticipation using function', () => {
-
+      expect(true).toBe(true);
     });
-
   });
 
   describe('getVariationName()', () => {
     //***Need to create a mock file for async promise
 
     it('test parameters are sent', () => {
-    
+      expect(true).toBe(true);
     });
 
     it('test orgId from cookie', () => {
-    
+      expect(true).toBe(true);
     });
 
     it('test isInGrowthExperimentGroup', () => {
-    
+      expect(true).toBe(true);
     });
 
     it('test tackExperimentViewed data', () => {
-    
+      expect(true).toBe(true);
     });
   });
 });

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -119,7 +119,7 @@ describe('Optimizely Service', () => {
       jest.resetAllMocks();
     });
 
-    it('expect trackExperimentViewed to have bene viewed', () => {
+    it('expect trackExperimentViewed to call trackAction', () => {
       storeExperimentParticipation(orgId, experimentKey, variationName);
       expect(isExperimentAlreadyViewed(orgId, experimentKey)).toBe(true);
 

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -29,7 +29,7 @@ describe('Optimizely Service', () => {
     experimentKey: 'experiment_key',
     groupExperimentName: 'experiment_group_test',
     experimentContainer: 'experiment_container',
-  }
+  };
 
   beforeEach(() => {
     window.localStorage.clear();
@@ -57,7 +57,9 @@ describe('Optimizely Service', () => {
       glob.userData = {
         analytics_id: '00000000-0000-0000-0000-000000000000',
       };
-      await expect(client.getUserId()).resolves.toBe('00000000-0000-0000-0000-000000000000');
+      await expect(client.getUserId()).resolves.toBe(
+        '00000000-0000-0000-0000-000000000000',
+      );
     });
 
     it('test waiting for userData to populate null', async () => {
@@ -82,7 +84,9 @@ describe('Optimizely Service', () => {
         window.dispatchEvent(userDataReady);
       }, 100);
 
-      await expect(client.getUserId()).resolves.toBe('00000000-0000-0000-0000-000000000000');
+      await expect(client.getUserId()).resolves.toBe(
+        '00000000-0000-0000-0000-000000000000',
+      );
     });
   });
 
@@ -184,37 +188,42 @@ describe('Optimizely Service', () => {
           analytics_id: '11111111-1111-1111-1111-111111111111',
         };
         forceAll.mockImplementation(() => false);
-        jest
-        .spyOn(Cookie, 'get')
-        .mockImplementation(() => ({ userId: '11111111-1111-1111-1111-111111111111' }));
+        jest.spyOn(Cookie, 'get').mockImplementation(() => ({
+          userId: '11111111-1111-1111-1111-111111111111',
+        }));
       });
 
       it('GrowthExperiment is control', () => {
         jest
-        .spyOn(client.client, 'getVariation').mockImplementationOnce(() => { return 'control' });
-        return client.getVariationName(options).then(data => {
-          expect(data).toBe(null)
-        })
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'control');
+        return client.getVariationName(options).then((data) => {
+          expect(data).toBe(null);
+        });
       });
 
       it('GrowthExperiment is treatment and variationName is control', () => {
         jest
-        .spyOn(client.client, 'getVariation').mockImplementationOnce(() => { return 'treatment' });
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'treatment');
         jest
-        .spyOn(client.client, 'getVariation').mockImplementationOnce(() => { return 'control' });
-        return client.getVariationName(options).then(data => {
-          expect(data).toBe('control')
-        })
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'control');
+        return client.getVariationName(options).then((data) => {
+          expect(data).toBe('control');
+        });
       });
 
       it('GrowthExperiment is treatment and variationName is treatment', () => {
         jest
-        .spyOn(client.client, 'getVariation').mockImplementationOnce(() => { return 'treatment' });
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'treatment');
         jest
-        .spyOn(client.client, 'getVariation').mockImplementationOnce(() => { return 'treatment' });
-        return client.getVariationName(options).then(data => {
-          expect(data).toBe('treatment')
-        })
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'treatment');
+        return client.getVariationName(options).then((data) => {
+          expect(data).toBe('treatment');
+        });
       });
     });
   });

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -162,7 +162,7 @@ describe('Optimizely Service', () => {
     it('test forceAll false, with valid options, get cookie but has no userId', async () => {
       const spy = jest.spyOn(Cookie, 'get').mockImplementation(() => 123);
       glob.forceAll = () => false;
-      glob.userData = {}
+      glob.userData = {};
       await expect(client.getVariationName(options)).resolves.toBe(null);
       expect(spy).toHaveBeenCalledWith(COOKIE_KEY);
     });

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -97,7 +97,6 @@ describe('Optimizely Service', () => {
       window.localStorage.clear();
     });
     it('experiment has not been viewed before', () => {
-      storeExperimentParticipation(orgId, experimentKey + '456', variationName);
       expect(isExperimentAlreadyViewed(orgId, experimentKey)).toBe(false);
     });
     it('experiment has been viewed before', () => {

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -1,7 +1,12 @@
 // import { optimize } from 'webpack';
 // import 'jest-localstorage-mock';
 import OptimizelyClient from './optimizely';
-import { storeExperimentParticipation, isExperimentAlreadyViewed, trackExperimentViewed, STORAGE_KEY } from './optimizely';
+import {
+  storeExperimentParticipation,
+  isExperimentAlreadyViewed,
+  trackExperimentViewed,
+  STORAGE_KEY,
+} from './optimizely';
 // import AnalyticsClient from '../services/analytics.js';
 // import * as optimizelySDK from '@optimizely/optimizely-sdk';
 // import * as optimizelySDK from '@optimizely/optimizely-sdk';
@@ -26,6 +31,10 @@ describe('Optimizely Service', () => {
   const client = new OptimizelyClient();
   const userDataReady = new CustomEvent('userDataReady');
 
+  const orgId = 'circle';
+  const experiemntKey = '123';
+  const variationName = 'peanut';
+
   beforeEach(() => {
     // might need to mock this each time
     // might not need all tests but specific
@@ -43,7 +52,7 @@ describe('Optimizely Service', () => {
     beforeEach(() => {
       // Ensure glob is cleaned up after each test
       glob.userData = null;
-    })
+    });
 
     it('test if userData exists but analytics_id undefined', () => {
       glob.userData = {};
@@ -87,20 +96,22 @@ describe('Optimizely Service', () => {
 
   //Function used in TrackExperimentViewed
   describe('isExperimentAlreadyViewed()', () => {
-    it('should be called with options object', () => {
-      //jest.spyOn(localStorage, "getItem");
-      //localStorage.getItem = jest.fn();
-      //expect(localStorage.getItem).toHaveBeenCalled();
-      isExperimentAlreadyViewed();
-      expect(true).toBe(true);
+    beforeEach(() => {
+      // ensure local storage clear
+      window.localStorage.clear();
+    });
+    it('experiment has not been viewed before', () => {
+      storeExperimentParticipation(orgId, experiemntKey + '456', variationName);
+      expect(isExperimentAlreadyViewed(orgId, experiemntKey)).toBe(false);
+    });
+    it('experiment has been viewed before', () => {
+      storeExperimentParticipation(orgId, experiemntKey, variationName);
+      expect(isExperimentAlreadyViewed(orgId, experiemntKey)).toBe(true);
     });
   });
 
   //Function used in TrackExperimentViewed
   describe('storeExperimentParticipation()', () => {
-    const orgId = 'circle'
-    const experiemntKey = '123'
-    const variationName = 'peanut'
     beforeEach(() => {
       // ensure local storage clear
       window.localStorage.clear();
@@ -112,32 +123,32 @@ describe('Optimizely Service', () => {
 
     it('test function returns if data missing and storage null', () => {
       expect(storeExperimentParticipation('', '', '')).toBe();
-      expect(window.localStorage.getItem(STORAGE_KEY)).toBe(null)
-    })
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe(null);
+    });
 
     it('test localStorage overriten and not null', () => {
-      storeExperimentParticipation('circle', '123', 'peanut');
-      expect(window.localStorage.getItem(STORAGE_KEY)).not.toBe(null)
+      storeExperimentParticipation(orgId, experiemntKey, 'peanut');
+      expect(window.localStorage.getItem(STORAGE_KEY)).not.toBe(null);
     });
-    
+
     it('test localStorage called', () => {
-      jest.spyOn(window.localStorage.__proto__, 'setItem')
-      window.localStorage.__proto__.setItem = jest.fn()
+      jest.spyOn(window.localStorage.__proto__, 'setItem');
+      window.localStorage.__proto__.setItem = jest.fn();
 
       jest.spyOn(window.localStorage.__proto__, 'getItem');
       window.localStorage.__proto__.getItem = jest.fn();
-      
+
       storeExperimentParticipation(orgId, experiemntKey, variationName);
 
       expect(window.localStorage.setItem).toHaveBeenCalled();
-      expect(localStorage.getItem).toBeCalledWith(STORAGE_KEY)
+      expect(localStorage.getItem).toBeCalledWith(STORAGE_KEY);
     });
   });
 
   //Function used in getVariationName
   describe('trackExperimentViewed()', () => {
     it('check experimentContainer', () => {
-      trackExperimentViewed()
+      trackExperimentViewed();
       expect(true).toBe(true);
     });
 

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -29,20 +29,18 @@ describe('Optimizely Service', () => {
   };
 
   beforeEach(() => {
+    // ensure local storage clear
     window.localStorage.clear();
   });
 
   afterEach(() => {
+    glob.userData = null;
+    glob.forceAll = null;
     jest.clearAllMocks();
     jest.resetAllMocks();
   });
 
   describe('getUserId()', () => {
-    beforeEach(() => {
-      // Ensure glob is cleaned up after each test
-      glob.userData = null;
-    });
-
     it('test if userData exists but analytics_id undefined', () => {
       glob.userData = {};
       return client.getUserId().then((data) => {
@@ -89,10 +87,6 @@ describe('Optimizely Service', () => {
 
   // Function used in TrackExperimentViewed
   describe('isExperimentAlreadyViewed()', () => {
-    beforeEach(() => {
-      // ensure local storage clear
-      window.localStorage.clear();
-    });
     it('no experiment has been viewed before', () => {
       expect(isExperimentAlreadyViewed(orgId, experimentKey)).toBe(null);
     });
@@ -110,13 +104,10 @@ describe('Optimizely Service', () => {
   describe('trackExperimentViewed()', () => {
     beforeEach(() => {
       global.AnalyticsClient = AnalyticsClient;
-      window.localStorage.clear();
-      jest.clearAllMocks();
     });
 
     afterEach(() => {
       delete global.AnalyticsClient;
-      jest.resetAllMocks();
     });
 
     it('expect trackExperimentViewed to not call trackAction as experiment viewed before', () => {
@@ -152,11 +143,6 @@ describe('Optimizely Service', () => {
   });
 
   describe('getVariationName()', () => {
-    afterEach(() => {
-      jest.clearAllMocks();
-      jest.resetAllMocks();
-    });
-
     it('test forceAll is true return treatment', async () => {
       glob.forceAll = () => true;
       await expect(client.getVariationName(options)).resolves.toBe('treatment');
@@ -176,6 +162,7 @@ describe('Optimizely Service', () => {
     it('test forceAll false, with valid options, get cookie but has no userId', async () => {
       const spy = jest.spyOn(Cookie, 'get').mockImplementation(() => 123);
       glob.forceAll = () => false;
+      glob.userData = {}
       await expect(client.getVariationName(options)).resolves.toBe(null);
       expect(spy).toHaveBeenCalledWith(COOKIE_KEY);
     });
@@ -228,15 +215,6 @@ describe('Optimizely Service', () => {
 
   //Function used in TrackExperimentViewed
   describe('storeExperimentParticipation()', () => {
-    beforeEach(() => {
-      // ensure local storage clear
-      window.localStorage.clear();
-    });
-
-    afterEach(() => {
-      jest.resetAllMocks();
-    });
-
     it('test function returns if data missing and storage null', () => {
       expect(storeExperimentParticipation('', '', '')).toBe();
       expect(window.localStorage.getItem(STORAGE_KEY)).toBe(null);

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -1,7 +1,16 @@
-// import OptimizelyClient from './optimizely';
+import { optimize } from 'webpack';
+import OptimizelyClient from './optimizely';
 // import * as optimizelySDK from '@optimizely/optimizely-sdk';
 // import { default as CookieOrginal } from 'js-cookie';
 // import glob from '../../../jest/global';
+
+
+/*Todo:
+Setup mock file for promise async
+Figure out localstorage syntax
+*/
+
+
 
 jest.mock('js-cookie');
 // const Cookie = CookieOrginal;
@@ -12,5 +21,87 @@ describe('Optimizely Service', () => {
   });
   it('true is true', () => {
     expect(true).toBe(true);
+  });
+
+  describe('getUserId()', () => {
+    //***Need to create a mock file for async promise
+
+    it('test if userData already exists', () => {
+    
+    });
+
+    it('test waiting for userData to populate', () => {
+    
+    });
+
+    //Should we add a no userData test?
+
+  });
+
+  //Function used in TrackExperimentViewed
+  describe('isExperimentAlreadyViewed()', () => {
+    it('should be called with options object', () => {
+      //jest.spyOn(localStorage, "getItem");
+      //localStorage.getItem = jest.fn();
+      //expect(localStorage.getItem).toHaveBeenCalled();
+    });
+  });
+
+  //Function used in TrackExperimentViewed
+  describe('storeExperimentParticipation()', () => {
+    it('test localStorage key', () => {
+      //jest.spyOn(localStorage, "getItem");
+      //localStorage.getItem = jest.fn();
+      //expect(localStorage.getItem).toHaveBeenCalled();
+    });
+
+    it('test experiments value', () => {
+
+    });
+
+    it('test set localStorage key', () => {
+
+    });
+
+  });
+
+  //Function used in getVariationName
+  describe('trackExperimentViewed()', () => {
+    it('check experimentContainer', () => {
+
+    });
+
+    it('check isExperimentAlreadyViewed on experimentKey', () => {
+
+    });
+
+    it('set trackAction Experiment Viewed properties', () => {
+
+    });
+
+    it('store ExperimentParticipation using function', () => {
+
+    });
+
+  });
+
+  describe('getVariationName()', () => {
+    //***Need to create a mock file for async promise
+
+    it('test parameters are sent', () => {
+    
+    });
+
+    it('test orgId from cookie', () => {
+    
+    });
+
+    it('test isInGrowthExperimentGroup', () => {
+    
+    });
+
+    it('test tackExperimentViewed data', () => {
+    
+    });
   });
 });

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -7,7 +7,7 @@ import {
   trackExperimentViewed,
   STORAGE_KEY,
 } from './optimizely';
-// import AnalyticsClient from '../services/analytics.js';
+import AnalyticsClient from '../services/analytics.js';
 // import * as optimizelySDK from '@optimizely/optimizely-sdk';
 // import * as optimizelySDK from '@optimizely/optimizely-sdk';
 // import { default as CookieOrginal } from 'js-cookie';
@@ -41,11 +41,12 @@ describe('Optimizely Service', () => {
     // this.client = optimizelySDK.createInstance({
     //   datafile: window.optimizelyDatafile,
     // });
-    jest.resetAllMocks();
+    window.localStorage.clear();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   describe('getUserId()', () => {
@@ -94,7 +95,7 @@ describe('Optimizely Service', () => {
     });
   });
 
-  //Function used in TrackExperimentViewed
+  // Function used in TrackExperimentViewed
   describe('isExperimentAlreadyViewed()', () => {
     beforeEach(() => {
       // ensure local storage clear
@@ -107,6 +108,51 @@ describe('Optimizely Service', () => {
     it('experiment has been viewed before', () => {
       storeExperimentParticipation(orgId, experiemntKey, variationName);
       expect(isExperimentAlreadyViewed(orgId, experiemntKey)).toBe(true);
+    });
+  });
+
+  //Function used in getVariationName
+  describe('trackExperimentViewed()', () => {
+    beforeEach(() => {
+      global.AnalyticsClient = AnalyticsClient;
+      window.localStorage.clear();
+      jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+      delete global.AnalyticsClient;
+      jest.resetAllMocks();
+    });
+
+    it('expect trackExperimentViewed to have bene viewed', () => {
+      storeExperimentParticipation(orgId, experiemntKey, variationName);
+      expect(isExperimentAlreadyViewed(orgId, experiemntKey)).toBe(true);
+
+      const spy = jest.spyOn(window.AnalyticsClient, 'trackAction');
+      trackExperimentViewed(
+        orgId,
+        experiemntKey,
+        ['container item'],
+        '5',
+        variationName,
+        '5',
+        '5',
+      );
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('expect trackExperimentViewed to have not been viewed', () => {
+      const spy = jest.spyOn(window.AnalyticsClient, 'trackAction');
+      trackExperimentViewed(
+        orgId,
+        experiemntKey,
+        ['container item'],
+        '5',
+        variationName,
+        '5',
+        '5',
+      );
+      expect(spy).toHaveBeenCalled();
     });
   });
 
@@ -142,26 +188,6 @@ describe('Optimizely Service', () => {
 
       expect(window.localStorage.setItem).toHaveBeenCalled();
       expect(localStorage.getItem).toBeCalledWith(STORAGE_KEY);
-    });
-  });
-
-  //Function used in getVariationName
-  describe('trackExperimentViewed()', () => {
-    it('check experimentContainer', () => {
-      trackExperimentViewed();
-      expect(true).toBe(true);
-    });
-
-    it('check isExperimentAlreadyViewed on experimentKey', () => {
-      expect(true).toBe(true);
-    });
-
-    it('set trackAction Experiment Viewed properties', () => {
-      expect(true).toBe(true);
-    });
-
-    it('store ExperimentParticipation using function', () => {
-      expect(true).toBe(true);
     });
   });
 

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -12,9 +12,6 @@ import { default as CookieOrginal } from 'js-cookie';
 jest.mock('js-cookie');
 const Cookie = CookieOrginal;
 
-import { forceAll } from '../experiments/forceAll'; // This will actually be the mock
-jest.mock('../experiments/forceAll', () => ({ forceAll: jest.fn() }));
-
 describe('Optimizely Service', () => {
   const client = new OptimizelyClient();
   const userDataReady = new CustomEvent('userDataReady');
@@ -161,26 +158,24 @@ describe('Optimizely Service', () => {
     });
 
     it('test forceAll is true return treatment', async () => {
-      forceAll.mockImplementation(() => true);
+      glob.forceAll = () => true;
       await expect(client.getVariationName(options)).resolves.toBe('treatment');
-      expect(forceAll.mock.calls.length).toBe(1);
     });
 
     it('test forceAll is false but options null', async () => {
       const errorObject = { error: 'Missing required options' };
-      forceAll.mockImplementation(() => false);
+      glob.forceAll = () => false;
       await expect(client.getVariationName(null)).rejects.toEqual(errorObject);
     });
 
     it('test forceAll is false, with valid options but no cookie', async () => {
-      forceAll.mockImplementation(() => false);
+      glob.forceAll = () => false;
       await expect(client.getVariationName(options)).resolves.toBe(null);
-      expect(forceAll.mock.calls.length).toBe(1);
     });
 
     it('test forceAll false, with valid options, get cookie but has no userId', async () => {
       const spy = jest.spyOn(Cookie, 'get').mockImplementation(() => 123);
-      forceAll.mockImplementation(() => false);
+      glob.forceAll = () => false;
       await expect(client.getVariationName(options)).resolves.toBe(null);
       expect(spy).toHaveBeenCalledWith(COOKIE_KEY);
     });
@@ -190,7 +185,7 @@ describe('Optimizely Service', () => {
         glob.userData = {
           analytics_id: '11111111-1111-1111-1111-111111111111',
         };
-        forceAll.mockImplementation(() => false);
+        glob.forceAll = () => false;
         jest.spyOn(Cookie, 'get').mockImplementation(() => ({
           userId: '11111111-1111-1111-1111-111111111111',
         }));

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -1,8 +1,15 @@
 // import { optimize } from 'webpack';
-// import OptimizelyClient from './optimizely';
+import OptimizelyClient from './optimizely';
+// import AnalyticsClient from '../services/analytics.js';
+// import * as optimizelySDK from '@optimizely/optimizely-sdk';
 // import * as optimizelySDK from '@optimizely/optimizely-sdk';
 // import { default as CookieOrginal } from 'js-cookie';
-// import glob from '../../../jest/global';
+import glob from '../../../jest/global';
+// import {
+//   setUserData,
+// } from '../site/user';
+
+// const jekyllProperties = { test: 'test' };
 
 /*Todo: MOCK FILES
 Setup mock file for promise async
@@ -15,24 +22,60 @@ jest.mock('js-cookie');
 
 describe('Optimizely Service', () => {
   beforeEach(() => {
+    // might need to mock this each time
+    // might not need all tests but specific
+    // this.client = optimizelySDK.createInstance({
+    //   datafile: window.optimizelyDatafile,
+    // });
     jest.resetAllMocks();
-  });
-  it('true is true', () => {
-    expect(true).toBe(true);
   });
 
   describe('getUserId()', () => {
-    //***Need to create a mock file for async promise
-
-    it('test if userData already exists', () => {
-      expect(true).toBe(true);
+    it('test if userData exists but analytics_id undefined', () => {
+      glob.userData = {};
+      const client = new OptimizelyClient();
+      return client.getUserId().then((data) => {
+        expect(data).toBe(null);
+      });
     });
 
-    it('test waiting for userData to populate', () => {
-      expect(true).toBe(true);
+    it('test if userData exists and analytics_id not null', async () => {
+      glob.userData = {
+        analytics_id: 'peanut butter',
+      };
+      const client = new OptimizelyClient();
+      await expect(client.getUserId()).resolves.toBe('peanut butter');
     });
 
-    //Should we add a no userData test?
+    it('test waiting for userData to populate null', async () => {
+      const client = new OptimizelyClient();
+      glob.userData = null;
+
+      setTimeout(() => {
+        glob.userData = {
+          analytics_id: undefined,
+        };
+        const userDataReady = new CustomEvent('userDataReady');
+        window.dispatchEvent(userDataReady);
+      }, 100);
+
+      await expect(client.getUserId()).resolves.toBe(null);
+    });
+
+    it('test if userData does not exist initially and defined later as peanut butter', async () => {
+      const client = new OptimizelyClient();
+      glob.userData = null;
+
+      setTimeout(() => {
+        glob.userData = {
+          analytics_id: 'peanut butter',
+        };
+        const userDataReady = new CustomEvent('userDataReady');
+        window.dispatchEvent(userDataReady);
+      }, 100);
+
+      await expect(client.getUserId()).resolves.toBe('peanut butter');
+    });
   });
 
   //Function used in TrackExperimentViewed


### PR DESCRIPTION
Jira link: [DD-72](https://circleci.atlassian.net/browse/DD-72 )
Preview link: [link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-72-add-unit-test-OptimizelyClient-preview/?force-all)

This story is for adding unit tests for the OptimizelyClient as it is a critical part of our experiment resolving process.

# Description
Work in progress, add unit tests to optimizely client

# What changed
- Function inside of optimiely had to be exported so that tests could be ran on them
- Keys were exported such that tests are dependant on latest key

# Reasons
Better test coverage

# Impact
Unit tests help make sure we are not breaking anything critical, especially when it comes to how we resolve experiments (in that case the OptimizelyClient)

# Definition of Done:
Critical aspects of the OptimizelyClient file are thoroughly tested. This includes:

getUserId
getVariationName
trackExperimentViewed
isExperimentAlreadyViewed
storeExperimentParticipation