### PR TITLE
Remove pre-installed software section

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -264,7 +264,7 @@ jobs:
          shell: cmd.exe
 ```
 
-**Note** It is possible to install updated or other Windows shell-tooling as well; for example, you could install the latest version of Powershell Core with the `dotnet` cli and use it in a job's successive steps:
+**Note:** It is possible to install updated or other Windows shell-tooling as well; for example, you could install the latest version of Powershell Core with the `dotnet` cli and use it in a job's successive steps:
 
 
 {:.tab.windowsblockfour.Cloud}
@@ -418,61 +418,7 @@ Also, consider reading documentation on some of CircleCI’s features:
 * Refer to the [Workflows]({{site.baseurl}}/2.0/workflows) document for examples of orchestrating job runs with concurrent, sequential, scheduled, and manual approval workflows.
 * Find complete reference information for all keys and pre-built Docker images in the [Configuring CircleCI]({{site.baseurl}}/2.0/configuration-reference/) and [CircleCI Images]({{site.baseurl}}/2.0/circleci-images/) documentation, respectively.
 
-## Software pre-installed in the Windows image
-{: #software-pre-installed-in-the-windows-image }
+## Software pre-installed on the Windows image
+{: #software-pre-installed-on-the-windows-image }
 
-**Windows Server 2019 with Visual Studio 2019**
-
-* Windows Server 2019 Core Datacenter Edition
-* Visual Studio 2019 Community Edition
-    * Additional licensing terms may apply to your organisation when using this version of Visual Studio on CircleCI. Please review the [Visual Studio 2019 Community Edition licensing terms](https://visualstudio.microsoft.com/license-terms/mlt031819/) before using this Visual Studio version in your Windows jobs.
-    * Azure SDK for Visual Studio 2019
-    * Visual Studio 2019 Build Tools
-* AWS
-    * AWS CLI 1.16.209
-    * Python 3.6.0
-    * Botocore 1.12.199
-* Shells:
-    * Powershell 5
-    * GNU bash 4.4.231 (x86_64-pc-msys)
-    * cmd
-* .NET Framework 5
-* .NET Core
-    * SDK 5.0.402
-    * SDK 5.0.401
-    * SDK 3.1.406 (x64)
-    * SDK 3.0.100-preview7-012821
-    * Runtime 3.0.0-preview6-27804-01
-    * SDK 2.2.401
-    * Runtime 2.2.6
-    * SDK 2.1.801
-* Nunit 3.10.0
-* Git 2.33.1
-* Git LFS 2.7.2
-* Gzip 1.3.12
-* 7zip 19.00
-* PsExec64 2.34
-* Windows 10 SDK
-    * 10.0.26624
-    * 10.1.18362.1
-* Docker Engine - Enterprise version 18.09.7
-* NuGet CLI 5.2.0.6090
-* Chocolatey v0.11.2
-* Azure Service Fabric
-    * SDK 3.3.617.9590
-    * Runtime 6.4.617.9590
-* Azure CLI 2.0.70
-* OpenJDK 12.0.2
-* Node.js 14.17.5
-* NVM (Node Version Manager) 1.1.7
-* Yarn 1.22.17
-* Ruby 2.6.3
-* Go 1.17
-* Python 3.9
-* Java 12.0.2
-* Miniconda 3
-* WinAppDriver 1.1.1809.18001
-* Text editors
-    * nano 2.5
-    * vim 8.2
-* jq 1.5
+To find information on what software is pre-installed on the Windows image, please visit the [Discuss](https://discuss.circleci.com/) page.


### PR DESCRIPTION
# Description
Removing the software section. Will adjust and link out to more specific resources when those links are available or when the information in included in DevHub.

Apologies for a very unclear commit message - I came back to this and had forgotten what I had done on that particular change 🙃 

# Reasons
This section kept getting out of date too quickly and there was a lack of communication around when changes happened.