### PR TITLE
Add example for MS SQL Server

### DIFF
--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -317,6 +317,69 @@ VALUES (
 );
 ```
 
+## Example project with Java and Microsoft SQL Server
+
+{: #example-mssql-project }
+
+The following example runs a maven build in the primary container and spins up a Microsoft SQL Server in a secondary container.
+It waits for the database to start up with the `wait-for` ORB and then runs `sqlcmd` to create a test database.
+Finally it runs the maven build and tests against the database `circle_test` on `localhost:1433`
+The test user is `sa` to keep it simple (the database is temporary just to run the tests, so security is not really an issue).
+
+{% raw %}
+
+```yaml
+version: 2.1
+
+orbs:
+  wait-for: cobli/wait-for@0.0.2
+
+var:
+  job:
+    - &jdkJobWithMssql
+      docker:
+        - image: cimg/openjdk:11.0
+        - image: mcr.microsoft.com/mssql/server:2019-latest
+          environment:
+            ACCEPT_EULA: y
+            SA_PASSWORD: YourStrongDbPassword
+
+jobs:
+  build:
+    <<: *jdkJobWithMssql
+    steps:
+      # See documentation at: https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools?view=sql-server-ver15#ubuntu
+      - checkout
+      - run:
+          name: Add Microsoft repo keys
+          command: curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+      - run:
+          name: Add Microsoft Ubuntu repository
+          command: curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
+      - run:
+          name: Install packages
+          command: sudo apt-get update -qq && sudo ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
+      # See documentation at: https://circleci.com/developer/orbs/orb/cobli/wait-for#commands-port
+      - wait-for/port:
+          description: wait for MS SQL Server
+          timeout: 600
+          seconds-between-retries: 10
+          port: 1433
+      - run:
+          name: Create test database
+          command: /opt/mssql-tools/bin/sqlcmd -U sa -P YourStrongDbPassword -Q "CREATE DATABASE circle_test"
+      - run:
+          name: Compile package and run tests
+          command: mvn package
+
+workflows:
+  version: 2
+  main:
+    jobs:
+      - build:
+```
+
+{% endraw %}
 
 ## See also
 {: #see-also }

--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -376,7 +376,7 @@ workflows:
   version: 2
   main:
     jobs:
-      - build:
+      - build
 ```
 
 {% endraw %}


### PR DESCRIPTION
# Description
Add example for MS SQL Server

# Reasons
Running MS SQL Server is a bit tricky in CircleCI. I want to share the build script worked out to save time for other devs.
Doing tests with MS SQL Server appears to be a common tasks, and I did not find anything functional in the CircleCI documentation.