### PR TITLE
Update local-cli.md

### DIFF
--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -379,10 +379,6 @@ The commands above will run the entire _build_ job (only jobs, not workflows, ca
 
 Although running jobs locally with `circleci` is very helpful, there are some limitations.
 
-**Docker on Mac**
-
-Local execution in Docker Desktop for Mac using cgroupsv2, is temporarily blocked pending system updates. Follow the [Github issue](https://github.com/CircleCI-Public/circleci-cli/issues/589) for the latest information.
-
 **Machine Executor**
 
 You cannot use the machine executor in local jobs. This is because the machine executor requires an extra VM to run its jobs.


### PR DESCRIPTION
Remove the Docker for Mac limitation, issue has been resolved.

# Description
There was a temporary limitation around local execute due to cgroupsv2 compatibility.

# Reasons
Issue has been resolved, removing mention from the docs. https://github.com/CircleCI-Public/circleci-cli/issues/589