### PR TITLE
[DD-268] Add banner atop legacy circle ci v1 api

### DIFF
--- a/src-api/source/javascripts/app/_toc.js
+++ b/src-api/source/javascripts/app/_toc.js
@@ -44,7 +44,8 @@
     };
 
     var refreshToc = function () {
-      var currentTop = $(document).scrollTop() + scrollOffset;
+      // 74 because v2-banner expands up to 74px scroll-margin-top is set to 74
+      var currentTop = $(document).scrollTop() + scrollOffset + 74;
 
       if (currentTop + windowHeight >= pageHeight) {
         // at bottom of page, so just select last header by making currentTop very large

--- a/src-api/source/layouts/layout.erb
+++ b/src-api/source/layouts/layout.erb
@@ -107,6 +107,11 @@ under the License.
       <div class="dark-box"></div>
       <div class="content">
         <div class="header-links">
+        
+        <aside class="notice">
+        v1 APIs will be deprecated within the next year. We recommend switching to the <a class="content-link" target="_blank" href="https://circleci.com/docs/api/v2/">v2 APIs</a>.
+        </aside>
+        
           <a class="content-link" target="_blank" href="https://circleci.com/docs/2.0">
             Documentation
             <%= image_tag "new-window.svg", width: '90%',  class: 'new-window' %>

--- a/src-api/source/layouts/layout.erb
+++ b/src-api/source/layouts/layout.erb
@@ -106,12 +106,10 @@ under the License.
     <div class="page-wrapper">
       <div class="dark-box"></div>
       <div class="content">
-        <div class="header-links">
-        
-        <aside class="notice">
-        v1 APIs will be deprecated within the next year. We recommend switching to the <a class="content-link" target="_blank" href="https://circleci.com/docs/api/v2/">v2 APIs</a>.
+        <aside class="v2-banner notice">
+          v1 APIs will be deprecated within the next year. We recommend switching to the <a class="content-link-v2banner" target="_blank" href="https://circleci.com/docs/api/v2/">v2 APIs</a>.
         </aside>
-        
+        <div class="header-links">
           <a class="content-link" target="_blank" href="https://circleci.com/docs/2.0">
             Documentation
             <%= image_tag "new-window.svg", width: '90%',  class: 'new-window' %>

--- a/src-api/source/layouts/layout.erb
+++ b/src-api/source/layouts/layout.erb
@@ -107,7 +107,7 @@ under the License.
       <div class="dark-box"></div>
       <div class="content">
         <aside class="v2-banner notice">
-          v1 APIs will be deprecated within the next year. We recommend switching to the <a class="content-link-v2banner" target="_blank" href="https://circleci.com/docs/api/v2/">v2 APIs</a>.
+          v1 APIs will be deprecated within the next year. We recommend switching to the <a target="_blank" href="https://circleci.com/docs/api/v2/">v2 APIs</a>.
         </aside>
         <div class="header-links">
           <a class="content-link" target="_blank" href="https://circleci.com/docs/2.0">

--- a/src-api/source/stylesheets/_variables.scss
+++ b/src-api/source/stylesheets/_variables.scss
@@ -39,6 +39,7 @@ $lang-select-active-bg: $examples-bg !default; // feel free to change this to bl
 $lang-select-pressed-bg: #111 !default; // color of language tab bg when mouse is pressed
 $main-bg: #FDFDFD !default;
 $aside-notice-bg: #8fbcd4 !default;
+$aside-v2banner-bg: #FBF8E5 !default;
 $aside-warning-bg: #c97a7e !default;
 $aside-success-bg: #6ac174 !default;
 $search-notice-bg: #c97a7e !default;

--- a/src-api/source/stylesheets/screen.css.scss
+++ b/src-api/source/stylesheets/screen.css.scss
@@ -540,6 +540,8 @@ html, body {
     &.v2-banner {
       margin-top: 0em;
       background: $aside-v2banner-bg;
+      position: sticky;
+      top: 0;
     }
   }
 

--- a/src-api/source/stylesheets/screen.css.scss
+++ b/src-api/source/stylesheets/screen.css.scss
@@ -358,15 +358,13 @@ html, body {
     clear: both;
   }
 
-
-
-  .header-links,  {
+  .header-links {
     margin-right: 50%;
     padding: 24px 28px;
     box-sizing: border-box;
     display: flex;
-
   }
+
   .content-link {
     color: #7F7F7F;
     display: flex;
@@ -379,12 +377,19 @@ html, body {
     }
   }
 
+  .content-link-v2banner {
+    color: #7F7F7F;
+    text-decoration: none;
+    font-family: Roboto;
+    font-weight: bold;
+    font-size: 14px;
+  }
+
   .new-window {
     color: grey;
     width: 12px;
     padding-left: 8px;
   }
-
 
   &>h1, &>h2, &>h3, &>h4, &>h5, &>h6, &>p, &>table, &>ul, &>ol, &>aside, &>dl {
     margin-right: $examples-width;
@@ -524,9 +529,7 @@ html, body {
   aside {
     padding-top: 1em;
     padding-bottom: 1em;
-    margin-top: 1.5em;
     margin-bottom: 1.5em;
-    background: $aside-notice-bg;
     line-height: 1.6;
 
     &.warning {
@@ -535,6 +538,16 @@ html, body {
 
     &.success {
       background-color: $aside-success-bg;
+    }
+
+    &.notice {
+      margin-top: 1.5em;
+      background: $aside-notice-bg;
+    }
+
+    &.v2-banner {
+      margin-top: 0em;
+      background: $aside-v2banner-bg;
     }
   }
 

--- a/src-api/source/stylesheets/screen.css.scss
+++ b/src-api/source/stylesheets/screen.css.scss
@@ -274,6 +274,7 @@ html, body {
   &.open {left: $nav-width}
 }
 
+h1,
 h2,
 h3,
 h4,

--- a/src-api/source/stylesheets/screen.css.scss
+++ b/src-api/source/stylesheets/screen.css.scss
@@ -377,14 +377,6 @@ html, body {
     }
   }
 
-  .content-link-v2banner {
-    color: #7F7F7F;
-    text-decoration: none;
-    font-family: Roboto;
-    font-weight: bold;
-    font-size: 14px;
-  }
-
   .new-window {
     color: grey;
     width: 12px;

--- a/src-api/source/stylesheets/screen.css.scss
+++ b/src-api/source/stylesheets/screen.css.scss
@@ -274,6 +274,13 @@ html, body {
   &.open {left: $nav-width}
 }
 
+h2,
+h3,
+h4,
+h5,
+h6{
+  scroll-margin-top: 74px;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // PAGE LAYOUT AND CODE SAMPLE BACKGROUND
@@ -539,7 +546,8 @@ html, body {
 
     &.v2-banner {
       margin-top: 0em;
-      background: $aside-v2banner-bg;
+      background: #FBF8E5;
+      position: -webkit-sticky;
       position: sticky;
       top: 0;
     }


### PR DESCRIPTION
Jira case: [DD-268](https://circleci.atlassian.net/jira/software/c/projects/DD/boards/477?modal=detail&selectedIssue=DD-268)
Preview link: [link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-268-Add-banner-atop-legacy-CircleCI-v1-API-preview/api/v1/#circleci-v1-api-overview)

# Description
Add banner atop legacy CircleCI v1 API docs to direct to CircleCI v2 API docs so that user use the v2 APIs

# Reasons:
Direct users to v2 APIs so the v1 APIs can eventually be deprecated

# Changes
- add in css for banner

# Before
<img width="1105" alt="Screen Shot 2021-12-16 at 7 57 19 PM" src="https://user-images.githubusercontent.com/86666932/146471142-96cacdbf-b400-4f43-8e73-985377d71df1.png">

# After
<img width="926" alt="Screen Shot 2021-12-21 at 3 40 36 PM" src="https://user-images.githubusercontent.com/86666932/146994755-1c7736ad-93b9-4b22-a594-e9364bbf9977.png">

Banner sticky to top
<img width="1210" alt="Screen Shot 2021-12-21 at 3 47 54 PM" src="https://user-images.githubusercontent.com/86666932/146995621-0fd28830-32a1-4959-8124-8c21b9f81355.png">

