### PR TITLE
Update api-developers-guide.md

### DIFF
--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -42,7 +42,7 @@ The CircleCI API utilizes token-based authentication to manage access to the API
 To add an API token, perform the steps listed below.
 
 1. Log in to the CircleCI web application.
-1. Visit the [Personal API Tokens page](https://app.circleci.com/settings/user/tokens) and follow the steps to add an API token.
+1. [Create a personal API token](https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token) by visitng the [Personal API Tokens page](https://app.circleci.com/settings/user/tokens) and follow the steps to add an API token.
 2.  To test your token call the API using the command below. You will need to set your API token as an environment variable before making a cURL call.
 
     ```shell

--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -42,15 +42,15 @@ The CircleCI API utilizes token-based authentication to manage access to the API
 To add an API token, perform the steps listed below.
 
 1. Log in to the CircleCI web application.
-1. [Create a personal API token](https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token) by visitng the [Personal API Tokens page](https://app.circleci.com/settings/user/tokens) and follow the steps to add an API token.
-2.  To test your token call the API using the command below. You will need to set your API token as an environment variable before making a cURL call.
+2. [Create a personal API token](https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token) by visitng the [Personal API Tokens](https://app.circleci.com/settings/user/tokens) page, and follow the steps to add an API token.
+3.  To test your token call the API using the command below. You will need to set your API token as an environment variable before making a cURL call.
 
     ```shell
     export CIRCLE_TOKEN={your_api_token}
     curl https://circleci.com/api/v2/me --header "Circle-Token: $CIRCLE_TOKEN"
     ```
 
-3.  You should see a JSON response similar to the example shown below.
+4.  You should see a JSON response similar to the example shown below.
 
     ```json
     {


### PR DESCRIPTION
Added link to "creating a personal API token" instructions

# Description
Added a link to instructions on how to create a personal API token  under the "Add an API token" section

# Reasons
Additional resource for clarity when customers are trying to create a personal API token