### PR TITLE
[DD-446] Implement option to disable read time

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -64,6 +64,7 @@ toc:
   min_level: 1
   max_level: 6
 
+readTime: true
 
 markdown: kramdown
 kramdown:

--- a/jekyll/_includes/quick-info-list.html
+++ b/jekyll/_includes/quick-info-list.html
@@ -5,6 +5,7 @@
   <div id='arrow' data-popper-arrow></div>
 </div>
 <div class="quick-info-list">
+  {% if page.readTime != false %}
   <img alt="Last updated" src="{{ site.baseurl }}/assets/img/docs/duration.svg">
   <time aria-describedby="tooltip-time" id="time-posted-on" datetime="{{  page.last_modified_at | date_to_xmlschema }}">
       {% assign dateStart = page.last_modified_at | date: '%s' %}
@@ -28,6 +29,7 @@
       • {{ ert }} min read
     </span>
   </time>
+  {% endif %}
   
   {% if page.version %}
   <div class="server-version-wrapper">

--- a/jekyll/_includes/quick-info-list.html
+++ b/jekyll/_includes/quick-info-list.html
@@ -5,7 +5,6 @@
   <div id='arrow' data-popper-arrow></div>
 </div>
 <div class="quick-info-list">
-  {% if page.readTime != false %}
   <img alt="Last updated" src="{{ site.baseurl }}/assets/img/docs/duration.svg">
   <time aria-describedby="tooltip-time" id="time-posted-on" datetime="{{  page.last_modified_at | date_to_xmlschema }}">
       {% assign dateStart = page.last_modified_at | date: '%s' %}
@@ -18,6 +17,7 @@
       {% else %} 
         <a href="{{ ghLink }}" target="_blank" class="no-external-icon">{{ page.last_modified_at | timeago }}</a>
       {% endif %}
+    {% if page.readTime %}
     <span class="ert">
       {% assign words_total = page.content | strip_html | number_of_words %}
       {% assign words_without_code = page.content | replace: '<pre class="highlight">', '<!--' | replace: '</pre>', '-->' | strip_html | number_of_words %}
@@ -28,8 +28,8 @@
       {% assign ert = words_without_code_read_time | plus: words_code_read_time | at_least: 1 %}
       • {{ ert }} min read
     </span>
+    {% endif %}
   </time>
-  {% endif %}
   
   {% if page.version %}
   <div class="server-version-wrapper">

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -547,6 +547,8 @@ Fixing styling for the code example tables in the "Migrating From..." pages
   font-weight: normal;
   font-size: 15px;
   color: #343434;
+  border-right: 1px solid #DDDDDD;
+  margin-right: 16px;
 }
 
 // badge tags
@@ -576,9 +578,8 @@ Fixing styling for the code example tables in the "Migrating From..." pages
 }
 
 .server-version-wrapper {
-  padding: 10px 16px;
+  padding: 10px 0px;
   flex-grow: 1;
-  border-left: 1px solid #DDDDDD;
 }
 
 #tooltip-time {


### PR DESCRIPTION
Ticket [Link](https://circleci.atlassian.net/browse/DD-446)

# Description
In [DD-425: Move the "top reasons why my build failed..." from support to docDEV IN PROGRESS](https://circleci.atlassian.net/browse/DD-425) we want to disable the read-time because it might not completely make sense for this page (no one read the entire page). We should add an option as a front matter variable to let this be customizable.

# Changes
- A variable called readTime: false can be set in a markdown page to disable the read time for the output page
- by defaults readTime needs to be true for all pages (in _config).

# How to test
You will have to test it locally by adding in new `readTime` value into md file
<img width="465" alt="Screen Shot 2022-03-02 at 3 37 06 PM" src="https://user-images.githubusercontent.com/86666932/156445536-ffb172e9-f370-4a54-a2c1-8148d0461869.png">


# Screenshots
## Before
<img width="1196" alt="Screen Shot 2022-03-02 at 3 42 30 PM" src="https://user-images.githubusercontent.com/86666932/156446304-848b7a59-3727-420b-8e01-daf45d341c30.png">

## After
<img width="1208" alt="Screen Shot 2022-03-02 at 3 52 47 PM" src="https://user-images.githubusercontent.com/86666932/156447753-ec7ed89c-46dd-4d7c-a9c1-b4a30327dfbd.png">

