### PR TITLE
Add custom script example to command_prefix runner config [RT-409]

### DIFF
--- a/jekyll/_cci2/runner-config-reference.adoc
+++ b/jekyll/_cci2/runner-config-reference.adoc
@@ -73,7 +73,6 @@ If specifying a custom script, it must:
 
 Example with `sudo` prefix:
 
-- config snippet
 ```yaml
 runner:
   command_prefix: ["sudo", "-niHu", "USERNAME", "--"]
@@ -81,13 +80,13 @@ runner:
 
 Example with custom script prefix:
 
-- config snippet
 ```yaml
 runner:
   command_prefix: ["/opt/circleci/wrapper.sh"]
 ```
 
-- `/opt/circleci/wrapper.sh`
+Prefix script saved as `/opt/circleci/wrapper.sh`:
+
 ```bash
 #!/bin/bash
 

--- a/jekyll/_cci2/runner-config-reference.adoc
+++ b/jekyll/_cci2/runner-config-reference.adoc
@@ -71,11 +71,32 @@ If specifying a custom script, it must:
 1. Take great care to ensure the task agent (that is, the arguments passed to it) runs
 2. Forward the exit code from task agent as its own exit code
 
-Example:
+Example with `sudo` prefix:
 
+- config snippet
 ```yaml
 runner:
   command_prefix: ["sudo", "-niHu", "USERNAME", "--"]
+```
+
+Example with custom script prefix:
+
+- config snippet
+```yaml
+runner:
+  command_prefix: ["/opt/circleci/wrapper.sh"]
+```
+
+- `/opt/circleci/wrapper.sh`
+```bash
+#!/bin/bash
+
+task_agent_cmd=${@:1}
+echo "About to run CircleCI task agent: ${task_agent_cmd}"
+$task_agent_cmd
+exit=$?
+echo "CircleCI task agent finished."
+exit $exit
 ```
 
 === runner.working_directory


### PR DESCRIPTION
# Description
Add example to show how to use a custom script for `command_prefix`.

generated page: https://github.com/circleci/circleci-docs/blob/2daf05334468c44d19817a90256cad1ba4f3cb0c/jekyll/_cci2/runner-config-reference.adoc#runner-command_prefix

# Reasons

https://circleci.atlassian.net/browse/RT-409