### PR TITLE
prepare for new UI -  do not merge yet

### DIFF
--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -143,7 +143,7 @@ IP ranges usage is visible in the "Plan Usage" page of the CircleCI app:
 
 ![Screenshot showing the location of the IP ranges feature]({{ site.baseurl }}/assets/img/docs/ip-ranges.png)
 
-On the Resources tab within the Job Details UI page, customers can view approximations of network transfer for any Docker job, even those without the IP ranges feature enabled.  This approximation can be used to predict the cost of enabling the IP ranges feature on a job without having to turn the feature on:
+On the **Resources** tab within the **Job Details** UI page, you can view approximations of network transfer for any Docker job, even those without the IP ranges feature enabled. This approximation can be used to predict the cost of enabling the IP ranges feature on a job without having to turn the feature on.
 
 **insert screenshot**
 

--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -145,7 +145,7 @@ IP ranges usage is visible in the "Plan Usage" page of the CircleCI app:
 
 On the **Resources** tab within the **Job Details** UI page, you can view approximations of network transfer for any Docker job, even those without the IP ranges feature enabled. This approximation can be used to predict the cost of enabling the IP ranges feature on a job without having to turn the feature on.
 
-**insert screenshot**
+![CircleCI about image]({{site.baseurl}}/assets/img/docs/resources-network-transfer.png)
 
 ## AWS and GCP IP Addresses
 {: #awsandgcpipaddresses }

--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -143,6 +143,10 @@ IP ranges usage is visible in the "Plan Usage" page of the CircleCI app:
 
 ![Screenshot showing the location of the IP ranges feature]({{ site.baseurl }}/assets/img/docs/ip-ranges.png)
 
+On the Resources tab within the Job Details UI page, customers can view approximations of network transfer for any Docker job, even those without the IP ranges feature enabled.  This approximation can be used to predict the cost of enabling the IP ranges feature on a job without having to turn the feature on:
+
+**insert screenshot**
+
 ## AWS and GCP IP Addresses
 {: #awsandgcpipaddresses }
 


### PR DESCRIPTION
context: 

we are adding some new information to the Resources tab under the CPU/RAM utilization graphs to aid customers in predicting cost of enabling the IP ranges feature.  I want to prepare the docs and ideally add a screenshot as well.  something like this:

![image](https://user-images.githubusercontent.com/86729349/155331066-e43d52a5-3140-451f-9975-b976d343c6c7.png)
