### PR TITLE
Clarify use of CIRCLE_USERNAME variable

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -594,7 +594,7 @@ Variable                                   | Type    | Value
 `CIRCLE_REPOSITORY_URL`{:.env_var}         | String  | The URL of your GitHub or Bitbucket repository.
 `CIRCLE_SHA1`{:.env_var}                   | String  | The SHA1 hash of the last commit of the current build.
 `CIRCLE_TAG`{:.env_var}                    | String  | The name of the git tag, if the current build is tagged. For more information, see the [Git Tag Job Execution]({{site.baseurl}}/2.0/workflows/#executing-workflows-for-a-git-tag).
-`CIRCLE_USERNAME`{:.env_var}               | String  | The GitHub or Bitbucket username of the user who triggered the pipeline.
+`CIRCLE_USERNAME`{:.env_var}               | String  | The GitHub or Bitbucket username of the user who triggered the pipeline (only if the user has a CircleCI account).
 `CIRCLE_WORKFLOW_ID`{:.env_var}            | String  | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
 `CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var}  | String  | An identifier for the [workspace]({{site.baseurl}}/2.0/glossary/#workspace) of the current job. This identifier is the same for every job in a given workspace.
 `CIRCLE_WORKING_DIRECTORY`{:.env_var}      | String  | The value of the `working_directory` key of the current job.


### PR DESCRIPTION
# Description
Explained that CIRCLE_USERNAME variable available only if user has CCI account.

# Reasons

https://circleci.atlassian.net/browse/DOCSTEAM-53
