### PR TITLE
Remove pre-installed software Android

### DIFF
--- a/jekyll/_cci2/android-machine-image.md
+++ b/jekyll/_cci2/android-machine-image.md
@@ -29,28 +29,7 @@ below for more details.
 ## Pre-installed Software
 {: #pre-installed-software }
 
-The Android machine image comes with the following pre-installed:
-
-### Android SDK
-{: #android-sdk }
-- sdkmanager
-- Android platform 23, 24, 25, 26, 27, 28, 29, 30, S
-- Build tools 30.0.3
-- emulator, platform-tools, tools
-- NDK (Side-by-side) 21.4.7075529
-- cmake 3.6.4111459
-- extras;android;m2repository, extras;google;m2repository, extras;google;google_play_service
-
-### Others
-{: #others }
-- gcloud
-- OpenJDK 8, OpenJDK 11 (default)
-- maven 3.6.3, gradle 6.8.3, ant
-- nodejs 12.21.0, 14.16.0 (default), 15.11.0
-- python 2.7.18, python 3.9.2
-- ruby 2.7.2, ruby 3.0.0
-- docker 20.10.5, docker-compose 1.28.5
-- jq 1.6
+Please view the quarterly update announcement on our [Discuss](https://discuss.circleci.com/t/android-images-2022-january-q1-update/42842) page for a list of current pre-installed software.
 
 ## Limitations
 {: #limitations }


### PR DESCRIPTION
# Description
Removing the pre-installed software for Android Image. Link out to quarterly update on Discuss instead.

# Reasons
The list was out of date and the content will move to DevHub in the future.