### PR TITLE
[DD-436] Track Docs Copy Code

### DIFF
--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -36,7 +36,7 @@ git clone git@gitlab.com:[owner]/[repo-name].git --bare
 ```shell
 cd [repo-name]
 git remote add enterprise git@[hostname]:[owner]/[repo-name].git
-```shell
+```
 . Push all local references (refs/\*) up to your remote GitHub Enterprise repository:
 +
 ```shell

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jekyll-dev": "bundle exec jekyll serve -s jekyll --incremental --host=0.0.0.0",
     "webpack-dev": "webpack --watch --mode=development",
     "dev": "concurrently \"docker-compose up -d https\" \"yarn webpack-dev\" \"yarn jekyll-dev\"",
-    "dev-clean": "bundle exec jekyll clean",
+    "dev-clean": "bundle exec jekyll clean && rm jekyll/.jekyll-metadata",
     "start": "./scripts/start.sh",
     "clean": "docker exec -it jekyll bundle exec jekyll clean",
     "cypress:open": "cypress open",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -53,4 +53,5 @@ $(() => {
   ); // ensure languageGuides is loaded; // imports all experiments
 
   Prism.highlightAll();
+  services.trackCopyCode.init();
 });

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -53,5 +53,6 @@ $(() => {
   ); // ensure languageGuides is loaded; // imports all experiments
 
   Prism.highlightAll();
+  // trackCopyCode service MUST be initialized after PrismJS is initialized
   services.trackCopyCode.init();
 });

--- a/src/js/services/index.js
+++ b/src/js/services/index.js
@@ -5,6 +5,7 @@ import OptimizelyClient from './optimizely';
 import * as rum from './rum';
 import * as progressbar from './progressbar';
 import * as sectionShareButton from './sectionShareButton';
+import * as trackCopyCode from './trackCopyCode';
 
 export default {
   AnalyticsClient,
@@ -14,4 +15,5 @@ export default {
   rum,
   progressbar,
   sectionShareButton,
+  trackCopyCode,
 };

--- a/src/js/services/trackCopyCode.js
+++ b/src/js/services/trackCopyCode.js
@@ -1,0 +1,22 @@
+const trackCopyCode = () => {
+  const copyBtnArr = Array.from(
+    document.getElementsByClassName('copy-to-clipboard-button'),
+  );
+
+  copyBtnArr.forEach((btn, index) => {
+    btn.addEventListener('click', () => {
+      const closestTocSection =
+        document.getElementById('active-toc-section').textContent;
+
+      window.AnalyticsClient.trackAction('docs-copy-code-clicked', {
+        page: window.location.pathname,
+        codeSnippetPosition: index + 1,
+        closestTocSection,
+      });
+    });
+  });
+};
+
+export function init() {
+  trackCopyCode();
+}

--- a/src/js/services/trackCopyCode.js
+++ b/src/js/services/trackCopyCode.js
@@ -5,6 +5,7 @@ const trackCopyCode = () => {
 
   copyBtnArr.forEach((btn, index) => {
     btn.addEventListener('click', () => {
+      // added this attribute in site/toc.js to help track where a code snippet is for pages with numerous snippets
       const closestTocSection =
         document.getElementById('active-toc-section').textContent;
 

--- a/src/js/site/toc.js
+++ b/src/js/site/toc.js
@@ -30,8 +30,10 @@ export function highlightTocOnScroll(headings) {
     clickedEntry.addEventListener('click', () => {
       sidebarItems.forEach((el) => {
         el.classList.remove('active');
+        el.removeAttribute('id');
       });
       clickedEntry.classList.add('active');
+      clickedEntry.setAttribute('id', 'active-toc-section');
     });
   });
 
@@ -59,8 +61,15 @@ export function highlightTocOnScroll(headings) {
             );
           }
 
-          sidebarItems.forEach((el) => el.classList.remove('active'));
+          sidebarItems.forEach((el) => {
+            el.classList.remove('active');
+            el.removeAttribute('id');
+          });
           sidebarItems[indexOfCurrentHeadline].classList.add('active');
+          sidebarItems[indexOfCurrentHeadline].setAttribute(
+            'id',
+            'active-toc-section',
+          );
         }
       },
       { threshold: [1.0], rootMargin: '0px 0px -60% 0px' },
@@ -78,6 +87,7 @@ export function highlightTocOnScroll(headings) {
     sidebarItems.forEach((item) => {
       if (item.textContent === firstHeadlineInViewport.textContent) {
         item.classList.add('active');
+        item.setAttribute('id', 'active-toc-section');
       }
     });
   }


### PR DESCRIPTION
[Ticket](https://circleci.atlassian.net/browse/DD-436)
[Preview Link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-436/track-copy-code-preview/?force-all)

# Changes

- add `trackCopyCode` service 
- add `id` attribute to `toc.js` to help provide clarity on code snippet position meta data for Amplitude
- include removing `.jekyll-metadata` file in `yarn dev clean` to account for cache issues occuring in incremental dev builds 
- fix code snippet syntax typo in `migrating-from-gitlab.adoc`

# Description
When moving to PrismJS, we forgot to add the `docs-copy-code-clicked` event tracking back. Being able to track this data is important for potential future experiments

# Considerations
We are keeping the event and meta data the same same as the previous `trackAction` for [hljs](https://github.com/circleci/circleci-docs/pull/5975/files#). An additional metadata entry, `closestTocSection`,  was added to account for pages with numerous code snippets to help discern where the code snippet actually is. 

# Tracking Events

- `docs-copy-code-clicked`

# Amplitude Log
![Screen Shot 2022-02-23 at 2 59 32 PM](https://user-images.githubusercontent.com/57234605/155423831-aed4fa2f-fefa-4301-9f1c-4c215e47756d.png)


# Screenshots
No visual changes 