### PR TITLE
Add first version of 14.04 to 20.04 migration guide

### DIFF
--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -28,7 +28,7 @@ Let's go through each of these changes separately.
 
 - kernel - The Linux kernel was bumped from v4.4 to v5.11.
 - Python - Python v2 is no longer installed by default from Ubuntu. CircleCI still installs it, and versions can be managed [via Pyenv](https://github.com/pyenv/pyenv).
-- OpenSSH - OpenSSH was updated to v8.2. This is a new enough version to not be affected by [GitHub's deprecation](https://github.blog/2021-09-01-improving-git-protocol-security-github/).
+- OpenSSH - OpenSSH was updated to v8.2. This is a new version that should not be affected by [GitHub's deprecation](https://github.blog/2021-09-01-improving-git-protocol-security-github/).
   - now refuses to use RSA keys smaller than 1024 bits
 - GNU Toolchain
   - glibc updated to v2.31

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -52,7 +52,7 @@ Let's go through each of these changes separately.
 - Bind 9.16
 - SystemD takes over from SysV.
 - gpg binary is provided by gnupg2
-- Chrony v3.5 replaces ntpd
+- Chrony v3.5 replaces ntpd.
 - Wireguard VPN support
 - rustc 1.41
 - HAProxy 2.0

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -21,7 +21,7 @@ version:
 
 There are many changes between Ubuntu 14.04 and 20.04 that you should be aware of before migrating.
 Many are changes that Canonical has made (the company behind Ubuntu), but also changes that CircleCI has made to the software that we pre-install.
-Let's go through them separately.
+Let's go through each of these changes separately.
 
 ### Changes to Ubuntu
 {: #change-to-ubuntu }

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -20,7 +20,7 @@ version:
 {: #changes }
 
 There are many changes between Ubuntu 14.04 and 20.04 that you should be aware of before migrating.
-Many are changes that Canonical have made (the company behind Ubuntu) but also changes that CircleCI have made to the software that we pre-install.
+Many are changes that Canonical has made (the company behind Ubuntu), but also changes that CircleCI has made to the software that we pre-install.
 Let's go through them separately.
 
 ### Changes to Ubuntu

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -46,7 +46,7 @@ Let's go through each of these changes separately.
 - Snap & Snapcraft - Support for running and build snap packages.
 - Java - OpenJDK v11 is now the default ,however, CircleCI pre-installs more versions.
 - OpenSSL upgraded from v1.1.0 to v1.1.1 enabling TLS v1.3
-- netplan supports IPv6 privacy extensions
+- netplan supports IPv6 privacy extensions.
 - netplan can bring up devices without an IP for anonymous bridges.
 - default DNS resolver is systemd-resolved.
 - Bind 9.16

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -27,7 +27,7 @@ Let's go through each of these changes separately.
 {: #change-to-ubuntu }
 
 - kernel - The Linux kernel was bumped from v4.4 to v5.11.
-- Python - Python v2 is no longer installed by default from Ubuntu. We, CircleCI, do pre-install it however and versions can be managed [via Pyenv](https://github.com/pyenv/pyenv).
+- Python - Python v2 is no longer installed by default from Ubuntu. CircleCI still installs it, and versions can be managed [via Pyenv](https://github.com/pyenv/pyenv).
 - OpenSSH - OpenSSH was updated to v8.2. This is a new enough version to not be affected by [GitHub's deprecation](https://github.blog/2021-09-01-improving-git-protocol-security-github/).
   - now refuses to use RSA keys smaller than 1024 bits
 - GNU Toolchain

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -45,7 +45,7 @@ Let's go through each of these changes separately.
 - MySQL updated to v5.7
 - Snap & Snapcraft - Support for running and build snap packages.
 - Java - OpenJDK v11 is now the default ,however, CircleCI pre-installs more versions.
-- OpenSSL upgraded  from v1.1.0 to v1.1.1 enabling TLS v1.3
+- OpenSSL upgraded from v1.1.0 to v1.1.1 enabling TLS v1.3
 - netplan supports IPv6 privacy extensions
 - netplan can bring up devices without an IP for anonymous bridges.
 - default DNS resolver is systemd-resolved.

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -19,7 +19,7 @@ version:
 ## Changes
 {: #changes }
 
-There's a lot of changes between Ubuntu 14.04 and 20.04.
+There are many changes between Ubuntu 14.04 and 20.04 that you should be aware of before migrating.
 Many are changes that Canonical have made (the company behind Ubuntu) but also changes that CircleCI have made to the software that we pre-install.
 Let's go through them separately.
 

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -36,7 +36,7 @@ Let's go through each of these changes separately.
   - GCC updated to v9,3
 - Apt updated to v1.2
 - Nginx updated to v1.18
-- nginx-core no longer ships with the legacy geoip module enabled by default
+- nginx-core no longer ships with the legacy geoip module enabled by default.
 - Apache has been built with TLSv1.3 support
 - Apache was updated to version 2.4.29. Additionally, HTTP/2 support is now enabled.
 - LXD updated to v3.0

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -29,7 +29,7 @@ Let's go through each of these changes separately.
 - kernel - The Linux kernel was bumped from v4.4 to v5.11.
 - Python - Python v2 is no longer installed by default from Ubuntu. CircleCI still installs it, and versions can be managed [via Pyenv](https://github.com/pyenv/pyenv).
 - OpenSSH - OpenSSH was updated to v8.2. This is a new version that should not be affected by [GitHub's deprecation](https://github.blog/2021-09-01-improving-git-protocol-security-github/).
-  - now refuses to use RSA keys smaller than 1024 bits
+  - Ubuntu now refuses to use RSA keys smaller than 1024 bits.
 - GNU Toolchain
   - glibc updated to v2.31
   - binutils updated to v2.26

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -51,7 +51,7 @@ Let's go through each of these changes separately.
 - default DNS resolver is systemd-resolved.
 - Bind 9.16
 - SystemD takes over from SysV.
-- gpg binary is provided by gnupg2
+- gpg binary is provided by gnupg2.
 - Chrony v3.5 replaces ntpd.
 - Wireguard VPN support
 - rustc 1.41

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -1,0 +1,85 @@
+---
+layout: classic-docs
+title: "Migrating from Ubuntu 14.04 to Ubuntu 20.04"
+short-title: "14.04 to 20.04 Migration"
+description: |
+  Helpful information to aid in migrating from the CircleCI Ubuntu 14.04 images
+  to the CircleCI Ubuntu 20.04 images. This is less of a step-by-step guide but
+  rather one that points of changes and common gotchas.
+order: 20
+version:
+- Cloud
+- Server v3.x
+- Server v2.x
+---
+
+* TOC
+{:toc}
+
+## Changes
+{: #changes }
+
+There's a lot of changes between Ubuntu 14.04 and 20.04.
+Many are changes that Canonical have made (the company behind Ubuntu) but also changes that CircleCI have made to the software that we pre-install.
+Let's go through them separately.
+
+### Changes to Ubuntu
+{: #change-to-ubuntu }
+
+- kernel - The Linux kernel was bumped from v4.4 to v5.11.
+- Python - Python v2 is no longer installed by default from Ubuntu. We, CircleCI, do pre-install it however and versions can be managed [via Pyenv](https://github.com/pyenv/pyenv).
+- OpenSSH - OpenSSH was updated to v8.2. This is a new enough version to not be affected by [GitHub's deprecation](https://github.blog/2021-09-01-improving-git-protocol-security-github/).
+  - now refuses to use RSA keys smaller than 1024 bits
+- GNU Toolchain
+  - glibc updated to v2.31
+  - binutils updated to v2.26
+  - GCC updated to v9,3
+- Apt updated to v1.2
+- Nginx updated to v1.18
+- nginx-core no longer ships with the legacy geoip module enabled by default
+- Apache has been built with TLSv1.3 support
+- Apache was updated to version 2.4.29. Additionally, HTTP/2 support is now enabled.
+- LXD updated to v3.0
+- PHP updated to v7.4
+- Perl 5.30
+- MySQL updated to v5.7
+- Snap & Snapcraft - Support for running and build snap packages.
+- Java - OpenJDK v11 is now the default however CircleCI pre-installs more versions.
+- OpenSSL upgraded  from v1.1.0 to v1.1.1 enabling TLS v1.3
+- netplan supports IPv6 privacy extensions
+- netplan can bring up devices without an IP for anonymous bridges
+- default DNS resolver is systemd-resolved
+- Bind 9.16
+- SystemD takes over from SysV
+- gpg binary is provided by gnupg2
+- Chrony v3.5 replaces ntpd
+- Wireguard VPN support
+- rustc 1.41
+- HAProxy 2.0
+- PostgreSQL 12
+
+### CircleCI Software Changes
+{: #circleci-software-changes }
+
+| Software | Ubuntu 14.04 (default) | Ubuntu 20.04 (January 2022 Q1) |
+| --- | --- | --- |
+| AWS CLI | 1.19.112 | 2.4.6 |
+| Google Chrome | 54.0.2840.100 | 96.0.4664.110 |
+| Docker | 17.09.0 | 20.10.11 |
+| Docker Compose | 1.14.0 | 1.29.2 |
+| Firefox | 47.0.1 | 95.0.1 |
+| GCP CLI | 174.0.0 | 365.0.0 |
+| Go | 1.10.2 | 1.17.3 |
+| Gradle | n/a | 7.3.2 |
+| Heroku | 6.99.0 | 7.59.2 |
+| jq | 1.5 | 1.6 |
+| Leiningen | 2.7.1 | 2.9.8 |
+| Maven | 3.2.5 | 3.8.4 |
+| Node.js | n/a | 16.13.0 |
+| npm | n/a | 8.3.0 |
+| OpenJDK | 1.8.0_131 | 11.0.13 |
+| Python2 | switch | switch |
+| Python3 | 3.4.3 | 3.9.7 |
+| Ruby | 2.3.1 | 3.0.2 |
+| SBT | n/a | 1.5.8 |
+| yq | n/a | 4.13.5

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -47,7 +47,7 @@ Let's go through each of these changes separately.
 - Java - OpenJDK v11 is now the default however CircleCI pre-installs more versions.
 - OpenSSL upgraded  from v1.1.0 to v1.1.1 enabling TLS v1.3
 - netplan supports IPv6 privacy extensions
-- netplan can bring up devices without an IP for anonymous bridges
+- netplan can bring up devices without an IP for anonymous bridges.
 - default DNS resolver is systemd-resolved
 - Bind 9.16
 - SystemD takes over from SysV

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -48,7 +48,7 @@ Let's go through each of these changes separately.
 - OpenSSL upgraded  from v1.1.0 to v1.1.1 enabling TLS v1.3
 - netplan supports IPv6 privacy extensions
 - netplan can bring up devices without an IP for anonymous bridges.
-- default DNS resolver is systemd-resolved
+- default DNS resolver is systemd-resolved.
 - Bind 9.16
 - SystemD takes over from SysV
 - gpg binary is provided by gnupg2

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -44,7 +44,7 @@ Let's go through each of these changes separately.
 - Perl 5.30
 - MySQL updated to v5.7
 - Snap & Snapcraft - Support for running and build snap packages.
-- Java - OpenJDK v11 is now the default however CircleCI pre-installs more versions.
+- Java - OpenJDK v11 is now the default ,however, CircleCI pre-installs more versions.
 - OpenSSL upgraded  from v1.1.0 to v1.1.1 enabling TLS v1.3
 - netplan supports IPv6 privacy extensions
 - netplan can bring up devices without an IP for anonymous bridges.

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -37,7 +37,7 @@ Let's go through each of these changes separately.
 - Apt updated to v1.2
 - Nginx updated to v1.18
 - nginx-core no longer ships with the legacy geoip module enabled by default.
-- Apache has been built with TLSv1.3 support
+- Apache has been built with TLSv1.3 support.
 - Apache was updated to version 2.4.29. Additionally, HTTP/2 support is now enabled.
 - LXD updated to v3.0
 - PHP updated to v7.4

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -5,7 +5,7 @@ short-title: "14.04 to 20.04 Migration"
 description: |
   Helpful information to aid in migrating from the CircleCI Ubuntu 14.04 images
   to the CircleCI Ubuntu 20.04 images. This is less of a step-by-step guide but
-  rather one that points of changes and common gotchas.
+  rather one that points to changes and common gotchas.
 order: 20
 version:
 - Cloud

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -50,7 +50,7 @@ Let's go through each of these changes separately.
 - netplan can bring up devices without an IP for anonymous bridges.
 - default DNS resolver is systemd-resolved.
 - Bind 9.16
-- SystemD takes over from SysV
+- SystemD takes over from SysV.
 - gpg binary is provided by gnupg2
 - Chrony v3.5 replaces ntpd
 - Wireguard VPN support


### PR DESCRIPTION
This is the first version for this guide. Creating this PR now as we need it available, with a steady URL, for comms coming soon for Linux VM deprecation.

The plans:

- this guide will get updated frequently to add more/better information as we learn it
- there will be 16.04 to 20.04, 14.04 to 22.04, and 16.04 to 22.04 versions of the guide in the future
- this guide won't currently be linked from another page, it will once we get more Image Docs merged in

Related/main organizing PR: https://github.com/circleci/circleci-docs/pull/6216