### PR TITLE
Update env-vars.md

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -49,7 +49,9 @@ The value of the environment variable will not be masked in the build output if:
 * the value of the environment variable is less than 4 characters
 * the value of the environment variable is equal to one of `true`, `True`, `false` or `False`
 
-**Note:** Secrets Masking will only prevent the value of the environment variable from appearing in your build output. If your secrets appear elsewhere, such as test results or artifacts, they will not be masked. In addition, the value of the environment variable is still accessible to users [debugging builds with SSH]({{site.baseurl}}/2.0/ssh-access-jobs).
+**Note:** Secrets Masking will only prevent the value of the environment variable from appearing in your build output. Invoking a bash shell with the `-x` or `-o xtrace` options may inadvertantly log unmasked secrets (please refer to [Using Shell Scripts]({{site.baseurl}}/2.0/using-shell-scripts)).
+
+If your secrets appear elsewhere, such as test results or artifacts, they will not be masked. In addition, the value of the environment variable is still accessible to users [debugging builds with SSH]({{site.baseurl}}/2.0/ssh-access-jobs).
 
 ## Renaming orgs and repositories
 {: #renaming-orgs-and-repositories }


### PR DESCRIPTION
Added language to make it clear that using these options with a bash shell could log their secrets in plaintext.

# Description
I added a warning to alert users that using debug options with a bash shell could lead to leaked secrets.
This is mentioned on a different page in our documentation:

https://circleci.com/docs/2.0/using-shell-scripts/

# Reasons
There are security implications if users are unknowingly logging out unmasked secrets. This sentence warns them against using the debug option.