### PR TITLE
[FIX]: fix padding for submit btn

### DIFF
--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -319,6 +319,7 @@ $btn-selected-blue: #004A95;
     }
 
     #submit-btn {
+      padding: 0;
       border: none;
       background: none;
       font-family: "Roboto";


### PR DESCRIPTION
# Changes

- update padding for submit btn

# Description
Removing the padding for the submit button so that its aligned according to the figma design (previously was `<a>` tag that had no inherent padding)

# Reasons
See original PR #6097 

# Screenshots

**Before:**
![Screen Shot 2022-01-10 at 3 15 10 PM](https://user-images.githubusercontent.com/57234605/148853684-f6dda5e7-fb19-4ff5-b427-f87802ce0356.png)

**After:**
![Screen Shot 2022-01-10 at 3 15 02 PM](https://user-images.githubusercontent.com/57234605/148853671-00c5106d-52da-4c88-b8bd-ea86f51c3a92.png)