### PR TITLE
Remove reference to -ja folder, fix link

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -5,7 +5,7 @@ There are two ways to work on CircleCI docs locally: with Docker and with [Ruby]
 
 ## 1. Local Development with Docker (recommended)
 
-If you are planning on making a pull request, please see the [pull request](https://github.com/circleci/circleci-docs#submitting-pull-requests) instructions first.
+If you are planning on making a pull request, please see the [pull request](https://github.com/circleci/circleci-docs/blob/master/docs/local-development.md#submitting-pull-requests) instructions first.
 
 1. Install Docker for your platform: <https://docs.docker.com/engine/install/>
 2. Clone the CircleCI docs repo: `git clone https://github.com/circleci/circleci-docs.git`
@@ -92,7 +92,7 @@ If you want to work on the way search works on docs, follow the below instructio
 
 The docs site includes Bootstrap 3, JS, and CSS, so you'll have access to all of its [reusable components](https://v4-alpha.getbootstrap.com/components/alerts/).
 
-All docs live in folders named after the version of CircleCI. The only one you need to worry about is `jekyll/_cci2` or `jekyll/_cci2_ja` if you want to work on our translated content. .
+All docs live in folders named after the version of CircleCI. The only folder relevant to editing docs locally is `jekyll/_cci2`.
 
 1. Create a branch and switch to it:
 


### PR DESCRIPTION
# Description
We can't accept PRs to our translated content since it will be overwritten by Crowdin. I've removed the reference to the -ja folder for local development. I also updated a url.

# Reasons
We've received a PR for translated content from last year that has been sitting. We unfortunately can't do anything with this as it will just get overwritten by Crowdin. Removing this line and only referencing the english folder will imply that is the location to make any changes allowed.