### PR TITLE
Update ip-ranges.md

### DIFF
--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -146,26 +146,33 @@ IP ranges usage is visible in the "Plan Usage" page of the CircleCI app:
 ## AWS and GCP IP Addresses
 {: #awsandgcpipaddresses }
 
-The machines that execute *all jobs* on CircleCI’s platform, not just jobs opted into IP ranges, are hosted on Amazon Web Services (AWS), Google Cloud Platform (GCP), and CircleCI's macOS Cloud. An exhaustive list of IP addresses that CircleCI’s traffic may come from on these cloud providers’ platforms can be found by looking up each cloud provider's IP address ranges. AWS & GCP offer endpoints to find this information.
+The machines that execute *all jobs* on CircleCI’s platform, not just jobs opted into IP ranges, are hosted on Amazon Web Services (AWS), Google Cloud Platform (GCP), and CircleCI's macOS Cloud (see below). An exhaustive list of IP addresses that CircleCI’s traffic may come from on these cloud providers’ platforms can be found by looking up each cloud provider's IP address ranges. AWS & GCP offer endpoints to find this information.
 
 - [AWS](https://ip-ranges.amazonaws.com/ip-ranges.json): CircleCI uses the *us-east-1* and *us-east-2* regions
 - [GCP](https://www.gstatic.com/ipranges/cloud.json): CircleCI uses the *us-east1* and *us-central1* regions
-- CircleCI macOS Cloud:
-  - 162.252.208.0/24
-  - 162.252.209.0/24
-  - 192.206.63.0/24
-  - 162.221.90.0/24
-  - 38.39.177.0/24
-  - 38.39.178.0/24
-  - 38.39.188.0/24
-  - 38.39.189.0/24 
-  - 38.39.186.0/24
-  - 38.39.187.0/24
-  - 38.39.184.0/24 
-  - 138.39.185.0/24
 
 CircleCI *does not recommend* configuring an IP-based firewall based on the AWS or GCP IP addresses, as the vast majority are not CircleCI’s machines. Additionally, there is *no guarantee* that the addresses in the AWS or GCP endpoints persist from day-to-day, as these addresses are reassigned continuously.
  
+## CircleCI macOS Cloud:
+{: #circleci-macos-cloud }
+
+In addition to AWS and GCP (above), CircleCI's macOS Cloud hosts jobs executed by machines. IP address ranges for CircleCI macOS Cloud:
+
+162.252.208.0/24
+162.252.209.0/24
+192.206.63.0/24
+162.221.90.0/24
+38.39.177.0/24
+38.39.178.0/24
+38.39.188.0/24
+38.39.189.0/24
+38.39.186.0/24
+38.39.187.0/24
+38.39.184.0/24
+38.39.185.0/24
+38.39.183.0/24
+198.206.135.0/24
+
 **IP ranges** is the recommended method for configuring an IP-based firewall to allow traffic from CircleCI’s platform.
 
 ## Known limitations


### PR DESCRIPTION
# Description
Separate out macOS IP ranges
Update IP ranges

# Reasons
macOS should have it's own section as it's not in AWS/GCP and the IP rages were outdated