### PR TITLE
We don't yet support k8s 1.22

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -122,11 +122,8 @@ Supported Kubernetes versions:
 | 3.0.0 - 3.2.1
 | < 1.21
 
-| 3.2.2
+| 3.2.2 - 3.3.0
 | 1.16 - 1.21
-
-| 3.3.0+
-| 1.16 - 1.22
 |===
 
 Creating a Kubernetes cluster is your responsibility. Please note:


### PR DESCRIPTION
SERVER-1632

We found a bug in our k8s 1.22 support. Until we update prometheus this will be the case.