### PR TITLE
Reorder steps for `launchctl` on mac

### DIFF
--- a/jekyll/_cci2/runner-installation-mac.adoc
+++ b/jekyll/_cci2/runner-installation-mac.adoc
@@ -104,16 +104,15 @@ Copy the following to `/Library/LaunchDaemons/com.circleci.runner.plist`, owned 
 
 == Enable the `launchd` service
 
-If you are following these instructions for a second time, you should unload the following existing service:
-
-```bash
-sudo launchctl unload '/Library/LaunchDaemons/com.circleci.runner.plist'
-```
-
 Now you can load the service:
 
 ```bash
 sudo launchctl load '/Library/LaunchDaemons/com.circleci.runner.plist'
+```
+
+NOTE: If you are following these instructions for a second time, you should unload the following existing service:
+```bash
+sudo launchctl unload '/Library/LaunchDaemons/com.circleci.runner.plist'
 ```
 
 == Verify the service is running


### PR DESCRIPTION
# Description
This PR reorders the steps for enabling the `launchctl` service on mac to make it less error prone for users who are installing runner for the first time

# Reasons
Jira: [RT-289](https://circleci.atlassian.net/browse/RT-289)

Screenshot:

<img width="1431" alt="Screen Shot 2022-01-06 at 17 17 53" src="https://user-images.githubusercontent.com/17708458/148461208-098bc000-ad46-4ae1-8a8b-49a40cc21141.png">
