### PR TITLE
remove references to enabling pipelines

### DIFF
--- a/jekyll/_cci2/jira-plugin.md
+++ b/jekyll/_cci2/jira-plugin.md
@@ -32,7 +32,6 @@ in Jira Cloud. To do this, you will need to:
 
 1. Make sure you followed the steps above to connect Jira Cloud with CircleCI.
 1. Make sure that you are using version `2.1` at the top of your `.circleci/config.yml` file.
-1. {% include snippets/enable-pipelines.md %}
 1. To get an API token for build information retrieval, go to [User Settings > Tokens](https://app.circleci.com/settings/user/tokens) and create a token. Copy the token. (*Note*: older versions of the JIRA orb may require you to retrieve a _Project API Token_, which is accessible from **Project Settings > API Permissions**)
 1. To give the integration access to the key, go to **Project Settings -> Environment Variables** and add a variable named _CIRCLE_TOKEN_ with the value being the token you just made.
 1. Add the Jira orb to your configuration and invoke it (see example below).

--- a/jekyll/_cci2/notifications.md
+++ b/jekyll/_cci2/notifications.md
@@ -81,14 +81,6 @@ documentation for handling web notifications.
 
 You can use Orbs to integrate various kinds of notifications into your configuration; currently, CircleCI offers a Slack orb and an IRC orb, but several third-party orbs also exist. Consider searching the [orb registry](https://circleci.com/developer/orbs?query=notification&filterBy=all) for _notifications_ to see what is available.
 
-### Prerequisites
-{: #prerequisites }
-
-Before integrating an orb into your configuration, you will need to perform two steps:
-
-1. Increment the `version` key in your config to `2.1` and;
-2. {% include snippets/enable-pipelines.md %}
-
 ### Using the Slack Orb
 {: #using-the-slack-orb }
 


### PR DESCRIPTION
This setting is deprecated. All projects (apart from server v2.x) have Pipelines enabled by default now.
