### PR TITLE
DD-303 Remove jekyll code from non jekyll file

### DIFF
--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -136,7 +136,6 @@ curl https://circleci.com/api/v1.1/me -H "Accept: application/json" -H "Circle-T
 If no accept header is specified (or it is empty), CircleCI will return the data in a Clojure EDN format. To receive the data as nicely formatted JSON, include any value for the `Accept` header (e.g `text/plain`). If you prefer to receive compact JSON with no whitespace or comments, use `application/json` as the `Accept` header.
 
 ## Cache-Control Header
-{: #cache-control-header }
 
 Some CircleCI APIs may emit a `Cache-Control` header to indicate that the response may be cached for a period of time. This feature can be used to avoid unnecessary re-fetching of data that will not change. If you plan to make a large volume of API requests you are strongly encouraged to make use of this header in order to improve your performance and lower your risk of being rate limited.
 


### PR DESCRIPTION
Jira link: [DD-303](https://circleci.atlassian.net/browse/DD-303)
Preview link: [link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-303-Jekyll-code-added-to-md-file-in-src-api-outside-of-jekyll-folder-preview/api/v1/#cache-control-header)

# Description
Remove jekyll code found in prod.
{: #cache-control-header }
Most likely a suggestion from circledocs-bot

<img width="858" alt="Screen Shot 2021-12-23 at 11 47 49 AM" src="https://user-images.githubusercontent.com/86666932/147269789-a856861b-1f8e-4831-81ed-652250319158.png">


# Before
<img width="942" alt="Screen Shot 2021-12-23 at 11 34 01 AM" src="https://user-images.githubusercontent.com/86666932/147268335-7fb1a6c7-6187-47c5-b2b3-13895033d8be.png">

# After
<img width="786" alt="Screen Shot 2021-12-23 at 11 34 53 AM" src="https://user-images.githubusercontent.com/86666932/147268439-d19d88ac-5b37-489f-8947-5f4973e13b66.png">

