### PR TITLE
[DD-334] Track if Users Enable Dark Mode

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -18,6 +18,7 @@ import './site';
 
 services.lang.init();
 services.rum.init();
+// Temporary service to check if user dark mode preferences
 trackDarkModePreference();
 
 $(() => {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -7,6 +7,7 @@ import 'highlightjs-badge';
 
 import services from './services';
 import '../styles/main.scss';
+import { trackDarkModePreference } from './site/main';
 
 // adding "Clients" to the window object so they can be accessed by other js inside Jekyll
 window.Cookie = Cookie;
@@ -17,6 +18,7 @@ import './site';
 
 services.lang.init();
 services.rum.init();
+trackDarkModePreference();
 
 $(() => {
   services.instantsearch.init();

--- a/src/js/site/main.js
+++ b/src/js/site/main.js
@@ -426,8 +426,8 @@ $(function () {
   Check if users have dark mode enabled
   Set key if user response has not already been tracked to ensure we dont get multiple events from the same user
  */
-$(document).ready(() => {
-  const storageKey = 'provided-dark-mode-reponse';
+const trackDarkModePreference = () => {
+  const storageKey = 'provided-dark-mode-response';
   if (localStorage.getItem(storageKey)) {
     return;
   } else {
@@ -438,4 +438,5 @@ $(document).ready(() => {
         window.matchMedia('(prefers-color-scheme: dark)').matches,
     });
   }
-});
+};
+trackDarkModePreference();

--- a/src/js/site/main.js
+++ b/src/js/site/main.js
@@ -422,10 +422,20 @@ $(function () {
   });
 });
 
+/*
+  Check if users have dark mode enabled
+  Set key if user response has not already been tracked to ensure we dont get multiple events from the same user
+ */
 $(document).ready(() => {
-  window.AnalyticsClient.trackAction('User Dark Mode Preference', {
-    darkModeEnabled:
-      window.matchMedia &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches,
-  });
+  const storageKey = 'provided-dark-mode-reponse';
+  if (localStorage.getItem(storageKey)) {
+    return;
+  } else {
+    localStorage.setItem(storageKey, true);
+    window.AnalyticsClient.trackAction('User Dark Mode Preference', {
+      darkModeEnabled:
+        window.matchMedia &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches,
+    });
+  }
 });

--- a/src/js/site/main.js
+++ b/src/js/site/main.js
@@ -421,3 +421,11 @@ $(function () {
     });
   });
 });
+
+$(document).ready(() => {
+  window.AnalyticsClient.trackAction('User Dark Mode Preference', {
+    darkModeEnabled:
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches,
+  });
+});

--- a/src/js/site/main.js
+++ b/src/js/site/main.js
@@ -426,7 +426,7 @@ $(function () {
   Check if users have dark mode enabled
   Set key if user response has not already been tracked to ensure we dont get multiple events from the same user
  */
-const trackDarkModePreference = () => {
+export function trackDarkModePreference() {
   const storageKey = 'provided-dark-mode-response';
   if (localStorage.getItem(storageKey)) {
     return;
@@ -438,5 +438,4 @@ const trackDarkModePreference = () => {
         window.matchMedia('(prefers-color-scheme: dark)').matches,
     });
   }
-};
-trackDarkModePreference();
+}


### PR DESCRIPTION
[Ticket](https://circleci.atlassian.net/browse/DD-334)
[Preview](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/track-darkmode-preview/?force-all)

# Changes

- add `trackAction` for user dark mode preference
- set storage key is user preference already recorded

# Description
We are gauging the interest of users to switch to dark mode since developers tend to work in dark mode and it’s considered as table-stakes

# Amplitude
<img width="694" alt="Screen Shot 2022-01-19 at 4 36 30 PM" src="https://user-images.githubusercontent.com/57234605/150240991-1c56657a-8d43-4881-9ee8-47fd47dd9395.png">

