### PR TITLE
Fix: Typo for eksctl

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -143,7 +143,7 @@ ifndef::env-gcp[]
 You can learn more about creating an Amazon EKS cluster https://aws.amazon.com/quickstart/architecture/amazon-eks/[here]. We recommend using https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html[`eksctl`] to create your cluster, which will create a VPC and select the proper security groups for you.
 
 . https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html[Install] and https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html[configure] the AWS CLI for your AWS account.
-. Install https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html[`eksctrl`].
+. Install https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html[`eksctl`].
 . Create your cluster by running the following (Cloud formation with `eksctl` and EKS can take more than 20 minutes to complete):
 +
 ```shell

--- a/jekyll/_cci2_ja/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2_ja/server-3-install-prerequisites.adoc
@@ -145,7 +145,7 @@ ifndef::env-gcp[]
 Amazon EKS クラスタ の作成に関する詳細はhttps://aws.amazon.com/quickstart/architecture/amazon-eks/[こちら]をご覧ください。 クラスタの作成にはhttps://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html[`eksctl`] の使用を推奨しています。 このツールにより、VPC の作成と適切なセキュリティグループの選択が自動で行われます。
 
 . AWS CLI をhttps://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html[インストール]し、お使いの AWS アカウント用にhttps://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html[設定します]。
-.  https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html[`eksctrl`]をインストールします。
+.  https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html[`eksctl`]をインストールします。
 . Create your cluster by running the following (Cloud formation with `eksctl` and EKS can take more than 20 minutes to complete):
 +
 ```shell


### PR DESCRIPTION
# Description
Changed `eksctrl` to `eksctl`

# Reasons
Typo