### PR TITLE
Reference new Python convenience images

### DIFF
--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -86,14 +86,14 @@ jobs:
   build:
     working_directory: ~/circleci-demo-python-django
     docker:
-      - image: circleci/python:3.6.4  # primary container for the build job
+      - image: cimg/python:3.10.1  # primary container for the build job
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 ```
 
 **Note:**
-`circleci/python:3.6.4` is a [convenience image]({{ site.baseurl }}/2.0/circleci-images/) provided by CircleCI.
+`cimg/python:3.10.1` is a [convenience image]({{ site.baseurl }}/2.0/circleci-images/) provided by CircleCI.
 These images are extensions of official Docker images
 and include tools useful for CI/CD environments.
 
@@ -110,7 +110,7 @@ jobs:
   build:
     working_directory: ~/circleci-demo-python-django
     docker:
-      - image: circleci/python:3.6.4 # every job must define an image for the docker executor and subsequent jobs may define a different image.
+      - image: cimg/python:3.10.1 # every job must define an image for the docker executor and subsequent jobs may define a different image.
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -262,8 +262,8 @@ jobs: # A basic unit of work in a run
     # directory where steps are run
     working_directory: ~/circleci-demo-python-django
     docker: # run the steps with Docker
-      # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
-      - image: circleci/python:3.6.4
+      # CircleCI Python images available at: https://hub.docker.com/r/cimg/python/
+      - image: cimg/python:3.10.1
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference


### PR DESCRIPTION
# Description
Updates the docs to reference the latest Python convenience images, rather than the deprecated ones.

Note: There is a reference to a deprecated Postgres image in here, but there's no replacement equivalent so I intentionally did not update that reference.

# Reasons
Ensure pointing CircleCI users to the latest and greatest, rather than deprecated images.