### PR TITLE
Add dedicated macOS resource doc

### DIFF
--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -116,7 +116,9 @@ You can learn more about the `config.yml` file in the [configuration reference g
 {: #xcode-cross-compilation }
 
 ### Universal Binaries
-{: #universal-binaries } Xcode currently supports the creation of universal
+{: #universal-binaries }
+
+Xcode currently supports the creation of universal
 binaries which can be run on both `x86_64` and `ARM64` CPU architectures without
 needing to ship separate executables. This is supported only under Xcode 12.2+
 although older Xcode versions can still be used to compile separate `x86_64` and
@@ -155,6 +157,74 @@ straightforward. To build ARM64 binaries, prepend the `xcodebuild` command with
 `ARCHS=ARM64 ONLY_ACTIVE_ARCH=NO` such that it reads `xcodebuild ARCHS=ARM64
 ONLY_ACTIVE_ARCH=NO ...`. For the `x86_64` architecture simply change `ARCHS` to
 `x86_64`.
+
+
+## Dedicated Hosts for macOS
+{: #dedicated-hosts-macos }
+
+The dedicated host resource class is a new macOS option for those developing, building, testing, and signing iOS, iPadOS, macOS, WatchOS, and tvOS applications using the Xcode IDE. These dedicated resources provide an isolated environment for increased security.
+
+This resource class requires a 24-hour minimum lease and runs on Intel-based Mac hardware.
+
+The identifier for the dedicated host resource is metal and supports the following Xcode images:
+
+- Xcode 13.0.0
+- Xcode 12.5.1
+- Xcode 12.4.0
+- Xcode 12.3.0
+- Xcode 12.2.0
+
+### Pricing and specs
+
+Once a dedicated host has been allocated, you have exclusive access to it for a minimum of 24 hours. If the dedicated host is already in use when a job is kicked off, an additional dedicated host is reserved (with its own 24 hour lease window).
+
+Each account can currently have a maximum of three concurrent dedicated hosts. Any time over the initial 24 hours that a dedicated host is in use will be charged a per-minute overage rate (see table below for pricing details).
+
+| Resource Class Name  | vCPU  | Memory  | Storage  | Cost  |
+|---|---|---|---|---|
+| `metal`  | 12  | 32 GB  | 200 GB  | 100 credits per minute (24-hour minimum)  |
+{: class="table table-striped"}
+
+### Known limitations
+
+- The resource class does not currently support test splitting or parallelism.
+- The host gets cleaned between jobs, which can take 5-45 minutes currently.
+
+### Example configuration file using macOS dedicated host resources
+
+```yaml
+# .circleci/config.yml
+version: 2.1
+jobs: 
+  build-and-test: 
+    macos:
+      xcode: 12.5.1 # indicate our selected version of Xcode
+    resource_class: metal # dedicated host, with 24-hour billing
+    steps: 
+      - checkout  
+      - run: bundle install
+      - run:
+          name: Fastlane
+          command: bundle exec fastlane $FASTLANE_LANE
+      - store_artifacts:
+          path: output
+      - store_test_results:
+          path: output/scan
+          
+workflows:
+  build-test:
+    jobs:
+      - build-and-test
+```
+
+### FAQ
+
+- Is there an Apple Silicon option for dedicated hosts?
+  - There are plans to support Apple Silicon hardware in the future, but the option is not available at this time.
+- Why is there a 24-hour minimum?
+  - Apple released an [updated end-user license agreement (EULA)](https://www.apple.com/legal/sla/docs/macOSBigSur.pdf) along with the release of Big Sur in November 2020, which requires cloud providers to lease Apple hardware to no more than one customer for a minimum of 24 hours.
+- How does a dedicated host differ from the other macOS resources on CircleCI?
+  - CircleCI's other macOS resources are run on isolated virtual machines, which means that multiple customers can be using VMs on the same host. Dedicated hosts provide exclusive access to an entire host, without worrying about sharing resources with other customers.
 
 ## Next steps
 {: #next-steps }


### PR DESCRIPTION
# Description
We have a new dedicated macOS resource class, which provides an XL macOS for our customers, with increased storage and a 24-hour individual job timeout.

The new docs have currently been added to an existing `hello-world-macos` page just as a draft/proof of concept but this can still be moved to a standalone page.
