### PR TITLE
Fix typo: workspace_id consistent across workflow.

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -596,7 +596,7 @@ Variable                                   | Type    | Value
 `CIRCLE_TAG`{:.env_var}                    | String  | The name of the git tag, if the current build is tagged. For more information, see the [Git Tag Job Execution]({{site.baseurl}}/2.0/workflows/#executing-workflows-for-a-git-tag).
 `CIRCLE_USERNAME`{:.env_var}               | String  | The GitHub or Bitbucket username of the user who triggered the pipeline (only if the user has a CircleCI account).
 `CIRCLE_WORKFLOW_ID`{:.env_var}            | String  | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
-`CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var}  | String  | An identifier for the [workspace]({{site.baseurl}}/2.0/glossary/#workspace) of the current job. This identifier is the same for every job in a given workspace.
+`CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var}  | String  | An identifier for the [workspace]({{site.baseurl}}/2.0/glossary/#workspace) of the current job. This identifier is the same for every job in a given workflow.
 `CIRCLE_WORKING_DIRECTORY`{:.env_var}      | String  | The value of the `working_directory` key of the current job.
 `CIRCLE_INTERNAL_TASK_DATA`{:.env_var}     | String  | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.
 `CIRCLE_COMPARE_URL`{:.env_var}            | String  | **Deprecated**. The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{site.baseurl}}/2.0/pipeline-variables/) as an alternative.


### PR DESCRIPTION
# Description
Fix typo: workspace_id consistent across workflow.

# Reasons
Existing copy doesn't make sense.