### PR TITLE
Update to newer Xcode image in macOS example config

### DIFF
--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -72,7 +72,7 @@ jobs: # a basic unit of work in a run
 
   build: 
     macos:
-      xcode: 11.3.0 # indicate our selected version of Xcode
+      xcode: 12.5.1 # indicate our selected version of Xcode
     steps: 
       - checkout
       - run:


### PR DESCRIPTION
# Description
Updated the example macOS config to point to a newer Xcode image.

# Reasons
Since many customers look at our docs when getting started (and often copy the examples directly), we want to encourage them to use the latest images.