### PR TITLE
fix a wrong spacing in the 2nd config.yml

### DIFF
--- a/jekyll/_cci2_ja/getting-started.md
+++ b/jekyll/_cci2_ja/getting-started.md
@@ -130,7 +130,7 @@ CircleCI を使用する際には、必ずしも Orb を使用する必要はあ
        steps:
          - checkout
          - run: echo "A more familiar hi" # 前述のコマンドに類似した echo コマンドを実行します。
-           - run: sleep 15 # 15 秒間スリープします
+         - run: sleep 15 # 15 秒間スリープします
    # このワークフローでは、マッピングを行い、上記で定義した 2 つのジョブを調整することができます。
    workflows:
      version: 2


### PR DESCRIPTION
Using `.circleci/config.yml` as indicated in Using the workflows functionality gives an error as follows:

Unable to parse YAMLwhile parsing a block mapping in 'string', line 22, column 9:          - run: echo "A more familiar hi" # ...             ^

The proposed spacing (killing two spaces) will eliminate the error.

# Description
This fix will eliminate the error caused by extra spacing that makes the list parsed incorrectly.

# Reasons
It's such a simple change that I went ahead with this PR instead of submitting an issue.