### PR TITLE
Update server-3-operator-orbs.adoc

### DIFF
--- a/jekyll/_cci2/server-3-operator-orbs.adoc
+++ b/jekyll/_cci2/server-3-operator-orbs.adoc
@@ -22,7 +22,10 @@ toc::[]
 
 ## Managing Orbs
 Orbs are accessed via the https://circleci.com/docs/2.0/local-cli/[CircleCI CLI]. Orbs require your CircleCI user to be
-an admin. They also require a https://circleci.com/docs/2.0/managing-api-tokens/[personal api token]. Providing a local
+an admin. They also require a https://circleci.com/docs/2.0/managing-api-tokens/[personal API token]. 
+Please ensure that you are using a personal API token generated **after** your user account is made an admin.
+
+Providing a local
 repository location using the `--host` option allows you to access your local server orbs vs the public cloud orbs. For
 example, if your server installation is located at `\http://circleci.somehostname.com`, then you can run orb commands
 local to that orb repository by passing `--host \http://cirlceci.somehostname.com`.


### PR DESCRIPTION
After checking-in with a customer whose user account was only made admin recently but was using an older token, it may be good to highlight that the used API token for operating with Orbs should be a token generated once the user account is made admin.

This should obvious and logical when reading the above, but arguably can be missed by the best of us.
For clarity and erring on being detailed, I think adding this note can be helpful.

# Description
Add notes to check that the API token used by the user when managing Orbs should be a token generated from the (now-admin) user.

# Reasons

https://circleci.zendesk.com/agent/tickets/100999