### PR TITLE
Fix network transfer guidance

### DIFF
--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -313,8 +313,7 @@ To calculate monthly storage costs from your daily usage, click on the **Storage
 {: #network }
 {:.no_toc}
 
-Billing for network usage is only applicable to traffic from CircleCI
-to self-hosted runners. [Read More]({{site.baseurl}}/2.0/persist-data/#overview-of-storage-and-network-transfer).
+Billing for network usage is only applicable to traffic from CircleCI to self-hosted runners. [Read More]({{site.baseurl}}/2.0/persist-data/#overview-of-storage-and-network-transfer).
 
 Your network overage GB/TB can be multiplied by 420 credits to estimate the total monthly costs. Example: 2 GB-Months overage x 420 credits = 840 credits ($.50).
 

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -313,9 +313,10 @@ To calculate monthly storage costs from your daily usage, click on the **Storage
 {: #network }
 {:.no_toc}
 
-To calculate monthly network costs from your usage, click on the **Network** tab to see if your organization has accrued any overages. In the same scenario as storage above, your network overage GB/TB can be multiplied by 420 credits to estimate the total monthly costs. Example: 2 GB-Months overage x 420 credits = 840 credits ($.50).
+Billing for network usage is only applicable to traffic from CircleCI
+to self-hosted runners. [Read More]({{site.baseurl}}/2.0/persist-data/#overview-of-storage-and-network-transfer).
 
-The GB allotment only applies to outbound traffic from CircleCI. Traffic within CircleCI is unlimited.
+Your network overage GB/TB can be multiplied by 420 credits to estimate the total monthly costs. Example: 2 GB-Months overage x 420 credits = 840 credits ($.50).
 
 #### How do I calculate my monthly IP ranges cost?
 {: #how-do-I-calculate-my-monthly-IP-ranges-costs }

--- a/jekyll/_cci2/persist-data.md
+++ b/jekyll/_cci2/persist-data.md
@@ -61,7 +61,7 @@ guide.
 
 The information below describes how your network and storage usage is accumulating, and should help you find ways to optimize and implement cost saving measures.
 
-**Note:** Your overall **Network Transfer** amount is not representative of your billable usage. Only certain actions will result in network egress, which in turn results in billable usage. Details of these actions are described below.
+**Note:** The only network traffic that will be billed for is that accrued through **restoring caches and workspaces to self-hosted runners**.
 {: class="alert alert-info" }
 
 To view your network and storage usage follow these steps:
@@ -75,22 +75,21 @@ Within the network and storage tabs you will find a breakdown of your usage for 
 ### Overview of all storage and network transfer
 {: #overview-of-storage-and-network-transfer }
 
-All data persistence operations within a job will accrue network and storage usage, the relevant actions are:
+All data persistence operations within a job will accrue storage usage, the relevant actions are:
 
-* Uploading and downloading caches
-* Uploading and downloading workspaces
+* Uploading caches
+* Uploading workspaces
 * Uploading artifacts
 * Uploading test results
 
 To determine which jobs utilize the above actions, you can search for the following commands in your project's `config.yml` file:
 
 * `save_cache`
-* `restore_cache`
 * `persist_to_workspace`
 * `store_artifacts`
 * `store_test_results`
 
-The relevant action resulting in network egress that will accrue network transfer usage (billable) is **restoring caches and workspaces to self-hosted runners**.
+The only network traffic that will be billed for is that accrued through **restoring caches and workspaces to self-hosted runners**.
 
 Details about your storage and network transfer usage can be viewed on your **Plan > Plan Usage** screen. On this screen you can find:
 
@@ -125,7 +124,9 @@ To calculate monthly storage costs from your daily usage, click on the **Storage
 
 To calculate monthly network costs from your usage, click on the **Network** tab to see if your organization has accrued any overages. In the same scenario as storage above, your network overage GB/TB can be multiplied by 420 credits to estimate the total monthly costs. Example: 2 GB-Months overage x 420 credits = 840 credits ($.50).
 
-The GB allotment only applies to outbound traffic from CircleCI. Traffic within CircleCI is unlimited.
+Billing for network usage is only applicable to traffic from CircleCI
+to self-hosted runners. If you are exclusively using our cloud-hosted executors,
+no network fees apply.
 
 ### How to optimize your storage and network transfer use
 {: #how-to-optimize-your-storage-and-network-transfer-use }
@@ -208,7 +209,5 @@ If you notice your workspace usage is high and would like to reduce it, try sear
 #### Reducing excess use of network egress
 {: #reducing-excess-use-of-network-egress }
 
-If you would like to try to reduce the amount of network egress that is contributing to network usage, you can try a few things:
-
-* For runner, deploy any cloud-based runners in AWS US-East-1.
-* Download artifacts once and store them on your site for additional processing.
+Usage of network transfer to self-hosted runners can be mitigated by hosting
+runners on AWS, specifically in `US-East-1`.

--- a/jekyll/_cci2/persist-data.md
+++ b/jekyll/_cci2/persist-data.md
@@ -61,7 +61,7 @@ guide.
 
 The information below describes how your network and storage usage is accumulating, and should help you find ways to optimize and implement cost saving measures.
 
-**Note:** The only network traffic that will be billed for is that accrued through **restoring caches and workspaces to self-hosted runners**.
+**Note:** The only network traffic that will be billed is that accrued through **restoring caches and workspaces to self-hosted runners**.
 {: class="alert alert-info" }
 
 To view your network and storage usage follow these steps:
@@ -124,9 +124,7 @@ To calculate monthly storage costs from your daily usage, click on the **Storage
 
 To calculate monthly network costs from your usage, click on the **Network** tab to see if your organization has accrued any overages. In the same scenario as storage above, your network overage GB/TB can be multiplied by 420 credits to estimate the total monthly costs. Example: 2 GB-Months overage x 420 credits = 840 credits ($.50).
 
-Billing for network usage is only applicable to traffic from CircleCI
-to self-hosted runners. If you are exclusively using our cloud-hosted executors,
-no network fees apply.
+Billing for network usage is only applicable to traffic from CircleCI to self-hosted runners. If you are exclusively using our cloud-hosted executors, no network fees apply.
 
 ### How to optimize your storage and network transfer use
 {: #how-to-optimize-your-storage-and-network-transfer-use }
@@ -209,5 +207,4 @@ If you notice your workspace usage is high and would like to reduce it, try sear
 #### Reducing excess use of network egress
 {: #reducing-excess-use-of-network-egress }
 
-Usage of network transfer to self-hosted runners can be mitigated by hosting
-runners on AWS, specifically in `US-East-1`.
+Usage of network transfer to self-hosted runners can be mitigated by hosting runners on AWS, specifically in `US-East-1`.


### PR DESCRIPTION
Only applicable to self-hosted runners

# Description
Update network transfer guidance to reflect the fact that it only applies to restoring caches/workspaces to self-hosted runners.

# Reasons
Current guidance is misleading.