### PR TITLE
Add second migration guide, and some tweaks

### DIFF
--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -19,7 +19,7 @@ version:
 ## Switching to a supported image
 {: #switching-to-a-supported-image }
 
-Swapping out the deprecated image for a supported one in the CircleCI config is straight forward.
+Swapping out the deprecated image for a supported one in the CircleCI config is straightforward.
 Additional work to get your pipelines to run with the newer image will depend on if the [changes below](#changes) apply to your project.
 Here's an example config using an Ubuntu 14.04 image vs one using a 20.04 image:
 

--- a/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/14.04-to-20.04-migration.md
@@ -59,6 +59,8 @@ The middle example above shows the use of the default image, which is specified 
 This image is an Ubuntu 14.04 image and is subject to the deprecation.
 Supported images (and tags) can be found in the [Developer Hub](https://circleci.com/developer/images?imageType=machine).
 
+**Note: This guide will be updated over time to include additional information and tips as CircleCI and customers share their experiences with this migration.**
+
 
 ## Changes
 {: #changes }

--- a/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
@@ -1,9 +1,9 @@
 ---
 layout: classic-docs
-title: "Migrating from Ubuntu 14.04 to Ubuntu 20.04"
-short-title: "14.04 to 20.04 Migration"
+title: "Migrating from Ubuntu 16.04 to Ubuntu 20.04"
+short-title: "16.04 to 20.04 Migration"
 description: |
-  Helpful information to aid in migrating from the CircleCI Ubuntu 14.04 images
+  Helpful information to aid in migrating from the CircleCI Ubuntu 16.04 images
   to the CircleCI Ubuntu 20.04 images. This is less of a step-by-step guide but
   rather one that points to changes and common gotchas.
 order: 20
@@ -21,25 +21,15 @@ version:
 
 Swapping out the deprecated image for a supported one in the CircleCI config is straight forward.
 Additional work to get your pipelines to run with the newer image will depend on if the [changes below](#changes) apply to your project.
-Here's an example config using an Ubuntu 14.04 image vs one using a 20.04 image:
+Here's an example config using an Ubuntu 16.04 image vs one using a 20.04 image:
 
-{:.tab.linuxVM.Explicit-Deprecated-Image}
+{:.tab.linuxVM.Deprecated-Image}
 ```yaml
 version: 2.1
 jobs:
   my-job:
     machine:
-      image: circleci/classic:201707-01
-    steps:
-      run: echo "do something"
-```
-
-{:.tab.linuxVM.Default-Deprecated-Image}
-```yaml
-version: 2.1
-jobs:
-  my-job:
-    machine: true
+      image: ubuntu-1604:202007-01
     steps:
       run: echo "do something"
 ```
@@ -55,15 +45,13 @@ jobs:
       run: echo "do something"
 ```
 
-The middle example above shows the use of the default image, which is specified when using `machine: true` in your config.
-This image is an Ubuntu 14.04 image and is subject to the deprecation.
 Supported images (and tags) can be found in the [Developer Hub](https://circleci.com/developer/images?imageType=machine).
 
 
 ## Changes
 {: #changes }
 
-There are many changes between Ubuntu 14.04 and 20.04 that you should be aware of before migrating.
+There are many changes between Ubuntu 16.04 and 20.04 that you should be aware of before migrating.
 Many are changes that Canonical has made (the company behind Ubuntu), but also changes that CircleCI has made to the software that we pre-install.
 Let's go through each of these changes separately.
 
@@ -105,25 +93,25 @@ Let's go through each of these changes separately.
 ### CircleCI Software Changes
 {: #circleci-software-changes }
 
-| Software | Ubuntu 14.04 (default) | Ubuntu 20.04 (January 2022 Q1) |
+| Software | Ubuntu 16.04 | Ubuntu 20.04 (January 2022 Q1) |
 | --- | --- | --- |
-| AWS CLI | 1.19.112 | 2.4.6 |
-| Google Chrome | 54.0.2840.100 | 96.0.4664.110 |
-| Docker | 17.09.0 | 20.10.11 |
-| Docker Compose | 1.14.0 | 1.29.2 |
-| Firefox | 47.0.1 | 95.0.1 |
-| GCP CLI | 174.0.0 | 365.0.0 |
-| Go | 1.10.2 | 1.17.3 |
-| Gradle | n/a | 7.3.2 |
-| Heroku | 6.99.0 | 7.59.2 |
+| AWS CLI | 1.19.60 | 2.4.6 |
+| Google Chrome | 90.0.4430.93 | 96.0.4664.110 |
+| Docker | 19.03.15 | 20.10.11 |
+| Docker Compose | 1.29.1 | 1.29.2 |
+| Firefox | 88.0 | 95.0.1 |
+| GCP CLI | 337.0.0 | 365.0.0 |
+| Go | 1.16.3 | 1.17.3 |
+| Gradle | 6.5 | 7.3.2 |
+| Heroku | 7.53.0 | 7.59.2 |
 | jq | 1.5 | 1.6 |
-| Leiningen | 2.7.1 | 2.9.8 |
-| Maven | 3.2.5 | 3.8.4 |
-| Node.js | n/a | 16.13.0 |
+| Leiningen | 2.9.3 | 2.9.8 |
+| Maven | 3.6.3 | 3.8.4 |
+| Node.js | 12.22.1 | 16.13.0 |
 | npm | n/a | 8.3.0 |
-| OpenJDK | 1.8.0_131 | 11.0.13 |
-| Python2 | switch | switch |
-| Python3 | 3.4.3 | 3.9.7 |
-| Ruby | 2.3.1 | 3.0.2 |
-| SBT | n/a | 1.5.8 |
+| OpenJDK | 1.8 | 11.0.13 |
+| Python2 | 2.7.18 | 3.9.4 |
+| Python3 | n/a | 3.9.7 |
+| Ruby | 3.0.1 | 3.0.2 |
+| SBT | 1.3.9 | 1.5.8 |
 | yq | n/a | 4.13.5

--- a/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
@@ -78,7 +78,7 @@ Let's go through each of these changes separately.
 - Perl 5.30
 - MySQL updated to v5.7
 - Snap & Snapcraft - Support for running and build snap packages.
-- Java - OpenJDK v11 is now the default ,however, CircleCI pre-installs more versions.
+- Java - OpenJDK v11 is now the default; however, CircleCI pre-installs more versions.
 - OpenSSL upgraded from v1.1.0 to v1.1.1 enabling TLS v1.3
 - netplan supports IPv6 privacy extensions.
 - netplan can bring up devices without an IP for anonymous bridges.

--- a/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
@@ -47,6 +47,8 @@ jobs:
 
 Supported images (and tags) can be found in the [Developer Hub](https://circleci.com/developer/images?imageType=machine).
 
+**Note: This guide will be updated over time to include additional information and tips as CircleCI and customers share their experiences with this migration.**
+
 
 ## Changes
 {: #changes }

--- a/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
@@ -117,3 +117,4 @@ Let's go through each of these changes separately.
 | Ruby | 3.0.1 | 3.0.2 |
 | SBT | 1.3.9 | 1.5.8 |
 | yq | n/a | 4.13.5
+{: class="table table-striped"}

--- a/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
+++ b/jekyll/_cci2/images/linux-vm/16.04-to-20.04-migration.md
@@ -19,7 +19,7 @@ version:
 ## Switching to a supported image
 {: #switching-to-a-supported-image }
 
-Swapping out the deprecated image for a supported one in the CircleCI config is straight forward.
+Swapping out the deprecated image for a supported one in the CircleCI config is straightforward.
 Additional work to get your pipelines to run with the newer image will depend on if the [changes below](#changes) apply to your project.
 Here's an example config using an Ubuntu 16.04 image vs one using a 20.04 image:
 


### PR DESCRIPTION
Hey team,

This is my second PR now for the migration guides. Specifically, this is for the deprecated Linux VM migration guides. In this PR:

- The original guide gets a new section at the top. This section provides a before and after config example of how swapping the image out might work.
- The original guide has been copied over for the 16.04 to 20.04 guide.
  - the top section was tweaked for 16.04. For example, there's no default image.
  - the CircleCI changes section was tweaked for the software that would be in 16.04 specifically.