### PR TITLE
Fix: Check for IntersectionObserver existence before using it

### DIFF
--- a/src/js/site/sidebar.js
+++ b/src/js/site/sidebar.js
@@ -138,7 +138,7 @@ export function highlightTocOnScroll() {
 
   // https://caniuse.com/intersectionobserver
   if (typeof IntersectionObserver !== 'undefined') {
-    var observer = new IntersectionObserver(
+    const observer = new IntersectionObserver(
       function (entry) {
         // check that 1) the item is visible/intersecting
         // and 2) that the sidebar items text actually has that headline before we make any changes.

--- a/src/js/site/sidebar.js
+++ b/src/js/site/sidebar.js
@@ -136,27 +136,30 @@ export function highlightTocOnScroll() {
     });
   });
 
-  var observer = new IntersectionObserver(
-    function (entry) {
-      // check that 1) the item is visible/intersecting
-      // and 2) that the sidebar items text actually has that headline before we make any changes.
-      if (
-        entry[0].isIntersecting === true &&
-        sidebarItemsText.includes(entry[0].target.innerText)
-      ) {
-        let intersectingEntry = entry[0].target;
-        let indexOfCurrentHeadline = allHeadlines.indexOf(intersectingEntry);
-        sidebarItems.forEach((el) => el.classList.remove('active'));
-        sidebarItems[indexOfCurrentHeadline].classList.add('active');
-      }
-    },
-    { threshold: [1.0], rootMargin: '0px 0px -60% 0px' },
-  );
+  // https://caniuse.com/intersectionobserver
+  if (typeof IntersectionObserver !== 'undefined') {
+    var observer = new IntersectionObserver(
+      function (entry) {
+        // check that 1) the item is visible/intersecting
+        // and 2) that the sidebar items text actually has that headline before we make any changes.
+        if (
+          entry[0].isIntersecting === true &&
+          sidebarItemsText.includes(entry[0].target.innerText)
+        ) {
+          let intersectingEntry = entry[0].target;
+          let indexOfCurrentHeadline = allHeadlines.indexOf(intersectingEntry);
+          sidebarItems.forEach((el) => el.classList.remove('active'));
+          sidebarItems[indexOfCurrentHeadline].classList.add('active');
+        }
+      },
+      { threshold: [1.0], rootMargin: '0px 0px -60% 0px' },
+    );
 
-  allHeadlines.forEach((headline) => {
-    observer.observe(headline);
-  });
-
+    allHeadlines.forEach((headline) => {
+      observer.observe(headline);
+    });
+  }
+  
   // on page load, find the highest item in the article view port that is also
   // in the sidebar and then add active class to it.
   const firstHeadlineInViewport = allHeadlines.find(isElementInViewport);

--- a/src/js/site/sidebar.js
+++ b/src/js/site/sidebar.js
@@ -159,7 +159,7 @@ export function highlightTocOnScroll() {
       observer.observe(headline);
     });
   }
-  
+
   // on page load, find the highest item in the article view port that is also
   // in the sidebar and then add active class to it.
   const firstHeadlineInViewport = allHeadlines.find(isElementInViewport);


### PR DESCRIPTION
# Description
- Check for typeof `IntersectionObserver` before using it.

# Reasons
While the `IntersectionObserver` is [fairly well supported everywhere](https://caniuse.com/intersectionobserver) we have a few errors every day on [DD](https://app.datadoghq.com/rum/error-tracking?issueId=f63406d4-6899-11ec-b77f-da7ad0900002&start=1641921449048&end=1641925049048&paused=false) that suggests that it might not be available for everyone completely. This PR prevents calling it without checking first.