### PR TITLE
[DD-345] Remove pre-wrap

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -358,7 +358,6 @@ body.homepage{
 
 code {
   padding: 2px;
-  white-space: pre-wrap !important;
   word-wrap: anywhere;
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -356,16 +356,8 @@ body.homepage{
 	}
 }
 
-table {
 table tr th:first-of-type code, table tr td:first-of-type code {
   white-space: nowrap !important;
-}
-    th,td {
-      code {
-        white-space: nowrap !important;
-      }
-    }
-  }
 }
 
 code {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -356,9 +356,20 @@ body.homepage{
 	}
 }
 
+table {
+  tr {
+    th,td {
+      code {
+        white-space: nowrap !important;
+      }
+    }
+  }
+}
+
 code {
   padding: 2px;
   word-wrap: anywhere;
+  white-space: pre-wrap !important;
 }
 
 code.env_var {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -357,7 +357,9 @@ body.homepage{
 }
 
 table {
-  tr {
+table tr th:first-of-type code, table tr td:first-of-type code {
+  white-space: nowrap !important;
+}
     th,td {
       code {
         white-space: nowrap !important;


### PR DESCRIPTION
Jira [link](https://circleci.atlassian.net/jira/software/c/projects/DD/boards/477?modal=detail&selectedIssue=DD-345)
Preview [link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-345-config-docs-for-save-cache-has-confusing-wrapping-preview/?force-all)

# Description
The left-hand column of the “Save Cache” table (“Template”) has very confusing line wrapping that makes it nearly unreadable.

The table is here: https://circleci.com/docs/2.0/configuration-reference/#savecache


# Before
<img width="1404" alt="Screen Shot 2022-02-01 at 10 37 33 AM" src="https://user-images.githubusercontent.com/86666932/151999565-65efebe8-d41f-4910-a322-be7c60eb398b.png">


# After
[link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-345-config-docs-for-save-cache-has-confusing-wrapping-preview/2.0/configuration-reference/#savecache)
<img width="1396" alt="Screen Shot 2022-02-01 at 10 48 33 AM" src="https://user-images.githubusercontent.com/86666932/152001625-66901da0-b35f-498d-8567-2b3106d43e6c.png">

