### PR TITLE
Fix: Add right-side padding on TOC for smaller breakpoint

### DIFF
--- a/src/styles/_sidebar.scss
+++ b/src/styles/_sidebar.scss
@@ -182,9 +182,9 @@ $sidebar-spacing-base: 5px;
 
 aside.full-height {
   .full-height-sticky {
-    position: sticky; 
-    max-height: calc(100vh - 140px); 
-    overflow: auto; 
+    position: sticky;
+    max-height: calc(100vh - 140px);
+    overflow: auto;
     padding-left: 5px;
     top: 83px;
     max-width: 400px;
@@ -221,7 +221,7 @@ aside.full-height {
 
   ul, li {
     list-style-type: none;
-    padding-left: 8px;
+    padding: 0px 8px;
     margin: 4px 0;
     &:first {
       padding-left: 0px;


### PR DESCRIPTION
# Description
- Add right-side padding on TOC items to account for smaller screens

# Reasons
The layout doesn't look correct on a smaller screen. This PR is adding padding on the right side of the TOC items to give a little more breathing room. 

# Screenshots

before:
![Screen Shot 2022-01-10 at 1 12 01 PM](https://user-images.githubusercontent.com/1449325/148841678-114cd591-ab0a-4d64-8988-8b130e210636.png)

after:
![Screen Shot 2022-01-10 at 1 11 42 PM](https://user-images.githubusercontent.com/1449325/148841688-1761dddd-c5a7-433d-aea6-a863d2d0339c.png)
