### PR TITLE
Add ex of platform command, separate out export commands

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -90,11 +90,19 @@ First, set one of these variables as appropriate for for your installation targe
 | `platform=darwin/arm64`
 |===
 
+Example:
+```bash
+export platform=darwin/amd64
+```
+
 Next, set the `circleci-launch-agent` version. Runners on cloud auto-update to the latest supported versions. For server, specific runner versions are validated for interoperability and runners do not auto-update. A table of server `circleci-launch-agent` versions can be found <<runner-for-server-compatibility,here>>.
 
 For cloud, you can run the following:
 ```bash
 export base_url="https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent"
+```
+followed by:
+```bash
 export agent_version=$(curl "${base_url}/release.txt")
 ```
 


### PR DESCRIPTION
# Description
On the Runner Installation for MacOS page we needed to add further clarification on how to run certain steps/commands.

# Reasons
The directions were unclear on how to set your platform.
Two commands were potentially being run concurrently when they should be run consecutively.