### PR TITLE
docs: add notes about scheduled pipeline run times

### DIFF
--- a/jekyll/_cci2/scheduled-pipelines.md
+++ b/jekyll/_cci2/scheduled-pipelines.md
@@ -187,3 +187,13 @@ curl --location --request GET 'https://circleci.com/api/v2/project/<project-slug
 * Is the actor who is set for the scheduled pipelines still part of the organization?
 * Is the branch set for the schedule deleted?
 * Is your GitHub organization using SAML protection? SAML tokens expire often, which can cause requests to GitHub to fail.
+
+**Q:** Why did my scheduled pipeline run later than expected?
+
+**A:** There is a nuanced difference in the scheduling expression with Scheduled Pipelines, compared to [the Cron expression](https://en.wikipedia.org/wiki/Cron#CRON_expression).
+
+For example, when you express the schedule as 1 per-hour for 08:00 UTC, the scheduled pipeline will run once within the 08:00 to 09:00 UTC window.
+Note that it does not mean that it will run at 08:00 UTC exactly.
+
+However, subsequent runs of the scheduled pipeline will always be run on the same time as its previous run.
+In other words, if a previous scheduled pipeline ran at 08:11 UTC, the next runs should also be at 08:11 UTC.


### PR DESCRIPTION
# Description
Added a FAQ question about the expected scheduled time for a scheduled pipeline.

# Reasons
As discussed internally, our scheduling system is not expressed like the CRON expression as such.