### PR TITLE
fix spelling

### DIFF
--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -42,7 +42,7 @@ Some example use cases where IP-based restricted access might be desired include
 
 Prior to offering IP ranges, the only solution CircleCI offered to configure and control static IP addresses was [CircleCI’s Runner](https://circleci.com/docs/2.0/runner-overview/). IP ranges now enables you to meet your IP-based security and compliance requirements using your existing workflows and platform.
 
-IP ranges only routes traffic through one of the defined IP address ranges _during job execution_.  Any step that occurs before the job has started to execute will not have its traffic routed thorugh one of the defined IP address ranges.  For example, pulling a Docker image happens before _job execution_, therefore that step will not have its traffic routed through one of the defined IP address ranges.
+IP ranges only routes traffic through one of the defined IP address ranges _during job execution_.  Any step that occurs before the job has started to execute will not have its traffic routed through one of the defined IP address ranges.  For example, pulling a Docker image happens before _job execution_, therefore that step will not have its traffic routed through one of the defined IP address ranges.
 
 ## Example configuration file using IP ranges
 {: #exampleconfiguration }

--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -42,7 +42,7 @@ Some example use cases where IP-based restricted access might be desired include
 
 Prior to offering IP ranges, the only solution CircleCI offered to configure and control static IP addresses was [CircleCI’s Runner](https://circleci.com/docs/2.0/runner-overview/). IP ranges now enables you to meet your IP-based security and compliance requirements using your existing workflows and platform.
 
-IP ranges only routes traffic through one of the defined IP address ranges _during job execution_.  Any step that occurs before the job has started to execute will not have its traffic routed through one of the defined IP address ranges.  For example, pulling a Docker image happens before _job execution_, therefore that step will not have its traffic routed through one of the defined IP address ranges.
+IP ranges only routes traffic through one of the defined IP address ranges _during job execution_. Any step that occurs before the job has started to execute will not have its traffic routed through one of the defined IP address ranges.  For example, pulling a Docker image happens before _job execution_, therefore that step will not have its traffic routed through one of the defined IP address ranges.
 
 ## Example configuration file using IP ranges
 {: #exampleconfiguration }


### PR DESCRIPTION
# Description
Fix "thorugh" to "through"

# Reasons
Spelling!