### PR TITLE
add info about bash.exe known limitations

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -399,6 +399,8 @@ The available options are:
 - bash.exe
 - cmd.exe
 
+Please note here is a known limitation with `bash.exe` at this time where bash doesn't not show the expected prompt.
+
 You can read more about using SSH in your builds [here]({{site.baseurl}}/2.0/ssh-access-jobs).
 
 ## Next steps

--- a/jekyll/_cci2/skip-build.md
+++ b/jekyll/_cci2/skip-build.md
@@ -88,7 +88,7 @@ A few points to note regarding the use of the auto-cancel feature:
 {: #steps-to-enable-auto-cancel-for-pipelines-triggered-by-pushes-to-github-or-the-api }
 {:.no_toc}
 
-**Notes:** It is important to carefully consider the impact of enabling the auto-cancel feature, for example, if you have configured automated deployment jobs on non-default branches.
+**Notes:** It is important to carefully consider the impact of enabling the auto-cancel feature, for example, if you have configured automated deployment jobs on non-default branches. An approval job will also remain on hold even when new commits are made with "Auto-cancel redundant builds" enabled.
 
 1. In the CircleCI application, go to your Project Settings.
 


### PR DESCRIPTION
# Description
A brief description of the changes.

Please note here is a known limitation with `bash.exe` at this time where bash doesn't not show the expected prompt.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.