### PR TITLE
Alexa mac updates

### DIFF
--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -135,8 +135,8 @@ jobs:
      image: ubuntu-2004:202010-01
 #...
  build3:
-   macos: # Specifies a macOS virtual machine with Xcode version 11.3
-     xcode: "11.3.0"
+   macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+     xcode: "12.5.1"
 # ...
 ```
 
@@ -171,8 +171,8 @@ jobs:
      image: ubuntu-2004:202010-01
 #...
  build3:
-   macos: # Specifies a macOS virtual machine with Xcode version 11.3
-     xcode: "11.3.0"
+   macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+     xcode: "12.5.1"
 # ...
 ```
 
@@ -207,8 +207,8 @@ jobs:
      image: ubuntu-1604:201903-01
 #...
  build3:
-   macos: # Specifies a macOS virtual machine with Xcode version 11.3
-     xcode: "11.3.0"
+   macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+     xcode: "12.5.1"
 # ...
 ```
 
@@ -279,8 +279,8 @@ The Primary Container is defined by the first image listed in a [`.circleci/conf
        image: ubuntu-1604:202007-01
 ...
    build3:
-     macos: # Specifies a macOS virtual machine with Xcode version 9.0
-       xcode: "9.0"
+     macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+       xcode: "12.5.1"
  ...
  ```
 

--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -798,7 +798,7 @@ executors:
       image: ubuntu-2004:202107-02
   macos: # macos executor running Xcode
     macos:
-      xcode: 12.5
+      xcode: 12.5.1
 
 jobs:
   test:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -435,14 +435,14 @@ Key | Required | Type | Description
 xcode | Y | String | The version of Xcode that is installed on the virtual machine, see the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) document for the complete list.
 {: class="table table-striped"}
 
-**Example:** Use a macOS virtual machine with Xcode version 11.3:
+**Example:** Use a macOS virtual machine with Xcode version 12.5.1:
 
 
 ```yaml
 jobs:
   build:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
 ```
 
 #### **`windows`**
@@ -611,7 +611,7 @@ large<sup>(3)</sup>| 8     | 16GB
 jobs:
   build:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     resource_class: large
     steps:
       ... // other config
@@ -1963,7 +1963,7 @@ executors:
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
   macos: &macos-executor
     macos:
-      xcode: 11.4
+      xcode: 12.5.1
 
 jobs:
   test:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -599,8 +599,9 @@ jobs:
 
 Class              | vCPUs | RAM
 -------------------|-------|-----
-medium (default)   | 4     | 8GB
-large<sup>(3)</sup>| 8     | 16GB
+medium (default)   | 4 @ 2.7 GHz    | 8GB
+macos.x86.medium.gen2   | 4 @ 3.2 GHz    | 8GB
+large<sup>(3)</sup>| 8 @ 2.7 GHz    | 16GB
 {: class="table table-striped"}
 
 ###### Example usage

--- a/jekyll/_cci2/deploying-ios.md
+++ b/jekyll/_cci2/deploying-ios.md
@@ -223,7 +223,7 @@ version: 2.1
 jobs:
   adhoc:
     macos:
-      xcode: "11.3.1"
+      xcode: "12.5.1"
     environment:
       FL_OUTPUT_DIR: output
     steps:

--- a/jekyll/_cci2/examples-intro.md
+++ b/jekyll/_cci2/examples-intro.md
@@ -106,7 +106,7 @@ _The macOS executor is not currently available on self-hosted installations of C
 jobs:
   build-and-test:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     steps:
       ...
       - run:

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -54,7 +54,7 @@ jobs:
   build: # name of your job
     machine: # executor type
       image: ubuntu-1604:202007-01 # VM will run Ubuntu 16.04 for this release date
-      
+
     steps:
       # Commands run in a Linux virtual machine environment
 ```
@@ -81,11 +81,11 @@ _The macOS executor is not currently available on self-hosted installations of C
 jobs:
   build: # name of your job
     macos: # executor type
-      xcode: 11.3.0
+      xcode: 12.5.1
 
     steps:
       # Commands run in a macOS virtual machine environment
-      # with Xcode 11.3 installed
+      # with Xcode 12.5.1 installed
 ```
 
 Find out more about using the `macos` executor [here]({{ site.baseurl }}/2.0/executor-types/#using-macos).

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -38,7 +38,7 @@ It is possible to specify a different executor type for every job in your ['.cir
 
 - Jobs that require Docker images (`docker`) may use an image for Node.js or Python. The [pre-built CircleCI Docker image]({{ site.baseurl }}/2.0/circleci-images/) from the CircleCI Dockerhub will help you get started quickly without learning all about Docker. These images are not a full operating system, so they will generally make building your software more efficient.
 - Jobs that require a complete Linux virtual machine (VM) image (`machine`) may use an Ubuntu version such as 16.04.
-- Jobs that require a macOS VM image (`macos`) may use an Xcode version such as 10.0.0.
+- Jobs that require a macOS VM image (`macos`) may use an Xcode version such as 12.5.1.
 
 ## Using Docker
 {: #using-docker }
@@ -300,11 +300,11 @@ You can also specify which version of Xcode should be used. See the [Supported X
 jobs:
   build:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
 
     steps:
       # Commands will execute in macOS container
-      # with Xcode 11.3 installed
+      # with Xcode 12.5.1 installed
       - run: xcodebuild -version
 ```
 

--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -63,17 +63,17 @@ version: 2.1
 jobs: # a basic unit of work in a run
   test: # your job name
     macos:
-      xcode: 12.5.1 # indicate our selected version of Xcode
+      xcode: 12.5.1 # indicate your selected version of Xcode
     steps: # a series of commands to run
       - checkout  # pull down code from your version control system.
       - run:
           name: Run Unit Tests
           command: xcodebuild test -scheme circleci-demo-macos
 
-  build: 
+  build:
     macos:
-      xcode: 12.5.1 # indicate our selected version of Xcode
-    steps: 
+      xcode: 12.5.1 # indicate your selected version of Xcode
+    steps:
       - checkout
       - run:
           # build our application
@@ -86,7 +86,7 @@ jobs: # a basic unit of work in a run
       - store_artifacts: # store this build output. Read more: https://circleci.com/docs/2.0/artifacts/
           path: app.zip
           destination: app
-          
+
 workflows:
   version: 2
   test_build:

--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -78,7 +78,7 @@ Using the basics from the Linux and Android examples above, you can add a job th
 jobs:
   build-macos:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
 ```
 
 Refer to the [Hello World on MacOS]({{site.baseurl}}/2.0/hello-world-macos) document for more information and a sample project.

--- a/jekyll/_cci2/ios-codesigning.md
+++ b/jekyll/_cci2/ios-codesigning.md
@@ -153,14 +153,14 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.0
+      xcode: 12.5.1
     steps:
       # ...
       - run: bundle exec fastlane test
 
   adhoc:
     macos:
-      xcode: 12.5.0
+      xcode: 12.5.1
     steps:
       # ...
       - run: bundle exec fastlane adhoc
@@ -211,7 +211,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -228,7 +228,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc

--- a/jekyll/_cci2/ios-tutorial.md
+++ b/jekyll/_cci2/ios-tutorial.md
@@ -45,7 +45,7 @@ For iOS projects, it is possible to run your tests with Fastlane Scan as follows
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       ...
       - run:
@@ -102,13 +102,13 @@ version: 2.1
 jobs:
   test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: fastlane scan
   deploy:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - deploy:

--- a/jekyll/_cci2/language-dart.md
+++ b/jekyll/_cci2/language-dart.md
@@ -171,7 +171,7 @@ jobs:
 ```yaml
   build-mac:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     steps:
       - run:
           name: Install Dart SDK
@@ -361,7 +361,7 @@ jobs:
 
   build-mac:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     steps:
       - run:
           name: Install Dart SDK

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -66,7 +66,7 @@ The `config-translation` endpoint can help you quickly get started with converti
      See the Using Machine section of the [Choosing an Executor Type](https://circleci.com/docs/2.0/executor-types/#using-machine) document for details about the available VM images.
      ```yaml
          macos:
-           xcode: 11.3.0
+           xcode: 12.5.1
      ```
 
 6. The `checkout:` step is required to run jobs on your source files. Nest `checkout:` under `steps:` for every job by search and replacing

--- a/jekyll/_cci2/migrating-from-aws.adoc
+++ b/jekyll/_cci2/migrating-from-aws.adoc
@@ -10,7 +10,7 @@ title: Migrating from AWS
 :toc: macro
 :toc-title:
 
-This document provides an overview of how to migrate from AWS CodeCommit to CircleCI. 
+This document provides an overview of how to migrate from AWS CodeCommit to CircleCI.
 
 NOTE: **Tips provided by ImagineX Consulting**
 
@@ -65,12 +65,12 @@ The AWS CodeBuild and CircleCI configurations will be different. It may be helpf
 |===
 | AWS | CircleCI
 
-2+| Define a job that executes a single build step. 
+2+| Define a job that executes a single build step.
 
 a|
 [source, json]
 ----
-phases:  
+phases:
   build:
     commands:
        - ./execute-script-for-job1.sh
@@ -177,8 +177,8 @@ workflows:
 a|
 [source, json]
 ----
-# Environments are selected in the CodeBuild 
-# web console or defined in a project  
+# Environments are selected in the CodeBuild
+# web console or defined in a project
 # configuration file:
 {
   "name": "linux project",
@@ -207,7 +207,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"
@@ -218,9 +218,9 @@ jobs:
 a|
 [source, json]
 ----
-# If custom cache is enabled in the web 
-# console, CLI or CloudFormation, cache 
-# locations can be specified in the 
+# If custom cache is enabled in the web
+# console, CLI or CloudFormation, cache
+# locations can be specified in the
 # buildspec.yml file:
 
 phases:

--- a/jekyll/_cci2/migrating-from-azuredevops.adoc
+++ b/jekyll/_cci2/migrating-from-azuredevops.adoc
@@ -72,7 +72,7 @@ The Azure DevOps Pipelines and CircleCI configurations will be different. It may
 |===
 | Azure DevOps | CircleCI
 
-2+| Define a job that executes a single build step. 
+2+| Define a job that executes a single build step.
 
 a|
 [source, ini]
@@ -208,7 +208,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-buildkite.adoc
+++ b/jekyll/_cci2/migrating-from-buildkite.adoc
@@ -10,7 +10,7 @@ title: Migrating from Buildkite
 :toc: macro
 :toc-title:
 
-This document provides an overview of how to migrate from Buildkite to CircleCI. 
+This document provides an overview of how to migrate from Buildkite to CircleCI.
 
 NOTE: **Tips provided by ImagineX Consulting**
 
@@ -66,7 +66,7 @@ The Buildkite and CircleCI configurations will be different. It may be helpful t
 |===
 | Buildkite | CircleCI
 
-2+| Define a job that executes a single build step. 
+2+| Define a job that executes a single build step.
 
 a|
 [source, yaml]
@@ -119,7 +119,7 @@ a|
 steps:
   - label: 'job1'
     command: 'make build dependencies'
- 
+
   - label: 'job2'
     command: 'make build artifacts'
 
@@ -197,7 +197,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -51,7 +51,7 @@ jobs:
       # job steps
   job_2:
     needs: job_1
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       # job steps
 ----
@@ -132,7 +132,7 @@ machine: true
 
 # macOS Executor
 macos:
-  xcode: 11.3.0
+  xcode: 12.5.1
 
 # Windows Executor
 # NOTE: Orb declaration needed. See docs
@@ -241,15 +241,15 @@ orbs:
 
 jobs:
   build:
-    # executor config here 
+    # executor config here
 
     steps:
       - slack-orb/notify:
           color: '#32788D'
-          message: Tests passed 
+          message: Tests passed
           title: Testing Slack Orb
-          author_name: Bobby 
-          webhook: # WEBHOOK 
+          author_name: Bobby
+          webhook: # WEBHOOK
 ----
 
 2+| Using conditional steps in the workflow. CircleCI offers https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute[basic conditions on steps] (e.g., on_success [default], +
@@ -264,10 +264,10 @@ jobs:
     # environment config here
 
     steps:
-      - name: My Failure Step 
+      - name: My Failure Step
         run: echo "Failed step"
         if: failure()
-      - name: My Always Step 
+      - name: My Always Step
         run: echo "Always step"
         if: always()
 ----

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -10,7 +10,7 @@ title: Migrating from GitLab
 :toc: macro
 :toc-title:
 
-This document provides an overview of how to migrate from GitLab to CircleCI. 
+This document provides an overview of how to migrate from GitLab to CircleCI.
 
 NOTE: **Tips provided by ImagineX Consulting**
 
@@ -196,7 +196,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osx-job:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-teamcity.adoc
+++ b/jekyll/_cci2/migrating-from-teamcity.adoc
@@ -107,7 +107,7 @@ a|
 [source, kotlin]
 ----
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script 
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 version: "2019.2"
 
@@ -151,7 +151,7 @@ jobs:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 
-    # Define steps for job 
+    # Define steps for job
     steps:
       - checkout
       - run: echo "Hello World!"
@@ -226,7 +226,7 @@ project {
     parallel {
         build(Test1)
         build(Test2)
-    } 
+    }
     build(Package)
     build(Publish)
   }
@@ -284,7 +284,7 @@ jobs:
   my-mac-job:
     # Executor definition
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
 
     # Steps definition
     steps:

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -1198,7 +1198,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 11.5.0
+      xcode: 12.5.1
     parameters:
       label:
         type: string
@@ -1300,7 +1300,7 @@ jobs:
 
   test-macos:
     macos:
-      xcode: 11.5.0
+      xcode: 12.5.1
     parameters:
       label:
         type: string
@@ -1374,7 +1374,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run:

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -175,7 +175,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -192,7 +192,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
@@ -547,7 +547,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -593,7 +593,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
 

--- a/jekyll/_cci2/testing-macos.md
+++ b/jekyll/_cci2/testing-macos.md
@@ -65,7 +65,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - run: echo 'chruby ruby-2.7' >> ~/.bash_profile
@@ -86,7 +86,7 @@ Fastlane allows you to avoid calling lengthy Xcode commands manually and instead
 write a simple configuration file to initiate the macOS app tests. With Fastlane
 you can build, sign (for testing) and test a macOS app. Please note that when
 using Fastlane, depending on the actions in your configuration, you may need to
-setup a 2-factor Authentication (2FA). 
+setup a 2-factor Authentication (2FA).
 See the [Fastlane Docs for more information](https://docs.fastlane.tools/best-practices/continuous-integration/#method-2-two-step-or-two-factor-authentication).
 
 A simple config can be found below. Note that this config relies on the project
@@ -134,7 +134,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/list-permissions
@@ -168,7 +168,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/list-permission-types
@@ -198,7 +198,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/add-uitest-permissions
@@ -218,7 +218,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/add-permission:
@@ -240,7 +240,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/delete-permission:

--- a/jekyll/_cci2_ja/concepts.md
+++ b/jekyll/_cci2_ja/concepts.md
@@ -130,8 +130,8 @@ jobs:
      image: ubuntu-2004:202010-01
 #...
  build3:
-     macos: # macOS 仮想マシンと Xcode バージョン 11.3 を指定します。
-       xcode: "11.3.0"
+     macos: # macOS 仮想マシンと Xcode バージョン 12.5.1 を指定します。
+       xcode: "12.5.1"
 # ...
 ```
 
@@ -166,8 +166,8 @@ jobs:
      image: ubuntu-2004:202010-01
 #...
  build3:
-   macos: # Specifies a macOS virtual machine with Xcode version 11.3
-     xcode: "11.3.0"
+   macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+     xcode: "12.5.1"
 # ...
 ```
 
@@ -204,8 +204,8 @@ jobs:
      image: ubuntu-1604:201903-01
 #...
  build3:
-   macos: # Specifies a macOS virtual machine with Xcode version 11.3
-     xcode: "11.3.0"
+   macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+     xcode: "12.5.1"
 # ...
 ```
 
@@ -275,8 +275,8 @@ jobs:
        image: ubuntu-1604:202007-01
 ...
    build3:
-     macos: # Specifies a macOS virtual machine with Xcode version 9.0
-       xcode: "9.0"
+     macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+       xcode: "12.5.1"
  ...
  ```
 
@@ -444,7 +444,7 @@ workflows:
 version: 2
 jobs:
   build1:
-    docker: # 各ジョブで Executor (docker、macos、machine) 
+    docker: # 各ジョブで Executor (docker、macos、machine)
     # を指定する必要があります。 これらの比較や他の例
     # については、circleci.com/ja/docs/2.0/executor-types/
     # を参照してください。
@@ -699,7 +699,7 @@ jobs:
 #...
     steps:    
 
-      - persist_to_workspace: # ダウンストリーム ジョブで使用するために、指定されたパス 
+      - persist_to_workspace: # ダウンストリーム ジョブで使用するために、指定されたパス
       # (workspace/echo-output) をワークスペースに維持します。 このパスは、絶対パスまたは
       # working_directory からの相対パスでなければなりません。 This is a directory on the container which is
       # taken to be the root directory of the workspace.

--- a/jekyll/_cci2_ja/configuration-cookbook.md
+++ b/jekyll/_cci2_ja/configuration-cookbook.md
@@ -586,7 +586,7 @@ workflows:
 version: 2.1
 
 # CircleCI のダイナミック コンフィグ機能を有効にする。
-setup: true 
+setup: true
 
 # ダイナミック コンフィグの使用には continuation Orb が必要。
 orbs:
@@ -601,7 +601,7 @@ jobs:
       - run: # コマンドの実行
           name: 設定ファイルの生成
           command: |
-            ./generate-config > generated_config.yml 
+            ./generate-config > generated_config.yml
       - continuation/continue:
           configuration_path: generated_config.yml # 新しく生成した設定ファイルを使用して続行
 
@@ -790,7 +790,7 @@ executors:
       image: ubuntu-2004:202107-02
   macos: # macos executor running Xcode
     macos:
-      xcode: 12.5
+      xcode: 12.5.1
 
 jobs:
   test:

--- a/jekyll/_cci2_ja/configuration-reference.md
+++ b/jekyll/_cci2_ja/configuration-reference.md
@@ -609,8 +609,9 @@ jobs:
 
 | クラス                 | vCPU | RAM  |
 | ------------------- | ---- | ---- |
-| medium (デフォルト)      | 4    | 8GB  |
-| large<sup>(3)</sup> | 8    | 16GB |
+| medium (デフォルト)      | 4 @ 2.7 GHz   | 8GB  |
+| macos.x86.medium.gen2   | 4 @ 3.2 GHz    | 8GB
+| large<sup>(3)</sup> | 8 @ 2.7 GHz   | 16GB |
 {: class="table table-striped"}
 
 ###### 例

--- a/jekyll/_cci2_ja/configuration-reference.md
+++ b/jekyll/_cci2_ja/configuration-reference.md
@@ -8,19 +8,19 @@ version:
   - Cloud
   - Server v2.x
 suggested:
-  - 
+  -
     title: 6 config optimization tips
     link: https://circleci.com/blog/six-optimization-tips-for-your-config/
-  - 
+  -
     title: Intro to dynamic config
     link: https://discuss.circleci.com/t/intro-to-dynamic-config-via-setup-workflows/39868
-  - 
+  -
     title: Using dynamic config
     link: https://circleci.com/blog/building-cicd-pipelines-using-dynamic-config/
-  - 
+  -
     title: Validate your config using local CLI
     link: https://support.circleci.com/hc/en-us/articles/360006735753?input_string=configuration+error
-  - 
+  -
     title: How to trigger a single job
     link: https://support.circleci.com/hc/en-us/articles/360041503393?input_string=changes+in+v2+api
 ---
@@ -208,7 +208,7 @@ executors:
           password: $DOCKERHUB_PASSWORD  # コンテキスト/プロジェクト UI 環境変数の参照
   macos: &macos-executor
     macos:
-      xcode: 11.4
+      xcode: 12.5.1
 
 jobs:
   test:
@@ -449,13 +449,13 @@ CircleCI は [macOS](https://developer.apple.com/jp/macos/) 上でのジョブ�
 | xcode | ○  | 文字列 | 仮想マシンにインストールする Xcode のバージョン。 iOS でのテストに関するドキュメントの「[サポートされている Xcode のバージョン]({{ site.baseurl }}/2.0/testing-ios/#サポートされている-xcode-のバージョン)」を参照してください。 |
 {: class="table table-striped"}
 
-**例:** macOS 仮想マシンを Xcode バージョン 11.3 で使用する場合
+**例:** macOS 仮想マシンを Xcode バージョン 12.5.1 で使用する場合
 
 ```yaml
 jobs:
   build:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
 ```
 
 #### **`windows`**
@@ -619,7 +619,7 @@ jobs:
 jobs:
   build:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     resource_class: large
     steps:
       ... // 他の構成
@@ -1911,7 +1911,7 @@ executors:
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
   macos: &macos-executor
     macos:
-      xcode: 11.4
+      xcode: 12.5.1
 
 jobs:
   test:

--- a/jekyll/_cci2_ja/deploying-ios.md
+++ b/jekyll/_cci2_ja/deploying-ios.md
@@ -223,7 +223,7 @@ version: 2.1
 jobs:
   adhoc:
     macos:
-      xcode: "11.3.1"
+      xcode: "12.5.1"
     environment:
       FL_OUTPUT_DIR: output
     steps:

--- a/jekyll/_cci2_ja/examples-intro.md
+++ b/jekyll/_cci2_ja/examples-intro.md
@@ -106,7 +106,7 @@ _macOS Executor は、オンプレミス版の CircleCI Server では現在サ�
 jobs:
   build-and-test:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     steps:
       ...
       - run:

--- a/jekyll/_cci2_ja/executor-intro.md
+++ b/jekyll/_cci2_ja/executor-intro.md
@@ -59,10 +59,10 @@ jobs:
 jobs:
   build: # ジョブの名前
     macos: # Executor タイプ
-      xcode: 11.3.0
+      xcode: 12.5.1
 
     steps:
-      # Xcode 11.3 がインストールされた
+      # Xcode 12.5.1 がインストールされた
       # macOS 仮想マシン環境で実行するコマンド
 ```
 

--- a/jekyll/_cci2_ja/executor-types.md
+++ b/jekyll/_cci2_ja/executor-types.md
@@ -39,7 +39,7 @@ version:
 
 - Docker イメージ (`docker`) を必要とするジョブには、Node.js または Python のイメージを使用します。 CircleCI Docker Hub にある[CircleCI イメージ]({{ site.baseurl }}/2.0/circleci-images/)を使用すると、Docker について完全に理解していなくてもすぐに着手できます。 このイメージはオペレーティング システムの全体ではないので、通常はソフトウェアのビルドの効率化が図れます。
 - Linux 仮想マシン (VM) の完全なイメージ (`machine`) を必要とするジョブには、Ubuntu バージョン (16.04 など) を使用します。
-- macOS VM イメージ (`macos`) を必要とするジョブには、Xcode バージョン (10.0.0 など) を使用します。
+- macOS VM イメージ (`macos`) を必要とするジョブには、Xcode バージョン (12.5.1 など) を使用します。
 
 ## Docker を使用する
 {: #using-docker }
@@ -267,10 +267,10 @@ _クラウド版 CircleCI で利用可能です。オンプレミス版では現
 jobs:
   build:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
 
     steps:
-      # コマンドは、Xcode 11.3 がインストール済みの
+      # コマンドは、Xcode 12.5.1 がインストール済みの
       # macOS コンテナ内で実行されます
       - run: xcodebuild -version
 ```

--- a/jekyll/_cci2_ja/hello-world-macos.md
+++ b/jekyll/_cci2_ja/hello-world-macos.md
@@ -51,17 +51,17 @@ version: 2.1
 jobs: # a basic unit of work in a run
   test: # your job name
     macos:
-      xcode: 11.3.0 # indicate our selected version of Xcode
+      xcode: 12.5.1 # indicate your selected version of Xcode
     steps: # a series of commands to run
       - checkout  # pull down code from your version control system.
       - run:
           name: Run Unit Tests
           command: xcodebuild test -scheme circleci-demo-macos
 
-  build: 
+  build:
     macos:
-      xcode: 11.3.0 # indicate our selected version of Xcode
-    steps: 
+      xcode: 12.5.1 # indicate your selected version of Xcode
+    steps:
       - checkout
       - run:
           # build our application

--- a/jekyll/_cci2_ja/hello-world.md
+++ b/jekyll/_cci2_ja/hello-world.md
@@ -25,7 +25,7 @@ This document describes how to get started with a basic build of your Linux, And
    version: 2.1
      jobs:
        build:
-         docker: 
+         docker:
            - image: circleci/node:4.8.2 # ジョブのコマンドが実行されるプライマリ コンテナ
          steps:
            - checkout # プロジェクト ディレクトリ内のコードをチェック アウトします
@@ -71,7 +71,7 @@ Linux と Android の例と基本的に変わらず、`macos` Executor および
 jobs:
   build-macos:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
 ```
 
 詳細とサンプル プロジェクトについては、「[macOS での Hello World]({{site.baseurl}}/ja/2.0/hello-world-macos)」を参照してください。

--- a/jekyll/_cci2_ja/ios-codesigning.md
+++ b/jekyll/_cci2_ja/ios-codesigning.md
@@ -127,14 +127,14 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.0
+      xcode: 12.5.1
     steps:
       # ...
       - run: bundle exec fastlane test
 
   adhoc:
     macos:
-      xcode: 12.5.0
+      xcode: 12.5.1
     steps:
       # ...
       - run: bundle exec fastlane adhoc
@@ -185,7 +185,7 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: "9.0"
+      xcode: "12.5.1"
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: output
@@ -204,7 +204,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: "9.0"
+      xcode: "12.5.1"
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: output

--- a/jekyll/_cci2_ja/ios-tutorial.md
+++ b/jekyll/_cci2_ja/ios-tutorial.md
@@ -44,7 +44,7 @@ iOS プロジェクトでは、fastlane Scan を使用して以下のように�
 jobs:
   build-and-test:
     macos:
-      xcode: "9.3.0"
+      xcode: "12.5.1"
     steps:
       ...
       - run:
@@ -104,13 +104,13 @@ version: 2.1
 jobs:
   test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: fastlane scan
   deploy:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - deploy:

--- a/jekyll/_cci2_ja/language-dart.md
+++ b/jekyll/_cci2_ja/language-dart.md
@@ -170,7 +170,7 @@ jobs:
 ```yaml
   build-mac:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     steps:
       - run:
           name: Install Dart SDK
@@ -360,7 +360,7 @@ jobs:
 
   build-mac:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     steps:
       - run:
           name: Install Dart SDK

--- a/jekyll/_cci2_ja/migrating-from-1-2.md
+++ b/jekyll/_cci2_ja/migrating-from-1-2.md
@@ -64,7 +64,7 @@ CircleCI では、[`.circleci/config.yml`]({{ site.baseurl }}/ja/2.0/configurati
      使用可能な VM イメージの詳細については、「Executor タイプを選択する」の「[Machine の使用](https://circleci.com/ja/docs/2.0/executor-types/#machine-の使用)」を参照してください。
      ```yaml
          macos:
-           xcode: "9.0"
+           xcode: "12.5.1"
      ```
 
 6. ソース ファイルに対してジョブを実行するには、`checkout:` ステップが必要です。 `steps:` の下に `checkout:` をネストして各ジョブを記述します。 それには、以下のコードを検索します。

--- a/jekyll/_cci2_ja/migrating-from-aws.adoc
+++ b/jekyll/_cci2_ja/migrating-from-aws.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-このドキュメントでは、AWS CodeCommit から CircleCI に移行する方法を概説します。 
+このドキュメントでは、AWS CodeCommit から CircleCI に移行する方法を概説します。
 
 NOTE: **ImagineX Consulting からのヒント**
 
@@ -60,7 +60,7 @@ AWS CodeBuildと CircleCI の設定は異なります。 ビルドステップ�
 |===
 | AWS | CircleCI
 
-2+| 1つのビルドステップを実行するジョブの定義 
+2+| 1つのビルドステップを実行するジョブの定義
 
 a|
 [source, json]
@@ -204,7 +204,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2_ja/migrating-from-azuredevops.adoc
+++ b/jekyll/_cci2_ja/migrating-from-azuredevops.adoc
@@ -67,7 +67,7 @@ The Azure DevOps Pipelines and CircleCI configurations will be different. It may
 |===
 | Azure DevOps | CircleCI
 
-2+| Define a job that executes a single build step. 
+2+| Define a job that executes a single build step.
 
 a|
 [source, ini]
@@ -203,7 +203,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2_ja/migrating-from-buildkite.adoc
+++ b/jekyll/_cci2_ja/migrating-from-buildkite.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-このドキュメントでは、Buildkite から CircleCI に移行する方法を概説します。 
+このドキュメントでは、Buildkite から CircleCI に移行する方法を概説します。
 
 NOTE: **ImagineX Consulting からのヒント**
 
@@ -61,7 +61,7 @@ Buildkiteと CircleCI の設定は異なります。 ビルドステップを変
 |===
 | Buildkite | CircleCI
 
-2+| 1つのビルドステップを実行するジョブの定義 
+2+| 1つのビルドステップを実行するジョブの定義
 
 a|
 [source, yaml]
@@ -192,7 +192,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2_ja/migrating-from-github.adoc
+++ b/jekyll/_cci2_ja/migrating-from-github.adoc
@@ -127,7 +127,7 @@ machine: true
 
 # macOS Executor
 macos:
-  xcode: 11.3.0
+  xcode: 12.5.1
 
 # Windows Executor
 # NOTE: Orb declaration needed. See docs
@@ -236,15 +236,15 @@ orbs:
 
 jobs:
   build:
-    # executor config here 
+    # executor config here
 
     steps:
       - slack-orb/notify:
           color: '#32788D'
-          message: Tests passed 
+          message: Tests passed
           title: Testing Slack Orb
-          author_name: Bobby 
-          webhook: # WEBHOOK 
+          author_name: Bobby
+          webhook: # WEBHOOK
 ----
 
 2+| Using conditional steps in the workflow. CircleCI offers https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute[basic conditions on steps] (e.g., on_success [default], +
@@ -259,10 +259,10 @@ jobs:
     # environment config here
 
     steps:
-      - name: My Failure Step 
+      - name: My Failure Step
         run: echo "Failed step"
         if: failure()
-      - name: My Always Step 
+      - name: My Always Step
         run: echo "Always step"
         if: always()
 ----

--- a/jekyll/_cci2_ja/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2_ja/migrating-from-gitlab.adoc
@@ -5,7 +5,7 @@
 :toc: macro
 :toc-title:
 
-このドキュメントでは、GitLab から CircleCI に移行する方法を概説します。 
+このドキュメントでは、GitLab から CircleCI に移行する方法を概説します。
 
 NOTE: **ImagineX Consulting からのヒント**
 
@@ -191,7 +191,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osx-job:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2_ja/migrating-from-teamcity.adoc
+++ b/jekyll/_cci2_ja/migrating-from-teamcity.adoc
@@ -1,4 +1,4 @@
-= TeamCity からの移行 
+= TeamCity からの移行
 :page-layout: classic-docs
 :page-liquid:
 :source-highlighter: pygments.rb
@@ -102,7 +102,7 @@ a|
 [source, kotlin]
 ----
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script 
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 version: "2019.2"
 
@@ -221,7 +221,7 @@ project {
     parallel {
         build(Test1)
         build(Test2)
-    } 
+    }
     build(Package)
     build(Publish)
   }
@@ -279,7 +279,7 @@ jobs:
   my-mac-job:
     # Executor の定義
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
 
     # ステップの定義
     steps:

--- a/jekyll/_cci2_ja/sample-config.md
+++ b/jekyll/_cci2_ja/sample-config.md
@@ -10,22 +10,22 @@ version:
   - Cloud
   - Server v2.x
 suggested:
-  - 
+  -
     title: Using dynamic config
     link: https://circleci.com/blog/building-cicd-pipelines-using-dynamic-config/
-  - 
+  -
     title: How to create a webhook
     link: https://circleci.com/blog/using-circleci-webhooks/
-  - 
+  -
     title: Automate your releases
     link: https://circleci.com/blog/automating-your-releases-with-circleci-and-the-github-cli-orb/
-  - 
+  -
     title: Customize your Slack notifications
     link: https://support.circleci.com/hc/en-us/articles/360052728991-How-to-customize-your-Slack-messages-when-using-CircleCI-s-Slack-Orb
-  - 
+  -
     title: Validate your config using local CLI
     link: https://support.circleci.com/hc/en-us/articles/360006735753?input_string=configuration+error
-  - 
+  -
     title: Deploy with approval-based workflows
     link: https://circleci.com/blog/deploying-with-approvals/
 ---
@@ -1202,7 +1202,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 11.5.0
+      xcode: 12.5.1
     parameters:
       label:
         type: string
@@ -1304,7 +1304,7 @@ jobs:
 
   test-macos:
     macos:
-      xcode: 11.5.0
+      xcode: 12.5.1
     parameters:
       label:
         type: string
@@ -1378,7 +1378,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run:

--- a/jekyll/_cci2_ja/testing-macos.md
+++ b/jekyll/_cci2_ja/testing-macos.md
@@ -30,14 +30,14 @@ Apple は、アクセス許可を付与するコマンドラインベースの�
 
 一意の `TCC.db` ファイルが 2 つ使用されています。 1つ目のコピーは、ホームディレクトリの `~/Library/Application Support/com.apple.TCC/TCC.db` に、2つ目のコピーは、 `/Library/Application Support/com.apple.TCC/TCC.db` にあります。 アクセス許可を追加または変更する場合は、実行時にアクセス許可が確実に有効となるようこの２つのファイル両方を編集する必要があります。
 
-System Integrity Protection (SIP: システム整合性保護) が有効な状態だと、ホームディレクトリに配置されているコピーへの書き込みは可能ですが、`/Library/Application Support/com.apple.TCC/TCC.db` への書き込みはできません (macOS Mojave以降)。 CircleCI 上では、Xcode 11.7 以降のすべてのイメージの SIP が無効になっています。 SIP が有効なイメージに対して `TCC.db` への書き込みを行うと、ジョブが失敗します。
+System Integrity Protection (SIP: システム整合性保護) が有効な状態だと、ホームディレクトリに配置されているコピーへの書き込みは可能ですが、`/Library/Application Support/com.apple.TCC/TCC.db` への書き込みはできません (macOS Mojave以降)。 CircleCI 上では、Xcode 12.5.1 以降のすべてのイメージの SIP が無効になっています。 SIP が有効なイメージに対して `TCC.db` への書き込みを行うと、ジョブが失敗します。
 
 アクセス許可の追加は、CircleCI の設定で `sqlite3` コマンドを使って手動で書くこともできますが、 [CircleCIでは、これを簡略化するための Orb](https://circleci.com/developer/orbs/orb/circleci/macos) を提供しています。
 
 ## サポートされている Xcode および macOS のバージョン
 {: #supported-xcode-and-macos-versions }
 
-macOS アプリのテストは、SIP を無効にする必要があるため、Xcode 11.7 以降のイメージでのみサポートされています。 これ以前のイメージは SIP が無効になっていないため、macOS アプリのテストには適しません。
+macOS アプリのテストは、SIP を無効にする必要があるため、Xcode 12.5.1 以降のイメージでのみサポートされています。 これ以前のイメージは SIP が無効になっていないため、macOS アプリのテストには適しません。
 
 詳細については、 [サポートされている Xcode バージョン]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) のリストを参照してください。
 
@@ -66,7 +66,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - run: echo 'chruby ruby-2.7' >> ~/.bash_profile
@@ -126,7 +126,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/list-permissions
@@ -161,7 +161,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/list-permission-types
@@ -191,7 +191,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/add-uitest-permissions
@@ -211,7 +211,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/add-permission:
@@ -233,7 +233,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/delete-permission:


### PR DESCRIPTION
# Description
Update macOS docs to encourage adoption of newer Xcode images and add Gen2 resource specs.

# Reasons
With today's release of the macOS Gen2 resources, we want to make sure we're encouraging best practices among customers by removing old Xcode image references.