### PR TITLE
[DD-299]: Update Globe SVG Format and Fix Display in Preview Link 

### DIFF
--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -37,7 +37,7 @@
         {% include_cached mobile-sidebar.html site=site page=page %}
         <div class="global-nav--list global-nav--external-links lang-selector-wrapper">
           <button id="globe-lang-btn" class="global-nav--language-picker" data-analytics-action="click-outer-cta">
-            <img src='/docs/assets/img/compass/globe.svg' class="globe-icon"></img>
+            <img src='{{ site.baseurl }}/assets/img/compass/globe.svg' class="globe-icon"></img>
             <span class="lang-picker-mobile">Select Language</span>
           </button>
           <div id="lang-picker" class="lang-picker">

--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -37,7 +37,7 @@
         {% include_cached mobile-sidebar.html site=site page=page %}
         <div class="global-nav--list global-nav--external-links lang-selector-wrapper">
           <button id="globe-lang-btn" class="global-nav--language-picker" data-analytics-action="click-outer-cta">
-            <span class="globe-icon">{% include utility-icons/globe.svg size="24" %}</span>
+            <img src='/docs/assets/img/compass/globe.svg' class="globe-icon"></img>
             <span class="lang-picker-mobile">Select Language</span>
           </button>
           <div id="lang-picker" class="lang-picker">

--- a/jekyll/assets/img/compass/globe.svg
+++ b/jekyll/assets/img/compass/globe.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg fill="none" aria-label="Globe" role="img" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="none" aria-label="Globe" role="img" height="18" width="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
     <g stroke="currentColor" stroke-miterlimit="10" stroke-width="1.25">
         <path d="m9.00001 17.3077c4.58819 0 8.30769-3.7195 8.30769-8.30771s-3.7195-8.307693-8.30769-8.307693c-4.58821 0-8.307688 3.719483-8.307688 8.307693s3.719478 8.30771 8.307688 8.30771z"></path>
         <path d="m9 17.3077c1.7639 0 3.1938-3.7195 3.1938-8.30771s-1.4299-8.307693-3.1938-8.307693c-1.76391 0-3.19385 3.719483-3.19385 8.307693s1.42994 8.30771 3.19385 8.30771z"></path>

--- a/jekyll/assets/img/compass/globe.svg
+++ b/jekyll/assets/img/compass/globe.svg
@@ -1,10 +1,5 @@
-{% if include.size %}
-  {% assign size = include.size %}
-{% else %}
-  {% assign size = 12 %}
-{% endif %}
-
-<svg fill="none" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg">
+<?xml version="1.0" encoding="utf-8"?>
+<svg fill="none" aria-label="Globe" role="img" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg">
     <g stroke="currentColor" stroke-miterlimit="10" stroke-width="1.25">
         <path d="m9.00001 17.3077c4.58819 0 8.30769-3.7195 8.30769-8.30771s-3.7195-8.307693-8.30769-8.307693c-4.58821 0-8.307688 3.719483-8.307688 8.307693s3.719478 8.30771 8.307688 8.30771z"></path>
         <path d="m9 17.3077c1.7639 0 3.1938-3.7195 3.1938-8.30771s-1.4299-8.307693-3.1938-8.307693c-1.76391 0-3.19385 3.719483-3.19385 8.307693s1.42994 8.30771 3.19385 8.30771z"></path>

--- a/src/js/experiments/forceAll.js
+++ b/src/js/experiments/forceAll.js
@@ -44,19 +44,5 @@ if (
         }
       </style>`,
     );
-
-    const globeBtn = document.getElementById('globe-lang-btn');
-    const globeImg = document.getElementsByClassName('globe-icon');
-    // remove exsisting globe img with broken path from DOM
-    globeBtn.removeChild(globeImg);
-
-    // create JEKYLL_BASENAME from preview url to use for globe img source
-    const previewURL = jekyllBaseName;
-    const start = previewURL.indexOf('/');
-    const imgPath = previewURL.substring(start);
-    globeBtn.insertAdjacentHTML(
-      'afterbegin',
-      `<img src="/${imgPath}assets/img/compass/globe.svg" class="globe-icon">`,
-    );
   });
 }

--- a/src/js/experiments/forceAll.js
+++ b/src/js/experiments/forceAll.js
@@ -44,5 +44,19 @@ if (
         }
       </style>`,
     );
+
+    const globeBtn = document.getElementById('globe-lang-btn');
+    const globeImg = document.getElementsByClassName('globe-icon');
+    // remove exsisting globe img with broken path from DOM
+    globeBtn.removeChild(globeImg);
+
+    // create JEKYLL_BASENAME from preview url to use for globe img source
+    const previewURL = jekyllBaseName;
+    const start = previewURL.indexOf('/');
+    const imgPath = previewURL.substring(start);
+    globeBtn.insertAdjacentHTML(
+      'afterbegin',
+      `<img src="/${imgPath}assets/img/compass/globe.svg" class="globe-icon">`,
+    );
   });
 }

--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -202,31 +202,34 @@ $btn-selected-blue: #004A95;
   }
 }
 
-
-
-
-
 .lang-selector-wrapper {
   position: relative;
 
     .global-nav--language-picker {
-    @media (max-width: $screen-md) {
+      @media (max-width: $screen-md) {
       padding: 0;
     }
-    @media (min-width: $screen-md) {
-      &:hover {
-        color: $btn-hover-green;
+      
+      display: flex;
+      align-items: center;
+      color: $black;
+      background-color: transparent;
+      background: none;
+      border: none;
+      padding: 2px 0 0 0;
+
+    .globe-icon {
+      background-color:transparent;
+      color: $black;
+      @media (min-width: $screen-md) {
+        &:hover {
+          filter: invert(39%) sepia(99%) saturate(634%) hue-rotate(105deg) brightness(83%) contrast(97%);
+        }
       }
-    }
-
-    display: flex;
-    align-items: center;
-    color: $black;
-    background-color: transparent;
-    background: none;
-    border: none;
-    padding: 8px 0 0 0;
-
+      @media (max-width: $screen-md) {
+        padding-top: 6px;
+      }
+    } 
     .lang-picker-mobile {
       display: none;
       @media (max-width: $screen-md) {
@@ -235,13 +238,7 @@ $btn-selected-blue: #004A95;
         font-size: 16px;
         font-family: inherit;
       }
-    }
-
-    @media (max-width: $screen-md) {
-      .globe-icon {
-        padding-top: 6px;
-      }
-    }
+    } 
   }
 
   .lang-picker {
@@ -279,6 +276,8 @@ $btn-selected-blue: #004A95;
     display: block;
   }
 }
+
+
 
 .global-nav--external-link {
   &s {

--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -277,8 +277,6 @@ $btn-selected-blue: #004A95;
   }
 }
 
-
-
 .global-nav--external-link {
   &s {
     @media (min-width: $screen-md) {


### PR DESCRIPTION
**Ticket:**[ DD-299](https://circleci.atlassian.net/browse/DD-299)
**Preview Link:** http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/update-globe-svg-preview/?force-all
**Note:** if globe icon is still broken, hard reset and clear browser cache with `cmd + shift + r` 

# Changes
- store `globe.svg` as an asset to be used in img tag
- update style and design of icon 

# Description
We dont currently have a working version of the globe icon for the language selector in our preview links due to not having the correct dynamic img path for our preview builds.

We are also updating the the actual format of the globe icon svg as previously we were including the entire svg directly in our HTML instead of storing it as an asset and referencing it in an img or picture tag. 

# Reasons
See associated PR #6084 

# Screenshots

**Before:**
<img width="1093" alt="Screen Shot 2021-12-22 at 5 13 29 PM" src="https://user-images.githubusercontent.com/57234605/147172778-5f8d3002-75be-4208-b4c6-08505f4f93ea.png">

**After:**
<img width="1088" alt="Screen Shot 2021-12-22 at 5 12 12 PM" src="https://user-images.githubusercontent.com/57234605/147172690-004a437b-ad4e-4432-b52c-f0afa90a4d2b.png">
