### PR TITLE
Added to Workflow Troubleshooting

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -641,6 +641,8 @@ to discern what might be failing.
 
 It has been observed that in some cases, a failure happens before the workflow runs (during pipeline processing). In this case, re-running the workflow will fail even though it was succeeding before the outage. To work around this, push a change to the project's repository. This will re-run pipeline processing first, and then run the workflow.
 
+Also note that jobs and workflows that are 90 days or older are unable to be re-run.
+
 ### Workflows waiting for status in GitHub
 {: #workflows-waiting-for-status-in-github }
 {:.no_toc}

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -641,7 +641,7 @@ to discern what might be failing.
 
 It has been observed that in some cases, a failure happens before the workflow runs (during pipeline processing). In this case, re-running the workflow will fail even though it was succeeding before the outage. To work around this, push a change to the project's repository. This will re-run pipeline processing first, and then run the workflow.
 
-Also note that jobs and workflows that are 90 days or older are unable to be re-run.
+Also, please note that you cannot re-run jobs and workflows that are 90 days or older.
 
 ### Workflows waiting for status in GitHub
 {: #workflows-waiting-for-status-in-github }


### PR DESCRIPTION
# Description
Added a reminder that jobs that are 90 days or older cannot be re-run.

# Reasons
A customer reached out with an issue where they could not re-run a job, the job was over 90 days old so a re-run is not possible but this is not stated in our docs, only in a discuss article from 2020.