### PR TITLE
Update ip-ranges.md

### DIFF
--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -9,16 +9,10 @@ version:
  - Cloud
 ---
 
-
 Enable CircleCI jobs to go through a set of well-defined IP address ranges.
-
 
 * TOC
 {:toc}
-
-**Note:** Details on the IP ranges pricing model can be found in this [Discuss post](https://discuss.circleci.com/t/ip-ranges-pricing-model/42464).
-{: class="alert alert-info"}
-
 
 ## Overview
 {: #overview }


### PR DESCRIPTION
# Description
Removing the banner for the pricing details (also removed extra spacing).

# Reasons
We don't need to mention the pricing details more than once in the same section. The link at the end of the overview section should suffice.