### PR TITLE
cypress PR

### DIFF
--- a/cypress/integration/sidebar/sidebar.spec.js
+++ b/cypress/integration/sidebar/sidebar.spec.js
@@ -23,12 +23,14 @@ describe('sidebar', () => {
               if(child.children) {
                 for (let subchild of child.children) {
                   if(subchild.link) {
-                    cy.get(`[href="/docs/${subchild.link}"]`).should('exist')
+                    const subchildlink = subchild.link + (subchild.hash ? `#${subchild.hash}` : '')
+                    cy.get(`[href="/docs/${subchildlink}"]`).should('exist')
                   }
                 }
               }
               if(child.link) {
-                cy.get(`[href="/docs/${child.link}"]`).should('exist')
+                const childlink = child.link + (child.hash ? `#${child.hash}` : '')
+                cy.get(`[href="/docs/${childlink}"]`).should('exist')
               }
             }
             

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,22 @@
+/// <reference types="cypress" />
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+// eslint-disable-next-line no-unused-vars
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -97,7 +97,8 @@ en:
     - name: Docker
       children:
         - name: Overview
-          link: 2.0/executor-types/#using-docker
+          link: 2.0/executor-types/
+          hash: using-docker
         - name: CircleCI Images
           link: 2.0/circleci-images/
         - name: Migrating to Next-Gen Images
@@ -115,7 +116,8 @@ en:
     - name: Machine
       children:
         - name: Overview
-          link: 2.0/executor-types/#using-machine
+          link: 2.0/executor-types/
+          hash: using-machine
         - name: Pre-installed software
           link: 2.0/docker-to-machine/
           hash: pre-installed-software
@@ -227,7 +229,8 @@ en:
     - name: Data Partnerships
       link: 2.0/insights-partnerships/
     - name: Insights API
-      link: api/v2/#tag/Insights
+      link: api/v2/
+      hash: tag/Insights
 
 - name: Projects
   icon: icons/sidebar/projects.svg
@@ -667,8 +670,9 @@ ja:
     - name: Docker
       children:
         - name: Overview
-          link: ja/2.0/executor-types/#using-docker
+          link: ja/2.0/executor-types/
           i18n_name: 概要
+          hash: using-docker
         - name: CircleCI Images
           link: ja/2.0/circleci-images/
           i18n_name: CircleCIイメージ
@@ -690,8 +694,9 @@ ja:
     - name: Machine
       children:
         - name: Overview
-          link: ja/2.0/executor-types/#using-machine
+          link: ja/2.0/executor-types/
           i18n_name: 概要
+          hash: using-machine
         - name: Pre-installed software
           link: ja/2.0/docker-to-machine/
           i18n_name: インストール済ソフト
@@ -831,7 +836,8 @@ ja:
       link: ja/2.0/insights-partnerships/
     - name: Insights API
       i18n_name: Insights API
-      link: api/v2/#tag/Insights
+      link: api/v2/
+      hash: tag/Insights
 
 - name: Projects
   i18n_name: プロジェクト

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -117,7 +117,8 @@ en:
         - name: Overview
           link: 2.0/executor-types/#using-machine
         - name: Pre-installed software
-          link: 2.0/docker-to-machine/#pre-installed-software
+          link: 2.0/docker-to-machine/
+          hash: pre-installed-software
         - name: Android Machine Image
           link: 2.0/android-machine-image
         - name: Arm Resources
@@ -692,7 +693,7 @@ ja:
           link: ja/2.0/executor-types/#using-machine
           i18n_name: 概要
         - name: Pre-installed software
-          link: ja/2.0/docker-to-machine/#pre-installed-software
+          link: ja/2.0/docker-to-machine/
           i18n_name: インストール済ソフト
         - name: Android Machine Image
           i18n_name: Android マシン イメージ

--- a/jekyll/_includes/mobile-sidebar.html
+++ b/jekyll/_includes/mobile-sidebar.html
@@ -50,7 +50,7 @@
                     {% if item.link %}
                       {% assign link_slug = item.link | slugify %}
                       <a class="{% if url_slug == link_slug %} active {% endif %}"
-                        href="{{ site.baseurl }}/{{ item.link }}"
+                        href="{{ site.baseurl }}/{{ item.link }}{% if item.hash %}#{{item.hash}}{% endif %}"
                         data-section="{{ section_slug }}"
                         data-proofer-ignore>{{ display_name }}
                       </a>
@@ -70,7 +70,7 @@
                 <li class="subnav-item">
                   {% assign link_slug = sub-item.link | slugify %}
                   <a class="{% if url_slug == link_slug %} active {% endif %}"
-                    href="{{ site.baseurl }}/{{ sub-item.link }}{% if item.hash %}#{{item.hash}}{% endif %}"
+                    href="{{ site.baseurl }}/{{ sub-item.link }}{% if sub-item.hash %}#{{sub-item.hash}}{% endif %}"
                     data-section="{{ section_slug }}"
                     data-proofer-ignore>{{ display_name }}</a>
                 </li>
@@ -87,7 +87,7 @@
               <li class="subnav-item">
                 {% assign link_slug = item.link | slugify %}
                 <a class="{% if url_slug == link_slug %} active {% endif %}"
-                  href="{{ site.baseurl }}/{{ item.link }}"
+                  href="{{ site.baseurl }}/{{ item.link }}{% if item.hash %}#{{item.hash}}{% endif %}"
                   data-section="{{ section_slug }}">
                   {{display_name}}
                 </a>

--- a/jekyll/_includes/sidebar.html
+++ b/jekyll/_includes/sidebar.html
@@ -52,7 +52,7 @@
                     {% if item.link %}
                       {% assign link_slug = item.link | slugify %}
                       <a class="{% if url_slug == link_slug %} active {% endif %}"
-                        href="{{ site.baseurl }}/{{ item.link }}"
+                        href="{{ site.baseurl }}/{{ item.link }}{% if item.hash %}#{{item.hash}}{% endif %}"
                         data-proofer-ignore
                         data-section="{{ section_slug }}">
                         {{ display_name }}
@@ -92,7 +92,7 @@
                 <li class="subnav-item">
                   {% assign link_slug = item.link | slugify %}
                   <a class="{% if url_slug == link_slug %} active {% endif %}"
-                    href="{{ site.baseurl }}/{{ item.link }}" data-section="{{ section_slug }}">
+                    href="{{ site.baseurl }}/{{ item.link }}{% if item.hash %}#{{item.hash}}{% endif %}" data-section="{{ section_slug }}">
                     {{display_name}}
                   </a>
                 </li>


### PR DESCRIPTION
Preview [link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-274-circle-ci-docs-add-cypress-e-2-e-testing-framework-preview/2.0/docker-to-machine/#pre-installed-software)

# Description
Revert using the hash inside of the sidenav.yml
Original PR [link](https://github.com/circleci/circleci-docs/pull/6190/files)

There was an issue that if you go to a link with a `#` in the url the proper side nav panel would not open up.

Example link on live: [link](https://circleci.com/docs/2.0/executor-types/#using-docker)
<img width="1208" alt="Screen Shot 2022-01-28 at 6 35 03 PM" src="https://user-images.githubusercontent.com/86666932/151635694-ba320d46-261d-4378-9844-3ab4b3e083b6.png">

Example link fixed: [link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-274-circle-ci-docs-add-cypress-e-2-e-testing-framework-preview/2.0/executor-types/#using-docker)
<img width="1188" alt="Screen Shot 2022-01-28 at 6 37 50 PM" src="https://user-images.githubusercontent.com/86666932/151635886-3114feee-2d19-4304-9387-4b39acaec42e.png">

