### PR TITLE
Use /tmp/ instead of ~/ in Mocha example for Collecting Test Metadata

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -143,16 +143,16 @@ A working `.circleci/config.yml` section for testing might look like this:
     steps:
       - checkout
       - run: npm install
-      - run: mkdir ~/junit
+      - run: mkdir /tmp/junit
       - run:
           command: mocha test --reporter mocha-junit-reporter
           environment:
-            MOCHA_FILE: ~/junit/test-results.xml
+            MOCHA_FILE: /tmp/junit/test-results.xml
           when: always
       - store_test_results:
-          path: ~/junit
+          path: /tmp/junit
       - store_artifacts:
-          path: ~/junit
+          path: /tmp/junit
 ```
 
 #### Mocha with nyc


### PR DESCRIPTION
# Description
This suggests using `/tmp/junit` instead of ` ~/junit` (per the sample code under _Metadata collection in custom test steps_) in the Mocha example for Collecting Test Metadata.

# Reasons
I couldn't get this working without making this change.