### PR TITLE
[DD-419] Helpful resources section is not properly working on some pages

### DIFF
--- a/jekyll/_cci2/authentication.adoc
+++ b/jekyll/_cci2/authentication.adoc
@@ -4,7 +4,7 @@ version:
 - Server v2.x
 - Server Admin
 
-suggested_links_has_experiments: true
+experiment_only_suggestions: true
 suggested:
   - title: How to refresh user permissions
     isExperiment: true

--- a/jekyll/_cci2/authentication.adoc
+++ b/jekyll/_cci2/authentication.adoc
@@ -3,8 +3,6 @@ description: "This document describes the various ways users of your CircleCI se
 version:
 - Server v2.x
 - Server Admin
-
-experiment_only_suggestions: true
 suggested:
   - title: How to refresh user permissions
     isExperiment: true

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -9,7 +9,7 @@ version:
 - Server v3.x
 - Server v2.x
 
-suggested_links_has_experiments: true
+experiment_only_suggestions: false
 suggested:
   - title: 6 config optimization tips
     link: https://circleci.com/blog/six-optimization-tips-for-your-config/

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -8,8 +8,6 @@ version:
 - Cloud
 - Server v3.x
 - Server v2.x
-
-experiment_only_suggestions: false
 suggested:
   - title: 6 config optimization tips
     link: https://circleci.com/blog/six-optimization-tips-for-your-config/

--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -8,7 +8,7 @@ version:
 - Cloud
 - Server v3.x
 - Server v2.x
-suggested_links_has_experiments: true
+experiment_only_suggestions: true
 suggested:
   - title: Context deadline exceeded after 1 hour - Build timed out
     isExperiment: true

--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -8,7 +8,6 @@ version:
 - Cloud
 - Server v3.x
 - Server v2.x
-experiment_only_suggestions: true
 suggested:
   - title: Context deadline exceeded after 1 hour - Build timed out
     isExperiment: true

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -8,7 +8,7 @@ version:
 - Cloud
 - Server v3.x
 - Server v2.x
-suggested_links_has_experiments: true
+experiment_only_suggestions: false
 suggested:
   - title: Keep environment variables private
     link: https://circleci.com/blog/keep-environment-variables-private-with-secret-masking/

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -8,7 +8,6 @@ version:
 - Cloud
 - Server v3.x
 - Server v2.x
-experiment_only_suggestions: false
 suggested:
   - title: Keep environment variables private
     link: https://circleci.com/blog/keep-environment-variables-private-with-secret-masking/
@@ -569,7 +568,7 @@ Start a run with the POST API call, see the [new build](https://circleci.com/doc
 ## Built-in environment variables
 {: #built-in-environment-variables }
 
-Built-in environment variables are exported in each job and can be used for more complex testing or deployment. 
+Built-in environment variables are exported in each job and can be used for more complex testing or deployment.
 
 {% include snippets/built-in-env-vars.md %}
 

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -8,7 +8,7 @@ version:
 - Cloud
 - Server v3.x
 - Server v2.x
-suggested_links_has_experiments: true
+experiment_only_suggestions: false
 suggested:
   - title: Manual job approval and scheduled workflow runs
     link: https://circleci.com/blog/manual-job-approval-and-scheduled-workflow-runs/

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -8,7 +8,6 @@ version:
 - Cloud
 - Server v3.x
 - Server v2.x
-experiment_only_suggestions: false
 suggested:
   - title: Manual job approval and scheduled workflow runs
     link: https://circleci.com/blog/manual-job-approval-and-scheduled-workflow-runs/

--- a/jekyll/_cci2_ja/authentication.adoc
+++ b/jekyll/_cci2_ja/authentication.adoc
@@ -4,7 +4,7 @@ version:
 - Server v2.x
 - サーバー管理
 
-suggested_links_has_experiments: true
+experiment_only_suggestions: true
 suggested:
   - title: アカウントのパーミッションの更新について
     isExperiment: true

--- a/jekyll/_cci2_ja/authentication.adoc
+++ b/jekyll/_cci2_ja/authentication.adoc
@@ -3,8 +3,6 @@ description: "このドキュメントでは、お客様の CircleCI Server v2 �
 version:
 - Server v2.x
 - サーバー管理
-
-experiment_only_suggestions: true
 suggested:
   - title: アカウントのパーミッションの更新について
     isExperiment: true

--- a/jekyll/_cci2_ja/configuration-reference.md
+++ b/jekyll/_cci2_ja/configuration-reference.md
@@ -9,7 +9,7 @@ version:
   - Server v3.x
   - Server v2.x
 
-suggested_links_has_experiments: true
+experiment_only_suggestions: false
 suggested:
   - 
     title: 6 つの構成オプション

--- a/jekyll/_cci2_ja/configuration-reference.md
+++ b/jekyll/_cci2_ja/configuration-reference.md
@@ -8,25 +8,23 @@ version:
   - Cloud
   - Server v3.x
   - Server v2.x
-
-experiment_only_suggestions: false
 suggested:
-  - 
+  -
     title: 6 つの構成オプション
     link: https://circleci.com/ja/blog/six-optimization-tips-for-your-config/
-  - 
+  -
     title: ダイナミック コンフィグの紹介
     link: https://discuss.circleci.com/t/intro-to-dynamic-config-via-setup-workflows/39868
-  - 
+  -
     title: ダイナミック コンフィグの使用
     link: https://circleci.com/ja/blog/building-cicd-pipelines-using-dynamic-config/
-  - 
+  -
     title: ローカル CLI を使用した設定のバリデーション
     link: https://support.circleci.com/hc/ja/articles/360006735753?input_string=configuration+error
-  - 
+  -
     title: ジョブをトリガーする方法
     link: https://support.circleci.com/hc/en-us/articles/360041503393?input_string=changes+in+v2+api
-    
+
   - title: ジョブの最大実行時間の更新について
     link: https://support.circleci.com/hc/ja/articles/4411086979867
     isExperiment: true

--- a/jekyll/_cci2_ja/contexts.md
+++ b/jekyll/_cci2_ja/contexts.md
@@ -9,7 +9,7 @@ version:
   - Server v3.x
   - Server v2.x
 
-suggested_links_has_experiments: true
+experiment_only_suggestions: true
 suggested:
   - title: 「Context deadline exceeded」 についてのエラーの解決方法（Freeプラン対応）
     link: https://support.circleci.com/hc/ja/articles/4410707277083

--- a/jekyll/_cci2_ja/contexts.md
+++ b/jekyll/_cci2_ja/contexts.md
@@ -8,8 +8,6 @@ version:
   - クラウド
   - Server v3.x
   - Server v2.x
-
-experiment_only_suggestions: true
 suggested:
   - title: 「Context deadline exceeded」 についてのエラーの解決方法（Freeプラン対応）
     link: https://support.circleci.com/hc/ja/articles/4410707277083

--- a/jekyll/_cci2_ja/workflows.md
+++ b/jekyll/_cci2_ja/workflows.md
@@ -9,7 +9,7 @@ version:
   - Server v3.x
   - Server v2.x
 
-suggested_links_has_experiments: true
+experiment_only_suggestions: false
 suggested:
   - 
     title: 手動でのジョブの承認およびワークフローのスケジュール実行

--- a/jekyll/_cci2_ja/workflows.md
+++ b/jekyll/_cci2_ja/workflows.md
@@ -8,19 +8,17 @@ version:
   - クラウド
   - Server v3.x
   - Server v2.x
-
-experiment_only_suggestions: false
 suggested:
-  - 
+  -
     title: 手動でのジョブの承認およびワークフローのスケジュール実行
     link: https://circleci.com/blog/manual-job-approval-and-scheduled-workflow-runs/
-  - 
+  -
     title: ブランチ毎のワークフローのフィルタリング
     link: https://support.circleci.com/hc/en-us/articles/115015953868?input_string=how+can+i+share+the+data+between+all+the+jobs+in+a+workflow
-  - 
+  -
     title: ワークフローをトリガーする方法
     link: https://support.circleci.com/hc/en-us/articles/360050351292?input_string=how+can+i+share+the+data+between+all+the+jobs+in+a+workflow
-  - 
+  -
     title: 条件付きワークフロー
     link: https://support.circleci.com/hc/en-us/articles/360043638052-Conditional-steps-in-jobs-and-conditional-workflows
 
@@ -668,12 +666,12 @@ GitHub で [Settings (設定)] > [Branches (ブランチ)] に移動し、保護
 
 ## ビデオ: ワークフローに複数のジョブを設定する
 {: #video-configure-multiple-jobs-with-workflows }
-{:.no_toc} 
+{:.no_toc}
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/3V84yEz6HwA" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen mark="crwd-mark"></iframe>
 
 ### ビデオ: 自動的にテストおよびデプロイを行うようビルドのスケジュールを設定する
 {: #video-how-to-schedule-your-builds-to-test-and-deploy-automatically }
-{:.no_toc} 
+{:.no_toc}
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/FCiMD6Gq34M" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen mark="crwd-mark"></iframe>

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -55,12 +55,12 @@
           <div class='full-height-sticky'>
 
             {% if page.suggested != false %}
-            <div id="helpful-resources" class="{% if page.suggested_links_has_experiments %}has-experiment-links {% endif%}">
+            <div id="helpful-resources" class="{% if page.experiment_only_suggestions %} has-experiment-links {% endif%}">
               <h5 class="helpful-heading">Helpful resources</h5>
               <div class="helpful-indent">
                 <ul class="section-nav">
                   {% for item in page.suggested %}
-                  <li class="helpful-entry helpful-h2">
+                  <li class="helpful-entry helpful-h2 {% if item.isExperiment %} has-experiment-links {% endif%}">
                     <a class="{% if item.isExperiment %} experimental-link {% endif %}" href="{{item.link}}" target="_blank">{{item.title}}</a>
                   </li>
                   {% endfor %}

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -63,7 +63,7 @@
                 <ul class="section-nav">
                   {% for item in page.suggested %}
                   <li class="helpful-entry helpful-h2 {% if item.isExperiment %} has-experiment-links {% endif%}">
-                    <a href="{{item.link}}" target="_blank">{{item.title}}</a>
+                    <a class="{% if item.isExperiment %} experimental-link {% endif %}" href="{{item.link}}" target="_blank">{{item.title}}</a>
                   </li>
                   {% endfor %}
                 </ul>

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -55,13 +55,15 @@
           <div class='full-height-sticky'>
 
             {% if page.suggested != false %}
-            <div id="helpful-resources" class="{% if page.experiment_only_suggestions %} has-experiment-links {% endif%}">
-              <h5 class="helpful-heading">Helpful resources</h5>
+            {% assign total_link = page.suggested | size %}
+            {% assign total_links_experiment = page.suggested | where: "isExperiment", true | size %}
+            <div id="helpful-resources" class="{% if total_link == total_links_experiment %} has-experiment-links {% endif%}">
+              <h5 class="helpful-heading">Helpful resources {{count_links_experiment}}</h5>
               <div class="helpful-indent">
                 <ul class="section-nav">
                   {% for item in page.suggested %}
                   <li class="helpful-entry helpful-h2 {% if item.isExperiment %} has-experiment-links {% endif%}">
-                    <a class="{% if item.isExperiment %} experimental-link {% endif %}" href="{{item.link}}" target="_blank">{{item.title}}</a>
+                    <a href="{{item.link}}" target="_blank">{{item.title}}</a>
                   </li>
                   {% endfor %}
                 </ul>

--- a/src/js/experiments/kbLinks.js
+++ b/src/js/experiments/kbLinks.js
@@ -1,18 +1,13 @@
-function renderExperimentalKnowledgeBaseLinks() {
-  // https://app.optimizely.com/v2/projects/16812830475/experiments/21129180862/variations
-  window.OptimizelyClient.getVariationName({
-    experimentKey: 'dd_docs_knowledge_base_pt2_test',
-    groupExperimentName: 'q4_fy22_docs_disco_experiment_group_test',
-    experimentContainer: '.full-height-sticky',
-  }).then((variation) => {
-    if (variation === 'treatment') {
-      const sidebar = $('.has-experiment-links');
-      sidebar.addClass('reveal');
-    }
-  });
-}
+window.OptimizelyClient.getVariationName({
+  experimentKey: 'dd_docs_knowledge_base_pt2_test',
+  groupExperimentName: 'q4_fy22_docs_disco_experiment_group_test',
+  experimentContainer: '.full-height-sticky',
+}).then((variation) => {
+  if (variation === 'treatment') {
+    const sidebar = $('.has-experiment-links');
+    sidebar.addClass('reveal');
+  }
 
-function trackExperimentalKnowledgeBaseLinks() {
   $('.experimental-link').click(function () {
     window.AnalyticsClient.trackAction(
       'docs-experimental-knowledgebase-link-clicked',
@@ -23,9 +18,4 @@ function trackExperimentalKnowledgeBaseLinks() {
       },
     );
   });
-}
-
-$(() => {
-  renderExperimentalKnowledgeBaseLinks();
-  trackExperimentalKnowledgeBaseLinks();
 });


### PR DESCRIPTION
Ticket [DD-419](https://circleci.atlassian.net/browse/DD-419))
[Preview](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-419-helpful-resources-section-is-not-properly-working-on-some-pages-preview/?force-all) - NOTE preview builds experiment always turned on so you should test locally to see experiment as control

# Impact
People not in the experiment are not seeing sections that should be permanent
Japanese was always seeing experiment

# Repro Steps
Open an Incognito tab
Go to [Configuring CircleCI - CircleCI](https://circleci.com/docs/2.0/configuration-reference/)  
Observe that the Helpful resources section is not showing up

## Changes
What needs to be hidden is the experiment links not the entire sidebar

# links to try in EN and JA
/env-vars
/authentication
/configuration-reference
/contexts
/workflows

Authentication no change - make sure no Helpful resource shown
Experiment
<img width="1288" alt="Screen Shot 2022-02-13 at 9 09 02 PM" src="https://user-images.githubusercontent.com/86666932/153788166-47ef2f99-c2f2-4810-8e29-94bb14e8373e.png">
Non experiment
<img width="1293" alt="Screen Shot 2022-02-13 at 9 09 30 PM" src="https://user-images.githubusercontent.com/86666932/153788206-72bb5156-5cc9-4a2d-97d0-6322e7d72513.png">


# Before
[link](https://circleci.com/docs/2.0/env-vars/)
In experiment
<img width="1281" alt="Screen Shot 2022-02-13 at 9 06 05 PM" src="https://user-images.githubusercontent.com/86666932/153787901-9a4dc057-7ec8-4582-8f6b-8c658a008291.png">

out of experiment
<img width="1286" alt="Screen Shot 2022-02-13 at 9 06 28 PM" src="https://user-images.githubusercontent.com/86666932/153787930-ae7be7a9-0245-4394-99f4-2f1af3a27a8a.png">

out of experiment in japanese would show the experiment link
<img width="1304" alt="Screen Shot 2022-02-13 at 9 29 00 PM" src="https://user-images.githubusercontent.com/86666932/153789929-c8fff56b-b31d-4f13-bc3d-bb8291faa206.png">


# After
In experiment no change
<img width="1281" alt="Screen Shot 2022-02-13 at 9 07 09 PM" src="https://user-images.githubusercontent.com/86666932/153787983-5ba54c55-db5a-4c35-9952-9ce72d722a67.png">

Out of experiment
<img width="1297" alt="Screen Shot 2022-02-13 at 9 06 56 PM" src="https://user-images.githubusercontent.com/86666932/153787964-41942032-15cb-4717-9593-8c77a0f19c35.png">

out of experiment japanese 'Context deadline exceeded' should not be seen it is part of experiment
<img width="1292" alt="Screen Shot 2022-02-13 at 9 29 30 PM" src="https://user-images.githubusercontent.com/86666932/153789963-8744d3d6-5ee3-416c-8642-c655f7a21e95.png">

