### PR TITLE
(NO-JIRA) Fix contexts table in server-3 docs

### DIFF
--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -205,7 +205,7 @@ Once you have successfully cloned the repository you can follow it from within y
 
 .Contexts
 [.table.table-striped]
-[cols=2*, options="header", stripes=even]
+[cols=3*, options="header", stripes=even]
 |===
 |Name
 |Environmental Variable Key


### PR DESCRIPTION
# Description
Fixes the contexts table in server-3 docs.

# Reasons
There was a formatting issue with the table showing contexts and their variables in the server-3 docs seen [here](https://circleci.com/docs/2.0/server-3-install-build-services/#github-enterprise).

**Before**:
![Screen Shot 2021-12-13 at 2 30 21 PM](https://user-images.githubusercontent.com/38337779/145899447-bb75482d-a1ee-49ee-af44-86862b21a1f2.png)
**After**:
![Screen Shot 2021-12-13 at 2 30 06 PM](https://user-images.githubusercontent.com/38337779/145899480-05342bd5-83a8-4419-a294-7f634c4f4633.png)

