### PR TITLE
Document the Kong healthcheck

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -174,6 +174,8 @@ For more information on adding a new DNS record, see the following documentation
 
 * link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-creating.html[Creating records by using the Amazon Route 53 Console] (AWS)
 
+NOTE: The Traefik load balancer has a healthcheck that serves a JSON payload at https://loadbalancer-address/status.
+
 === Validation
 
 You should now be able to navigate to your CircleCI server installation and log in to the application successfully. Now let’s move on to build services. It may take a while for all your services to be up. You can periodically check by running the following command (you are looking for the “frontend” pod to be status of running and ready should show 1/1): 


### PR DESCRIPTION
[SERVER-1564](https://circleci.atlassian.net/browse/SERVER-1564)

Everything is still referencing Traefik so I left it as-is
and filed [SERVER-1622](https://circleci.atlassian.net/browse/SERVER-1622) to address the change.