### PR TITLE
[DD-417] Update Signup CTA Copy

### DIFF
--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -45,9 +45,9 @@
         </div>
 
         <div class="global-nav--footer">
-          <a href="{{ '/signup/' | outer_url }}" class="btn-primary visitor-item" target="_blank"
+          <a href="{{ '/signup/' | outer_url }}" id='signup-cta' class="btn-primary visitor-item" target="_blank"
             data-analytics-action="click-outer-cta">
-            Start Building for Free
+            Sign Up
           </a>
           <a href="https://app.circleci.com/dashboard" class="btn-primary dashboard-link">
             Go to Application

--- a/jekyll/_includes/global-nav.html
+++ b/jekyll/_includes/global-nav.html
@@ -47,7 +47,7 @@
         <div class="global-nav--footer">
           <a href="{{ '/signup/' | outer_url }}" class="btn-primary visitor-item" target="_blank"
             data-analytics-action="click-outer-cta">
-            Sign Up
+            Start Building for Free
           </a>
           <a href="https://app.circleci.com/dashboard" class="btn-primary dashboard-link">
             Go to Application

--- a/src/js/experiments/index.js
+++ b/src/js/experiments/index.js
@@ -2,9 +2,11 @@ import forceAll from './forceAll';
 import kbLinks from './kbLinks';
 import languageGuides from './languageGuides';
 import './snippetFeedback';
+import signUpCTA from './signUpCTA';
 
 export default {
   forceAll,
   languageGuides,
   kbLinks,
+  signUpCTA,
 };

--- a/src/js/experiments/signUpCTA.js
+++ b/src/js/experiments/signUpCTA.js
@@ -3,6 +3,7 @@ window.OptimizelyClient.getVariationName({
   experimentKey: 'dd_update_signup_cta_test',
   groupExperimentName: 'q1_fy23_docs_disco_experiment_group_test',
   experimentContainer: '.global-nav--footer',
+  guestExperiment: true,
 }).then((variation) => {
   if (variation === 'treatment') {
     const ctaBtn = document.getElementById('signup-cta');

--- a/src/js/experiments/signUpCTA.js
+++ b/src/js/experiments/signUpCTA.js
@@ -1,0 +1,14 @@
+// https://app.optimizely.com/v2/projects/16812830475/experiments/21229840508/variations
+window.OptimizelyClient.getVariationName({
+  experimentKey: 'dd_update_signup_cta_test',
+  groupExperimentName: 'q1_fy23_docs_disco_experiment_group_test',
+  experimentContainer: '.global-nav--footer',
+}).then((variation) => {
+  if (variation === 'treatment') {
+    const ctaBtn = document.getElementById('signup-cta');
+    ctaBtn.innerHTML = 'Start Building for Free';
+    ctaBtn.addEventListener('click', () => {
+      window.AnalyticsClient.trackAction('Clicked New Signup CTA');
+    });
+  }
+});


### PR DESCRIPTION
[Ticket](https://circleci.atlassian.net/browse/DD-417)
[Preview Link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-417/update-signup-CTA-experiment-preview/?force-all)
**NOTE:** Tested with the work @rsylvian did on #6427 guest user experiments. Was able to get treatment variation for as an unsigned in user.

To test out please log out of CCI and view in preview link. If you see the control variation delete your local host and cookies and refresh until you see variation copy

# Changes

- update copy for CTA button in header

# Description
Update the sign-up CTA button verbiage for non-logged-in users to "Start Building for Free" so it's more encouraging to sign-up.

# Considerations
We originally wanted to run this as an experiment but realized that we are unable to do so due to the user not being able to be segmented into a control or treatment group with Optimizely as they are not signed in. 

# Tracking Events

- `Clicked New Signup CTA`

# Screenshots
**Before:**
<img width="801" alt="Screen Shot 2022-02-18 at 4 29 16 PM" src="https://user-images.githubusercontent.com/57234605/154778072-a54141f8-fdd0-40d9-a24c-2c609d8fe3ef.png">

**After:**
<img width="801" alt="Screen Shot 2022-02-18 at 4 29 04 PM" src="https://user-images.githubusercontent.com/57234605/154778068-4a1ef52b-bc9b-46ae-98a1-336e2fc24fd7.png">
