### PR TITLE
Update ip-ranges.md

### DIFF
--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -153,10 +153,10 @@ The machines that execute *all jobs* on CircleCI’s platform, not just jobs opt
 
 CircleCI *does not recommend* configuring an IP-based firewall based on the AWS or GCP IP addresses, as the vast majority are not CircleCI’s machines. Additionally, there is *no guarantee* that the addresses in the AWS or GCP endpoints persist from day-to-day, as these addresses are reassigned continuously.
  
-## CircleCI macOS Cloud:
+## CircleCI macOS Cloud
 {: #circleci-macos-cloud }
 
-In addition to AWS and GCP (see above), CircleCI's macOS Cloud hosts jobs executed by machines. IP address ranges for CircleCI macOS Cloud:
+In addition to AWS and GCP (see above), CircleCI's macOS Cloud hosts jobs executed by machines. The following IP address ranges are used by CircleCI macOS Cloud:
 
 - 162.252.208.0/24
 - 162.252.209.0/24
@@ -173,7 +173,8 @@ In addition to AWS and GCP (see above), CircleCI's macOS Cloud hosts jobs execut
 - 38.39.183.0/24
 - 198.206.135.0/24
 
-**IP ranges** is the recommended method for configuring an IP-based firewall to allow traffic from CircleCI’s platform.
+**IP ranges** is the recommended method for configuring an IP-based firewall to allow traffic from CircleCI’s platform. 
+**Note** you will not need to opt your job into the ip ranges feature by adding `circleci_ip_ranges: true` when using a macOS executor.
 
 ## Known limitations
 {: #knownlimitations}

--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -174,7 +174,7 @@ In addition to AWS and GCP (see above), CircleCI's macOS Cloud hosts jobs execut
 - 198.206.135.0/24
 
 **IP ranges** is the recommended method for configuring an IP-based firewall to allow traffic from CircleCI’s platform. 
-**Note** you will not need to opt your job into the ip ranges feature by adding `circleci_ip_ranges: true` when using a macOS executor.
+**Note:** You will not need to opt your job into the IP ranges feature by adding `circleci_ip_ranges: true` when using a macOS executor.
 
 ## Known limitations
 {: #knownlimitations}

--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -174,7 +174,7 @@ In addition to AWS and GCP (see above), CircleCI's macOS Cloud hosts jobs execut
 - 198.206.135.0/24
 
 **IP ranges** is the recommended method for configuring an IP-based firewall to allow traffic from CircleCI’s platform. 
-**Note:** You will not need to opt your job into the IP ranges feature by adding `circleci_ip_ranges: true` when using a macOS executor.
+**Note:** macOS builds are automatically restricted within the IP ranges listed here. In other words, you do not have to explicitly set `circleci_ip_ranges: true` for macOS builds.
 
 ## Known limitations
 {: #knownlimitations}


### PR DESCRIPTION
# Description
clarified that users do not need to opt into ip ranges feature in cofig for macos 
# Reasons
verbiage sounded like the ip ranges feature worked the same as ip ranges for docker. The ip ranges feature does not need to be enabled as we can provide a list of mac os ip ranges. 