### PR TITLE
updated `AWS_DEFAULT_REGION` to `AWS_REGION`

### DIFF
--- a/jekyll/_cci2/ecs-ecr.md
+++ b/jekyll/_cci2/ecs-ecr.md
@@ -61,7 +61,7 @@ Variable                 | Description
 -------------------------|------------
 AWS_ACCESS_KEY_ID        | Security credentials for AWS.
 AWS_SECRET_ACCESS_KEY    | Security credentials for AWS.
-AWS_DEFAULT_REGION       | Used by the AWS CLI.
+AWS_REGION               | Used by the AWS CLI.
 AWS_ACCOUNT_ID           | Required for deployment. [Find your AWS Account ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#FindingYourAWSId).
 AWS_RESOURCE_NAME_PREFIX | Prefix for some required AWS resources. Should correspond to the value of `aws_resource_prefix` in `terraform_setup/terraform.tfvars`.
 AWS_ECR_ACCOUNT_URL      | Amazon ECR account URL that maps to an AWS account, e.g. {awsAccountNum}.dkr.ecr.us-west-2.amazonaws.com


### PR DESCRIPTION
I followed the docs to deploy to ECS, but it was throwing an error during deployment in the pipeline. Following the logs, it looks like aws expects `$AWS_REGION` variable for region. Adding an environment variable with name `AWS_REGION` fixed that

# Description
updated `AWS_DEFAULT_REGION` environment variable to `AWS_REGION`

# Reasons
I followed the docs to deploy to ECS, but it was throwing an error during deployment in the pipeline. Following the logs, it looks like aws expects `$AWS_REGION` variable for region. Adding an environment variable with name `AWS_REGION` fixed that