### PR TITLE
[FIX]DD-446: Disable Read Time Fix

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -16,6 +16,7 @@ devhub_base_url: "https://circleci.com/developer"
 blog_base_url: "https://circleci.com/blog"
 support_base_url: "https://support.circleci.com"
 noindex: false
+readtime: true
 
 exclude:
   - .jekyll-cache
@@ -63,8 +64,6 @@ algolia:
 toc:
   min_level: 1
   max_level: 6
-
-readTime: true
 
 markdown: kramdown
 kramdown:

--- a/jekyll/_includes/quick-info-list.html
+++ b/jekyll/_includes/quick-info-list.html
@@ -7,21 +7,22 @@
 <div class="quick-info-list">
   <img alt="Last updated" src="{{ site.baseurl }}/assets/img/docs/duration.svg">
   <time aria-describedby="tooltip-time" id="time-posted-on" datetime="{{  page.last_modified_at | date_to_xmlschema }}">
-      {% assign dateStart = page.last_modified_at | date: '%s' %}
-      {% assign nowTimestamp = 'now' | date: '%s' %}  
-      {% assign timestampDiff = nowTimestamp | minus: dateStart %}
-      {% assign yearInSeconds = 60 | times: 60 | times: 24 | times: 365 %}
-      {% assign ghLink = site.gh_url | append: '/commits/master/jekyll/' | append: page.path %}
-      {% if timestampDiff > yearInSeconds %}
-        <a href="{{ ghLink }}" target="_blank" class="no-external-icon">1+ year ago</a>
-      {% else %} 
-        <a href="{{ ghLink }}" target="_blank" class="no-external-icon">{{ page.last_modified_at | timeago }}</a>
-      {% endif %}
-    {% if page.readTime %}
+    {% assign dateStart = page.last_modified_at | date: '%s' %}
+    {% assign nowTimestamp = 'now' | date: '%s' %}
+    {% assign timestampDiff = nowTimestamp | minus: dateStart %}
+    {% assign yearInSeconds = 60 | times: 60 | times: 24 | times: 365 %}
+    {% assign ghLink = site.gh_url | append: '/commits/master/jekyll/' | append: page.path %}
+    {% if timestampDiff > yearInSeconds %}
+    <a href="{{ ghLink }}" target="_blank" class="no-external-icon">1+ year ago</a>
+    {% else %}
+    <a href="{{ ghLink }}" target="_blank" class="no-external-icon">{{ page.last_modified_at | timeago }}</a>
+    {% endif %}
+    {% if page.readtime != false %}
     <span class="ert">
       {% assign words_total = page.content | strip_html | number_of_words %}
-      {% assign words_without_code = page.content | replace: '<pre class="highlight">', '<!--' | replace: '</pre>', '-->' | strip_html | number_of_words %}
-  
+      {% assign words_without_code = page.content | replace: '
+      <pre class="highlight">', '<!--' | replace: '</pre>', '-->' | strip_html | number_of_words %}
+
       {% assign words_code_read_time = words_total | minus: words_without_code | divided_by: 500 %}
       {% assign words_without_code_read_time = words_without_code | divided_by: 250 %}
 
@@ -30,7 +31,7 @@
     </span>
     {% endif %}
   </time>
-  
+
   {% if page.version %}
   <div class="server-version-wrapper">
     <img alt="Tags" class="server-version-tag-svg" src="{{ site.baseurl }}/assets/img/docs/tag.svg">

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -548,8 +548,6 @@ Fixing styling for the code example tables in the "Migrating From..." pages
   font-weight: normal;
   font-size: 15px;
   color: #343434;
-  // border-right: 1px solid #DDDDDD;
-  // margin-right: 16px;
 }
 
 // badge tags

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -548,8 +548,8 @@ Fixing styling for the code example tables in the "Migrating From..." pages
   font-weight: normal;
   font-size: 15px;
   color: #343434;
-  border-right: 1px solid #DDDDDD;
-  margin-right: 16px;
+  // border-right: 1px solid #DDDDDD;
+  // margin-right: 16px;
 }
 
 // badge tags
@@ -579,8 +579,9 @@ Fixing styling for the code example tables in the "Migrating From..." pages
 }
 
 .server-version-wrapper {
-  padding: 10px 0px;
+  padding: 10px 16px;
   flex-grow: 1;
+  border-left: 1px solid #DDDDDD
 }
 
 #tooltip-time {


### PR DESCRIPTION
# Changes

- revert styles
- declare `!= false` for pages to show readtime

# Description
Fixing a bug that occurred in #6460 for disabling read time

# Considerations
If we want to disable the read time for a page, we have to add the `readtime: false` variable and value to the front matter
<img width="419" alt="Screen Shot 2022-03-03 at 3 43 27 PM" src="https://user-images.githubusercontent.com/57234605/156657764-9ca9a565-4c47-4575-855d-1b30162159ef.png">

