### PR TITLE
Fix xcode image reference mismatch

### DIFF
--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       # Commands run in a macOS virtual machine environment
-      # with Xcode 11.3 installed
+      # with Xcode 12.5.1 installed
 ```
 
 Find out more about using the `macos` executor [here]({{ site.baseurl }}/2.0/executor-types/#using-macos).


### PR DESCRIPTION
# Description
The example config referenced two different Xcode versions, so this PR will correct that.