### PR TITLE
Update links/header text

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -158,7 +158,7 @@ A Workflow is comprised of one or more uniquely named jobs. Jobs are specified i
 Jobs have a maximum runtime of 1 (Free), 3 (Performance), or 5 (Scale) hours depending on pricing plan. If your jobs are timing out, consider a larger [resource class]({{site.baseurl}}/2.0/configuration-reference/#resourceclass) and/or [parallelism]({{site.baseurl}}/2.0/parallelism-faster-jobs).  Additionally, you can upgrade your pricing plan or run some of your jobs concurrently using [workflows]({{ site.baseurl }}/2.0/workflows/).
 
 ### **<`job_name`>**
-{: #lessjobnamegreater }
+{:job-name}
 
 Each job consists of the job's name as a key and a map as a value. A name should be case insensitive unique within a current `jobs` list. The value map has the following attributes:
 
@@ -1551,7 +1551,7 @@ jobs | Y | List | A list of jobs to run with their dependencies
 {: class="table table-striped"}
 
 ##### **<`job_name`>**
-{: #lessjobnamegreater }
+{: #job-name-in-workflow }
 
 A job name that exists in your `config.yml`.
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -30,9 +30,9 @@ There are several ways to use environment variables in CircleCI to provide varie
 
 To add **private keys** or **secret environment variables** for use throughout your private project, use the [Environment Variables page under Project Settings](#setting-an-environment-variable-in-a-project) in the CircleCI application. The variable values are neither readable nor editable in the app after they are set. To change the value of an environment variable, delete the current variable and add it again with the new value.
 
-Private environment variables enable you to store secrets safely even when your project is public. Refer to the [Building Open Source Projects]({{ site.baseurl }}/2.0/oss/) page for associated settings information.
+Private environment variables enable you to store secrets safely even when your project is public. Refer to the [Building Open Source Projects]({{site.baseurl}}/2.0/oss/) page for associated settings information.
 
-Use Contexts to [further restrict access to environment variables](#setting-an-environment-variable-in-a-context). Contexts are set from the Organization Settings in the CircleCI application. For more information about controlling access to env vars with Contexts, refer to the [Restricting a Context]({{ site.baseurl }}/2.0/contexts/#restricting-a-context) documentation.
+Use Contexts to [further restrict access to environment variables](#setting-an-environment-variable-in-a-context). Contexts are set from the Organization Settings in the CircleCI application. For more information about controlling access to env vars with Contexts, refer to the [Restricting a Context]({{site.baseurl}}/2.0/contexts/#restricting-a-context) documentation.
 
 ## Secrets masking
 {: #secrets-masking }
@@ -46,7 +46,7 @@ The value of the environment variable will not be masked in the build output if:
 * the value of the environment variable is less than 4 characters
 * the value of the environment variable is equal to one of `true`, `True`, `false` or `False`
 
-**Note:** Secrets Masking will only prevent the value of the environment variable from appearing in your build output. If your secrets appear elsewhere, such as test results or artifacts, they will not be masked. In addition, the value of the environment variable is still accessible to users [debugging builds with SSH]({{ site.baseurl }}/2.0/ssh-access-jobs).
+**Note:** Secrets Masking will only prevent the value of the environment variable from appearing in your build output. If your secrets appear elsewhere, such as test results or artifacts, they will not be masked. In addition, the value of the environment variable is still accessible to users [debugging builds with SSH]({{site.baseurl}}/2.0/ssh-access-jobs).
 
 ## Renaming orgs and repositories
 {: #renaming-orgs-and-repositories }
@@ -75,20 +75,20 @@ Environment variables are used according to a specific precedence order, as foll
 2. Environment variables declared with the `environment` key [for a `run` step](#setting-an-environment-variable-in-a-step).
 3. Environment variables set with the `environment` key [for a job](#setting-an-environment-variable-in-a-job).
 4. Special CircleCI environment variables defined in the [CircleCI Built-in Environment Variables](#built-in-environment-variables) section of this document.
-5. Context environment variables (assuming the user has access to the Context). See the [Contexts]( {{ site.baseurl }}/2.0/contexts/) documentation for instructions.
+5. Context environment variables (assuming the user has access to the Context). See the [Contexts]({{site.baseurl}}/2.0/contexts/) documentation for instructions.
 6. [Project-level environment variables](#setting-an-environment-variable-in-a-project) set on the Project Settings page.
 
 Environment variables declared inside a shell command `run step`, for example `FOO=bar make install`, will override environment variables declared with the `environment` and `contexts` keys. Environment variables added on the Contexts page will take precedence over variables added on the Project Settings page.
 
-![Env Var Order]({{ site.baseurl }}/assets/img/docs/env-var-order.png)
+![Env Var Order]({{site.baseurl}}/assets/img/docs/env-var-order.png)
 
 #### Notes on security
 {: #notes-on-security }
 {:.no_toc}
 
-Do not add secrets or keys inside the `.circleci/config.yml` file. The full text of `config.yml` is visible to developers with access to your project on CircleCI. Store secrets or keys in [project](#setting-an-environment-variable-in-a-project) or [context](#setting-an-environment-variable-in-a-context) settings in the CircleCI app. For more information, see the [Encryption]({{ site.baseurl }}/2.0/security/#encryption) section of the Security document.
+Do not add secrets or keys inside the `.circleci/config.yml` file. The full text of `config.yml` is visible to developers with access to your project on CircleCI. Store secrets or keys in [project](#setting-an-environment-variable-in-a-project) or [context](#setting-an-environment-variable-in-a-context) settings in the CircleCI app. For more information, see the [Encryption]({{site.baseurl}}/2.0/security/#encryption) section of the Security document.
 
-Running scripts within configuration may expose secret environment variables. See the [Using Shell Scripts]({{ site.baseurl }}/2.0/using-shell-scripts/#shell-script-best-practices) document for best practices for secure scripts.
+Running scripts within configuration may expose secret environment variables. See the [Using Shell Scripts]({{site.baseurl}}/2.0/using-shell-scripts/#shell-script-best-practices) document for best practices for secure scripts.
 
 ### Example configuration of environment variables
 {: #example-configuration-of-environment-variables }
@@ -158,7 +158,7 @@ Notice there are two similar steps in the above image and config - "What branch 
 
 In general, CircleCI does not support interpolating environment variable into build config. Values used are treated as literals. This can cause issues when defining `working_directory`, modifying `PATH`, and sharing variables across multiple `run` steps.
 
-An exception to this rule is the docker image section in order to support [Private Images]({{ site.baseurl }}/2.0/private-images/).
+An exception to this rule is the docker image section in order to support [Private Images]({{site.baseurl}}/2.0/private-images/).
 
 In the example below, `$ORGNAME` and `$REPONAME` will not be interpolated.
 
@@ -203,7 +203,7 @@ workflows:
 
 ```
 
-For more information, read the documentation on [using the parameters declaration]({{ site.baseurl }}/2.0/reusing-config/#using-the-parameters-declaration).
+For more information, read the documentation on [using the parameters declaration]({{site.baseurl}}/2.0/reusing-config/#using-the-parameters-declaration).
 
 Another possible method to interpolate values into your config is to use a `run` step to export environment variables to `BASH_ENV`, as shown below.
 
@@ -272,7 +272,7 @@ For more information, refer to your shell's documentation on setting environment
 ## Setting an environment variable in a step
 {: #setting-an-environment-variable-in-a-step }
 
-To set an environment variable in a step, use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#run).
+To set an environment variable in a step, use the [`environment` key]({{site.baseurl}}/2.0/configuration-reference/#run).
 
 ```yaml
 version: 2.1
@@ -301,7 +301,7 @@ to be accessible in more than one step, export the value [using `BASH_ENV`](#usi
 ## Setting an environment variable in a job
 {: #setting-an-environment-variable-in-a-job }
 
-To set an environment variable in a job, use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#job_name).
+To set an environment variable in a job, use the [`environment` key]({{site.baseurl}}/2.0/configuration-reference/#job_name).
 
 ```yaml
 version: 2.1
@@ -324,9 +324,9 @@ jobs:
 
 1. In the CircleCI application, go to your organization settings by clicking the link in the left hand navigation.
 
-    ![Contexts]({{ site.baseurl }}/assets/img/docs/org-settings-contexts-v2.png)
+    ![Contexts]({{site.baseurl}}/assets/img/docs/org-settings-contexts-v2.png)
 
-2. Select the Context you want to associate your envorinment variable with, or create a new one by clicking the Create Context button.
+2. Select the Context you want to associate your environment variable with, or create a new one by clicking the Create Context button.
 3. Click Add Environment Variable and enter a name and value.
 4. Use your new environment variable in your `.circleci/config.yml` once the context is added under the workflows key, as follows:
 
@@ -354,14 +354,14 @@ jobs:
             echo $MY_ENV_VAR
 ```
 
-Creating a context allows you to share environment variables across multiple projects, and control who has access. For more information, see the [Contexts documentation]({{ site.baseurl }}/2.0/contexts/).
+Creating a context allows you to share environment variables across multiple projects, and control who has access. For more information, see the [Contexts documentation]({{site.baseurl}}/2.0/contexts/).
 
 ## Setting an environment variable in a project
 {: #setting-an-environment-variable-in-a-project }
 
 1. In the CircleCI application, go to your project's settings by clicking the gear icon on the Pipelines page, or the three dots on other pages in the application.
 
-    ![Environment Variables]({{ site.baseurl }}/assets/img/docs/project-settings-env-var-v2.png)
+    ![Environment Variables]({{site.baseurl}}/assets/img/docs/project-settings-env-var-v2.png)
 
 2. Click on Environment Variables.
 3. Add new variables by clicking the Add Variable button and enter a name and value.
@@ -395,9 +395,9 @@ Once created, environment variables are hidden and uneditable in the application
 ## Setting an environment variable in a container
 {: #setting-an-environment-variable-in-a-container }
 
-Environment variables can also be set for a Docker container. To do this, use the [`environment` key]({{ site.baseurl }}/2.0/configuration-reference/#docker).
+Environment variables can also be set for a Docker container. To do this, use the [`environment` key]({{site.baseurl}}/2.0/configuration-reference/#docker).
 
-**Note**: Environment variables set in this way are not available to _steps_ run within the container, they are only available to the entrypoint/command run _by_ the container. By default, CircleCI will ignore the entrypoint for a job's primary container. For the primary container's environment variables to be useful, you will need to preserve the entrypoint. For more information, see the [_adding an entrypoint_ section of the Custom Images guide]({{ site.baseurl }}/2.0/custom-images/#adding-an-entrypoint).
+**Note**: Environment variables set in this way are not available to _steps_ run within the container, they are only available to the entrypoint/command run _by_ the container. By default, CircleCI will ignore the entrypoint for a job's primary container. For the primary container's environment variables to be useful, you will need to preserve the entrypoint. For more information, see the [_adding an entrypoint_ section of the Custom Images guide]({{site.baseurl}}/2.0/custom-images/#adding-an-entrypoint).
 
 ```yaml
 version: 2.1
@@ -551,7 +551,7 @@ curl \
 ```
 
 In the above example,
-`$CIRCLE_TOKEN` is a [personal API token]({{ site.baseurl }}/2.0/managing-api-tokens/#creating-a-personal-api-token).
+`$CIRCLE_TOKEN` is a [personal API token]({{site.baseurl}}/2.0/managing-api-tokens/#creating-a-personal-api-token).
 
 The build will see the environment variables:
 
@@ -593,22 +593,22 @@ Variable                                   | Type    | Value
 `CIRCLE_PULL_REQUESTS`{:.env_var}          | List    | Comma-separated list of URLs of the current build's associated pull requests.
 `CIRCLE_REPOSITORY_URL`{:.env_var}         | String  | The URL of your GitHub or Bitbucket repository.
 `CIRCLE_SHA1`{:.env_var}                   | String  | The SHA1 hash of the last commit of the current build.
-`CIRCLE_TAG`{:.env_var}                    | String  | The name of the git tag, if the current build is tagged. For more information, see the [Git Tag Job Execution]({{ site.baseurl }}/2.0/workflows/#executing-workflows-for-a-git-tag).
+`CIRCLE_TAG`{:.env_var}                    | String  | The name of the git tag, if the current build is tagged. For more information, see the [Git Tag Job Execution]({{site.baseurl}}/2.0/workflows/#executing-workflows-for-a-git-tag).
 `CIRCLE_USERNAME`{:.env_var}               | String  | The GitHub or Bitbucket username of the user who triggered the pipeline.
 `CIRCLE_WORKFLOW_ID`{:.env_var}            | String  | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
-`CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var}  | String  | An identifier for the [workspace](https://circleci.com/docs/2.0/glossary/#workspace) of the current job. This identifier is the same for every job in a given workspace.
+`CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var}  | String  | An identifier for the [workspace]({{site.baseurl}}/2.0/glossary/#workspace) of the current job. This identifier is the same for every job in a given workspace.
 `CIRCLE_WORKING_DIRECTORY`{:.env_var}      | String  | The value of the `working_directory` key of the current job.
 `CIRCLE_INTERNAL_TASK_DATA`{:.env_var}     | String  | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.
-`CIRCLE_COMPARE_URL`{:.env_var}            | String  | **Deprecated**. The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{ site.baseurl }}/2.0/pipeline-variables/) as an alternative.
+`CIRCLE_COMPARE_URL`{:.env_var}            | String  | **Deprecated**. The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{site.baseurl}}/2.0/pipeline-variables/) as an alternative.
 `CI_PULL_REQUEST`{:.env_var}               | String  | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUEST` instead.
 `CI_PULL_REQUESTS`{:.env_var}              | List    | **Deprecated**. Kept for backward compatibility with CircleCI 1.0. Use `CIRCLE_PULL_REQUESTS` instead.
 {:class="table table-striped"}
 
-**Note:** For a list of pipeline values and parameters, refer to the [Pipeline Variables]({{ site.baseurl }}/2.0/pipeline-variables/#pipeline-values) page.
+**Note:** For a list of pipeline values and parameters, refer to the [Pipeline Variables]({{site.baseurl}}/2.0/pipeline-variables/#pipeline-values) page.
 
 ## See also
 {: #see-also }
 {:.no_toc}
 
-[Contexts]( {{ site.baseurl }}/2.0/contexts/)
+[Contexts]({{site.baseurl}}/2.0/contexts/)
 [Keep environment variables private with secret masking](https://circleci.com/blog/keep-environment-variables-private-with-secret-masking/)


### PR DESCRIPTION
# Description
Taking care of some English suggestions to links/headers that were a part of an open source PR that couldn't be addressed because it was majority Japanese content updates which can't be merged.

# Reasons
Some of the internal docs links were entered as external links + some of those links were going to confusing URLs based on headers which also needed updating.