### PR TITLE
Clear up language around different orb types

### DIFF
--- a/jekyll/_cci2/code-coverage.md
+++ b/jekyll/_cci2/code-coverage.md
@@ -678,7 +678,9 @@ jobs:
 ### Codecov
 {: #codecov }
 
-Codecov has an [orb](https://circleci.com/orbs) to help make uploading your coverage report easy.
+Codecov has an [orb](https://circleci.com/developer/orbs/orb/codecov/codecov) to help simplify the process of uploading your coverage reports. 
+
+**Note:** The Codecov orb is a Partner orb, and so uncertified orbs need to be alled for your organisation in order to use it. This setting is available at **Organization Settings > Security** in the CircleCI web app.
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/code-coverage.md
+++ b/jekyll/_cci2/code-coverage.md
@@ -680,7 +680,7 @@ jobs:
 
 Codecov has an [orb](https://circleci.com/developer/orbs/orb/codecov/codecov) to help simplify the process of uploading your coverage reports. 
 
-**Note:** The Codecov orb is a Partner orb. You or your organization admin will need to opt-in to using uncertified orbs in order to use it. This setting is available at **Organization Settings > Security** in the CircleCI web app.
+**Note:** The Codecov orb is a Partner orb. You or your organization admin will need to opt in to using uncertified orbs in order to use it. This setting is available at **Organization Settings > Security** in the CircleCI web app.
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/code-coverage.md
+++ b/jekyll/_cci2/code-coverage.md
@@ -680,7 +680,7 @@ jobs:
 
 Codecov has an [orb](https://circleci.com/developer/orbs/orb/codecov/codecov) to help simplify the process of uploading your coverage reports. 
 
-**Note:** The Codecov orb is a Partner orb, and so uncertified orbs need to be alled for your organisation in order to use it. This setting is available at **Organization Settings > Security** in the CircleCI web app.
+**Note:** The Codecov orb is a Partner orb. You or your organization admin will need to opt-in to using uncertified orbs in order to use it. This setting is available at **Organization Settings > Security** in the CircleCI web app.
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -14,45 +14,6 @@ verison:
 
 [CircleCI orbs](https://circleci.com/orbs/) are shareable packages of configuration elements, including [jobs]({{site.baseurl}}/2.0/reusing-config/#authoring-parameterized-jobs), [commands]({{site.baseurl}}/2.0/reusing-config/#authoring-reusable-commands), and [executors]({{site.baseurl}}/2.0/reusing-config/#authoring-reusable-executors). Orbs make writing and customizing CircleCI config simple. The reusable configuration elements used in orbs are explained fully in the [Reusable Configuration Reference]({{site.baseurl}}/2.0/reusing-config/).
 
-## Private orbs vs. public orbs
-{: #private-orbs-vs-public-orbs }
-
-There are two different types of orbs you can use in your configuration, depending on how you want to publish your orbs. If you prefer to publish your orb internally, and not to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), you will want to use a private orb. However, if you want to publish your orb to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), use a public orb. Each type of orb is described in the sections below.
-
-### Private orbs
-{: #private-orbs }
-
-
-**Note:** _Private orbs are available on any of our [plans listed on our plans page](https://circleci.com/pricing)._
-{: class="alert alert-warning"}
-
-Using a private orb enables you to author an orb while ensuring the following:
-
-* your orb does not appear in the CircleCI Orb Registry.
-
-* your orb cannot be viewed or used by someone outside of your organization.
-
-* your orb cannot be used in a pipeline that does not belong to your organization.
-
-By choosing to use a private orb instead of a public orb, you also need to understand certain limitations inherent in using private orbs, which include:
-
-* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, either paste the content of the orb into the "orbs" stanza of your configuration inline or use the `circleci config validate --org-slug <your-org-slug> <path/to/config.yml>` command to validate your configuration.
-
-* You cannot use private orbs from one organization in another organization's pipelines, regardless of the relationship between organizations. This means that even if you commit code and start a pipeline, and have the necessary membership in both organizations, you can use a private orb from your configuration file, but not from another orb.
-
-### Public orbs
-{: #public-orbs }
-
-Public orbs are used by most users when authoring and publishing orbs to the [CircleCI Orb Registry](https://circleci.com/developer/orbs). When authoring a public orb, you are enabling all  CircleCI users to use your orb in their own configurations.
-
-### Authoring orbs
-{: #authoring-orbs }
-
-Both public and private orbs can be authored in two ways:
-
-* Using the [Manual Orb Authoring Process](https://circleci.com/docs/2.0/orb-author-validate-publish/)
-* Using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit)  (recommended)
-
 ## Orb configuration elements
 {: #orb-configuration-elements }
 
@@ -282,6 +243,44 @@ _[See: Writing Inline Orbs]({{site.baseurl}}/2.0/reusing-config/#writing-inline-
 - Not accessible outside of the repository
 - Not public
 - Not accessible via CircleCI CLI
+
+## Private orbs vs. public orbs
+{: #private-orbs-vs-public-orbs }
+
+There are two ways to publish an orb: publin or private. If you prefer to publish your orb internally, and not to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), you will want to use a private orb. However, if you want to publish your orb to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), use a public orb. Each type of orb is described in the sections below.
+
+### Private orbs
+{: #private-orbs }
+
+**Note:** _Private orbs are available on any of our [plans listed on our plans page](https://circleci.com/pricing)._
+{: class="alert alert-warning"}
+
+Using a private orb enables you to author an orb while ensuring the following:
+
+* your orb does not appear in the CircleCI Orb Registry.
+
+* your orb cannot be viewed or used by someone outside of your organization.
+
+* your orb cannot be used in a pipeline that does not belong to your organization.
+
+By choosing to use a private orb instead of a public orb, you also need to understand certain limitations inherent in using private orbs, which include:
+
+* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, either paste the content of the orb into the "orbs" stanza of your configuration inline or use the `circleci config validate --org-slug <your-org-slug> <path/to/config.yml>` command to validate your configuration.
+
+* You cannot use private orbs from one organization in another organization's pipelines, regardless of the relationship between organizations. This means that even if you commit code and start a pipeline, and have the necessary membership in both organizations, you can use a private orb from your configuration file, but not from another orb.
+
+### Public orbs
+{: #public-orbs }
+
+Public orbs are used by most users when authoring and publishing orbs to the [CircleCI Orb Registry](https://circleci.com/developer/orbs). When authoring a public orb, you are enabling all  CircleCI users to use your orb in their own configurations.
+
+### Authoring orbs
+{: #authoring-orbs }
+
+Both public and private orbs can be authored in two ways:
+
+* Using the [Manual Orb Authoring Process](https://circleci.com/docs/2.0/orb-author-validate-publish/)
+* Using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit)  (recommended)
 
 ## Orb packing
 {: #orb-packing }

--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -12,11 +12,46 @@ verison:
 * TOC
 {:toc}
 
-## Quick start
-{: #quick-start }
-{:.no_toc}
-
 [CircleCI orbs](https://circleci.com/orbs/) are shareable packages of configuration elements, including [jobs]({{site.baseurl}}/2.0/reusing-config/#authoring-parameterized-jobs), [commands]({{site.baseurl}}/2.0/reusing-config/#authoring-reusable-commands), and [executors]({{site.baseurl}}/2.0/reusing-config/#authoring-reusable-executors). Orbs make writing and customizing CircleCI config simple. The reusable configuration elements used in orbs are explained fully in the [Reusable Configuration Reference]({{site.baseurl}}/2.0/reusing-config/).
+
+## Private orbs vs. public orbs
+{: #private-orbs-vs-public-orbs }
+
+There are two different types of orbs you can use in your configuration, depending on how you want to publish your orbs. If you prefer to publish your orb internally, and not to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), you will want to use a private orb. However, if you want to publish your orb to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), use a public orb. Each type of orb is described in the sections below.
+
+### Private orbs
+{: #private-orbs }
+
+
+**Note:** _Private orbs are available on any of our [plans listed on our plans page](https://circleci.com/pricing)._
+{: class="alert alert-warning"}
+
+Using a private orb enables you to author an orb while ensuring the following:
+
+* your orb does not appear in the CircleCI Orb Registry.
+
+* your orb cannot be viewed or used by someone outside of your organization.
+
+* your orb cannot be used in a pipeline that does not belong to your organization.
+
+By choosing to use a private orb instead of a public orb, you also need to understand certain limitations inherent in using private orbs, which include:
+
+* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, either paste the content of the orb into the "orbs" stanza of your configuration inline or use the `circleci config validate --org-slug <your-org-slug> <path/to/config.yml>` command to validate your configuration.
+
+* You cannot use private orbs from one organization in another organization's pipelines, regardless of the relationship between organizations. This means that even if you commit code and start a pipeline, and have the necessary membership in both organizations, you can use a private orb from your configuration file, but not from another orb.
+
+### Public orbs
+{: #public-orbs }
+
+Public orbs are used by most users when authoring and publishing orbs to the [CircleCI Orb Registry](https://circleci.com/developer/orbs). When authoring a public orb, you are enabling all  CircleCI users to use your orb in their own configurations.
+
+### Authoring orbs
+{: #authoring-orbs }
+
+Both public and private orbs can be authored in two ways:
+
+* Using the [Manual Orb Authoring Process](https://circleci.com/docs/2.0/orb-author-validate-publish/)
+* Using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit)  (recommended)
 
 ## Orb configuration elements
 {: #orb-configuration-elements }

--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -247,10 +247,10 @@ _[See: Writing Inline Orbs]({{site.baseurl}}/2.0/reusing-config/#writing-inline-
 ## Private orbs vs. public orbs
 {: #private-orbs-vs-public-orbs }
 
-There are two ways to publish an orb: public or private: 
+There are two ways to publish an orb: public or private:
 
-* If you prefer to publish your orb so that only those within your organization can see and use it, you should publish a private orb. 
-* If you want to publish your orb to the [CircleCI Orb Registry](https://circleci.com/developer/orbs) for use by anyone, create a public orb. 
+* If you prefer to publish your orb so that only those within your organization can see and use it, you should publish a private orb.
+* If you want to publish your orb to the [CircleCI Orb Registry](https://circleci.com/developer/orbs) for use by anyone, create a public orb.
 
 Private orbs are described in more detail below.
 
@@ -270,7 +270,7 @@ Using a private orb enables you to author an orb while ensuring the following:
 
 By choosing to use a private orb instead of a public orb, you also need to understand certain inherent limitations, which include:
 
-* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, use ond of the following options 
+* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, use ond of the following options:
 
     * Paste the content of the orb into the `orbs` stanza of your configuration.
     * Use the `circleci config validate --org-slug <your-org-slug> <path/to/config.yml>` command to validate your configuration. The org slug is defined as `<your-VCS>/<your-org-name>`, for example, `gh/circleci`.

--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -265,7 +265,7 @@ Using a private orb enables you to author an orb while ensuring the following:
 
 By choosing to use a private orb instead of a public orb, you also need to understand certain limitations inherent in using private orbs, which include:
 
-* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, either paste the content of the orb into the "orbs" stanza of your configuration inline or use the `circleci config validate --org-slug <your-org-slug> <path/to/config.yml>` command to validate your configuration.
+* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, either paste the content of the orb into the "orbs" stanza of your configuration inline or use the `circleci config validate --org-slug <your-org-slug> <path/to/config.yml>` command to validate your configuration. The org slug is defined as `<your-VCS>/<your-org-name>`, for example, `gh/circleci`.
 
 * You cannot use private orbs from one organization in another organization's pipelines, regardless of the relationship between organizations. This means that even if you commit code and start a pipeline, and have the necessary membership in both organizations, you can use a private orb from your configuration file, but not from another orb.
 

--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -247,7 +247,12 @@ _[See: Writing Inline Orbs]({{site.baseurl}}/2.0/reusing-config/#writing-inline-
 ## Private orbs vs. public orbs
 {: #private-orbs-vs-public-orbs }
 
-There are two ways to publish an orb: publin or private. If you prefer to publish your orb internally, and not to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), you will want to use a private orb. However, if you want to publish your orb to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), use a public orb. Each type of orb is described in the sections below.
+There are two ways to publish an orb: public or private: 
+
+* If you prefer to publish your orb so that only those within your organization can see and use it, you should publish a private orb. 
+* If you want to publish your orb to the [CircleCI Orb Registry](https://circleci.com/developer/orbs) for use by anyone, create a public orb. 
+
+Private orbs are described in more detail below.
 
 ### Private orbs
 {: #private-orbs }
@@ -257,22 +262,20 @@ There are two ways to publish an orb: publin or private. If you prefer to publis
 
 Using a private orb enables you to author an orb while ensuring the following:
 
-* your orb does not appear in the CircleCI Orb Registry.
+* Your orb will not appear in the [CircleCI Orb Registry](https://circleci.com/developer/orbs) unless you have the direct URL and are authenticated to the org that created it.
 
-* your orb cannot be viewed or used by someone outside of your organization.
+* Your orb cannot be viewed or used by someone outside of your organization.
 
-* your orb cannot be used in a pipeline that does not belong to your organization.
+* Your orb cannot be used in a pipeline that does not belong to your organization.
 
-By choosing to use a private orb instead of a public orb, you also need to understand certain limitations inherent in using private orbs, which include:
+By choosing to use a private orb instead of a public orb, you also need to understand certain inherent limitations, which include:
 
-* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, either paste the content of the orb into the "orbs" stanza of your configuration inline or use the `circleci config validate --org-slug <your-org-slug> <path/to/config.yml>` command to validate your configuration. The org slug is defined as `<your-VCS>/<your-org-name>`, for example, `gh/circleci`.
+* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, use ond of the following options 
+
+    * Paste the content of the orb into the `orbs` stanza of your configuration.
+    * Use the `circleci config validate --org-slug <your-org-slug> <path/to/config.yml>` command to validate your configuration. The org slug is defined as `<your-VCS>/<your-org-name>`, for example, `gh/circleci`.
 
 * You cannot use private orbs from one organization in another organization's pipelines, regardless of the relationship between organizations. This means that even if you commit code and start a pipeline, and have the necessary membership in both organizations, you can use a private orb from your configuration file, but not from another orb.
-
-### Public orbs
-{: #public-orbs }
-
-Public orbs are used by most users when authoring and publishing orbs to the [CircleCI Orb Registry](https://circleci.com/developer/orbs). When authoring a public orb, you are enabling all  CircleCI users to use your orb in their own configurations.
 
 ### Authoring orbs
 {: #authoring-orbs }

--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -262,7 +262,7 @@ Private orbs are described in more detail below.
 
 Using a private orb enables you to author an orb while ensuring the following:
 
-* Your orb will not appear in the [CircleCI Orb Registry](https://circleci.com/developer/orbs) unless you have the direct URL and are authenticated to the org that created it.
+* Your orb will not appear in the [CircleCI Orb Registry](https://circleci.com/developer/orbs) unless you have the direct URL and are authenticated with the org that created it.
 
 * Your orb cannot be viewed or used by someone outside of your organization.
 

--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -85,12 +85,16 @@ Orbs in the registry will appear with one of three different namespace designati
 | Community | Written by the community |
 {: class="table table-striped"}
 
-**Note:** _In order to use uncertified orbs, your organization’s administrator must opt-in to allow 3rd-party uncertified orb usage on the **Organization Settings > Security** page for your org._
+**Note:** _In order to use uncertified orbs (Partner or Community), your organization’s administrator must opt-in to allow uncertified orb usage on the **Organization Settings > Security** page for your org._
 {: class="alert alert-warning"}
 
 Each orb contains its own description and documentation listed in the orb registry. Often, orbs will have a set of usage examples to get you started.
 
 If you would like to contribute to an existing orb or file an issue on the orb's repository, many orb authors will include the git repository link.
+
+## Public or private
+{: #public-or-private }
+Orbs can be published publicly to the orb registy, for anyone to use, or privately, so only those within your organisaiton can use them. To understamd these concepts further read the [Public Orbs vs Private Orbs]({{site.baseurl}}/2.0/orb-concepts/#private-orbs-vs-public-orbs) section of the Orb Concepts page.
 
 ## Identifying orbs
 {: #identifying-orbs }

--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -85,7 +85,7 @@ Orbs in the registry will appear with one of three different namespace designati
 | Community | Written by the community |
 {: class="table table-striped"}
 
-**Note:** _In order to use uncertified orbs (Partner or Community), your organization’s administrator must opt-in to allow uncertified orb usage on the **Organization Settings > Security** page for your org._
+**Note:** _In order to use uncertified orbs (partner or community), your organization’s administrator must opt-in to allow uncertified orb usage on the **Organization Settings > Security** page for your org._
 {: class="alert alert-warning"}
 
 Each orb contains its own description and documentation listed in the orb registry. Often, orbs will have a set of usage examples to get you started.

--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -96,7 +96,7 @@ If you would like to contribute to an existing orb, or file an issue on the orb'
 {: #public-or-private }
 Orbs can be published in one of two ways:
 
-* **Publicly**: Searchable in orb registry, and available for anyone to use 
+* **Publicly**: Searchable in the orb registry, and available for anyone to use 
 * **Privately**: Only available to use within your organization, and only findable in the registry with a direct URL and when authenticated 
 
 To understand these concepts further read the [Public Orbs vs Private Orbs]({{site.baseurl}}/2.0/orb-concepts/#private-orbs-vs-public-orbs) section of the Orb Concepts page.

--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -90,11 +90,16 @@ Orbs in the registry will appear with one of three different namespace designati
 
 Each orb contains its own description and documentation listed in the orb registry. Often, orbs will have a set of usage examples to get you started.
 
-If you would like to contribute to an existing orb or file an issue on the orb's repository, many orb authors will include the git repository link.
+If you would like to contribute to an existing orb, or file an issue on the orb's repository, many orb authors will include the git repository link.
 
 ## Public or private
 {: #public-or-private }
-Orbs can be published publicly to the orb registy, for anyone to use, or privately, so only those within your organisaiton can use them. To understamd these concepts further read the [Public Orbs vs Private Orbs]({{site.baseurl}}/2.0/orb-concepts/#private-orbs-vs-public-orbs) section of the Orb Concepts page.
+Orbs can be published in one of two ways:
+
+* **Publicly**: Searchable in orb registry, and available for anyone to use 
+* **Privately**: Only available to use within your organization, and only findable in the registry with a direct URL and when authenticated 
+
+To understand these concepts further read the [Public Orbs vs Private Orbs]({{site.baseurl}}/2.0/orb-concepts/#private-orbs-vs-public-orbs) section of the Orb Concepts page.
 
 ## Identifying orbs
 {: #identifying-orbs }

--- a/jekyll/_cci2/orb-intro.md
+++ b/jekyll/_cci2/orb-intro.md
@@ -12,51 +12,9 @@ version:
 * TOC
 {:toc}
 
-## Quick start
-{: #quick-start }
-{:.no_toc}
-
 CircleCI orbs are open-source, shareable packages of parameterizable [reusable configuration]({{site.baseurl}}/2.0/reusing-config/) elements, including [jobs]({{site.baseurl}}/2.0/reusing-config/#authoring-parameterized-jobs), [commands]({{site.baseurl}}/2.0/reusing-config/#authoring-reusable-commands), and [executors]({{site.baseurl}}/2.0/reusing-config/#executor). Use orbs to reduce configuration complexity and help you integrate with your software and services stack quickly and easily across many projects.
 
 Published orbs can be found on our [Orb Registry](https://circleci.com/developer/orbs), or you can [author your own orb]({{site.baseurl}}/2.0/orb-author-intro/).
-
-## Private orbs vs. public orbs
-{: #private-orbs-vs-public-orbs }
-
-There are two different types of orbs you can use in your configuration, depending on how you want to publish your orbs. If you prefer to publish your orb internally, and not to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), you will want to use a private orb. However, if you want to publish your orb to the [CircleCI Orb Registry](https://circleci.com/developer/orbs), use a public orb. Each type of orb is described in the sections below.
-
-### Private orbs
-{: #private-orbs }
-
-
-**Note:** _Private orbs are available on any of our [plans listed on our plans page](https://circleci.com/pricing)._
-{: class="alert alert-warning"}
-
-Using a private orb enables you to author an orb while ensuring the following:
-
-* your orb does not appear in the CircleCI Orb Registry.
-
-* your orb cannot be viewed or used by someone outside of your organization.
-
-* your orb cannot be used in a pipeline that does not belong to your organization.
-
-By choosing to use a private orb instead of a public orb, you also need to understand certain limitations inherent in using private orbs, which include:
-
-* You will be unable to use the `circleci config validate` command to validate your configuration. You may, however, either paste the content of the orb into the "orbs" stanza of your configuration inline or use the `circleci config validate --org-slug <your-org-slug> <path/to/config.yml>` command to validate your configuration.
-
-* You cannot use private orbs from one organization in another organization's pipelines, regardless of the relationship between organizations. This means that even if you commit code and start a pipeline, and have the necessary membership in both organizations, you can use a private orb from your configuration file, but not from another orb.
-
-### Public orbs
-{: #public-orbs }
-
-Public orbs are used by most users when authoring and publishing orbs to the [CircleCI Orb Registry](https://circleci.com/developer/orbs). When authoring a public orb, you are enabling all  CircleCI users to use your orb in their own configurations.
-### Authoring orbs
-{: #authoring-orbs }
-
-Both public and private orbs can be authored in two ways:
-
-* Using the [Manual Orb Authoring Process](https://circleci.com/docs/2.0/orb-author-validate-publish/)
-* Using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit)  (recommended)
 
 ## Benefits of using orbs
 {: #benefits-of-using-orbs }


### PR DESCRIPTION
* clear up language around orb types - there are no 3rd party orbs,only Certified and Uncertified. And within Uncertified there are Partner and Community
* move descriptions of public and private orbs to the orbs concepts page
* make content accurate - private orbs can be viewed in the dev hub if you are logged in and have a direct URL
* general readability improvements
* add a note to codecov orb usage example to make people aware they need to opt-in to use uncertified orbs