### PR TITLE
Add banner for NS billing date

### DIFF
--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -298,7 +298,7 @@ You can choose to pay for premium features per active user, compute, and optiona
 {: #how-do-I-calculate-my-monthly-storage-and-network-costs }
 {:.no_toc}
 
-**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022 date. Current usage can be found on the [CircleCI web application](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
+**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022 date. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
 {: class="alert alert-info" }
 
 Calculate your monthly storage and network costs by finding your storage and network usage on the [CircleCI web app](https://app.circleci.com/) by navigating to Plan > Plan Usage.

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -298,7 +298,7 @@ You can choose to pay for premium features per active user, compute, and optiona
 {: #how-do-I-calculate-my-monthly-storage-and-network-costs }
 {:.no_toc}
 
-**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
+**NOTE:** Billing for network egress and storage will start to take effect on **March 1 2022** (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
 {: class="alert alert-info" }
 
 Calculate your monthly storage and network costs by finding your storage and network usage on the [CircleCI web app](https://app.circleci.com/) by navigating to Plan > Plan Usage.

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -301,7 +301,7 @@ You can choose to pay for premium features per active user, compute, and optiona
 **NOTE:** Billing for network egress and storage will start to take effect on **March 1 2022** (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
 {: class="alert alert-info" }
 
-Calculate your monthly storage and network costs by finding your storage and network usage on the [CircleCI web app](https://app.circleci.com/) by navigating to Plan > Plan Usage.
+Calculate your monthly storage and network costs by finding your storage and network usage on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan** Usage.
 
 ##### Storage
 {: #storage }

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -298,7 +298,7 @@ You can choose to pay for premium features per active user, compute, and optiona
 {: #how-do-I-calculate-my-monthly-storage-and-network-costs }
 {:.no_toc}
 
-**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022 date. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
+**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
 {: class="alert alert-info" }
 
 Calculate your monthly storage and network costs by finding your storage and network usage on the [CircleCI web app](https://app.circleci.com/) by navigating to Plan > Plan Usage.

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -298,7 +298,10 @@ You can choose to pay for premium features per active user, compute, and optiona
 {: #how-do-I-calculate-my-monthly-storage-and-network-costs }
 {:.no_toc}
 
-Calculate your monthly storage and network costs by finding your storage and network usage on the [CircleCI app](https://app.circleci.com/) by navigating to Plan > Plan Usage.
+**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022 date. Current usage can be found on the [CircleCI web application](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
+{: class="alert alert-info" }
+
+Calculate your monthly storage and network costs by finding your storage and network usage on the [CircleCI web app](https://app.circleci.com/) by navigating to Plan > Plan Usage.
 
 ##### Storage
 {: #storage }

--- a/jekyll/_cci2/persist-data.md
+++ b/jekyll/_cci2/persist-data.md
@@ -98,7 +98,7 @@ Details about individual step storage and network transfer usage can be found in
 ### How to calculate an approximation of your monthly costs
 {: #how-to-calculate-an-approximation-of-your-monthly-costs}
 
-**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
+**NOTE:** Billing for network egress and storage will start to take effect on **March 1 2022** (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
 {: class="alert alert-info" }
 
 Charges apply when an organization has runner network egress beyond the included GB allotment for storage and network usage.

--- a/jekyll/_cci2/persist-data.md
+++ b/jekyll/_cci2/persist-data.md
@@ -84,7 +84,7 @@ To determine which jobs utilize the above actions, you can search for the follow
 
 The relevant action resulting in network egress that will accrue network transfer usage (billable) is **restoring caches and workspaces to self-hosted runners**.
 
-Details about your storage and network transfer usage can be viewed on your Plan > Plan Usage screen. On this screen you can find:
+Details about your storage and network transfer usage can be viewed on your **Plan > Plan Usage** screen. On this screen you can find:
 
 * Billable Network Transfer & Egress (table at the top of the screen)
 * Network and storage usage for individual projects (Projects tab)
@@ -97,6 +97,9 @@ Details about individual step storage and network transfer usage can be found in
 
 ### How to calculate an approximation of your monthly costs
 {: #how-to-calculate-an-approximation-of-your-monthly-costs}
+
+**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022 date. Current usage can be found on the [CircleCI web application](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
+{: class="alert alert-info" }
 
 Charges apply when an organization has runner network egress beyond the included GB allotment for storage and network usage.
 

--- a/jekyll/_cci2/persist-data.md
+++ b/jekyll/_cci2/persist-data.md
@@ -98,7 +98,7 @@ Details about individual step storage and network transfer usage can be found in
 ### How to calculate an approximation of your monthly costs
 {: #how-to-calculate-an-approximation-of-your-monthly-costs}
 
-**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022 date. Current usage can be found on the [CircleCI web application](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
+**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022 date. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
 {: class="alert alert-info" }
 
 Charges apply when an organization has runner network egress beyond the included GB allotment for storage and network usage.

--- a/jekyll/_cci2/persist-data.md
+++ b/jekyll/_cci2/persist-data.md
@@ -98,7 +98,7 @@ Details about individual step storage and network transfer usage can be found in
 ### How to calculate an approximation of your monthly costs
 {: #how-to-calculate-an-approximation-of-your-monthly-costs}
 
-**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022 date. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
+**NOTE:** Billing for network egress and storage will start to take effect on March 1 2022 (subject to change). CircleCI is adding variables and controls to help you manage network and storage usage. The information in this section is applicable after the changes take effect on March 1, 2022. Current usage can be found on the [CircleCI web app](https://app.circleci.com/) by navigating to **Plan > Plan Usage**.
 {: class="alert alert-info" }
 
 Charges apply when an organization has runner network egress beyond the included GB allotment for storage and network usage.


### PR DESCRIPTION
# Description
Add a similar messaging as Outer in the form of a banner to indicate the March 1 N&S billing update.

# Reasons
We've made a lot of changes to the docs about N&S costs and those changes are not GA and have been delayed.