### PR TITLE
Add `guestExperiment`option for OptimizelyClient

### DIFF
--- a/jest/global.js
+++ b/jest/global.js
@@ -13,7 +13,7 @@ global.analytics = {
   user: jest.fn(() => userFn),
 };
 
-global.global._DATADOG_SYNTHETICS_BROWSER = false;
+global._DATADOG_SYNTHETICS_BROWSER = false;
 
 class IntersectionObserver {
   constructor() {}

--- a/jest/global.js
+++ b/jest/global.js
@@ -2,13 +2,18 @@ import $ from 'jquery';
 
 global.$ = global.jQuery = $;
 
+const userFn = {
+  anonymousId: jest.fn(),
+};
+
 global.analytics = {
   page: jest.fn(),
   track: jest.fn(),
   identify: jest.fn(),
+  user: jest.fn(() => userFn),
 };
 
-global._DATADOG_SYNTHETICS_BROWSER = false;
+global.global._DATADOG_SYNTHETICS_BROWSER = false;
 
 class IntersectionObserver {
   constructor() {}
@@ -24,7 +29,7 @@ class IntersectionObserver {
   unobserve() {
     return null;
   }
-};
+}
 
 global.IntersectionObserver = IntersectionObserver;
 

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -67,7 +67,7 @@ class OptimizelyClient {
       const attributes = options.attributes ?? {};
 
       // capture if we are trying to run this experiment as a guest experiment
-      // defautl to false as most of our experiments are for logged in users
+      // default to false as most of our experiments are for logged in users
       const isGuestExperiment = options.guestExperiment ?? false;
 
       // Then, we check if we have the cookie. If the cookie is not present

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -17,6 +17,10 @@ class OptimizelyClient {
   getUserId(isGuestExperiment) {
     return new Promise((resolve) => {
       if (isGuestExperiment) {
+        // Analytics.js generates a universally unique ID (UUID) for the viewer during the library’s initialization phase
+        // and sets this as anonymousId for each new visitor.
+        // This call is always valid and will never return null. From the docs:
+        // If the user’s anonymousId is null (meaning not set) when you call this function, Analytics.js automatically generated and sets a new anonymousId for the user.
         resolve(analytics.user().anonymousId());
       }
 
@@ -64,7 +68,8 @@ class OptimizelyClient {
       // defines additional attributes we will want to send to optimizely to qualify/disqualify a user
       const attributes = options.attributes ?? {};
 
-      // TODO(romain): add comment
+      // capture if we are trying to run this experiment as a guest experiment
+      // defautl to false as most of our experiments are for logged in users
       const isGuestExperiment = options.guestExperiment ?? false;
 
       // Then, we check if we have the cookie. If the cookie is not present
@@ -75,7 +80,8 @@ class OptimizelyClient {
         return resolve(null);
       }
 
-      //TODO(romain): add comment
+      // orgId is used as a localstorage key but since a guest doesn't have an org attached yet
+      // we create a "default" one
       if (isGuestExperiment) {
         orgId = 'no-org-id';
       }
@@ -97,12 +103,13 @@ class OptimizelyClient {
               id: userId,
             };
 
+            // if we are not in a guest experiment, we need to bucket by orgId
+            // so users from the same org see the same variation
             if (!isGuestExperiment) {
               optimizelyAttributes.$opt_bucketing_id = orgId;
             }
 
-            // We check if user whether the user is in the provided
-            // exclusion group or not
+            // We check whether the user is in the provided exclusion group or not
             const isInGrowthExperimentGroup = this.client.getVariation(
               options.groupExperimentName,
               userId,
@@ -183,7 +190,7 @@ export const trackExperimentViewed = (
       experimentId,
       experimentName: experimentKey,
       allocationType: isGuestExperiment ? 'user_id' : 'organization_id',
-      orgId,
+      orgId: isGuestExperiment ? null : orgId,
       projectId: null, // This experiment is measured at the org level
       userId,
       variationId,

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -16,19 +16,17 @@ class OptimizelyClient {
   }
   getUserId(isGuestExperiment) {
     return new Promise((resolve) => {
-      if (isGuestExperiment) {
-        // Analytics.js generates a universally unique ID (UUID) for the viewer during the library’s initialization phase
-        // and sets this as anonymousId for each new visitor.
-        // This call is always valid and will never return null. From the docs:
-        // If the user’s anonymousId is null (meaning not set) when you call this function, Analytics.js automatically generated and sets a new anonymousId for the user.
-        resolve(analytics.user().anonymousId());
-      }
-
       if (window.userData) {
         // if we already have userData
         resolve(
           window.userData.analytics_id ? window.userData.analytics_id : null,
         );
+      } else if (isGuestExperiment) {
+        // Analytics.js generates a universally unique ID (UUID) for the viewer during the library’s initialization phase
+        // and sets this as anonymousId for each new visitor.
+        // This call is always valid and will never return null. From the docs:
+        // If the user’s anonymousId is null (meaning not set) when you call this function, Analytics.js automatically generated and sets a new anonymousId for the user.
+        resolve(analytics.user().anonymousId());
       } else {
         // If we are here it means we are still waiting on getting notified
         // that the call to /api/v1/me has resolved and the new userData is available

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -18,10 +18,9 @@ describe('Optimizely Service logged-in users', () => {
   const orgId = 'circle';
   const experimentKey = 'experiment_key';
   const variationName = 'variation_name';
+  const anonymousId = '22222222-2222-2222-2222-222222222222';
 
   const options = {
-    organizationId: '00000000-0000-0000-0000-000000000000',
-    userAnalyticsId: '11111111-1111-1111-1111-111111111111',
     experimentKey,
     groupExperimentName: 'experiment_group_test',
     experimentContainer: 'experiment_container',
@@ -35,8 +34,6 @@ describe('Optimizely Service logged-in users', () => {
   afterEach(() => {
     glob.userData = null;
     glob.forceAll = null;
-    jest.clearAllMocks();
-    jest.resetAllMocks();
   });
 
   describe('getUserId()', () => {
@@ -54,6 +51,29 @@ describe('Optimizely Service logged-in users', () => {
       await expect(client.getUserId()).resolves.toBe(
         glob.userData.analytics_id,
       );
+    });
+  });
+
+  describe('getUserId() in a Guest Experiment', () => {
+    glob.analytics.user().anonymousId.mockReturnValue(anonymousId);
+
+    it('returns anonymousId when userData is not here', async () => {
+      glob.userData = null;
+      await expect(client.getUserId(true)).resolves.toBe(anonymousId);
+    });
+
+    it('returns analytics_id when userData has a valid analytics_id', async () => {
+      glob.userData = {
+        analytics_id: '00000000-0000-0000-0000-000000000000',
+      };
+      await expect(client.getUserId(true)).resolves.toBe(
+        glob.userData.analytics_id,
+      );
+    });
+
+    it('returns null when userData is empty', async () => {
+      glob.userData = {};
+      await expect(client.getUserId(true)).resolves.toBe(null);
     });
   });
 
@@ -127,193 +147,7 @@ describe('Optimizely Service logged-in users', () => {
       await expect(client.getVariationName(null)).rejects.toEqual(errorObject);
     });
 
-    it('returns null when no cookie', async () => {
-      await expect(client.getVariationName(options)).resolves.toBe(null);
-    });
-
-    it('returns null when no userId', async () => {
-      const spy = jest.spyOn(Cookie, 'get').mockImplementation(() => 123);
-      glob.userData = {};
-      await expect(client.getVariationName(options)).resolves.toBe(null);
-      expect(spy).toHaveBeenCalledWith(COOKIE_KEY);
-    });
-
-    describe('getVariationName when an organization is in the exclusion group', () => {
-      beforeEach(() => {
-        glob.userData = {
-          analytics_id: '11111111-1111-1111-1111-111111111111',
-        };
-        jest.spyOn(Cookie, 'get').mockImplementation(() => ({
-          userId: '11111111-1111-1111-1111-111111111111',
-        }));
-      });
-
-      it('returns null when growthExperiment is control', () => {
-        jest
-          .spyOn(client.client, 'getVariation')
-          .mockImplementationOnce(() => 'control');
-        return client.getVariationName(options).then((data) => {
-          expect(data).toBe(null);
-        });
-      });
-
-      it('returns control when growthExperiment is treatment and variationName is control', () => {
-        jest
-          .spyOn(client.client, 'getVariation')
-          .mockImplementationOnce(() => 'treatment');
-        jest
-          .spyOn(client.client, 'getVariation')
-          .mockImplementationOnce(() => 'control');
-        return client.getVariationName(options).then((data) => {
-          expect(data).toBe('control');
-        });
-      });
-
-      it('returns treatment when growthExperiment is treatment and variationName is treatment', () => {
-        jest
-          .spyOn(client.client, 'getVariation')
-          .mockImplementationOnce(() => 'treatment');
-        jest
-          .spyOn(client.client, 'getVariation')
-          .mockImplementationOnce(() => 'treatment');
-        return client.getVariationName(options).then((data) => {
-          expect(data).toBe('treatment');
-        });
-      });
-    });
-  });
-
-  //Function used in TrackExperimentViewed
-  describe('storeExperimentParticipation()', () => {
-    it('should not effect local storage if options invalid', () => {
-      expect(storeExperimentParticipation('', '', '')).toBe();
-      expect(window.localStorage.getItem(STORAGE_KEY)).toBe(null);
-    });
-
-    it('should effect local storage if options are valid', () => {
-      storeExperimentParticipation(orgId, experimentKey, variationName);
-      expect(window.localStorage.getItem(STORAGE_KEY)).not.toBe(null);
-    });
-  });
-});
-
-describe('Optimizely Service guest users', () => {
-  const client = new OptimizelyClient();
-
-  const orgId = 'no-org-id';
-  const experimentKey = 'experiment_key';
-  const variationName = 'variation_name';
-
-  const options = {
-    organizationId: '00000000-0000-0000-0000-000000000000',
-    userAnalyticsId: '11111111-1111-1111-1111-111111111111',
-    experimentKey,
-    groupExperimentName: 'experiment_group_test',
-    experimentContainer: 'experiment_container',
-    guestExperiment: true,
-  };
-
-  beforeEach(() => {
-    // ensure local storage clear
-    window.localStorage.clear();
-  });
-
-  afterEach(() => {
-    glob.userData = null;
-    glob.forceAll = null;
-    jest.clearAllMocks();
-    jest.resetAllMocks();
-  });
-
-  describe('getUserId()', () => {
-    it('returns null when userData is empty', () => {
-      glob.userData = {};
-      return client.getUserId().then((data) => {
-        expect(data).toBe(null);
-      });
-    });
-
-    it('returns analytics_id when userData has a valid analytics_id', async () => {
-      glob.userData = {
-        analytics_id: '00000000-0000-0000-0000-000000000000',
-      };
-      await expect(client.getUserId()).resolves.toBe(
-        glob.userData.analytics_id,
-      );
-    });
-  });
-
-  // Function used in TrackExperimentViewed
-  describe('isExperimentAlreadyViewed()', () => {
-    it('returns false when experiment has not been viewed before', () => {
-      expect(isExperimentAlreadyViewed(orgId, experimentKey)).toBe(false);
-    });
-    it('returns true when experiment has been viewed before', () => {
-      storeExperimentParticipation(orgId, experimentKey, variationName);
-      expect(isExperimentAlreadyViewed(orgId, experimentKey)).toBe(true);
-    });
-  });
-
-  //Function used in getVariationName
-  describe('trackExperimentViewed()', () => {
-    beforeEach(() => {
-      global.AnalyticsClient = AnalyticsClient;
-    });
-
-    afterEach(() => {
-      delete global.AnalyticsClient;
-    });
-
-    it('does not call trackAction when experiment viewed before', () => {
-      const spy = jest.spyOn(window.AnalyticsClient, 'trackAction');
-      storeExperimentParticipation(orgId, experimentKey, variationName);
-
-      trackExperimentViewed(
-        orgId,
-        experimentKey,
-        ['container item'],
-        '5',
-        variationName,
-        '5',
-        '5',
-      );
-
-      expect(spy).not.toHaveBeenCalled();
-    });
-
-    it('does call trackAction when experiment not viewed before', () => {
-      const spy = jest.spyOn(window.AnalyticsClient, 'trackAction');
-
-      trackExperimentViewed(
-        orgId,
-        experimentKey,
-        ['container item'],
-        '5',
-        variationName,
-        '5',
-        '5',
-      );
-
-      expect(spy).toHaveBeenCalledWith('Experiment Viewed', expect.any(Object));
-    });
-  });
-
-  describe('getVariationName()', () => {
-    beforeEach(() => {
-      glob.forceAll = () => false;
-    });
-
-    it('returns treatment when forceAll is true', async () => {
-      glob.forceAll = () => true;
-      await expect(client.getVariationName(options)).resolves.toBe('treatment');
-    });
-
-    it('returns error when options null', async () => {
-      const errorObject = { error: 'Missing required options' };
-      await expect(client.getVariationName(null)).rejects.toEqual(errorObject);
-    });
-
-    it('returns null when no cookie', async () => {
+    it('returns null when no org cookie', async () => {
       await expect(client.getVariationName(options)).resolves.toBe(null);
     });
 

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -12,7 +12,7 @@ import { default as CookieOrginal } from 'js-cookie';
 jest.mock('js-cookie');
 const Cookie = CookieOrginal;
 
-describe('Optimizely Service', () => {
+describe('Optimizely Service logged-in users', () => {
   const client = new OptimizelyClient();
 
   const orgId = 'circle';
@@ -22,9 +22,195 @@ describe('Optimizely Service', () => {
   const options = {
     organizationId: '00000000-0000-0000-0000-000000000000',
     userAnalyticsId: '11111111-1111-1111-1111-111111111111',
-    experimentKey: 'experiment_key',
+    experimentKey,
     groupExperimentName: 'experiment_group_test',
     experimentContainer: 'experiment_container',
+  };
+
+  beforeEach(() => {
+    // ensure local storage clear
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    glob.userData = null;
+    glob.forceAll = null;
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  describe('getUserId()', () => {
+    it('returns null when userData is empty', () => {
+      glob.userData = {};
+      return client.getUserId().then((data) => {
+        expect(data).toBe(null);
+      });
+    });
+
+    it('returns analytics_id when userData has a valid analytics_id', async () => {
+      glob.userData = {
+        analytics_id: '00000000-0000-0000-0000-000000000000',
+      };
+      await expect(client.getUserId()).resolves.toBe(
+        glob.userData.analytics_id,
+      );
+    });
+  });
+
+  // Function used in TrackExperimentViewed
+  describe('isExperimentAlreadyViewed()', () => {
+    it('returns false when experiment has not been viewed before', () => {
+      expect(isExperimentAlreadyViewed(orgId, experimentKey)).toBe(false);
+    });
+    it('returns true when experiment has been viewed before', () => {
+      storeExperimentParticipation(orgId, experimentKey, variationName);
+      expect(isExperimentAlreadyViewed(orgId, experimentKey)).toBe(true);
+    });
+  });
+
+  //Function used in getVariationName
+  describe('trackExperimentViewed()', () => {
+    beforeEach(() => {
+      global.AnalyticsClient = AnalyticsClient;
+    });
+
+    afterEach(() => {
+      delete global.AnalyticsClient;
+    });
+
+    it('does not call trackAction when experiment viewed before', () => {
+      const spy = jest.spyOn(window.AnalyticsClient, 'trackAction');
+      storeExperimentParticipation(orgId, experimentKey, variationName);
+
+      trackExperimentViewed(
+        orgId,
+        experimentKey,
+        ['container item'],
+        '5',
+        variationName,
+        '5',
+        '5',
+      );
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('does call trackAction when experiment not viewed before', () => {
+      const spy = jest.spyOn(window.AnalyticsClient, 'trackAction');
+
+      trackExperimentViewed(
+        orgId,
+        experimentKey,
+        ['container item'],
+        '5',
+        variationName,
+        '5',
+        '5',
+      );
+
+      expect(spy).toHaveBeenCalledWith('Experiment Viewed', expect.any(Object));
+    });
+  });
+
+  describe('getVariationName()', () => {
+    beforeEach(() => {
+      glob.forceAll = () => false;
+    });
+
+    it('returns treatment when forceAll is true', async () => {
+      glob.forceAll = () => true;
+      await expect(client.getVariationName(options)).resolves.toBe('treatment');
+    });
+
+    it('returns error when options null', async () => {
+      const errorObject = { error: 'Missing required options' };
+      await expect(client.getVariationName(null)).rejects.toEqual(errorObject);
+    });
+
+    it('returns null when no cookie', async () => {
+      await expect(client.getVariationName(options)).resolves.toBe(null);
+    });
+
+    it('returns null when no userId', async () => {
+      const spy = jest.spyOn(Cookie, 'get').mockImplementation(() => 123);
+      glob.userData = {};
+      await expect(client.getVariationName(options)).resolves.toBe(null);
+      expect(spy).toHaveBeenCalledWith(COOKIE_KEY);
+    });
+
+    describe('getVariationName when an organization is in the exclusion group', () => {
+      beforeEach(() => {
+        glob.userData = {
+          analytics_id: '11111111-1111-1111-1111-111111111111',
+        };
+        jest.spyOn(Cookie, 'get').mockImplementation(() => ({
+          userId: '11111111-1111-1111-1111-111111111111',
+        }));
+      });
+
+      it('returns null when growthExperiment is control', () => {
+        jest
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'control');
+        return client.getVariationName(options).then((data) => {
+          expect(data).toBe(null);
+        });
+      });
+
+      it('returns control when growthExperiment is treatment and variationName is control', () => {
+        jest
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'treatment');
+        jest
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'control');
+        return client.getVariationName(options).then((data) => {
+          expect(data).toBe('control');
+        });
+      });
+
+      it('returns treatment when growthExperiment is treatment and variationName is treatment', () => {
+        jest
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'treatment');
+        jest
+          .spyOn(client.client, 'getVariation')
+          .mockImplementationOnce(() => 'treatment');
+        return client.getVariationName(options).then((data) => {
+          expect(data).toBe('treatment');
+        });
+      });
+    });
+  });
+
+  //Function used in TrackExperimentViewed
+  describe('storeExperimentParticipation()', () => {
+    it('should not effect local storage if options invalid', () => {
+      expect(storeExperimentParticipation('', '', '')).toBe();
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe(null);
+    });
+
+    it('should effect local storage if options are valid', () => {
+      storeExperimentParticipation(orgId, experimentKey, variationName);
+      expect(window.localStorage.getItem(STORAGE_KEY)).not.toBe(null);
+    });
+  });
+});
+
+describe('Optimizely Service guest users', () => {
+  const client = new OptimizelyClient();
+
+  const orgId = 'no-org-id';
+  const experimentKey = 'experiment_key';
+  const variationName = 'variation_name';
+
+  const options = {
+    organizationId: '00000000-0000-0000-0000-000000000000',
+    userAnalyticsId: '11111111-1111-1111-1111-111111111111',
+    experimentKey,
+    groupExperimentName: 'experiment_group_test',
+    experimentContainer: 'experiment_container',
+    guestExperiment: true,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
# Description
- Add a `guestExperiment` option for `getVariationName()` function
- Add more test to validate that `getUserId()` works well with logged in user & guest users

# Reasons
We want to start to run experiments on guest users. We can call `analytics.user().anonymousId()` to get a consistent anonymous `userId` that can be used to resolve the experiment variation. More info: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/identity/#anonymous-ids

# Screesnhots
Trying the implementation on @tshen815 experiment: https://github.com/circleci/circleci-docs/pull/6396

![Screen Shot 2022-02-28 at 5 19 33 PM](https://user-images.githubusercontent.com/1449325/156092996-7c43f399-b10d-48c3-91c7-2c6969810639.png)
![Screen Shot 2022-02-28 at 5 19 36 PM](https://user-images.githubusercontent.com/1449325/156092998-562ee383-33bf-47b2-9f0d-68ffbd44e8e7.png)

"resetting" the device (by clearing local storage and cookie), we also get `control` since you get assigned a new `anonymousId`:
![Screen Shot 2022-02-28 at 5 25 03 PM](https://user-images.githubusercontent.com/1449325/156092999-9654a006-0196-4a0d-98c1-a689e2333ba9.png)
