### PR TITLE
Update example macOS config xcode image

### DIFF
--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -63,7 +63,7 @@ version: 2.1
 jobs: # a basic unit of work in a run
   test: # your job name
     macos:
-      xcode: 11.3.0 # indicate our selected version of Xcode
+      xcode: 12.5.1 # indicate our selected version of Xcode
     steps: # a series of commands to run
       - checkout  # pull down code from your version control system.
       - run:


### PR DESCRIPTION
# Description
Updated the example macOS config to point to a newer Xcode image.

# Reasons
Since many customers look at our docs when getting started (and often copy the examples directly), we want to encourage them to use the latest images.