### PR TITLE
Fix: Bring back DD synthetics tests for CI

### DIFF
--- a/.datadog/development.synthetics.json
+++ b/.datadog/development.synthetics.json
@@ -1,10 +1,10 @@
 {
-    "tests": [
-        {
-            "id": "as2-nqg-wcu"
-        },
-        {
-            "id": "3tu-7d6-qk7"
-        }
-    ]
+  "tests": [
+    {
+      "id": "wvz-xga-k4d"
+    },
+    {
+      "id": "9gh-kp8-7pp"
+    }
+  ]
 }

--- a/.datadog/production.synthetics.json
+++ b/.datadog/production.synthetics.json
@@ -1,10 +1,10 @@
 {
-    "tests": [
-        {
-            "id": "sfs-zqk-cfq"
-        },
-        {
-            "id": "747-gcy-3tk"
-        }
-    ]
+  "tests": [
+    {
+      "id": "sfs-zqk-cfq"
+    },
+    {
+      "id": "747-gcy-3tk"
+    }
+  ]
 }


### PR DESCRIPTION
# Description
- Use new Tests IDs for tests running on CI

# Reasons
The DD synthetics tests got removed by mistake and so we had to create new ones and adjust the IDs in the `.datadog` directory. 

# Results
![Screen Shot 2022-01-19 at 6 20 30 PM](https://user-images.githubusercontent.com/1449325/150259214-1894e1f1-b24d-4b8e-8ee0-f1160e52f9c1.png)

