### PR TITLE
Update local-cli.md

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -379,6 +379,10 @@ The commands above will run the entire _build_ job (only jobs, not workflows, ca
 
 Although running jobs locally with `circleci` is very helpful, there are some limitations.
 
+**Docker on Mac**
+
+Local execution in Docker Desktop for Mac using cgroupsv2, is temporarily blocked pending system updates. Follow the [Github issue](https://github.com/CircleCI-Public/circleci-cli/issues/589) for the latest information. 
+
 **Machine Executor**
 
 You cannot use the machine executor in local jobs. This is because the machine executor requires an extra VM to run its jobs.

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -381,7 +381,7 @@ Although running jobs locally with `circleci` is very helpful, there are some li
 
 **Docker on Mac**
 
-Local execution in Docker Desktop for Mac using cgroupsv2, is temporarily blocked pending system updates. Follow the [Github issue](https://github.com/CircleCI-Public/circleci-cli/issues/589) for the latest information. 
+Local execution in Docker Desktop for Mac using cgroupsv2, is temporarily blocked pending system updates. Follow the [Github issue](https://github.com/CircleCI-Public/circleci-cli/issues/589) for the latest information.
 
 **Machine Executor**
 


### PR DESCRIPTION
# Description
Added the limitation currently caused by cgroupsv2 in Docker for Mac. Users on the latest version of Docker are temporarily blocked from using local execute.

# Reasons
https://github.com/CircleCI-Public/circleci-cli/issues/589
Will remove once resolved.