### PR TITLE
`OptimizelyClient.getVariationName()` should return null when analytics object is not available

### DIFF
--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -26,9 +26,7 @@ class OptimizelyClient {
         // and sets this as anonymousId for each new visitor.
         // This call is always valid and will never return null. From the docs:
         // If the user’s anonymousId is null (meaning not set) when you call this function, Analytics.js automatically generated and sets a new anonymousId for the user.
-        resolve(
-          analytics && analytics.user() ? analytics.user().anonymousId() : null,
-        );
+        resolve(analytics?.user()?.anonymousId() ?? null);
       } else {
         // If we are here it means we are still waiting on getting notified
         // that the call to /api/v1/me has resolved and the new userData is available

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -26,7 +26,9 @@ class OptimizelyClient {
         // and sets this as anonymousId for each new visitor.
         // This call is always valid and will never return null. From the docs:
         // If the user’s anonymousId is null (meaning not set) when you call this function, Analytics.js automatically generated and sets a new anonymousId for the user.
-        resolve(analytics.user().anonymousId());
+        resolve(
+          analytics && analytics.user() ? analytics.user().anonymousId() : null,
+        );
       } else {
         // If we are here it means we are still waiting on getting notified
         // that the call to /api/v1/me has resolved and the new userData is available

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -76,7 +76,7 @@ describe('Optimizely Service logged-in users', () => {
       await expect(client.getUserId(true)).resolves.toBe(null);
     });
 
-    it("returns null when analytics doesn't exists", async () => {
+    it("returns null when analytics doesn't exist", async () => {
       glob.analytics = null;
       await expect(client.getUserId(true)).resolves.toBe(null);
     });

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -75,6 +75,11 @@ describe('Optimizely Service logged-in users', () => {
       glob.userData = {};
       await expect(client.getUserId(true)).resolves.toBe(null);
     });
+
+    it("returns null when analytics doesn't exists", async () => {
+      glob.analytics = null;
+      await expect(client.getUserId(true)).resolves.toBe(null);
+    });
   });
 
   // Function used in TrackExperimentViewed


### PR DESCRIPTION
# Description
- Check for `analytics` & `analytics.user()` existance before requesting the `anonymousId`

# Reasons

We are seeing multiple errors since we launched the new guest user experiment resolver. They are most likely happening because Ad blockers are preventing segment to load.
![image](https://user-images.githubusercontent.com/1449325/156469042-372c6ff4-beaf-4b67-afe2-2429aa0ef9f8.png)
