### PR TITLE
Server-1544 | Add GCP workload identity for VM services

### DIFF
--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -665,6 +665,8 @@ gcloud projects add-iam-policy-binding <YOUR_PROJECT_ID> --member serviceAccount
 
 . *Get JSON Key File*
 +
+If you are using https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload identities] for GKE, this step is not required. 
++
 After running the following command, you should have a file named `circleci-server-vm-keyfile` in your local working directory. You will need this when you configure your server installation.
 +
 ```shell

--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -673,6 +673,16 @@ After running the following command, you should have a file named `circleci-serv
 gcloud iam service-accounts keys create circleci-server-vm-keyfile --iam-account <YOUR_SERVICE_ACCOUNT_EMAIL>
 ```
 
+. *Enable Workload Identity for Service Account*
++
+This step is required only if you are using https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload identities] for GKE.
++
+```shell
+gcloud iam service-accounts add-iam-policy-binding <YOUR_SERVICE_ACCOUNT_EMAIL> \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:<GCP_PROJECT_ID>.svc.id.goog[circleci-server/vm-service]"
+```
+
 . *Configure Server*
 +
 Configure VM Service through the KOTS admin console. Details of the available configuration options can be found in the https://circleci.com/docs/2.0/server-3-operator-vm-service[VM Service] guide.

--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -194,6 +194,26 @@ gcloud iam service-accounts keys create <PATH_TO_STORE_CREDENTIALS> --iam-accoun
 ```
 endif::env-aws[]
 
+===== Enabling Workload Identity in GKE
+https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload identities] for GKE allow workloads/pods in your GKE cluster to impersonate IAM service accounts to access Google Cloud services without using static service account credentials. You have to enable workload identities on your GKE cluster to use it. 
+
+====== Step 1: Enable Workload Identity on existing cluster
+```shell
+  gcloud container clusters update "<CLUSTER_NAME>" \
+    --region="<REGION>" \
+    --workload-pool="<PROJECT_ID>.svc.id.goog"
+```
+
+====== Step 2: Updating existing node pools
+```shell
+  gcloud container node-pools update "<NODEPOOL_NAME>" \
+    --cluster="<CLUSTER_NAME>" \
+    --workload-metadata="GKE_METADATA" \
+    --region="<REGION>"
+```
+    You have to repeat the above command for all the existing node pools.
+
+
 === Create a new GitHub OAuth app
 
 CAUTION: If GitHub Enterprise and CircleCI server are not on the same domain then images will fail to load.

--- a/jekyll/_cci2/server-3-operator-vm-service.adoc
+++ b/jekyll/_cci2/server-3-operator-vm-service.adoc
@@ -113,7 +113,15 @@ https://www.googleapis.com/compute/v1/projects/<host-project>/global/networks/<n
 ```
 https://www.googleapis.com/compute/v1/projects/<service-project>/regions/<your-region>/subnetworks/<subnetwork-name>
 ```
-* *GCP Service Account JSON file* (required): Copy and paste the contents of your https://cloud.google.com/iam/docs/service-accounts[service account JSON file].
+
+* *GCP IAM Access Type* (required): One of the following is required. Either select `GCP Service Account JSON file` and provide:
+
+** *GCP Service Account JSON file* (required): Copy and paste the contents of your https://cloud.google.com/iam/docs/service-accounts[service account JSON file] if using the static GCP IAM service account credential.
++
+Or select `IAM Workload Identity` and provide: 
+
+** *GCP IAM Workload Identity* (required): Copy and paste the VM service account email address (`service-account-name`@`project-id`.iam.gserviceaccount.com ) which you have created https://circleci.com/docs/2.0/server-3-install-build-services/#gcp-3[here] in point 2 & 3.
+
 * *Number of <VM-type> VMs to keep prescaled*: By default, this field is set to 0, which will create and provision instances
 of a resource type on demand. You have the option of preallocating up to 5 instances per resource type. Preallocating
 instances lowers the start time allowing for faster machine and `remote_docker` builds. 


### PR DESCRIPTION
# Description
Add GCP IAM Workload Identity for K8s Service Account in CCI Cluster 
  
# Reasons
[SERVER-1544](https://circleci.atlassian.net/browse/SERVER-1544)
[GCP Workload Identiyy for K8s](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)

# Screenshots
*Kots Config View*

![image](https://user-images.githubusercontent.com/3430610/156099008-e2761884-b80e-4dcf-9a85-0eccb6d8f5cc.png)
![image](https://user-images.githubusercontent.com/3430610/156099162-cb1110c1-359f-4204-b224-46801b7228a6.png)

**Code Change**
[server-1544 | GCP workload identity for VM Services](https://github.com/circleci/server/pull/4980)