### PR TITLE
[Fix] Grey left of sidebar on large width displays

### DIFF
--- a/src/styles/_progressbar.scss
+++ b/src/styles/_progressbar.scss
@@ -40,5 +40,5 @@ body::before {
     bottom: 0;
     width: 100%;
     z-index: -1;
-    background: white;
+    background: linear-gradient(to right, #F7F7F7 0%, #F7F7F7 calc(50% - 860px), #fff calc(50% - 860px), #fff 100%);;
 }


### PR DESCRIPTION
# Description
[Issue cropped up after Progress Bar](https://circleci.slack.com/archives/C021NCSEM44/p1641314809268800)

# Reasons
Make UI visually as it was before

**Before**
<img width="1792" alt="Screen Shot 2022-01-04 at 9 25 57 AM" src="https://user-images.githubusercontent.com/42252054/148099067-d32e6225-b3e6-4c7e-befe-9a7ac44fcb19.png">

**After**
<img width="1792" alt="Screen Shot 2022-01-04 at 9 25 49 AM" src="https://user-images.githubusercontent.com/42252054/148099083-4b4368ea-0bd8-4c59-b1cf-47030adbdebc.png">
