### PR TITLE
Add macOS resource class options table

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -285,7 +285,16 @@ The IP range `192.168.53.0/24` is reserved by CircleCI for the internal use on m
 
 _Available on CircleCI Cloud - not currently available on self-hosted installations_
 
-Using the `macos` executor allows you to run your job in a macOS environment on a VM. You can also specify which version of Xcode should be used. See the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) document for the complete list of version numbers and information about technical specifications for the VMs running each particular version of Xcode.
+Using the `macos` executor allows you to run your job in a macOS environment on a VM. In macOS, the following resources classes are available:
+
+Class                 | vCPUs | RAM
+----------------------|-------|-----
+medium                | 4 @ 2.7 GHz     | 8GB
+macos.x86.medium.gen2 | 4 @ 3.2 GHz     | 8GB
+large                 | 8 @ 2.7 GHz     | 16GB
+{: class="table table-striped"}
+
+You can also specify which version of Xcode should be used. See the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) document for the complete list of version numbers and information about technical specifications for the VMs running each particular version of Xcode.
 
 ```yaml
 jobs:


### PR DESCRIPTION
# Description
We're adding a new resource class option to the macOS executor.

# Reasons
Since the new `macos.x86.medium.gen2` resource option has the same basic specs as our standard `medium`, I've added the processor speeds to the table so customers will more easily understand what the differences are between the various options.