### PR TITLE
[DD-323] Temporarily disable code snippet line numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@optimizely/optimizely-sdk": "4.6.2",
     "@popperjs/core": "^2.10.1",
     "highlightjs-badge": "0.1.9",
-    "highlightjs-line-numbers.js": "^2.8.0",
     "jquery": "3.6.0",
     "js-cookie": "2.2.1",
     "lodash.debounce": "4.0.8",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4,7 +4,6 @@
  */
 import * as Cookie from 'js-cookie';
 import 'highlightjs-badge';
-import 'highlightjs-line-numbers.js';
 
 import services from './services';
 import '../styles/main.scss';

--- a/src/js/site/main.js
+++ b/src/js/site/main.js
@@ -2,9 +2,6 @@ import { createPopper } from '@popperjs/core';
 import { highlightURLHash } from './highlightURLHash';
 
 hljs.initHighlightingOnLoad();
-hljs.initLineNumbersOnLoad({
-  singleLine: true,
-});
 
 const showEvents = ['mouseover', 'hover', 'mouseenter', 'focus'];
 const hideEvents = ['mouseout', 'mouseleave', 'blur'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4328,11 +4328,6 @@ hosted-git-info@^4.0.1:
   dependencies:
     lru-cache "^6.0.0"
 
-highlightjs-line-numbers.js@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/highlightjs-line-numbers.js/-/highlightjs-line-numbers.js-2.8.0.tgz#479ea8cff0c31fadc1578a66fa03e38b801f9ca6"
-  integrity sha512-TEf1gw0c8mb8nan0QwliqS7obT4cpUd9hzsGzsZLweteNnWea/VIqy5/aQqsa5wnz9lnvmtAkS1ZtDTjB/goYQ==
-
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"


### PR DESCRIPTION
Ticket: [DD-342](https://circleci.atlassian.net/browse/DD-342)

# Description
- Remove package and `initLineNumbersOnLoad()` 

# Reasons
The line plugin is causing the copied code to lose its formatting. There isn't a specific error about the formatting, so this could be confusing to people who may not know what to look for