### PR TITLE
removing unnecessary line in creating gcp prereqs

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -608,8 +608,7 @@ gcloud iam service-accounts list \
 ```shell
 gcloud iam roles create circleci_server \
     --project <PROJECT_ID> \
-    --title "CircleCI Server" \
-    --permissions \ compute.disks.get,compute.disks.create,compute.disks.createSnapshot,compute.snapshots.get,compute.snapshots.create,compute.snapshots.useReadOnly,compute.snapshots.delete,compute.zones.get
+    --title "CircleCI Server"
 ```
 
 ```shell


### PR DESCRIPTION
# Description
the line removed references permissions used for vm-service, however this section of the doc is about object storage.
the command does not need these permissions as the object storage permissions are added in a later command

# Reasons
https://circleci.atlassian.net/browse/SERVER-1485