### PR TITLE
[DD-314]: Refactor Language Submission Process

### DIFF
--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -48,7 +48,7 @@
                 <span class="lang-form-title">Request a language</span>
                 <input id="lang-req" class="lang-form" type="text" placeholder="Language" maxLength='12'
                   autocomplete="off">
-                <a id="submit-btn">Submit</a>
+                <button id="submit-btn" disabled>Submit</button>
               </div>
             </div>
           </div>

--- a/src/js/services/lang.js
+++ b/src/js/services/lang.js
@@ -68,7 +68,6 @@ const handleChangeLanguageNav = () => {
 const languageRequest = () => {
   const langForm = $('.lang-form');
   const submitBtn = $('#submit-btn');
-  const input = $('#lang-req')[0];
 
   // Add styles for input form when active
   langForm.on('click', () => {
@@ -82,17 +81,18 @@ const languageRequest = () => {
   });
 
   // Toggle submit button UI and button state based on user input
-  langForm.on('keyup', () => {
-    submitBtn.removeAttr('disabled');
-    if (input.value == '') {
+  langForm.on('keyup', (e) => {
+    if (e.currentTarget.value == '') {
       submitBtn.attr('disabled', 'disabled');
+    } else {
+      submitBtn.removeAttr('disabled');
     }
   });
 
   submitBtn.on('click', () => {
-    langForm.css('pointer-events', 'none');
+    langForm.addClass('lang-submitted');
     window.AnalyticsClient.trackAction('New Language Request', {
-      requestedLanguage: input.value,
+      requestedLanguage: langForm[0].value,
       browserNativeLang: window.navigator.language,
       app: 'Docs',
       location: window.location.href,
@@ -100,7 +100,7 @@ const languageRequest = () => {
     });
     // Swap out button with submit message after submission
     submitBtn.replaceWith(
-      '<span id=lang-submitted>' + 'Thank you for your help' + '</span>',
+      `<span id=lang-submitted>Thank you for your help</span>`,
     );
   });
 };

--- a/src/js/services/lang.js
+++ b/src/js/services/lang.js
@@ -65,9 +65,11 @@ const handleChangeLanguageNav = () => {
 /*
   Handle functionality and UI changes for language request input form and new language submission when an input is provided
 */
-const langForm = $('.lang-form');
-
 const languageRequest = () => {
+  const langForm = $('.lang-form');
+  const submitBtn = $('#submit-btn');
+  const input = $('#lang-req')[0];
+
   // Add styles for input form when active
   langForm.on('click', () => {
     langForm.addClass('active');
@@ -78,40 +80,30 @@ const languageRequest = () => {
       }
     });
   });
-};
 
-const submitLanguage = () => {
-  const submitBtn = $('#submit-btn');
-  const input = $('#lang-req')[0];
+  // Toggle submit button UI and button state based on user input
+  langForm.on('keyup', () => {
+    submitBtn.removeAttr('disabled');
+    if (input.value == '') {
+      submitBtn.attr('disabled', 'disabled');
+    }
+  });
 
-  if (input.value.length > 0) {
-    // If user input present, adjust UI and add event listener to submit data on click to amplitude
-    submitBtn.css({ opacity: '100%', cursor: 'pointer' });
-    submitBtn.on('click', () => {
-      clearInterval(checkLangInput);
-      langForm.css('pointer-events', 'none');
-
-      window.AnalyticsClient.trackAction('New Language Request', {
-        requestedLanguage: input.value,
-        browserNativeLang: window.navigator.language,
-        app: 'Docs',
-        location: window.location.href,
-        path: window.location.pathname,
-      });
-      // Swap out button with submit message after submission
-      submitBtn.replaceWith(
-        '<span id=lang-submitted>' + 'Thank you for your help' + '</span>',
-      );
+  submitBtn.on('click', () => {
+    langForm.css('pointer-events', 'none');
+    window.AnalyticsClient.trackAction('New Language Request', {
+      requestedLanguage: input.value,
+      browserNativeLang: window.navigator.language,
+      app: 'Docs',
+      location: window.location.href,
+      path: window.location.pathname,
     });
-  }
-  // If no user input present, adjust UI and remove event from submit btn
-  if (!input.value.length) {
-    submitBtn.css({ opacity: '50%', cursor: 'not-allowed' });
-    submitBtn.off('click');
-  }
+    // Swap out button with submit message after submission
+    submitBtn.replaceWith(
+      '<span id=lang-submitted>' + 'Thank you for your help' + '</span>',
+    );
+  });
 };
-// use intervals to check if user provided input to alter UI and toggle on click event for submit btn
-const checkLangInput = setInterval(submitLanguage, 500);
 
 export function init() {
   setLanguageSelectorOnLoad();

--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -302,17 +302,21 @@ $btn-selected-blue: #004A95;
       line-height: 18px;
       color: $black;
       opacity: 0.5;
+
       &:hover {
         border: 1px solid $black;
         background: $white;
       }
     }
-      .active {
-        border: 1px solid #1D97E4;
-        background: $white;
-        opacity: 1;
-        pointer-events: none;
-      }
+    .active {
+      border: 1px solid #1D97E4;
+      background: $white;
+      opacity: 1;
+      pointer-events: none;
+    }
+    .lang-submitted {
+      pointer-events: none;
+    }
 
     #submit-btn {
       border: none;

--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -315,8 +315,8 @@ $btn-selected-blue: #004A95;
       }
 
     #submit-btn {
-      opacity: 50%;
-      cursor: not-allowed;
+      border: none;
+      background: none;
       font-family: "Roboto";
       color: $btn-hover-blue;
       font-style: normal;
@@ -324,6 +324,11 @@ $btn-selected-blue: #004A95;
       font-size: 12px;
       line-height: 14px;
       margin-left: 106px;
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
     }
 
     #lang-submitted {


### PR DESCRIPTION
**Ticket:** [DD-314](https://circleci.atlassian.net/browse/DD-314)
**Preview:** http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/request-new-language-preview/?force-all



# Changes
- use `<button>` in place of `<a>` with correct styles when disabled
- refactor how language form input is processed and submitted to amplitude 

# Description
Addressing  a bug where the language input is sent to amplitude multiple times upon submission on click due to how it is being handled and processed in lang.js . We are also refactoring the Submit button to be more SEO friendly. 

# Considerations
Refactor associated with: #6097 