### PR TITLE
Gave workflow `version` anchor a unique name

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1461,7 +1461,7 @@ workflows:
 Used for orchestrating all jobs. Each workflow consists of the workflow name as a key and a map as a value. A name should be unique within the current `config.yml`. The top-level keys for the Workflows configuration are `version` and `jobs`.
 
 ### **`version`**
-{: #version }
+{: #workflow-version }
 The Workflows `version` field is used to issue warnings for deprecation or breaking changes during Beta.
 
 Key | Required | Type | Description


### PR DESCRIPTION
# Description
Changed the workflow version anchor a unqiue name

# Reasons
In the _On This Page_ section both the top-level **version** and the workflows **version** elements are linked to `#version`.  

Without a unique identifier, both of those entries link to the top-level **version** meaning when I click **version** within the **workflows** hierarchy _it does not go to worklows/version_, but goes to config.yaml/version.