### PR TITLE
Doc: update fork link

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -44,7 +44,7 @@ If you already have a stable Ruby environment (currently Ruby 2.7.4) and feel co
 
 ## Submitting Pull Requests
 
-If you want to submit a pull request to update the docs, you'll need to [make a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of this repo and follow the steps in [Local Development with Docker](https://github.com/circleci/circleci-docs/blob/master/docs/local-development.md#1-local-development-with-docker-recommended) above. After you are finished with your changes, please follow our [Contributing Guide](CONTRIBUTING.md) to submit a pull request.
+If you want to submit a pull request to update the docs, you'll need to [make a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of this repo and follow the steps described in the [Local Development with Docker](https://github.com/circleci/circleci-docs/blob/master/docs/local-development.md#1-local-development-with-docker-recommended) section. After you are finished with your changes, please follow our [Contributing Guide](CONTRIBUTING.md) to submit a pull request.
 
 ## Building js assets
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -44,7 +44,7 @@ If you already have a stable Ruby environment (currently Ruby 2.7.4) and feel co
 
 ## Submitting Pull Requests
 
-If you want to submit a pull request to update the docs, you'll need to [make a fork](https://github.com/circleci/circleci-docs#fork-destination-box) of this repo and follow the steps in [Local Development with Docker](https://github.com/circleci/circleci-docs/blob/master/docs/local-development.md#1-local-development-with-docker-recommended) above. After you are finished with your changes, please follow our [Contributing Guide](CONTRIBUTING.md) to submit a pull request.
+If you want to submit a pull request to update the docs, you'll need to [make a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) of this repo and follow the steps in [Local Development with Docker](https://github.com/circleci/circleci-docs/blob/master/docs/local-development.md#1-local-development-with-docker-recommended) above. After you are finished with your changes, please follow our [Contributing Guide](CONTRIBUTING.md) to submit a pull request.
 
 ## Building js assets
 


### PR DESCRIPTION
# Description
- Replace fork link to actually send reader to the GH Doc 

# Reasons
The original link is a little confusing and only brings you to a place where you can see the `Fork` button. I think we should replace it and instead link to the Github doc so readers can learn how the Fork/PR workflow works. 