### PR TITLE
Add workflow banner, fix broken link

### DIFF
--- a/jekyll/_cci2/v.2.17-overview.md
+++ b/jekyll/_cci2/v.2.17-overview.md
@@ -94,7 +94,7 @@ This document provides a summary of features and product notes for the release o
 {: #steps-to-update-to-circleci-server-v217 }
 Steps to update to CircleCI Server v2.17 are as follows:
 
-1. Take a snapshot of your installation so you can rollback later if necessary (optional but recommended)
+1. Take a snapshot of your installation so you can roll back later if necessary (optional but recommended)
 2. Check you are running Docker v17.12.1 and update if necessary
 3. Update Replicated to v2.34.1 (steps in section below)
 4. Navigate to your Management Console dashboard (e.g. `<your-circleci-hostname>.com:8800`) and select the v2.17 upgrade
@@ -111,7 +111,7 @@ To take a snapshot of your installation:
 **Note:** It is also possible to automate this process with the AWS API. Subsequent AMIs/snapshots are only as large as the difference (changed blocks) since the last snapshot, such that storage costs are not necessarily larger for more frequent snapshots, see Amazon's EBS snapshot billing document for details.
 Once you have the snapshot you are free to make changes on the Services machine.
 
-If you do need to rollback at any point, see our [restore from backup](http://localhost:4000/docs/2.0/backup/#restoring-from-backup) guide.
+If you do need to roll back at any point, see our [restore from backup]({{site.baseurl}}/2.0/backup/#restoring-from-backup) guide.
 
 ### Update Replicated
 {: #update-replicated }

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -254,6 +254,10 @@ After approving, the rest of the workflow runs as directed.
 ## Scheduling a workflow
 {: #scheduling-a-workflow }
 
+<div class="alert alert-warning" role="alert">
+  <strong>Scheduled workflows will be phased out starting June 3, 2022.</strong> Visit the scheduled pipelines <a href="{{site.baseurl}}/2.0/scheduled-pipelines/#get-started">migration guide</a> to find out how to migrate existing scheduled workflows to scheduled pipelines, or to set up scheduled pipelines from scratch.
+</div>
+
 It can be inefficient and expensive to run a workflow for every commit for every branch. Instead, you can schedule a workflow to run at a certain time for specific branches. This will disable commits from triggering jobs on those branches.
 
 Consider running workflows that are resource-intensive or that generate reports on a schedule rather than on every commit by adding a `triggers` key to the configuration. The `triggers` key is **only** added under your `workflows` key. This feature enables you to schedule a workflow run by using `cron` syntax to represent Coordinated Universal Time (UTC) for specified branches.


### PR DESCRIPTION
# Description
Add banner notifying users of sunsetting scheduled workflows.
Fix link in a server doc.
Correct instances of rollback as a noun vs roll back as a verb.

# Reasons
There is still a significant number of users who are using scheduled workflows who have not migrated yet. Hopefully this will be an additional reminder to migrate to scheduled pipelines. 