### PR TITLE
[FIX]: Remove Old Language Selector in Sidebar

### DIFF
--- a/jekyll/_includes/sidebar.html
+++ b/jekyll/_includes/sidebar.html
@@ -104,16 +104,5 @@
       </ul>
       {% endfor %}
     </div>
-    <div class="lang-picker">
-      <select id="sidebarLangSelect">
-        <option value="en">English</option>
-        <option value="ja">日本語</option>
-      </select>
-    </div>
   </nav>
-
-  <script>
-    // Add the current language to the window for auto setting the dropdown to current language.
-    window.currentLang = "{{lang}}"
-  </script>
 </div>


### PR DESCRIPTION
**Associated Ticket:** [DD-272](https://circleci.atlassian.net/browse/DD-272)

# Changes
- remove old language selector in sidebar

# Description
When reverting `sidebar.html` to origin master version, the old language selector was accidentally left in 

# Reasons
See #6084 