### PR TITLE
[WEB-696] Split GTM noscript, move include to head

### DIFF
--- a/jekyll/_includes/google-tag-manager-noscript.html
+++ b/jekyll/_includes/google-tag-manager-noscript.html
@@ -1,0 +1,2 @@
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-W9HDVK"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/jekyll/_includes/google-tag-manager.html
+++ b/jekyll/_includes/google-tag-manager.html
@@ -1,5 +1,3 @@
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-W9HDVK"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/jekyll/_includes/head.html
+++ b/jekyll/_includes/head.html
@@ -7,6 +7,9 @@
 	<meta name="description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 	{% if page.redirect %}<meta http-equiv="refresh" content="0; url={{ page.redirect }}">{% endif %}
   	{% assign current_url = page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url %}
+	{% if jekyll.environment == "production" %}
+		{% include_cached google-tag-manager.html %}
+	{% endif %}
 	<link rel="canonical" href="{{current_url}}">
   	<link rel="alternate" hreflang="{{page.lang}}" href="{{current_url}}" />
   	{% if page.lang == "en" %}

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -3,7 +3,7 @@
 {% include_cached head.html site=site page=page %}
 <body class="{% if page.page-type == "index" or page.page-type == "homepage" %}homepage{% endif %}">
 {% if jekyll.environment == "production" %}
-  {% include_cached google-tag-manager.html %}
+  {% include_cached google-tag-manager-noscript.html %}
 {% endif %}
 
 <div class="outer">


### PR DESCRIPTION
Per Google, they want the GTM tag as high in the head as possible, and the noscript version in the body (also as high as possible).

I selected this position in the head somewhat arbitrarily, but it's below the items that are actually critical to be at the beginning (meta charset, redirect).