### PR TITLE
Update security.md

### DIFF
--- a/jekyll/_cci2/security.md
+++ b/jekyll/_cci2/security.md
@@ -73,6 +73,8 @@ Complete Audit logs may be downloaded from the Audit Log page within the Admin s
 
 **Note:** In some situations, the internal machinery may generate duplicate events in the audit logs. The `id` field of the downloaded logs is unique per event and can be used to identify duplicate entries.
 
+Per [our data retention policy](https://circleci.com/privacy/#information) audit logs can be retrieved for up to 12 months. 
+
 ### Audit log events
 {: #audit-log-events }
 {:.no_toc}

--- a/jekyll/_cci2/security.md
+++ b/jekyll/_cci2/security.md
@@ -73,7 +73,7 @@ Complete Audit logs may be downloaded from the Audit Log page within the Admin s
 
 **Note:** In some situations, the internal machinery may generate duplicate events in the audit logs. The `id` field of the downloaded logs is unique per event and can be used to identify duplicate entries.
 
-Per [our data retention policy](https://circleci.com/privacy/#information) audit logs can be retrieved for up to 12 months. 
+Per [our data retention policy](https://circleci.com/privacy/#information), audit logs can be retrieved for up to 12 months. 
 
 ### Audit log events
 {: #audit-log-events }


### PR DESCRIPTION
We now only support retrieving audit logs for up to 12 months.

# Description
Updated docs to communicate policy that we only support retrieval of audit logs for up to 1 year. 

# Reasons
Previously we supported retrieval of audit logs indefinitely. Due to a change in how/where we store this data, audit logs are now only supported for up to 1 year. 