### PR TITLE
Call out contexts & project specific env vars are not possible in sec…

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -422,6 +422,8 @@ jobs:
 
 The following example shows separate environment variable settings for the primary container image (listed first) and the secondary or service container image.
 
+**Note**: While hard coded environment variable values will be passed on correctly to the secondary or service container, contexts or project specific environment variables won't be interpolated for non-primary containers.
+
 ```yaml
 version: 2.1
 

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -422,7 +422,7 @@ jobs:
 
 The following example shows separate environment variable settings for the primary container image (listed first) and the secondary or service container image.
 
-**Note**: While hard coded environment variable values will be passed on correctly to the secondary or service container, contexts or project specific environment variables won't be interpolated for non-primary containers.
+**Note**: While hard-coded environment variable values will be passed on correctly to the secondary or service container, contexts or project specific environment variables will not be interpolated for non-primary containers.
 
 ```yaml
 version: 2.1


### PR DESCRIPTION
…ondary containers

# Description
Adding in the following line to example 2 of Setting an environment variable in a container:
```
**Note**: While hard coded environment variable values will be passed on correctly to the secondary or service container, contexts or project specific environment variables won't be interpolated for non-primary containers.
```

# Reasons:
- Adding a note to highlight the inability to pass in project or context specific env vars to secondary/service containers as it's currently not possible.