### PR TITLE
[DD-417] Update the Sign-up CTA button verbiage 

### DIFF
--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -47,7 +47,7 @@
         <div class="global-nav--footer">
           <a href="{{ '/signup/' | outer_url }}" class="btn-primary visitor-item" target="_blank"
             data-analytics-action="click-outer-cta">
-            Sign Up
+            Start Building for Free
           </a>
           <a href="https://app.circleci.com/dashboard" class="btn-primary dashboard-link">
             Go to Application


### PR DESCRIPTION
[Ticket](https://circleci.atlassian.net/browse/DD-417) 
[Preview Link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-417/update-CTA-copy-preview/?force-all)

# Changes

- update copy for button html when not signed in

# Considerations
update the sign-up CTA button verbiage for non logged-in users to "Start Building for Free" so it's more encouraging to sign-up

# Screenshots
**Before:**
<img width="991" alt="Screen Shot 2022-02-15 at 11 23 00 PM" src="https://user-images.githubusercontent.com/57234605/154215828-8f47861a-3394-4ffd-8707-af0d744c44fe.png">

**After:**
<img width="1004" alt="Screen Shot 2022-02-15 at 11 21 46 PM" src="https://user-images.githubusercontent.com/57234605/154215637-82d157cb-efbc-44d6-bcac-8e1bb187c878.png">

