### PR TITLE
Add back a note about runner launch-agent environment on Linux

### DIFF
--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -66,6 +66,8 @@ sudo mkdir -p /opt/circleci/workdir
 sudo chown -R circleci /opt/circleci/workdir
 ```
 
+NOTE: Unlike the task agent, which uses the environment of the `circleci` user, the launch agent will need to have any required environment variables (e.g., proxy settings) explicitly defined in the unit configuration file. These can be set by `Environment=` or `EnvironmentFile=`. https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment[Please visit the `systemd` documentation for more information].
+
 == Configure SELinux policy (RHEL 8)
 
 An SELinux policy is required for runner to accept and launch jobs on RHEL 8 systems (earlier versions of RHEL are unsupported). Note that this policy does not add any permissions to the ones that may be required by individual jobs on this runner install.

--- a/jekyll/_cci2_ja/runner-installation-linux.adoc
+++ b/jekyll/_cci2_ja/runner-installation-linux.adoc
@@ -114,6 +114,8 @@ TimeoutStopSec=18300
 WantedBy = multi-user.target
 ```
 
+NOTE: Unlike the task agent, which uses the environment of the `circleci` user, the launch agent will need to have any required environment variables (e.g., proxy settings) explicitly defined in the unit configuration file. These can be set by `Environment=` or `EnvironmentFile=`. https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment[Please visit the `systemd` documentation for more information].
+
 You can now enable the service:
 
 ```bash


### PR DESCRIPTION
# Description
Add back a note about setting runner launch-agent environment on Linux (e.g., for proxy settings, etc.).

I think this may have got omitted accidentally after the runner docs reshuffle a while back.

Original PR: https://github.com/circleci/circleci-docs/pull/5795