### PR TITLE
Update Xcode 13.2 RC to Release

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -52,7 +52,7 @@ Running or testing Apple Silicon apps natively is currently not possible as Circ
 
  Config   | Xcode Version                   | macOS Version | macOS UI Testing Supported | Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|-------------------|--------------
- `13.2.0` | Xcode 13.2 RC (13C90) | 11.6.2 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6613/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-2-rc-released/42204)
+ `13.2.0` | Xcode 13.2 (13C90) | 11.6.2 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6613/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-2-rc-released/42204)
  `13.1.0` | Xcode 13.1 (13A1030d) | 11.6.1 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6269/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-1-rc-released/41577)
  `13.0.0` | Xcode 13.0 (13A233) | 11.5.2 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6052/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-rc-released/41256)
  `12.5.1` | Xcode 12.5.1 (12E507) | 11.4.0 | Yes | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v5775/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-5-1-released/40490)


### PR DESCRIPTION
No change in build number for the release version of Xcode 13.2, therefore we do not need to re-build this image. Updating docs accordingly