### PR TITLE
Remove deprecated deploy step from config, update examples

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1174,6 +1174,12 @@ A path is not required here because the cache will be restored to the location f
 ```
 {% endraw %}
 
+#### **`deploy` - DEPRECATED**
+{: #deploy-deprecated }
+{:.no_toc}
+
+Please see [run](#run) for current processes.
+
 ##### **`store_artifacts`**
 {: #storeartifacts }
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1174,7 +1174,7 @@ A path is not required here because the cache will be restored to the location f
 ```
 {% endraw %}
 
-#### **`deploy` - DEPRECATED**
+##### **`deploy` - DEPRECATED**
 {: #deploy-deprecated }
 {:.no_toc}
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -187,7 +187,7 @@ A map of environment variable names and values. These will override any environm
 #### `parallelism`
 {: #parallelism }
 
-If `parallelism` is set to N > 1, then N independent executors will be set up and each will run the steps of that job in parallel. This can help optimize your test steps; you can split your test suite, using the CircleCI CLI, across parallel containers so the job will complete in a shorter time. Certain parallelism-aware steps can opt out of the parallelism and only run on a single executor (for example [`deploy` step](#deploy--deprecated)). Learn more about [parallel jobs]({{ site.baseurl }}/2.0/parallelism-faster-jobs/).
+If `parallelism` is set to N > 1, then N independent executors will be set up and each will run the steps of that job in parallel. This can help optimize your test steps; you can split your test suite, using the CircleCI CLI, across parallel containers so the job will complete in a shorter time. Certain parallelism-aware steps can opt out of the parallelism and only run on a single executor. Learn more about [parallel jobs]({{ site.baseurl }}/2.0/parallelism-faster-jobs/).
 
 Example:
 
@@ -770,6 +770,9 @@ Each built-in step is described in detail below.
 
 Used for invoking all command-line programs, taking either a map of configuration values, or, when called in its short-form, a string that will be used as both the `command` and `name`. Run commands are executed using non-login shells by default, so you must explicitly source any dotfiles as part of the command.
 
+**Note:** the `run` step replaces the deprecated `deploy` step. If your job has a parallelism of 1, the deprecated `deploy` step can be swapped out directly for the `run` step. If your job has parallelism >1, use [workflows](#workflows) plus associated [filtering]({{site.baseurl}}/2.0/configuration-reference/#jobfilters) and/or [scheduled pipelines]({{site.baseurl}}/2.0/scheduled-pipelines/). See [fan-out/fan-in examples]({{site.baseurl}}/2.0/workflows/#fan-outfan-in-workflow-example) for more details.
+{: class="alert alert-info"}
+
 Key | Required | Type | Description
 ----|-----------|------|------------
 command | Y | String | Command to run via the shell
@@ -1170,43 +1173,6 @@ A path is not required here because the cache will be restored to the location f
       - /foo
 ```
 {% endraw %}
-
-##### **`deploy` – DEPRECATED**
-{: #deploy-deprecated }
-
-**This key is deprecated. For improved control over your deployments use [workflows](#workflows) plus associated filtering and/or [scheduled pipelines](https://circleci.com/docs/2.0/scheduled-pipelines/).** See [fan-out/fan-in examples](https://circleci.com/docs/2.0/workflows/#fan-outfan-in-workflow-example) for more details.
-
-Special step for deploying artifacts.
-
-`deploy` uses the same configuration map and semantics as [`run`](#run) step. Jobs may have more than one `deploy` step.
-
-In general `deploy` step behaves just like `run` with two exceptions:
-
-- In a job with `parallelism`, the `deploy` step will only be executed by node #0 and only if all nodes succeed. Nodes other than #0 will skip this step.
-- In a job that runs with SSH, the `deploy` step will not execute, and the following action will show instead:
-  > **skipping deploy**
-  > Running in SSH mode.  Avoid deploying.
-
-When using the `deploy` step, it is also helpful to understand how you can use workflows to orchestrate jobs and trigger jobs. For more information about using workflows, refer to the following pages:
-
-- [Workflows](https://circleci.com/docs/2.0/workflows/)
-- [`workflows`](https://circleci.com/docs/2.0/configuration-reference/#section=configuration)
-
-###### Example
-{: #example }
-{:.no_toc}
-
-``` YAML
-- deploy:
-    command: |
-      if [ "${CIRCLE_BRANCH}" == "main" ]; then
-        ansible-playbook site.yml
-      fi
-```
-
-**Note:** The `run` step allows you to use a shortcut like `run: my command`; however, if you try to use a similar shortcut for the `deploy` step like `deploy: my command`, then you will receive the following error message in CircleCI:
-
-`In step 3 definition: This type of step does not support compressed syntax`
 
 ##### **`store_artifacts`**
 {: #storeartifacts }

--- a/jekyll/_cci2/ios-tutorial.md
+++ b/jekyll/_cci2/ios-tutorial.md
@@ -14,7 +14,7 @@ This document describes how to automate builds, testing, and deployment of an iO
 * TOC
 {:toc}
 
-**Note:** There is also documentation for [testing iOS]({{ site.baseurl}}/2.0/testing-ios/) and [getting started on MacOS]({{ site.baseurl }}/2.0/hello-world-macos/).
+**Note:** There is also documentation for [testing iOS]({{site.baseurl}}/2.0/testing-ios/) and [getting started on MacOS]({{site.baseurl}}/2.0/hello-world-macos/).
 
 ## Overview
 {: #overview }
@@ -26,14 +26,14 @@ The following sections walk through how to write Jobs and Steps that use `xcodeb
 {: #prerequisites }
 {:.no_toc}
 
-- Add your project to CircleCI, see [Hello World]( {{ site.baseurl }}/2.0/hello-world/).
+- Add your project to CircleCI, see [Hello World]({{site.baseurl}}/2.0/hello-world/).
 - This tutorial assumes you have an Xcode workspace for your project with at least one shared scheme and that the selected scheme has a test action. If you do not already have a shared scheme, you can add this in Xcode by completing the following steps:
 
 1. Open your Xcode workspace or project.
 2. Use the scheme selector to open the Manage Schemes dialogue box as shown in the following image.
-![Xcode Scheme Selector](  {{ site.baseurl }}/assets/img/docs/ios-getting-started-scheme-selector.png)
+![Xcode Scheme Selector]({{site.baseurl}}/assets/img/docs/ios-getting-started-scheme-selector.png)
 3. In the manage schemes dialog, select the scheme you wish to build, and ensure that the Shared checkbox is enabled.
-![Manage Schemes Dialogue](  {{ site.baseurl }}/assets/img/docs/ios-getting-started-manage-schemes.png)
+![Manage Schemes Dialogue]({{site.baseurl}}/assets/img/docs/ios-getting-started-manage-schemes.png)
 4. Commit and push the schemes.
 
 ## Running tests
@@ -57,12 +57,12 @@ jobs:
 
 ```
 
-Refer to [the Xcode version section]({{ site.baseurl }}/2.0/testing-ios/#supported-xcode-versions) of the iOS testing document for the complete list of supported versions.
+Refer to [the Xcode version section]({{site.baseurl}}/2.0/testing-ios/#supported-xcode-versions) of the iOS testing document for the complete list of supported versions.
 
 ## Code signing and certificates
 {: #code-signing-and-certificates }
 
-Refer to [the code signing doc]({{ site.baseurl }}/2.0/ios-codesigning/) for details.
+Refer to [the code signing doc]({{site.baseurl}}/2.0/ios-codesigning/) for details.
 
 To further customize your build process to use custom tools or run your own scripts, use the `config.yml` file, see the [Sample 2.0 config.yml]( {{ site.baseurl }}/2.0/sample-config/) document for customizations.
 
@@ -130,7 +130,7 @@ workflows:
 ## Advanced configuration
 {: #advanced-configuration }
 
-See the [Testing iOS Applications on macOS](https://circleci.com/docs/2.0/testing-ios/) document for more
+See the [Testing iOS Applications on macOS]({{site.baseurl}}/2.0/testing-ios/) document for more
 advanced details on configuring iOS projects.
 
 ## Example application on GitHub

--- a/jekyll/_cci2/ios-tutorial.md
+++ b/jekyll/_cci2/ios-tutorial.md
@@ -111,7 +111,7 @@ jobs:
       xcode: 12.5.1
     steps:
       - checkout
-      - deploy:
+      - run:
           name: Deploy
           command: fastlane release_appstore
 

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -11,7 +11,7 @@ version:
 - Server v2.x
 ---
 
-This document will walk you through a Scala application [`.circleci/config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) in the following sections:
+This document will walk you through a Scala application [`.circleci/config.yml`]({{site.baseurl}}/2.0/configuration-reference/) in the following sections:
 
 * TOC
 {:toc}
@@ -20,7 +20,7 @@ This document will walk you through a Scala application [`.circleci/config.yml`]
 {: #overview }
 {:.no_toc}
 
-This document assumes that your [project’s AWS Permission settings](https://circleci.com/docs/2.0/deployment-integrations/#aws) are configured with valid AWS keys that are permitted to read and write to an S3 bucket. The examples in this post upload build packages to the specified S3 bucket.
+This document assumes that your [project’s AWS Permission settings]({{site.baseurl}}/2.0/deployment-integrations/#aws) are configured with valid AWS keys that are permitted to read and write to an S3 bucket. The examples in this post upload build packages to the specified S3 bucket.
 
 ## Sample Scala project source code
 {: #sample-scala-project-source-code }
@@ -37,7 +37,7 @@ mkdir .circleci/
 touch .circleci/config.yml
 ```
 
-These commands create a directory named `.circleci` & the next command creates a new file named `config.yml` within the `.circleci` directory.  Again you **must** use the names .circleci for the dir and config.yml.  Learn more about the [version 2.0 prerequisites here]({{ site.baseurl }}/2.0/migrating-from-1-2/).
+These commands create a directory named `.circleci` & the next command creates a new file named `config.yml` within the `.circleci` directory.  Again you **must** use the names .circleci for the dir and config.yml.  Learn more about the [version 2.0 prerequisites here]({{site.baseurl}}/2.0/migrating-from-1-2/).
 
 ### Scala config.yml file
 {: #scala-configyml-file }
@@ -94,14 +94,14 @@ jobs:
 ## Schema walkthrough
 {: #schema-walkthrough }
 
-Every `config.yml` starts with the [`version`]({{ site.baseurl }}/2.0/configuration-reference/#version) key.
+Every `config.yml` starts with the [`version`]({{site.baseurl}}/2.0/configuration-reference/#version) key.
 This key is used to issue warnings about breaking changes.
 
 ```yaml
 version: 2
 ```
 
-The next key in the schema is the jobs & build keys.  These keys are required and represent the default entry point for a run. The build section hosts the remainder of the schema which executes our commands. This will be explained below.
+The next key in the schema is the jobs & build keys. These keys are required and represent the default entry point for a run. The build section hosts the remainder of the schema which executes our commands. This will be explained below.
 
 ```yaml
 version: 2
@@ -203,14 +203,14 @@ The following keys represent actions performed after the multi-line command is e
 ```
 
 Below is an explanation of the preceding example:
-- [`checkout`]({{ site.baseurl }}/2.0/configuration-reference/#checkout): basically git clones the project repo from GitHub into the container
-- [`restore_cache`]({{ site.baseurl }}/2.0/configuration-reference/#restore_cache) key: specifies the name of the cache files to restore. The key name is specified in the save_cache key that is found later in the schema. If the key specified is not found then nothing is restored and continues to process.
-- [`run`]({{ site.baseurl }}/2.0/configuration-reference/#run) command `cat /dev/null | sbt clean update dist`: executes the sbt compile command that generates the package .zip file.
+- [`checkout`]({{site.baseurl}}/2.0/configuration-reference/#checkout): basically git clones the project repo from GitHub into the container
+- [`restore_cache`]({{site.baseurl}}/2.0/configuration-reference/#restore_cache) key: specifies the name of the cache files to restore. The key name is specified in the save_cache key that is found later in the schema. If the key specified is not found then nothing is restored and continues to process.
+- [`run`]({{site.baseurl}}/2.0/configuration-reference/#run) command `cat /dev/null | sbt clean update dist`: executes the sbt compile command that generates the package .zip file.
 
 **Note:** `cat /dev/null` is normally used to prevent a command from hanging if it prompts for interactive input and does not detect whether it is running with an interactive TTY. `sbt` will prompt on failures by default.
 
-- [`store_artifacts`]({{ site.baseurl }}/2.0/configuration-reference/#store_artifacts) path: specifies the path to the source file to copy to the ARTIFACT zone in the image.
-- [`save_cache`]({{ site.baseurl }}/2.0/configuration-reference/#save_cache) path: saves the specified directories for use in future builds when specified in the [`restore_cache`]({{ site.baseurl }}/2.0/configuration-reference/#restore_cache) keys.
+- [`store_artifacts`]({{site.baseurl}}/2.0/configuration-reference/#store_artifacts) path: specifies the path to the source file to copy to the ARTIFACT zone in the image.
+- [`save_cache`]({{site.baseurl}}/2.0/configuration-reference/#save_cache) path: saves the specified directories for use in future builds when specified in the [`restore_cache`]({{site.baseurl}}/2.0/configuration-reference/#restore_cache) keys.
 
 The final portion of the 2.0 schema is the run command key which moves and renames the compiled samplescala.zip to the $CIRCLE_ARTIFACTS/ directory.  The file is then uploaded to the AWS S3 bucket specified.
 
@@ -229,5 +229,5 @@ The run command is another multi-line execution.
 {:.no_toc}
 
 - Refer to the [Migrating Your Scala/sbt Schema from CircleCI 1.0 to CircleCI](https://circleci.com/blog/migrating-your-scala-sbt-schema-from-circleci-1-0-to-circleci-2-0/) for the original blog post.
-- See the [Deploy]({{ site.baseurl }}/2.0/deployment-integrations/) document for more example deploy target configurations.
+- See the [Deploy]({{site.baseurl}}/2.0/deployment-integrations/) document for more example deploy target configurations.
 - How to [parallelize tests in SBT on CircleCI](https://tanin.nanakorn.com/technical/2018/09/10/parallelise-tests-in-sbt-on-circle-ci.html)

--- a/jekyll/_cci2/language-scala.md
+++ b/jekyll/_cci2/language-scala.md
@@ -85,7 +85,7 @@ jobs:
             - "~/.ivy2/cache"
             - "~/.sbt"
             - "~/.m2"
-      - deploy:
+      - run:
           command: |
               mv target/universal/samplescala.zip $CIRCLE_ARTIFACTS/$ARTIFACT_BUILD
               aws s3 cp $CIRCLE_ARTIFACTS/$ARTIFACT_BUILD s3://samplescala.blogs/builds/ --metadata {\"git_sha1\":\"$CIRCLE_SHA1\"}
@@ -212,17 +212,17 @@ Below is an explanation of the preceding example:
 - [`store_artifacts`]({{ site.baseurl }}/2.0/configuration-reference/#store_artifacts) path: specifies the path to the source file to copy to the ARTIFACT zone in the image.
 - [`save_cache`]({{ site.baseurl }}/2.0/configuration-reference/#save_cache) path: saves the specified directories for use in future builds when specified in the [`restore_cache`]({{ site.baseurl }}/2.0/configuration-reference/#restore_cache) keys.
 
-The final portion of the 2.0 schema are the deploy command keys which move and rename the compiled samplescala.zip to the $CIRCLE_ARTIFACTS/ directory.  The file is then uploaded to the AWS S3 bucket specified.
+The final portion of the 2.0 schema is the run command key which moves and renames the compiled samplescala.zip to the $CIRCLE_ARTIFACTS/ directory.  The file is then uploaded to the AWS S3 bucket specified.
 
 ```yaml
 steps:
-  - deploy:
+  - run:
       command: |
         mv target/universal/samplescala.zip $CIRCLE_ARTIFACTS/$ARTIFACT_BUILD
         aws s3 cp $CIRCLE_ARTIFACTS/$ARTIFACT_BUILD s3://samplescala.blogs/builds/ --metadata {\"git_sha1\":\"$CIRCLE_SHA1\"}
 ```
 
-The deploy command is another multi-line execution.
+The run command is another multi-line execution.
 
 ## See also
 {: #see-also }


### PR DESCRIPTION
# Description
Remove the information about the deploy step in the config ref and link to the new step/alternatives.
Adjust the examples on two pages that still used the deploy key. _Note: there is still one page referencing deploy steps for v1 of the API that needs addressing._

# Reasons
[Jira Ticket](https://circleci.atlassian.net/jira/software/projects/DOCSTEAM/boards/412?selectedIssue=DOCSTEAM-99)
Some people are still using the deploy step. By removing the information and replacing the examples, we hope to decrease the usage. 