### PR TITLE
[DD-293] Fix header Nav Height when Expanded

### DIFF
--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -13,7 +13,6 @@ $btn-selected-green: #00701B;
 $btn-outer-blue: #0078CA;
 $btn-hover-blue: #0062B0;
 $btn-selected-blue: #004A95;
-$desktop-header-nav-height: 68.5px;
 
 // Copy of outer blog-nav, renmaed to global-nav
 ///////////////////////////////////////////////////////////////////////////////
@@ -147,7 +146,7 @@ $desktop-header-nav-height: 68.5px;
     display: flex;
     flex-direction: row;
     align-items: center;
-    min-height: 48px;
+    max-height: 48px;
   }
 }
 
@@ -461,13 +460,6 @@ a.nav-skip-button {
 
 .no-display {
   display: none;
-}
-
-// Ensures header does not expand after opening the dropdown menu and expanding the window view size
-@media (min-width: $screen-sm) {
-  .global-nav--component .global-nav--row-desktop {
-    height: $desktop-header-nav-height;
-  }
 }
 
 // -- Docs Disco Experiments

--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -147,6 +147,7 @@ $btn-selected-blue: #004A95;
     flex-direction: row;
     align-items: center;
     max-height: 48px;
+    min-height: 48px;
   }
 }
 

--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -462,6 +462,13 @@ a.nav-skip-button {
   display: none;
 }
 
+// Ensures header does not expand after opening the dropdown menu and expanding the window view size
+@media (min-width: $screen-sm) {
+  .global-nav--component .global-nav--row-desktop {
+    height: 68.5px;
+  }
+}
+
 // -- Docs Disco Experiments
 
 .dd-global-nav--component {

--- a/src/styles/_global-nav.scss
+++ b/src/styles/_global-nav.scss
@@ -13,6 +13,7 @@ $btn-selected-green: #00701B;
 $btn-outer-blue: #0078CA;
 $btn-hover-blue: #0062B0;
 $btn-selected-blue: #004A95;
+$desktop-header-nav-height: 68.5px;
 
 // Copy of outer blog-nav, renmaed to global-nav
 ///////////////////////////////////////////////////////////////////////////////
@@ -465,7 +466,7 @@ a.nav-skip-button {
 // Ensures header does not expand after opening the dropdown menu and expanding the window view size
 @media (min-width: $screen-sm) {
   .global-nav--component .global-nav--row-desktop {
-    height: 68.5px;
+    height: $desktop-header-nav-height;
   }
 }
 


### PR DESCRIPTION
[Ticket](https://circleci.atlassian.net/browse/DD-293)
[Preview](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/header-preview/?force-all)

# Changes

- set header height with media query for views larger than 768px

# Description
Addressing bug where header becomes broken and expands in height if users shrink down the window, opens and closes the drop down menu, and then expands the window view again. Users have to reload the page to fix issue.

