### PR TITLE
Clarify organization

### DIFF
--- a/jekyll/_cci2/customizations.adoc
+++ b/jekyll/_cci2/customizations.adoc
@@ -206,7 +206,7 @@ To use second machine type (`large` in the example above), a further step is req
 ```
 circleci dev-console
 ```
-. Run the following (substituting your organization name):
+. Run the following (substituting your CircleCI organization name):
 ```
 (admin/set-org-feature-unsafe "<org_name>" :picard-allowed-resource-classes :val #{"l1.large"})
 ```

--- a/jekyll/_cci2/orb-author-validate-publish.md
+++ b/jekyll/_cci2/orb-author-validate-publish.md
@@ -8,7 +8,7 @@ version:
 
 This guide covers the steps required to create a simple orb, manually, without using the orb development kit. We recommend the orb development kit for most orb projects, to find out more, see the [Orb Authoring Guide]({{site.baseurl}}/2.0/orb-author).
 
-1. If you have not already done so, claim a namespace for your user/organization using the following command, substituting your namespace choice and GitHub org name:
+1. If you have not already done so, claim a namespace for your user/organization using the following command, substituting your namespace choice and GitHub organization name:
 ```shell
 circleci namespace create <my-namespace> github <my-gh-org>
 ```

--- a/jekyll/_cci2/v.2.18-overview.md
+++ b/jekyll/_cci2/v.2.18-overview.md
@@ -12,7 +12,7 @@ This document provides a summary of features and product notes for the release o
 {: #requirements-for-upgrading }
 
 <div class="alert alert-warning" role="alert">
-<b>Warning:</b> If at any time your organization name has been changed, there is a <a href="https://circleci.com/docs/2.0/updating-server/#org-rename-script">script</a> that <b>must</b> be run before stating the upgrade process.
+<b>Warning:</b> If at any time your CircleCI organization name has been changed, there is a <a href="https://circleci.com/docs/2.0/updating-server/#org-rename-script">script</a> that <b>must</b> be run before stating the upgrade process.
 </div>
 
 ## Notes and best practices

--- a/jekyll/_cci2/v.2.18-overview.md
+++ b/jekyll/_cci2/v.2.18-overview.md
@@ -12,7 +12,7 @@ This document provides a summary of features and product notes for the release o
 {: #requirements-for-upgrading }
 
 <div class="alert alert-warning" role="alert">
-<b>Warning:</b> If at any time your CircleCI organization name has been changed, there is a <a href="https://circleci.com/docs/2.0/updating-server/#org-rename-script">script</a> that <b>must</b> be run before stating the upgrade process.
+<b>Warning:</b> If at any time your CircleCI organization name has been changed, there is a <a href="https://circleci.com/docs/2.0/updating-server/#org-rename-script">script</a> that <b>must</b> be run before starting the upgrade process.
 </div>
 
 ## Notes and best practices

--- a/jekyll/_cci2/v.2.19-overview.adoc
+++ b/jekyll/_cci2/v.2.19-overview.adoc
@@ -21,7 +21,7 @@ WARNING: Before upgrading to 2.19.3, if you are using an IAM role scoped to a no
 
 WARNING: For AWS installs, *before upgrading* to v2.19, follow <<update-nomad-clients#important,this guide>> to update your nomad launch configuration.
 
-WARNING: If you are upgrading from pre v2.18.x, and have at any time changed your organization name, there is a <<updating-server#org-rename-script,script>> that *must* be run before starting the upgrade process. If you are already running v2.18.x, you will have run this already.
+WARNING: If you are upgrading from pre v2.18.x, and have at any time changed your CircleCI organization name, there is a <<updating-server#org-rename-script,script>> that *must* be run before starting the upgrade process. If you are already running v2.18.x, you will have run this already.
 
 ## Notes and Best Practices
 


### PR DESCRIPTION
# Description
Make a few clarifications that we mean CircleCI organization name, not GitHub

# Reasons
Because we deal with both CCI usernames and GH usernames, sometimes this can be confusing out of context. The ticket seemed like there would be a lot of work to do, but searching the docs for certain terms came up with very few results. There might be outstanding issues when we just use the term "organization" or "org" without the continued phrase "organization name" or "org name" but that is so many results that it doesn't make sense to have on one ticket.
[Jira Ticket](https://circleci.atlassian.net/jira/software/projects/DOCSTEAM/boards/412?selectedIssue=DOCSTEAM-45)