### PR TITLE
Update pipeline-variables.md

### DIFF
--- a/jekyll/_cci2/pipeline-variables.md
+++ b/jekyll/_cci2/pipeline-variables.md
@@ -30,14 +30,12 @@ pipeline.project.type       | The lower-case name of the VCS provider, E.g. “g
 pipeline.git.tag            | The name of the git tag that was pushed to trigger the pipeline. If the pipeline was not triggered by a tag, then this is the empty string.
 pipeline.git.branch         | The name of the git branch that was pushed to trigger the pipeline.
 pipeline.git.revision       | The long (40-character) git SHA that is being built.
-pipeline.git.base_revision  | The long (40-character) git SHA of the build prior to the one being built.
+pipeline.git.base_revision  | The long (40-character) git SHA of the build prior to the one being built. <br/><br/> **Note:** While in most cases `pipeline.git.base_revision` will be the SHA of the pipeline that ran before your currently running pipeline, there are some caveats. When the build is the first build for a branch, the variable will not be present. In addition, if the build was triggered via the API, the variable will not be present.
 pipeline.in_setup           | True if the pipeline is in the setup phase, i.e. running a [setup workflow]({{ site.baseurl }}/2.0/dynamic-config/).
 pipeline.trigger_source     | The source that triggers the pipeline, current values are `webhook`, `api`, `scheduled_pipeline`
 pipeline.schedule.name      | The name of the schedule if it is a scheduled pipeline. Value will be empty string if the pipeline is triggerd by other sources
 pipeline.schedule.id        | The unique id of the schedule if it is a scheduled pipeline. Value will be empty string if the pipeline is triggerd by other sources
 {: class="table table-striped"}
-
-Note: While in most cases `pipeline.git.base_revision` will be the SHA of the pipeline that ran before your currently running pipeline, there are some caveats. When the build is the first build for a branch, the variable will not be present. In addition, if the build was triggered via the API, the variable will not be present.
 
 For example:
 
@@ -59,7 +57,7 @@ jobs:
       - run: echo $CIRCLE_COMPARE_URL
 ```
 
-Note: When using the above method to set the variables in the `environment` key if the pipeline variable is empty it will set the variable to `<nil>`. If you need an empty string instead, [set the variable in a shell command]({{ site.baseurl }}/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command).
+**Note:** When using the above method to set the variables in the `environment` key if the pipeline variable is empty it will set the variable to `<nil>`. If you need an empty string instead, [set the variable in a shell command]({{ site.baseurl }}/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command).
 
 ## Pipeline parameters in configuration
 {: #pipeline-parameters-in-configuration }


### PR DESCRIPTION
# Description

Moved the note on `pipeline.git.base_revision` from outside of the table listing to within the pipeline parameter's description itself.
Upon discussion with a customer, it was mentioned that we should placed it "closer" to the source, for better call to attention to this known limitation.

I've also made the `Note:` stanzas bold, based on the styling of most other documentation pages i see here on our Docs.


# Reasons

Updates based on [a customer feedback](https://circleci.zendesk.com/agent/tickets/101081).