### PR TITLE
Rephrasing explanation for server 2.x customizations

### DIFF
--- a/jekyll/_cci2/customizations.adoc
+++ b/jekyll/_cci2/customizations.adoc
@@ -38,7 +38,7 @@ toc::[]
 
 | Container Customizations
 | `/etc/circleconfig/XXX/customizations`
-| Used lots of places in replicated
+| Used in lots of places by CircleCI containers
 
 | `/etc/hosts`
 | `/etc/hosts`
@@ -187,7 +187,7 @@ Let's take a look at one of the options in more detail
 :medium {:id "d1.medium" :availability :general :ui {:cpu 4.0 :ram 8192 :class :medium} :outer {:cpu 4.0 :ram 8192}
 ```
 
-* `:medium`  - this is the name that your developers will use to refer to the resource class in their config.yml and the is the external facing name of the resource class.
+* `:medium`  - this is the name that your developers will use to refer to the resource class in their config.yml and the keyword `medium` is the external facing name of the resource class.
 * `:id "d1.medium"` - this is the internal name for the resource class. You can customize this ID for Docker resource classes.
 * `:availability :general` - required field
 * `:ui {:cpu 4.0 :ram 8192 :class :medium}` - Information used by the CircleCI UI. This this should be kept in parity with :outer - see below.


### PR DESCRIPTION
# Description
Rephrasing ambiguous/improper wording on explanations about customizations of server 2.x.

# Reasons
While l10n work has been ongoing the team found out several phrases which were unreasonably difficult to translate. Most of them stems from some ambiguity of the phrases. This PR address them by clarifying what it should mean, both to facilitate translation works and to make things clearer to our customers.