### PR TITLE
Clarify Runner Windows SKU requirements. [RT-323]

### DIFF
--- a/jekyll/_cci2/runner-installation-windows.adoc
+++ b/jekyll/_cci2/runner-installation-windows.adoc
@@ -16,7 +16,7 @@ NOTE: Please review the xref:runner-installation.adoc[Installing the CircleCI Ru
 
 toc::[]
 
-NOTE: This has been tested for Windows Server 2019 and Windows Server 2016, both in Datacenter Edition with Desktop Experience.
+NOTE: This has been tested for Windows Server 2019 and Windows Server 2016, both in Datacenter Edition.  Other Server SKUs with Desktop Experience and Remote Desktop Services should also work.
 
 With this procedure, you install CircleCI launch agent and its dependencies, i.e., Chocolatey, Git and Gzip, on your Windows Server.
 


### PR DESCRIPTION
# Description
Clarify exact services Runner on Windows needs.

# Reasons
The Windows installation scripts have been updated to be compatible with more SKUs.

- I've tested the installation process works with Windows Server 2019
  Datacenter Core w/ Desktop and RDS installed.

