### PR TITLE
Update runner k8s doc with env configuration

### DIFF
--- a/jekyll/_cci2/runner-on-kubernetes.adoc
+++ b/jekyll/_cci2/runner-on-kubernetes.adoc
@@ -105,6 +105,8 @@ Customizable parameters are left inside the `+values.yaml+` file. See the follow
 
 | `+agentVersion+`  | -         | N         | The `circleci-task-agent` version to pin. This is only used for CircleCI server installations.
 
+| `+env+`           | -         | N         | Environment variables to set in the `launch-agent` pod. Including values for xref:runner-config-reference.adoc[runner configuration] 
+
 | all other values  | -         | N         | Modify at your own discretion and risk.
 
 |===


### PR DESCRIPTION
# Description
Adding a new configuration value for the values.yaml chart for the runner kubernetes release. This allows users to specify environment variables for the pod they are running runner in. 

# Reasons
To update the docs with the new configuration option added in this [runner k8s PR](https://github.com/CircleCI-Public/circleci-runner-k8s/pull/9)