### PR TITLE
add server-specific orb author guide

### DIFF
--- a/jekyll/_cci2/orb-author-intro.md
+++ b/jekyll/_cci2/orb-author-intro.md
@@ -7,6 +7,7 @@ categories: [getting-started]
 order: 1
 version:
 - Cloud
+- Server v3.x
 ---
 
 * TOC
@@ -57,7 +58,7 @@ Orb CLI commands are scoped to different user permission levels, set by your VCS
 
 Every organization registered on CircleCI is able to claim **one** unique [namespace]({{site.baseurl}}/2.0/orb-concepts/#namespaces). This includes your personal organization and any organization you are a member of. As each organization or user account is limited to a single namespace, in order to register the namespace for an organization you must be the _owner_ of the organization.
 
-_note: Within CircleCI, we sometimes refer to individual users as "organizations" or "personal organizations", since from our perspective there aren't notable differences. Hence some commands refer to an `org-name`. This can simply be your GitHub username._
+**Note:** Within CircleCI, we sometimes refer to individual users as "organizations" or "personal organizations", since from our perspective there aren't notable differences. Hence some commands refer to an `org-name`. This can simply be your GitHub username.
 
 Enter the following command to claim your namespace, if you have not yet claimed one:
 ```shell
@@ -69,8 +70,8 @@ where `name` is the namespace you wish to claim, `vcs-type` is the type of your 
 ### Next steps
 {: #next-steps }
 
-Continue on to the  [Orb Authoring Process]({{site.baseurl}}/2.0/orb-author/) guide for information on developing your orb.
-
+* Continue on to the  [Orb Authoring Process]({{site.baseurl}}/2.0/orb-author/) guide for information on developing your orb.
+* If you are developing orbs or use on an installtaion on CircleCI server, read the [Orb Authoring Process on Server]({{site.baseurl}}/2.0/orb-author-server/) guide for information on developing your orb.
 
 ## See also
 {: #see-also }

--- a/jekyll/_cci2/orb-author-intro.md
+++ b/jekyll/_cci2/orb-author-intro.md
@@ -67,16 +67,9 @@ circleci namespace create <name> <vcs-type> <org-name> [flags]
 
 where `name` is the namespace you wish to claim, `vcs-type` is the type of your version control system (i.e. `github` or `bitbucket`), and `org-name` is the name of your organization.
 
-### Next steps
+## Next steps
 {: #next-steps }
 
 * Continue on to the  [Orb Authoring Process]({{site.baseurl}}/2.0/orb-author/) guide for information on developing your orb.
 * If you are developing orbs or use on an installtaion on CircleCI server, read the [Orb Authoring Process on Server]({{site.baseurl}}/2.0/orb-author-server/) guide for information on developing your orb.
-
-## See also
-{: #see-also }
-{:.no_toc}
-
-- [Orb Authoring]({{site.baseurl}}/2.0/orb-author/)
-- [Orb Concepts]({{site.baseurl}}/2.0/orb-concepts/)
-- [Orb Author FAQ]({{site.baseurl}}/2.0/orb-author-faq/)
+* Alternatively, to find out more about orbs read the [Orb Concepts]({{site.baseurl}}/2.0/orb-concepts/) page.

--- a/jekyll/_cci2/orb-author-intro.md
+++ b/jekyll/_cci2/orb-author-intro.md
@@ -71,5 +71,5 @@ where `name` is the namespace you wish to claim, `vcs-type` is the type of your 
 {: #next-steps }
 
 * Continue on to the  [Orb Authoring Process]({{site.baseurl}}/2.0/orb-author/) guide for information on developing your orb.
-* If you are developing orbs or use on an installtaion on CircleCI server, read the [Orb Authoring Process on Server]({{site.baseurl}}/2.0/orb-author-server/) guide for information on developing your orb.
+* If you are developing orbs or use on an installation on CircleCI server, read the [Orb Authoring Process on Server]({{site.baseurl}}/2.0/orb-author-server/) guide for information on developing your orb.
 * Alternatively, to find out more about orbs read the [Orb Concepts]({{site.baseurl}}/2.0/orb-concepts/) page.

--- a/jekyll/_cci2/orb-author-intro.md
+++ b/jekyll/_cci2/orb-author-intro.md
@@ -58,7 +58,7 @@ Orb CLI commands are scoped to different user permission levels, set by your VCS
 
 Every organization registered on CircleCI is able to claim **one** unique [namespace]({{site.baseurl}}/2.0/orb-concepts/#namespaces). This includes your personal organization and any organization you are a member of. As each organization or user account is limited to a single namespace, in order to register the namespace for an organization you must be the _owner_ of the organization.
 
-**Note:** Within CircleCI, we sometimes refer to individual users as "organizations" or "personal organizations", since from our perspective there aren't notable differences. Hence some commands refer to an `org-name`. This can simply be your GitHub username.
+**Note:** Within CircleCI, we sometimes refer to individual users as "organizations" or "personal organizations", since from our perspective there are no notable differences. Hence, some commands refer to an `org-name`. This can simply be your GitHub or Bitbucket username.
 
 Enter the following command to claim your namespace, if you have not yet claimed one:
 ```shell

--- a/jekyll/_cci2/orb-author-server.md
+++ b/jekyll/_cci2/orb-author-server.md
@@ -51,11 +51,11 @@ The name of your repository is not critical, but we recommend something similar 
 To initialize a **[public]({{site.baseurl}}/2.0/orb-intro/#public-orbs)** orb:
 <!---->
 ```shell
-circleci orb init /path/to/myProject-orb
+circleci orb init /path/to/myProject-orb --host <your-server-hostname>
 ```
 To initialize a **[private]({{site.baseurl}}/2.0/orb-intro/#private-orbs)** orb:
 ```shell
-circleci orb init /path/to/myProject-orb --private
+circleci orb init /path/to/myProject-orb --private --host <your-server-hostname>
 ```
 <!---->
     Once an orb is initialized, it **cannot be switched from public to private or vice versa**. Please make sure to add the `--private` flag if you intend to create a private orb.
@@ -334,12 +334,12 @@ List your available orbs using the CLI:
 
 To list **[public]({{site.baseurl}}/2.0/orb-intro/#public-orbs)** orbs:
 ```shell
-circleci orb list <my-namespace>
+circleci orb list <my-namespace> --host <your-server-hostname>
 ```
 
 To list **[private]({{site.baseurl}}/2.0/orb-intro/#private-orbs)** orbs:
 ```shell
-circleci orb list <my-namespace> --private
+circleci orb list <my-namespace> --private --host <your-server-hostname>
 ```
 
 For more information on how to use the `circleci orb` command, see the CLI [documentation](https://circleci-public.github.io/circleci-cli/circleci_orb.html).

--- a/jekyll/_cci2/orb-author-server.md
+++ b/jekyll/_cci2/orb-author-server.md
@@ -31,11 +31,11 @@ The orb development kit refers to a suite of tools that work together to simplif
 ### Getting started
 {: #getting-started }
 
-**Note:** While the outlined process below only mentions GitHub, the development kit also works with Bitbucket repositories.
-
 To begin creating your new orb with the orb development kit, follow these steps. The starting point is creating a new repository on [GitHub.com](https://github.com).
 
 Ensure the organization on GitHub is the owner for the [CircleCI namespace]({{site.baseurl}}/2.0/orb-concepts/#namespaces) for which you are developing your orb. If this is your own personal organization and namespace, you need not worry.
+
+Providing a local repository location using the `--host` option allows you to access your local server orbs, rather than public cloud orbs. For example, if your server installation is located at `\http://circleci.somehostname.com`, then you can run orb commands local to that orb repository by passing `--host \http://cirlceci.somehostname.com`.
 
 1. **Create a new [GitHub repository](https://github.com/new).**
 <br>
@@ -51,11 +51,11 @@ The name of your repository is not critical, but we recommend something similar 
 To initialize a **[public]({{site.baseurl}}/2.0/orb-intro/#public-orbs)** orb:
 <!---->
 ```shell
-circleci orb init /path/to/myProject-orb --host <your-server-hostname>
+circleci orb init /path/to/myProject-orb --host <your-server-installation-domain>
 ```
 To initialize a **[private]({{site.baseurl}}/2.0/orb-intro/#private-orbs)** orb:
 ```shell
-circleci orb init /path/to/myProject-orb --private --host <your-server-hostname>
+circleci orb init /path/to/myProject-orb --private --host <your-server-installation-domain>
 ```
 <!---->
     Once an orb is initialized, it **cannot be switched from public to private or vice versa**. Please make sure to add the `--private` flag if you intend to create a private orb.

--- a/jekyll/_cci2/orb-author-server.md
+++ b/jekyll/_cci2/orb-author-server.md
@@ -1,0 +1,345 @@
+---
+layout: classic-docs
+title: "Orb Authoring Process for Server"
+description: "Starting point for authoring CircleCI orbs for server."
+categories: [getting-started]
+order: 1
+version:
+- Server v3.x
+---
+
+* TOC
+{:toc}
+
+## Introduction
+{: #introduction }
+
+This orb authoring guide assumes you have read the [Introduction to orbs]({{site.baseurl}}/2.0/orb-intro) document, the [Introduction to authoring an orb]({{site.baseurl}}/2.0/orb-author-intro) document, and claimed your namespace. At this point you are ready to develop an orb.
+
+Whether you are writing your first orb or getting ready for production level, we recommend using our [orb development kit](#orb-development-kit) to get started. Alternatively, as orbs are packages of [reusable configuration]({{site.baseurl}}/2.0/reusing-config), they can be written [manually]({{site.baseurl}}/2.0/orb-author-validate-publish), as singular `yaml` files, and published using our [circleci orb cli]({{site.baseurl}}/2.0/local-cli/#installation).
+
+## Orb Development Kit
+{: #orb-development-kit }
+
+The orb development kit refers to a suite of tools that work together to simplify the orb development process, with automatic testing and deployment on CircleCI. The orb development kit is made up of the following components:
+
+* [Orb Project Template](https://github.com/CircleCI-Public/Orb-Project-Template)
+* [Orb Pack]({{site.baseurl}}/2.0/orb-concepts/#orb-packing)
+* [Orb Init](https://circleci-public.github.io/circleci-cli/circleci_orb_init.html)
+* [Orb Tools Orb](https://circleci.com/developer/orbs/orb/circleci/orb-tools)
+
+### Getting started
+{: #getting-started }
+
+**Note:** While the outlined process below only mentions GitHub, the development kit also works with Bitbucket repositories.
+
+To begin creating your new orb with the orb development kit, follow these steps. The starting point is creating a new repository on [GitHub.com](https://github.com).
+
+Ensure the organization on GitHub is the owner for the [CircleCI namespace]({{site.baseurl}}/2.0/orb-concepts/#namespaces) for which you are developing your orb. If this is your own personal organization and namespace, you need not worry.
+
+1. **Create a new [GitHub repository](https://github.com/new).**
+<br>
+The name of your repository is not critical, but we recommend something similar to "myProject-orb". ![Orb Registry]({{site.baseurl}}/assets/img/docs/new_orb_repo_gh.png)
+
+    When complete, you will be brought to a page confirming your new repository and you should see the generated git URL. Write down the git URL, you will need it in step 4. You can select SSH or HTTPS, which ever you can authenticate with. ![Orb Registry]({{site.baseurl}}/assets/img/docs/github_new_quick_setup.png)
+
+    **Note:** While you must create a local directory for your orb before initializing, it is not necessary to pull down the orb repository. This process will be completed in the `orb init` process and pulling the repository beforehand will cause issues.
+    {: class="alert alert-warning"}
+
+1. **Open a terminal and initialize your new orb project using the `orb init` CLI command.** **If you are using CircleCI server, you should ensure the `--private` flag is used here to keep your orbs private within your installation.**
+<br>
+To initialize a **[public]({{site.baseurl}}/2.0/orb-intro/#public-orbs)** orb:
+<!---->
+```shell
+circleci orb init /path/to/myProject-orb
+```
+To initialize a **[private]({{site.baseurl}}/2.0/orb-intro/#private-orbs)** orb:
+```shell
+circleci orb init /path/to/myProject-orb --private
+```
+<!---->
+    Once an orb is initialized, it **cannot be switched from public to private or vice versa**. Please make sure to add the `--private` flag if you intend to create a private orb.
+
+    The `circleci orb init` command is called, followed by a path that will be created and initialized for our orb project. It is best practice to use the same name for this directory and the git project repo.
+
+1. **Choose the fully automated orb setup option.**
+<br>
+<!---->
+```shell
+  ? Would you like to perform an automated setup of this orb?:
+      ▸ Yes, walk me through the process.
+  No, I'll handle everything myself.
+```
+<!---->
+    When choosing the manual option, see [Manual Orb Authoring Process]({{site.baseurl}}/2.0/orb-author-validate-publish/) for instructions on how to publish your orb.
+
+    When choosing the fully automated option, the [Orb-Project-Template](https://github.com/CircleCI-Public/Orb-Project-Template) will be downloaded and automatically modified with your customized settings. The project will be followed on CircleCI with an automated CI/CD pipeline included.
+
+    For more information on the included CI/CD pipeline, see the [Orb Publishing Process]({{site.baseurl}}/2.0/creating-orbs/) documentation.
+
+    Alternatively, if you would simply like a convenient way of downloading the [Orb-Project-Template](https://github.com/CircleCI-Public/Orb-Project-Template) you can opt to handle everything yourself.
+
+1. **Answer questions to configure and set up your orb.**
+<br>
+    In the background, the `orb init` command will be copying and customizing the [Orb Project Template](https://github.com/CircleCI-Public/Orb-Project-Template) based on your inputs. There are detailed `README.md` files within each directory that contain helpful information specific to the contents of each directory. You will also be asked for the remote git repository URL that you obtained back in step 1.
+
+    The [Orb Project Template](https://github.com/CircleCI-Public/Orb-Project-Template) contains a full CI/CD pipeline (described in [Orb Publishing Process]({{site.baseurl}}/2.0/creating-orbs/)) which automatically [packs]({{site.baseurl}}/2.0/orb-concepts/#orb-packing), [tests]({{site.baseurl}}/2.0/testing-orbs/), and publishes your orb.
+
+    In the setup process you will be asked if you would like to save your [Personal API Token]({{site.baseurl}}/2.0/managing-api-tokens/) into an `orb-publishing` [context]({{site.baseurl}}/2.0/contexts/). Saving this token is necessary for publishing development and production versions of your orb.
+
+    **Ensure the context is restricted**
+    <br/>
+    Restrict a context by navigating to _Organization Settings > Contexts_.
+    <br/><br/>
+    After completing your orb, you should see a new context called `orb-publishing`. Click into `orb-publishing` and add a _Security Group_. Use Security Groups to limit access to users that are allowed to trigger jobs. Only these users will have access to the private [Personal API Token]({{site.baseurl}}/2.0/managing-api-tokens/).
+    <br/><br/>
+    For more information, see the [Contexts]({{site.baseurl}}/2.0/contexts/#restricting-a-context) guide.
+    {: class="alert alert-warning"}
+
+1. **Push the changes up to Github.**
+<br>
+    During the setup process, the `orb init` command takes steps to prepare your automated orb development pipeline. The modified template code produced by the CLI must be pushed to the repository before the CLI can continue and automatically follow your project on circleci.com. Run the following command from a separate terminal when prompted to do so, substituting the name of your default branch:
+    ```shell
+    git push origin <default-branch>
+    ```
+    Once complete, return to your terminal and confirm the changes have been pushed.
+
+1. **Complete and write your orb.**
+<br>
+    The CLI will finish by automatically following your new orb project on CircleCI and generating the first development version `<namespace>/<orb>@dev:alpha` for testing (a hello-world sample).
+
+    You will be provided with a link to the project building on CircleCI where you can view the validation, packing, testing, and publication process.
+    You should also see the CLI has automatically migrated you into a new development branch, named `alpha`.
+
+    From your new branch you are now ready to make and push changes. From this point on, on every commit, your orb will be packed, validated, tested (optional), and can be published.
+
+    When you are ready to deploy the first major version of your orb, find information on deploying changes with semver versioning in the [Orb Publishing Process]({{site.baseurl}}/2.0/creating-orbs/) guide.
+
+### Writing your orb
+{: #writing-your-orb }
+
+Before you begin working on your orb, ensure you are on a non-default branch. We typically recommend starting your orb on the `alpha` branch.
+
+```shell
+$ git branch
+
+* alpha
+  main
+```
+
+If you have run the `circleci orb init` command, you will automatically be in the `alpha` branch and have a repository with `.circleci` and `src` directories.
+
+**_Example: Orb Project Structure_**
+
+| type | name|
+| --- | --- |
+| <i class="fa fa-folder" aria-hidden="true"></i> | [.circleci](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/.circleci) |
+| <i class="fa fa-folder" aria-hidden="true"></i> | [.github](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/.github) |
+| <i class="fa fa-folder" aria-hidden="true"></i> | [src](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/src) |
+| <i class="fa fa-file-text-o" aria-hidden="true"></i> | [.gitignore](https://github.com/CircleCI-Public/Orb-Project-Template/blob/master/.gitignore) |
+| <i class="fa fa-file-text-o" aria-hidden="true"></i> | [CHANGELOG.md](https://github.com/CircleCI-Public/Orb-Project-Template/blob/master/CHANGELOG.md) |
+| <i class="fa fa-file-text-o" aria-hidden="true"></i> | [LICENSE](https://github.com/CircleCI-Public/Orb-Project-Template/blob/master/LICENSE) |
+| <i class="fa fa-file-text-o" aria-hidden="true"></i> | [README.md](https://github.com/CircleCI-Public/Orb-Project-Template/blob/master/README.md) |
+{: class="table table-striped"}
+
+#### Orb source
+{: #orb-source }
+
+Navigate to the `src` directory to look at the included sections.
+
+**_Example: Orb Project "src" Directory_**
+
+| type | name|
+| --- | --- |
+| <i class="fa fa-folder" aria-hidden="true"></i> | [commands](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/src/commands) |
+| <i class="fa fa-folder" aria-hidden="true"></i> | [examples](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/src/examples) |
+| <i class="fa fa-folder" aria-hidden="true"></i> | [executors](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/src/executors) |
+| <i class="fa fa-folder" aria-hidden="true"></i> | [jobs](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/src/jobs) |
+| <i class="fa fa-file-text-o" aria-hidden="true"></i>| [@orb.yml](https://github.com/CircleCI-Public/Orb-Project-Template/blob/master/src/%40orb.yml) |
+{: class="table table-striped"}
+
+The directories listed above represent orb components that can be included with your orb. @orb.yml acts as the root of your orb. You may additionally see [`scripts`](#scripts) and [`tests`](#testing-orbs) directories in your project for optional orb development enhancements, which we will cover in the [Scripts](#scripts) section and the [Orb Testing Methodologies]({{site.baseurl}}/2.0/testing-orbs/) guide.
+
+Each directory within `src` corresponds with a [reusable configuration]({{site.baseurl}}/2.0/reusing-config) component type, which can be added or removed from the orb. If, for example, your orb does not require any `executors` or `jobs`, these directories can be deleted.
+
+##### @orb.yml
+{: #orbyml }
+{:.no_toc}
+
+@orb.yml acts as the "root" to your orb project and contains the config version, the orb description, the display key, and imports any additional orbs if needed.
+
+Use the `display` key to add clickable links to the orb registry for both your `home_url` (the home of the product or service), and `source_url` (the git repository URL).
+
+```yaml
+version: 2.1
+
+description: >
+  Sample orb description
+
+display:
+  home_url: "https://www.website.com/docs"
+  source_url: "https://www.github.com/EXAMPLE_ORG/EXAMPLE_PROJECT"
+```
+
+##### Commands
+{: #commands }
+{:.no_toc}
+
+Author and add [Reusable Commands]({{site.baseurl}}/2.0/reusing-config/#authoring-reusable-commands) to the `src/commands` directory. Each _YAML_ file within this directory will be treated as an orb command, with a name which matches its filename.
+
+Below is the _[greet.yml](https://github.com/CircleCI-Public/Orb-Project-Template/blob/master/src/commands/greet.yml)_ command example from the [Orb Project Template](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/src).
+
+```yaml
+description: >
+  # What will this command do?
+  # Descriptions should be short, simple, and clear.
+parameters:
+  greeting:
+    type: string
+    default: "Hello"
+    description: "Select a proper greeting"
+steps:
+  - run:
+      name: Hello World
+      command: echo << parameters.greeting >> world
+```
+
+##### Examples
+{: #examples }
+{:.no_toc}
+
+Author and add [Usage Examples]({{site.baseurl}}/2.0/orb-concepts/#usage-examples) to the `src/examples` directory. Usage Examples are not for use directly by end users in their project configs, but they provide a way for you, the orb developer, to share use-case specific examples on the [Orb Registry](https://circleci.com/developer/orbs) for users to reference.
+
+Each _YAML_ file within this directory will be treated as an orb usage example, with a name which matches its filename.
+
+View a full example from the [Orb Project Template](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/src/examples).
+
+##### Executors
+{: #executors }
+{:.no_toc}
+
+Author and add [Parameterized Executors]({{site.baseurl}}/2.0/reusing-config/#authoring-reusable-executors) to the `src/executors` directory.
+
+Each _YAML_ file within this directory will be treated as an orb executor, with a name that matches its filename.
+
+View a full example from the [Orb Project Template](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/src/executors).
+
+##### Jobs
+{: #jobs }
+{:.no_toc}
+
+Author and add [Parameterized Jobs]({{site.baseurl}}/2.0/reusing-config/#authoring-parameterized-jobs) to the `src/jobs` directory.
+
+Each _YAML_ file within this directory will be treated as an orb job, with a name that matches its filename.
+
+Jobs can include orb commands and other steps to fully automate tasks with minimal user configuration.
+
+View the _[hello.yml](https://github.com/CircleCI-Public/Orb-Project-Template/blob/master/src/jobs/hello.yml)_ job example from the [Orb Project Template](https://github.com/CircleCI-Public/Orb-Project-Template/tree/master/src/jobs).
+
+```yaml
+description: >
+  # What will this job do?
+  # Descriptions should be short, simple, and clear.
+
+docker:
+  - image: cimg/base:stable
+parameters:
+  greeting:
+    type: string
+    default: "Hello"
+    description: "Select a proper greeting"
+steps:
+  - greet:
+      greeting: "<< parameters.greeting >>"
+```
+
+#### Scripts
+{: #scripts }
+
+One of the major benefits of the orb development kit is a script inclusion feature. When using the `circleci orb pack` command (automated when using the orb development kit), you can use the value `<<include(file)>>` within your orb config code, for any key, to include the file contents directly in the orb.
+
+This is especially useful when writing complex orb commands, which might contain a lot of _bash_ code, _(although you could use python too!)_.
+
+{:.tab.scripts.Orb_Development_Kit_Packing}
+```yaml
+parameters:
+  to:
+    type: string
+    default: "World"
+    description: "Hello to whom?"
+steps:
+  - run:
+      environment:
+        PARAM_TO: <<parameters.to>>
+      name: Hello Greeting
+      command: <<include(scripts/greet.sh)>>
+```
+
+{:.tab.scripts.Standard_YAML_Config}
+```yaml
+parameters:
+  to:
+    type: string
+    default: "World"
+    description: "Hello to whom?"
+steps:
+  - run:
+      name: Hello Greeting
+      command: echo "Hello <<parameters.to>>"
+```
+
+##### Why include scripts?
+{: #why-include-scripts }
+{:.no_toc}
+
+CircleCI configuration is written in `YAML`. Logical code such as `bash` can be encapsulated and executed on CircleCI through `YAML`, but, for developers, it is not convenient to write and test programmatic code within a non-executable format. Also, parameters can become cumbersome in more complex scripts as the `<<parameter>>` syntax is a CircleCI native YAML enhancement, and not something that can be interpreted and executed locally.
+
+Using the orb development kit and the `<<include(file)>>` syntax, you can import existing scripts into your orb, locally execute and test your orb scripts, and even utilize true testing frameworks for your code.
+
+##### Using parameters with scripts
+{: #using-parameters-with-scripts }
+{:.no_toc}
+
+To keep your scripts portable and locally executable, it is best practice to expect a set of environment variables within your scripts and set them at the config level. The `greet.sh` file, which was included with the special `<<include(file)>>` syntax above in our `greet.yml` command file, looks like this:
+
+```shell
+echo Hello "${PARAM_TO}"
+```
+
+This way, you can both mock and test your scripts locally.
+
+### Testing orbs
+{: #testing-orbs }
+
+Much like any other software, there are multiple ways to test your code and it is entirely up to you as the developer to implement as many tests as desired. Within your config file right now there will be a job named [integration-test-1](https://github.com/CircleCI-Public/Orb-Project-Template/blob/96c5d2798114fffe7903e2f5c9f021023993f338/.circleci/config.yml#L27) that will need to be updated to test your orb components. This is a type of _integration testing_. Unit testing with orbs is possible as well.
+
+Read our full [Orb Testing Methodologies]({{site.baseurl}}/2.0/testing-orbs/) documentation.
+
+### Keeping a changelog
+{: #keeping-a-changelog }
+
+Deciphering the difference between two versions of an orb can prove tricky. Along with semantic versioning, we recommend leveraging a changelog to more clearly describe changes between versions. The orb template comes with the `CHANGELOG.md` file, which should be updated with each new version of your orb. The file uses the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+
+### Publishing your orb
+{: #publishing-your-orb }
+
+With the orb development kit, a fully automated CI/CD pipeline is automatically configured within `.circleci/config.yml`. This configuration makes it simple to automatically deploy semantically versioned releases of your orbs.
+
+For more information, see the [Orb Publishing Process]({{site.baseurl}}/2.0/creating-orbs/) guide.
+
+### Listing your orbs
+{: #listing-your-orbs }
+
+List your available orbs using the CLI:
+
+To list **[public]({{site.baseurl}}/2.0/orb-intro/#public-orbs)** orbs:
+```shell
+circleci orb list <my-namespace>
+```
+
+To list **[private]({{site.baseurl}}/2.0/orb-intro/#private-orbs)** orbs:
+```shell
+circleci orb list <my-namespace> --private
+```
+
+For more information on how to use the `circleci orb` command, see the CLI [documentation](https://circleci-public.github.io/circleci-cli/circleci_orb.html).

--- a/jekyll/_cci2/orb-author-server.md
+++ b/jekyll/_cci2/orb-author-server.md
@@ -98,7 +98,7 @@ circleci orb init /path/to/myProject-orb --private --host <your-server-hostname>
 
 1. **Push the changes up to Github.**
 <br>
-    During the setup process, the `orb init` command takes steps to prepare your automated orb development pipeline. The modified template code produced by the CLI must be pushed to the repository before the CLI can continue and automatically follow your project on circleci.com. Run the following command from a separate terminal when prompted to do so, substituting the name of your default branch:
+    During the setup process, the `orb init` command takes steps to prepare your automated orb development pipeline. The modified template code produced by the CLI must be pushed to the repository before the CLI can continue and automatically follow your project on circleCI.com. Run the following command from a separate terminal when prompted to do so, substituting the name of your default branch:
     ```shell
     git push origin <default-branch>
     ```
@@ -343,3 +343,8 @@ circleci orb list <my-namespace> --private --host <your-server-hostname>
 ```
 
 For more information on how to use the `circleci orb` command, see the CLI [documentation](https://circleci-public.github.io/circleci-cli/circleci_orb.html).
+
+## Next steps
+{: #next-steps }
+
+* Find out about managing orbs for server in the [Managing Orbs]({{site.baseurl}}/2.0/server-3-operator-orbs/) guide guide.

--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -7,6 +7,7 @@ categories: [getting-started]
 order: 1
 verison:
 - Cloud
+- Server v3.x
 ---
 
 * TOC

--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -7,6 +7,7 @@ categories: [getting-started]
 order: 1
 version:
 - Cloud
+- Server v3.x
 ---
 
 * TOC

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -7,6 +7,7 @@ categories: [getting-started]
 order: 1
 version:
 - Cloud
+- Server v3.x
 ---
 
 * TOC

--- a/jekyll/_cci2/server-3-operator-orbs.adoc
+++ b/jekyll/_cci2/server-3-operator-orbs.adoc
@@ -33,15 +33,18 @@ circleci orb list
 ```
 
 To list available private orbs (registered in your local server orb repository), run the following command:
+
 ```bash
-circleci orb list --host <your server install domain> --token <your api token>
+circleci orb list --host <your-server-install-domain> --token <your-api-token>
 ```
 ## Import a public orb
 To import a public orb to your local server orb repository, run the following command:
 
 ```bash
-circleci admin import-orb ns[orb[@version]] --host <your server installation domain> --token <your api token>
+circleci admin import-orb <namespace>[<orb-name>[@<orb-version>]] --host <your-server-installation-domain> --token <your-api-token>
 ```
+
+NOTE: you can choose to only specify a namespace, in which case the most recent versions of all orbs in the namespace will be imported.
 
 ## Fetch a public orb’s updates
 To update a public orb in your local server orb repository with a new version, run:

--- a/jekyll/_cci2/server-3-operator-orbs.adoc
+++ b/jekyll/_cci2/server-3-operator-orbs.adoc
@@ -3,7 +3,7 @@ version:
 - Server v3.x
 - Server Admin
 ---
-= CircleCI Server v3.x Orbs
+= CircleCI Server v3.x Managing Orbs
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Use this document to learn about orbs and how to manage them within CircleCI server v3.x.

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -389,7 +389,7 @@ en:
           link: 2.0/server-3-operator-proxy
         - name: User Accounts
           link: 2.0/server-3-operator-user-accounts
-        - name: Orbs
+        - name: Managing Orbs
           link: 2.0/server-3-operator-orbs
         - name: VM Service
           link: 2.0/server-3-operator-vm-service

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -211,6 +211,8 @@ en:
           link: 2.0/orb-author-intro/
         - name: Author an Orb
           link: 2.0/orb-author/
+        - name: Author an Orb for Server
+          link: 2.0/orb-author-server/
         - name: Orb Author FAQ
           link: 2.0/orb-author-faq/
         - name: Orb Authoring Best Practices


### PR DESCRIPTION
The current orb authoring guide talks about categorising orbs, which is not available for server customers. Creating a separate guide to avoid confusion.