### PR TITLE
[FIX] Initialize lang.js when DOM is Loaded

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -16,7 +16,6 @@ window.OptimizelyClient = new services.OptimizelyClient();
 
 import './site';
 
-services.lang.init();
 services.rum.init();
 // Temporary service to check if user dark mode preferences
 trackDarkModePreference();
@@ -28,5 +27,6 @@ $(() => {
   services.highlightjsBadge.init();
   services.progressbar.init();
   services.sectionShareButton.init();
+  services.lang.init();
   import(/* webpackPrefetch: true */ './experiments'); // imports all experiments
 });


### PR DESCRIPTION

# Changes

- initializing `lang.js` when the DOM is fully loaded in `app.js`

# Description
We are getting errors in rollbar due to `langValue.domEl` being null as we are trying to add an event to the element before the DOM has been fully loaded and the element has been defined

# Reasons
Addressing the errors from rollbar [here](https://rollbar.com/circle/circleci-docs/items/2901/?item_page=0&) 