### PR TITLE
Add CTA to the top of the code pane in API v2

### DIFF
--- a/src-api/v2/template.hbs
+++ b/src-api/v2/template.hbs
@@ -13,6 +13,30 @@
       padding: 0;
       margin: 0;
     }
+
+    .side-section-cta {
+      position: absolute;
+      right: 0;
+      top: 32px;
+      width: 400px;
+      min-height: 100px;
+      z-index: 1;
+      width: calc((100% - 260px) * 0.4);
+      background: #1a2326;
+      display: flex;
+      padding: 32px;
+      box-sizing: border-box;
+      color: #efefef;
+      font-family: 'Roboto';
+      font-size: 14px;
+    }
+
+    @media(max-width: 1200px) {
+      .side-section-cta {
+        display: none;
+      }
+    }
+
   </style>
   {{{redocHead}}}
   {{#unless disableGoogleFont}}
@@ -26,6 +50,9 @@
 
 <body>
   {{{redocHTML}}}
+  <div class="side-section-cta">
+    Scroll down for code samples, example requests and responses. Above each snippet you can change the language / framework used to make the request.
+  </div>
 </body>
 
 </html>

--- a/src-api/v2/template.hbs
+++ b/src-api/v2/template.hbs
@@ -22,9 +22,10 @@
       min-height: 100px;
       z-index: 1;
       width: calc((100% - 260px) * 0.4);
-      background: #1a2326;
+      background: #11171A;
       display: flex;
       padding: 32px;
+      line-height: 1.5;
       box-sizing: border-box;
       color: #efefef;
       font-family: 'Roboto';


### PR DESCRIPTION
# Description
It was requested that we add a clarifying call to action to the top code samples pane in our API v2 documentation.

Ticket: [DD-323](https://circleci.atlassian.net/browse/DD-323)

Todo: Waiting on suggestions or changes to copy.

# Reasons
Users were expression confusion at the blank space at the top of the page.

# Screenshots 

## Before
![image](https://user-images.githubusercontent.com/12987958/152172516-519cc28e-14fb-4fd5-9e9c-64c4c50af7bb.png)


## After

![image](https://user-images.githubusercontent.com/12987958/152172379-25be9361-4c30-4f10-be0b-dd520ed64130.png)
