### PR TITLE
Update macOS docs for freemium launch

### DIFF
--- a/jekyll/_cci2/examples-intro.md
+++ b/jekyll/_cci2/examples-intro.md
@@ -100,8 +100,6 @@ jobs:
 
 ## macOS
 {: #macos }
-_The macOS executor is not currently available on self-hosted installations of CircleCI Server_
-
 ```
 jobs:
   build-and-test:

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -74,9 +74,6 @@ Find out more about using the `machine` executor [here]({{ site.baseurl }}/2.0/e
 
 ## macOS
 {: #macos }
-
-_The macOS executor is not currently available on self-hosted installations of CircleCI server_
-
 ```
 jobs:
   build: # name of your job

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -279,9 +279,6 @@ The IP range `192.168.53.0/24` is reserved by CircleCI for the internal use on m
 
 ## Using macOS
 {: #using-macos }
-
-_Available on CircleCI Cloud - not currently available on self-hosted installations_
-
 Using the `macos` executor allows you to run your job in a macOS environment on a VM. In macOS, the following resources classes are available:
 
 Class                 | vCPUs | RAM

--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -22,7 +22,6 @@ example iOS project]({{ site.baseurl }}/2.0/ios-tutorial/).
 To follow along with this document you will need:
 
 - An [account](https://circleci.com/signup/) on CircleCI.
-- A subscription to a [paid plan](https://circleci.com/pricing/#build-os-x) to enable building on the macOS executor.
 - An Apple computer with XCode installed on it (if you want to open the example project).
 
 ## Overview of the macOS executor

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -72,7 +72,7 @@ Running or testing Apple Silicon apps natively is currently not possible as Circ
 ## Getting started
 {: #getting-started }
 
-Select a macOS project repository you would like to build from the **Add Projects** page of the CircleCI application. You will need to ensure you have a [plan that allows macOS builds](https://circleci.com/pricing/), or if your project is open source, you can [apply for a special plan](https://circleci.com/open-source/) with free monthly build credits.
+Select a macOS project repository you would like to build from the **Add Projects** page of the CircleCI application.
 
 We highly recommend using [Fastlane](https://fastlane.tools) to build and sign your apps in CircleCI. Fastlane requires minimal configuration in most cases and simplifies the build-test-deploy process.
 


### PR DESCRIPTION
# Description
Remove warnings in docs that using macOS executor requires a paid plan and isn't supported on server.

# Reasons
With today's launch of freemium support for macOS, the paid plan prerequisite is no longer accurate. Additionally, Server has supported macOS since v3.1