### PR TITLE
server-1647 Added Notes for using Private Image Repository

### DIFF
--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -381,12 +381,12 @@ Once you have configured the environmental variables and contexts, rerun the rea
 image::realitycheck-pipeline.png[Screenshot showing the realitycheck project building in the CircleCI app]
 
 ==== Enabling Nomad Client for External Image Repository
-To enable a Nomad client to download images from an external or private repo, you can implement one of the two solutions suggested below:
+To enable the Nomad client so it can download images from an external or private repo, you can implement one of the two solutions suggested below:
 
-* Change the image registry from public to private/internal network so the Nomad client can download the images without any authentication.
-* Embed the private image repository credentials in a Nomad client image at `/root/.docker/config.json`, assuming the credentials are static.
+* Keep the image registry as `Public` within `Internal network` so the Nomad client can download the images without any authentication.
+* Or, Embed the private image repository credentials in the Nomad client image at `/root/.docker/config.json`, assuming the credentials are static.
 
-NOTE: If you are using AWS, GCP, or any other cloud image registry, most of them are using temporary image repository credentials (for example, AWS ECR,GCP Container Registry), valid to use for a limited time. As soon as those credentials expire, your Nomad client will be unable to download the image from a private image repository if the image does not exist in a Nomad client. You must refresh the credentials again on those Nomad clients to pull the new images.
+NOTE: If you are using Amazon Web Services (AWS), Google Cloud  Platform (GCP), or any other cloud image registry, most of these registries use temporary image repository credentials, valid to use for a limited time. As soon as those credentials expire, your Nomad client will be unable to download the image from the private image repository if the image does not already exist in a Nomad client. You must refresh the credentials again on those Nomad clients to pull the images.
 
 
 === VM service

--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -380,14 +380,9 @@ Once you have configured the environmental variables and contexts, rerun the rea
 
 image::realitycheck-pipeline.png[Screenshot showing the realitycheck project building in the CircleCI app]
 
-==== Enabling Nomad Client for External Image Repository
-To enable the Nomad client so it can download images from an external or private repo, you can implement one of the two solutions suggested below:
+==== Hosting Build Agent Image in External Image Repository
 
-* Keep the image registry as `Public` within `Internal network` so the Nomad client can download the images without any authentication.
-* Or, Embed the private image repository credentials in the Nomad client image at `/root/.docker/config.json`, assuming the credentials are static.
-
-NOTE: If you are using Amazon Web Services (AWS), Google Cloud  Platform (GCP), or any other cloud image registry, most of these registries use temporary image repository credentials, valid to use for a limited time. As soon as those credentials expire, your Nomad client will be unable to download the image from the private image repository if the image does not already exist in a Nomad client. You must refresh the credentials again on those Nomad clients to pull the images.
-
+If you are hosting build agent image (`circleci/picard`), used by Nomad client, in an external or private repo, you have to keep the private image registry as Public and unauthenticated.
 
 === VM service
 

--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -380,6 +380,15 @@ Once you have configured the environmental variables and contexts, rerun the rea
 
 image::realitycheck-pipeline.png[Screenshot showing the realitycheck project building in the CircleCI app]
 
+==== Enabling Nomad Client for External Image Repository
+For enabling Nomad Client to download images from External or Private repo, You can follow below step -
+
+* Make Image Registry Public to Private/Internal Network so that Nomad client can download them without any authentication.
+* Or, Embed the Private Image repository credentials in Nomad Client Image at `/root/.docker/config.json` assuming credentials are static.
+
+NOTE: If you are using AWS, GCP or any other cloud image registry, most of them are using temporary image repository (i.e. - AWS ECR,GCP Container Registry) credentials valid only for limited time to use. As soon as those credentials are expired, your nomad client will be unable to download the image from private image repository if image is not existing in Nomad client. You have to refresh the credentials again on those nomad client to pull the new images.
+
+
 === VM service
 
 VM service configures VM and remote docker jobs. You can configure a number of options for VM service, such as scaling rules. VM service is unique to EKS and GKE installations because it specifically relies on features of these cloud providers.

--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -323,6 +323,9 @@ Provided in the output from `terraform apply`
 * *Nomad Server Certificate Authority (CA) Certificate (required)* -
 Provided in the output from `terraform apply`
 
+* *Build Agent Image* - 
+Consult customer support to set up
+
 Click the *Save config* button to update your installation and redeploy server.
 
 ==== Nomad Clients Validation
@@ -379,10 +382,6 @@ Once you have successfully cloned the repository, you can follow it from within 
 Once you have configured the environmental variables and contexts, rerun the realitycheck tests. You should see the features and resource jobs complete successfully. Your test results should look something like the following:
 
 image::realitycheck-pipeline.png[Screenshot showing the realitycheck project building in the CircleCI app]
-
-==== Hosting Build Agent Image in External Image Repository
-
-If you are hosting build agent image (`circleci/picard`), used by Nomad client, in an external or private repo, you have to keep the private image registry as Public and unauthenticated.
 
 === VM service
 

--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -381,12 +381,12 @@ Once you have configured the environmental variables and contexts, rerun the rea
 image::realitycheck-pipeline.png[Screenshot showing the realitycheck project building in the CircleCI app]
 
 ==== Enabling Nomad Client for External Image Repository
-For enabling Nomad Client to download images from External or Private repo, You can follow below step -
+To enable a Nomad client to download images from an external or private repo, you can implement one of the two solutions suggested below:
 
-* Make Image Registry Public to Private/Internal Network so that Nomad client can download them without any authentication.
-* Or, Embed the Private Image repository credentials in Nomad Client Image at `/root/.docker/config.json` assuming credentials are static.
+* Change the image registry from public to private/internal network so the Nomad client can download the images without any authentication.
+* Embed the private image repository credentials in a Nomad client image at `/root/.docker/config.json`, assuming the credentials are static.
 
-NOTE: If you are using AWS, GCP or any other cloud image registry, most of them are using temporary image repository (i.e. - AWS ECR,GCP Container Registry) credentials valid only for limited time to use. As soon as those credentials are expired, your nomad client will be unable to download the image from private image repository if image is not existing in Nomad client. You have to refresh the credentials again on those nomad client to pull the new images.
+NOTE: If you are using AWS, GCP, or any other cloud image registry, most of them are using temporary image repository credentials (for example, AWS ECR,GCP Container Registry), valid to use for a limited time. As soon as those credentials expire, your Nomad client will be unable to download the image from a private image repository if the image does not exist in a Nomad client. You must refresh the credentials again on those Nomad clients to pull the new images.
 
 
 === VM service


### PR DESCRIPTION
# Description
Enabling the Nomad Client to use Private Image repo, rather than public docker repository

# Reasons
Customers want to use their own image repository to pull the image i.e. - `circleci/picard`