### PR TITLE
Add instructions to reinstall runner on Windows [RT-142]

### DIFF
--- a/jekyll/_cci2/runner-installation-windows.adoc
+++ b/jekyll/_cci2/runner-installation-windows.adoc
@@ -48,7 +48,7 @@ After setup completes, the launch agent starts automatically and begins looking 
 
 Uninstalling CircleCI runner will prepare the system for installation again.
 
-. Download the https://github.com/CircleCI-Public/runner-installation-files/tree/main/windows-install[`Uninstall-CircleCIRunner.ps1` script] from Github to an easily accessible location.
+. Download the https://github.com/CircleCI-Public/runner-installation-files/tree/main/windows-install[`Uninstall-CircleCIRunner.ps1` script] from GitHub to an easily accessible location.
 . Open PowerShell as an administrator and navigate to the directory where you placed the script file.
 
 . Run the following in your PowerShell:

--- a/jekyll/_cci2/runner-installation-windows.adoc
+++ b/jekyll/_cci2/runner-installation-windows.adoc
@@ -42,3 +42,17 @@ The installation will be output into your PowerShell interface.
 . As part of the installation, the configuration file for the Runner (`launch-agent-config.yaml`) will open in Notepad. Please fill the file out with the requested information (see xref:runner-config-reference.adoc[Runner Configuration Reference]). The configuration file is located in the installation directory - `C:\Program Files\CircleCI`, by default.
 
 After setup completes, the launch agent starts automatically and begins looking for jobs to process.
+
+
+== Uninstall / Reinstall Steps
+
+Uninstalling CircleCI runner will prepare the system for installation again.
+
+. Download the https://github.com/CircleCI-Public/runner-installation-files/tree/main/windows-install[`Uninstall-CircleCIRunner.ps1` script] from Github to an easily accessible location.
+. Open PowerShell as an administrator and navigate to the directory where you placed the script file.
+
+. Run the following in your PowerShell:
++
+```
+./Uninstall-CircleCIRunner.ps1
+```


### PR DESCRIPTION
# Description
The Windows installation of runner is quite involved, if anything goes wrong, it can be difficult to try to reinstall.  This adds reinstall steps.

# Reasons

https://circleci.atlassian.net/browse/RT-142

