### PR TITLE
[DD-329]: Disable Search when Mobile Menu Open

### DIFF
--- a/src/js/site/nav.js
+++ b/src/js/site/nav.js
@@ -44,6 +44,13 @@ $(document).ready(function () {
     });
   });
 
+  // Remove search open when mobile menu is open
+  const mobileMenu = $('.global-nav--toggle');
+  const mobileSearchIcon = $('.global-nav--search-button');
+  mobileMenu.on('click', () => {
+    mobileSearchIcon.toggleClass('no-display');
+  });
+
   // Open dropdowns on keyboard focus
   $(document).ready(function () {
     $('.nav-item').each(function () {

--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -604,11 +604,6 @@ a.nav-skip-button {
   display: none;
 }
 
-@media (min-width: $screen-sm) {
-  .global-nav--component .global-nav--row-desktop {
-    height: 68.5px;
-  }
-}
 // -- Docs Disco Experiments
 
 .dd-global-nav--component {

--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -604,6 +604,11 @@ a.nav-skip-button {
   display: none;
 }
 
+@media (min-width: $screen-sm) {
+  .global-nav--component .global-nav--row-desktop {
+    height: 68.5px;
+  }
+}
 // -- Docs Disco Experiments
 
 .dd-global-nav--component {


### PR DESCRIPTION
[Ticket](https://circleci.atlassian.net/browse/DD-329)
[Preview](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/disable-search-when-mobile-menu-open-preview/?force-all)

# Changes

-  toggle display for search icon when mobile menu is clicked

# Description
There is a bug for the mobile view where we still allow the search feature to work when the mobile menu is open.

# Reasons
The search button and feature should be disabled when the mobile menu is open to present a more unified and cleaner experience while also getting rid of the menu layout change that is currently occurring. 

# Screenshots
**Before:**

https://user-images.githubusercontent.com/57234605/149603918-1bd076aa-4d0f-435b-a20d-f3d2dc2459d1.mp4

**After:**

https://user-images.githubusercontent.com/57234605/149603963-e8c4eb2e-2baa-4622-9341-dbb47acf7775.mp4


