### PR TITLE
Add banner for scheduled workflows, fix link

### DIFF
--- a/jekyll/_cci2/v.2.17-overview.md
+++ b/jekyll/_cci2/v.2.17-overview.md
@@ -111,7 +111,7 @@ To take a snapshot of your installation:
 **Note:** It is also possible to automate this process with the AWS API. Subsequent AMIs/snapshots are only as large as the difference (changed blocks) since the last snapshot, such that storage costs are not necessarily larger for more frequent snapshots, see Amazon's EBS snapshot billing document for details.
 Once you have the snapshot you are free to make changes on the Services machine.
 
-If you do need to rollback at any point, see our [restore from backup](http://localhost:4000/docs/2.0/backup/#restoring-from-backup) guide.
+If you do need to rollback at any point, see our [restore from backup]({{site.baseurl}}/2.0/backup/#restoring-from-backup) guide.
 
 ### Update Replicated
 {: #update-replicated }

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -254,6 +254,10 @@ After approving, the rest of the workflow runs as directed.
 ## Scheduling a workflow
 {: #scheduling-a-workflow }
 
+<div class="alert alert-warning" role="alert">
+  <strong>Scheduled workflows will be phased out starting in June 2022.</strong> Visit the scheduled pipelines <a href="{{site.baseurl}}/2.0/scheduled-pipelines/#get-started">migration guide</a> to find out how to migrate existing scheduled workflows to scheduled pipelines, or to set up scheduled pipelines from scratch.
+</div>
+
 It can be inefficient and expensive to run a workflow for every commit for every branch. Instead, you can schedule a workflow to run at a certain time for specific branches. This will disable commits from triggering jobs on those branches.
 
 Consider running workflows that are resource-intensive or that generate reports on a schedule rather than on every commit by adding a `triggers` key to the configuration. The `triggers` key is **only** added under your `workflows` key. This feature enables you to schedule a workflow run by using `cron` syntax to represent Coordinated Universal Time (UTC) for specified branches.

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -255,7 +255,7 @@ After approving, the rest of the workflow runs as directed.
 {: #scheduling-a-workflow }
 
 <div class="alert alert-warning" role="alert">
-  <strong>Scheduled workflows will be phased out starting in June 2022.</strong> Visit the scheduled pipelines <a href="{{site.baseurl}}/2.0/scheduled-pipelines/#get-started">migration guide</a> to find out how to migrate existing scheduled workflows to scheduled pipelines, or to set up scheduled pipelines from scratch.
+  <strong>Scheduled workflows will be phased out starting June 3, 2022.</strong> Visit the scheduled pipelines <a href="{{site.baseurl}}/2.0/scheduled-pipelines/#get-started">migration guide</a> to find out how to migrate existing scheduled workflows to scheduled pipelines, or to set up scheduled pipelines from scratch.
 </div>
 
 It can be inefficient and expensive to run a workflow for every commit for every branch. Instead, you can schedule a workflow to run at a certain time for specific branches. This will disable commits from triggering jobs on those branches.


### PR DESCRIPTION
# Description
Adding a banner to the scheduled workflows section of our docs to indicate that scheduled workflows are sunsetting in the spring. I also randomly found a link in an unrelated page that was an incorrect format, so I fixed that.

# Reasons
There are still a lot of people who haven't migrated scheduled workflows to scheduled pipelines after communication has gone out about it. Hopefully this banner will help prevent new users from setting them up as well as remind users that the feature is being phased out.
![s_workflow_banner](https://user-images.githubusercontent.com/20114388/145422882-558e695c-8caf-4e2a-a1b8-00a8492efe39.png)
