### PR TITLE
Put GHE & CircleCI on same domain

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -169,6 +169,9 @@ gcloud iam service-accounts keys create <PATH_TO_STORE_CREDENTIALS> --iam-accoun
 ```
 
 === Create a new GitHub OAuth app
+
+CAUTION: If GitHub Enterprise and CircleCI server are not on the same domain then images will fail to load.
+
 Registering and setting up a new GitHub OAuth app for CircleCI server allows for authorization control to your server installation using GitHub OAuth and for updates to GitHub projects/repos using build status information.
 
 . In your browser navigate to **your GitHub instance** > **Settings** > **Developer Settings** > **OAuth Apps** and click the **New OAuth App** button.


### PR DESCRIPTION
SERVER-1497

Warn users that failing to host CircleCI & GHE on the same
domain will lead to images failing to load. (This is a GH bug)