### PR TITLE
Update img ref in Executor Type doc

### DIFF
--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -51,10 +51,10 @@ Docker increases performance by building only what is required for your applicat
 jobs:
   build:
     docker:
-      - image: buildpack-deps:trusty
+      - image: cimg/node:lts
 ```
 
-In this example, all steps run in the container created by the first image listed under the `build` job. To make the transition easy, CircleCI maintains convenience images on Docker Hub for popular languages. See [Using Pre-Built CircleCI Docker Images]({{ site.baseurl }}/2.0/circleci-images/) for the complete list of names and tags. If you need a Docker image that installs Docker and has Git, consider using `docker:stable-git`, which is an official [Docker image](https://hub.docker.com/_/docker/).
+In this example, all steps run in the container created by the first image listed under the `build` job. To make the transition easy, CircleCI maintains convenience images on Docker Hub for popular languages. See [Using Pre-Built CircleCI Docker Images]({{ site.baseurl }}/2.0/circleci-images/) for the complete list of names and tags. If you need a Docker image that installs Docker and has Git, consider using `cimg/base:current`.
 
 ### Docker image best practices
 {: #docker-image-best-practices }
@@ -83,17 +83,15 @@ jobs:
   build:
     docker:
     # Primary container image where all steps run.
-     - image: buildpack-deps:trusty
+     - image: cimg/base:current
     # Secondary container image on common network.
-     - image: mongo:2.6.8-jessie
+     - image: cimg/mariadb:10.6
        command: [mongod, --smallfiles]
 
-    working_directory: ~/
-
     steps:
-      # command will execute in trusty container
-      # and can access mongo on localhost
-      - run: sleep 5 && nc -vz localhost 27017
+      # command will execute in an Ubuntu-based container
+      # and can access MariaDB on localhost
+      - run: sleep 5 && nc -vz localhost 3306
 ```
 Docker images may be specified in a few ways:
 
@@ -226,7 +224,7 @@ Where example usage looks like the following:
 jobs:
   build:
     docker:
-      - image: buildpack-deps:trusty
+      - image: cimg/base:current
     resource_class: xlarge
     steps:
     #  ...  other config
@@ -252,7 +250,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:current
     resource_class: large
 ```
 


### PR DESCRIPTION
The Docker image updates are because it makes more sense to show our own images as examples when it fits the situation.

The machine image update is because the Ubuntu 16.04 images are deprecated.