### PR TITLE
Contexts & project specific env vars in secondary containers

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -422,6 +422,8 @@ jobs:
 
 The following example shows separate environment variable settings for the primary container image (listed first) and the secondary or service container image.
 
+**Note**: While hard-coded environment variable values will be passed on correctly to the secondary or service container, contexts or project specific environment variables will not be interpolated for non-primary containers.
+
 ```yaml
 version: 2.1
 


### PR DESCRIPTION
# Description
This is from @jabsci 's [PR](https://github.com/circleci/circleci-docs/pull/6439) which did not trigger a build. 

# Reasons
Passing in project or context specific env vars to secondary/service containers is currently not possible.