### PR TITLE
Macos gen2 updates

### DIFF
--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -135,8 +135,8 @@ jobs:
      image: ubuntu-2004:202010-01
 #...
  build3:
-   macos: # Specifies a macOS virtual machine with Xcode version 11.3
-     xcode: "11.3.0"
+   macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+     xcode: "12.5.1"
 # ...
 ```
 
@@ -171,8 +171,8 @@ jobs:
      image: ubuntu-2004:202010-01
 #...
  build3:
-   macos: # Specifies a macOS virtual machine with Xcode version 11.3
-     xcode: "11.3.0"
+   macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+     xcode: "12.5.1"
 # ...
 ```
 
@@ -207,8 +207,8 @@ jobs:
      image: ubuntu-1604:201903-01
 #...
  build3:
-   macos: # Specifies a macOS virtual machine with Xcode version 11.3
-     xcode: "11.3.0"
+   macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+     xcode: "12.5.1"
 # ...
 ```
 
@@ -279,8 +279,8 @@ The Primary Container is defined by the first image listed in a [`.circleci/conf
        image: ubuntu-1604:202007-01
 ...
    build3:
-     macos: # Specifies a macOS virtual machine with Xcode version 9.0
-       xcode: "9.0"
+     macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
+       xcode: "12.5.1"
  ...
  ```
 

--- a/jekyll/_cci2/configuration-cookbook.md
+++ b/jekyll/_cci2/configuration-cookbook.md
@@ -798,7 +798,7 @@ executors:
       image: ubuntu-2004:202107-02
   macos: # macos executor running Xcode
     macos:
-      xcode: 12.5
+      xcode: 12.5.1
 
 jobs:
   test:

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -600,8 +600,9 @@ jobs:
 
 Class              | vCPUs | RAM
 -------------------|-------|-----
-medium (default)   | 4     | 8GB
-large<sup>(3)</sup>| 8     | 16GB
+medium (default)   | 4 @ 2.7 GHz    | 8GB
+macos.x86.medium.gen2   | 4 @ 3.2 GHz    | 8GB
+large<sup>(3)</sup>| 8 @ 2.7 GHz    | 16GB
 {: class="table table-striped"}
 
 ###### Example usage

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -436,14 +436,14 @@ Key | Required | Type | Description
 xcode | Y | String | The version of Xcode that is installed on the virtual machine, see the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) document for the complete list.
 {: class="table table-striped"}
 
-**Example:** Use a macOS virtual machine with Xcode version 11.3:
+**Example:** Use a macOS virtual machine with Xcode version 12.5.1:
 
 
 ```yaml
 jobs:
   build:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
 ```
 
 #### **`windows`**
@@ -612,7 +612,7 @@ large<sup>(3)</sup>| 8     | 16GB
 jobs:
   build:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     resource_class: large
     steps:
       ... // other config
@@ -1964,7 +1964,7 @@ executors:
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
   macos: &macos-executor
     macos:
-      xcode: 11.4
+      xcode: 12.5.1
 
 jobs:
   test:

--- a/jekyll/_cci2/deploying-ios.md
+++ b/jekyll/_cci2/deploying-ios.md
@@ -223,7 +223,7 @@ version: 2.1
 jobs:
   adhoc:
     macos:
-      xcode: "11.3.1"
+      xcode: "12.5.1"
     environment:
       FL_OUTPUT_DIR: output
     steps:

--- a/jekyll/_cci2/examples-intro.md
+++ b/jekyll/_cci2/examples-intro.md
@@ -106,7 +106,7 @@ _The macOS executor is not currently available on self-hosted installations of C
 jobs:
   build-and-test:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     steps:
       ...
       - run:

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -54,7 +54,7 @@ jobs:
   build: # name of your job
     machine: # executor type
       image: ubuntu-1604:202007-01 # VM will run Ubuntu 16.04 for this release date
-      
+
     steps:
       # Commands run in a Linux virtual machine environment
 ```
@@ -81,7 +81,7 @@ _The macOS executor is not currently available on self-hosted installations of C
 jobs:
   build: # name of your job
     macos: # executor type
-      xcode: 11.3.0
+      xcode: 12.5.1
 
     steps:
       # Commands run in a macOS virtual machine environment

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -300,7 +300,7 @@ You can also specify which version of Xcode should be used. See the [Supported X
 jobs:
   build:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
 
     steps:
       # Commands will execute in macOS container

--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -63,17 +63,17 @@ version: 2.1
 jobs: # a basic unit of work in a run
   test: # your job name
     macos:
-      xcode: 12.5.1 # indicate our selected version of Xcode
+      xcode: 12.5.1 # indicate your selected version of Xcode
     steps: # a series of commands to run
       - checkout  # pull down code from your version control system.
       - run:
           name: Run Unit Tests
           command: xcodebuild test -scheme circleci-demo-macos
 
-  build: 
+  build:
     macos:
-      xcode: 12.5.1 # indicate our selected version of Xcode
-    steps: 
+      xcode: 12.5.1 # indicate your selected version of Xcode
+    steps:
       - checkout
       - run:
           # build our application
@@ -86,7 +86,7 @@ jobs: # a basic unit of work in a run
       - store_artifacts: # store this build output. Read more: https://circleci.com/docs/2.0/artifacts/
           path: app.zip
           destination: app
-          
+
 workflows:
   version: 2
   test_build:

--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -78,7 +78,7 @@ Using the basics from the Linux and Android examples above, you can add a job th
 jobs:
   build-macos:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
 ```
 
 Refer to the [Hello World on MacOS]({{site.baseurl}}/2.0/hello-world-macos) document for more information and a sample project.

--- a/jekyll/_cci2/ios-codesigning.md
+++ b/jekyll/_cci2/ios-codesigning.md
@@ -153,14 +153,14 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.0
+      xcode: 12.5.1
     steps:
       # ...
       - run: bundle exec fastlane test
 
   adhoc:
     macos:
-      xcode: 12.5.0
+      xcode: 12.5.1
     steps:
       # ...
       - run: bundle exec fastlane adhoc
@@ -211,7 +211,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -228,7 +228,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc

--- a/jekyll/_cci2/ios-tutorial.md
+++ b/jekyll/_cci2/ios-tutorial.md
@@ -45,7 +45,7 @@ For iOS projects, it is possible to run your tests with Fastlane Scan as follows
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       ...
       - run:
@@ -102,13 +102,13 @@ version: 2.1
 jobs:
   test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: fastlane scan
   deploy:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - deploy:

--- a/jekyll/_cci2/language-dart.md
+++ b/jekyll/_cci2/language-dart.md
@@ -171,7 +171,7 @@ jobs:
 ```yaml
   build-mac:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     steps:
       - run:
           name: Install Dart SDK
@@ -361,7 +361,7 @@ jobs:
 
   build-mac:
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
     steps:
       - run:
           name: Install Dart SDK

--- a/jekyll/_cci2/migrating-from-1-2.md
+++ b/jekyll/_cci2/migrating-from-1-2.md
@@ -66,7 +66,7 @@ The `config-translation` endpoint can help you quickly get started with converti
      See the Using Machine section of the [Choosing an Executor Type](https://circleci.com/docs/2.0/executor-types/#using-machine) document for details about the available VM images.
      ```yaml
          macos:
-           xcode: 11.3.0
+           xcode: 12.5.1
      ```
 
 6. The `checkout:` step is required to run jobs on your source files. Nest `checkout:` under `steps:` for every job by search and replacing

--- a/jekyll/_cci2/migrating-from-aws.adoc
+++ b/jekyll/_cci2/migrating-from-aws.adoc
@@ -10,7 +10,7 @@ title: Migrating from AWS
 :toc: macro
 :toc-title:
 
-This document provides an overview of how to migrate from AWS CodeCommit to CircleCI. 
+This document provides an overview of how to migrate from AWS CodeCommit to CircleCI.
 
 NOTE: **Tips provided by ImagineX Consulting**
 
@@ -65,12 +65,12 @@ The AWS CodeBuild and CircleCI configurations will be different. It may be helpf
 |===
 | AWS | CircleCI
 
-2+| Define a job that executes a single build step. 
+2+| Define a job that executes a single build step.
 
 a|
 [source, json]
 ----
-phases:  
+phases:
   build:
     commands:
        - ./execute-script-for-job1.sh
@@ -177,8 +177,8 @@ workflows:
 a|
 [source, json]
 ----
-# Environments are selected in the CodeBuild 
-# web console or defined in a project  
+# Environments are selected in the CodeBuild
+# web console or defined in a project
 # configuration file:
 {
   "name": "linux project",
@@ -207,7 +207,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"
@@ -218,9 +218,9 @@ jobs:
 a|
 [source, json]
 ----
-# If custom cache is enabled in the web 
-# console, CLI or CloudFormation, cache 
-# locations can be specified in the 
+# If custom cache is enabled in the web
+# console, CLI or CloudFormation, cache
+# locations can be specified in the
 # buildspec.yml file:
 
 phases:

--- a/jekyll/_cci2/migrating-from-azuredevops.adoc
+++ b/jekyll/_cci2/migrating-from-azuredevops.adoc
@@ -72,7 +72,7 @@ The Azure DevOps Pipelines and CircleCI configurations will be different. It may
 |===
 | Azure DevOps | CircleCI
 
-2+| Define a job that executes a single build step. 
+2+| Define a job that executes a single build step.
 
 a|
 [source, ini]
@@ -208,7 +208,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-buildkite.adoc
+++ b/jekyll/_cci2/migrating-from-buildkite.adoc
@@ -10,7 +10,7 @@ title: Migrating from Buildkite
 :toc: macro
 :toc-title:
 
-This document provides an overview of how to migrate from Buildkite to CircleCI. 
+This document provides an overview of how to migrate from Buildkite to CircleCI.
 
 NOTE: **Tips provided by ImagineX Consulting**
 
@@ -66,7 +66,7 @@ The Buildkite and CircleCI configurations will be different. It may be helpful t
 |===
 | Buildkite | CircleCI
 
-2+| Define a job that executes a single build step. 
+2+| Define a job that executes a single build step.
 
 a|
 [source, yaml]
@@ -119,7 +119,7 @@ a|
 steps:
   - label: 'job1'
     command: 'make build dependencies'
- 
+
   - label: 'job2'
     command: 'make build artifacts'
 
@@ -197,7 +197,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -51,7 +51,7 @@ jobs:
       # job steps
   job_2:
     needs: job_1
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       # job steps
 ----
@@ -132,7 +132,7 @@ machine: true
 
 # macOS Executor
 macos:
-  xcode: 11.3.0
+  xcode: 12.5.1
 
 # Windows Executor
 # NOTE: Orb declaration needed. See docs
@@ -241,15 +241,15 @@ orbs:
 
 jobs:
   build:
-    # executor config here 
+    # executor config here
 
     steps:
       - slack-orb/notify:
           color: '#32788D'
-          message: Tests passed 
+          message: Tests passed
           title: Testing Slack Orb
-          author_name: Bobby 
-          webhook: # WEBHOOK 
+          author_name: Bobby
+          webhook: # WEBHOOK
 ----
 
 2+| Using conditional steps in the workflow. CircleCI offers https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute[basic conditions on steps] (e.g., on_success [default], +
@@ -264,10 +264,10 @@ jobs:
     # environment config here
 
     steps:
-      - name: My Failure Step 
+      - name: My Failure Step
         run: echo "Failed step"
         if: failure()
-      - name: My Always Step 
+      - name: My Always Step
         run: echo "Always step"
         if: always()
 ----

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -10,7 +10,7 @@ title: Migrating from GitLab
 :toc: macro
 :toc-title:
 
-This document provides an overview of how to migrate from GitLab to CircleCI. 
+This document provides an overview of how to migrate from GitLab to CircleCI.
 
 NOTE: **Tips provided by ImagineX Consulting**
 
@@ -196,7 +196,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osx-job:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-teamcity.adoc
+++ b/jekyll/_cci2/migrating-from-teamcity.adoc
@@ -107,7 +107,7 @@ a|
 [source, kotlin]
 ----
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script 
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 
 version: "2019.2"
 
@@ -151,7 +151,7 @@ jobs:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 
-    # Define steps for job 
+    # Define steps for job
     steps:
       - checkout
       - run: echo "Hello World!"
@@ -226,7 +226,7 @@ project {
     parallel {
         build(Test1)
         build(Test2)
-    } 
+    }
     build(Package)
     build(Publish)
   }
@@ -284,7 +284,7 @@ jobs:
   my-mac-job:
     # Executor definition
     macos:
-      xcode: "11.3.0"
+      xcode: "12.5.1"
 
     # Steps definition
     steps:

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -1198,7 +1198,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 11.5.0
+      xcode: 12.5.1
     parameters:
       label:
         type: string
@@ -1300,7 +1300,7 @@ jobs:
 
   test-macos:
     macos:
-      xcode: 11.5.0
+      xcode: 12.5.1
     parameters:
       label:
         type: string
@@ -1374,7 +1374,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     steps:
       - checkout
       - run:

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -175,7 +175,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -192,7 +192,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
@@ -547,7 +547,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -593,7 +593,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 11.3.0
+      xcode: 12.5.1
     environment:
       FL_OUTPUT_DIR: output
 

--- a/jekyll/_cci2/testing-macos.md
+++ b/jekyll/_cci2/testing-macos.md
@@ -65,7 +65,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - run: echo 'chruby ruby-2.7' >> ~/.bash_profile
@@ -86,7 +86,7 @@ Fastlane allows you to avoid calling lengthy Xcode commands manually and instead
 write a simple configuration file to initiate the macOS app tests. With Fastlane
 you can build, sign (for testing) and test a macOS app. Please note that when
 using Fastlane, depending on the actions in your configuration, you may need to
-setup a 2-factor Authentication (2FA). 
+setup a 2-factor Authentication (2FA).
 See the [Fastlane Docs for more information](https://docs.fastlane.tools/best-practices/continuous-integration/#method-2-two-step-or-two-factor-authentication).
 
 A simple config can be found below. Note that this config relies on the project
@@ -134,7 +134,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/list-permissions
@@ -168,7 +168,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/list-permission-types
@@ -198,7 +198,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/add-uitest-permissions
@@ -218,7 +218,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/add-permission:
@@ -240,7 +240,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 11.7.0
+      xcode: 12.5.1
     steps:
         - checkout
         - mac-permissions/delete-permission:


### PR DESCRIPTION
# Description
Update macOS docs to encourage adoption of newer Xcode images and add Gen2 resource specs.

# Reasons
With today's release of the macOS Gen2 resources, we want to make sure we're encouraging best practices among customers by removing old Xcode image references.