### PR TITLE
add server 3 version of intro to nomad guide

### DIFF
--- a/jekyll/_cci2/features.md
+++ b/jekyll/_cci2/features.md
@@ -62,7 +62,7 @@ System Administrators are able to gather [metrics for monitoring]({{ site.baseur
 ### Nomad cluster
 {: #nomad-cluster }
 
-CircleCI uses Nomad as the primary job scheduler. Refer to the [basic introduction to Nomad]({{ site.baseurl }}/2.0/nomad/) for understanding how to operate the Nomad Cluster in your CircleCI server installation.
+CircleCI uses Nomad as the primary job scheduler. Refer to the [basic introduction to Nomad]({{ site.baseurl }}/2.0/server-3-operator-nomad/) for understanding how to operate the Nomad Cluster in your CircleCI server installation.
 
 ### APIs
 {: #apis }

--- a/jekyll/_cci2/server-3-operator-nomad.adoc
+++ b/jekyll/_cci2/server-3-operator-nomad.adoc
@@ -1,6 +1,6 @@
 ---
 version:
-- Server v2.x
+- Server v3.x
 - Server Admin
 ---
 = Introduction to Nomad Cluster Operation
@@ -32,14 +32,14 @@ image::nomad-diagram-v2.png[Diagram of the Nomad cluster]
 
 The following section is a basic guide to operating a Nomad cluster in your installation.
 
-The `nomad` CLI is installed in the Service instance. It is pre-configured to talk to the Nomad cluster, so it is possible to use the `nomad` command to run the following commands in this section.
+The `nomad` CLI is installed in the Nomad pod. It is pre-configured to talk to the Nomad cluster, so it is possible to use the `nomad` command to run the following commands in this section.
 
 === Checking the Jobs Status
 
 The get a list of statuses for all jobs in your cluster, run:
 
 ```shell
-nomad status
+kubectl exec -it nomad-pod-IDm -- nomad status
 ```
 
 The `Status` is the most important field in the output, with the following status type definitions:
@@ -55,7 +55,7 @@ The `Status` is the most important field in the output, with the following statu
 To get a list of your Nomad clients, run:
 
 ```shell
-nomad node-status
+kubectl exec -it nomad-pod-IDm -- nomad node-status
 ```
 
 NOTE: `nomad node-status` reports both Nomad clients that are currently serving (status `active`) and Nomad clients that were taken out of the cluster (status `down`). Therefore, you need to count the number of `active` Nomad clients to know the current capacity of your cluster.
@@ -63,7 +63,7 @@ NOTE: `nomad node-status` reports both Nomad clients that are currently serving 
 To get more information about a specific client, run the following from that client:
 
 ```shell
-nomad node-status -self
+kubectl exec -it nomad-pod-IDm -- nomad node-status -self
 ```
 
 This will give information such as how many jobs are running on the client and the resource utilization of the client.
@@ -73,7 +73,7 @@ This will give information such as how many jobs are running on the client and t
 As noted in the Nomad Jobs section above, a Nomad Job corresponds to an execution of a CircleCI job. Therefore, Nomad Job logs can sometimes help to understand the status of a CircleCI job if there is a problem. To get logs for a specific job, run:
 
 ```shell
-nomad logs -job -stderr <nomad-job-id>
+kubectl exec -it nomad-pod-IDm -- nomad logs -job -stderr <nomad-job-id>
 ```
 
 NOTE: Be sure to specify the `-stderr` flag as this is where most Build Agent logs appear.
@@ -86,31 +86,6 @@ Complete the following steps to get logs from the allocation of the specified jo
 . Get the allocation ID of the job with `nomad status <job-id>` command.
 . Get the logs from the allocation with `nomad logs -stderr <allocation-id>`
 
-// ## Scaling the Nomad Cluster
-// Nomad itself does not provide a scaling method for cluster, so you must implement one. This section provides basic operations regarding scaling a cluster.
-
-=== Scaling the Cluster
-
-By default, your Nomad Client is set up within an Auto Scaling Group (ASG) within AWS. To view settings:
-
-. Go to your EC2 Dashboard and select Auto Scaling Groups from the left hand menu
-. Select your Nomad Client
-. Select Actions > Edit to set Desired/Minimum/Maximum counts. This defines the number of Nomad Clients to spin up and keep available. Use the Scaling Policy tab to scale up your group automatically at your busiest times, see below for best practices for defining scaling policies. Use <<monitoring#nomad-job-metrics,nomad job metrics>> to assist in defining your scaling policies.
-
-==== Auto Scaling Policy Best Practices
-
-There is a https://circleci.com/blog/mathematical-justification-for-not-letting-builds-queue/[blog post series] wherein CircleCI engineering spent time running simulations of cost savings for the purpose of developing a general set of best practices for Auto Scaling. Consider the following best practices when setting up AWS Auto Scaling:
-
-. In general, size your cluster large enough to avoid queueing builds. That is, less than one second of queuing for most workloads and less than 10 seconds for workloads run on expensive hardware or at highest parallellism. Sizing to reduce queuing to zero is best practice because of the high cost of developer time. It is difficult to create a model in which developer time is cheap enough for under-provisioning to be cost-effective.
-
-. Create an Auto Scaling Group with a Step Scaling policy that scales up during the normal working hours of the majority of developers and scales back down at night. Scaling up during the weekday normal working hours and back down at night is the best practice to keep queue times down during peak development, without over provisioning at night when traffic is low. Looking at millions of builds over time, a bell curve during normal working hour emerges for most data sets.
-
-This is in contrast to auto scaling throughout the day based on traffic fluctuations, because modelling revealed that boot times are actually too long to prevent queuing in real time. Use http://docs.aws.amazon.com/autoscaling/latest/userguide/as-scaling-simple-step.html[Amazon's Step Policy] instructions to set this up along with Cloudwatch Alarms.
-
-// commenting until we have non-aws installations?
-// Scaling up Nomad cluster is very straightforward. To scale up, you need to register new Nomad clients into the cluster. If a Nomad client knows the IP addresses of Nomad servers, then the client can register to the cluster automatically.
-// HashiCorp recommends using Consul or other service discovery mechanisms to make this more robust in production. For more information, see the following pages in the official documentation for [Clustering](https://www.nomadproject.io/intro/getting-started/cluster.html), [Service Discovery](https://www.nomadproject.io/docs/service-discovery/index.html), and [Consul Integration](https://www.nomadproject.io/docs/agent/configuration/consul.html).
-
 === Shutting Down a Nomad Client
 
 When you want to shutdown a Nomad client, you must first set the client to `drain` mode. In `drain` mode, the client will finish any jobs that have already been allocated but will not be allocated any new jobs.
@@ -118,17 +93,18 @@ When you want to shutdown a Nomad client, you must first set the client to `drai
 . To drain a client, log in to the client and set the client to drain mode with `node-drain` command as follows:
 +
 ```shell
-nomad node-drain -self -enable
+kubectl exec -it nomad-pod-IDm -- nomad node-drain -self -enable
 ```
 . Then, make sure the client is in drain mode using the `node-status` command:
 +
 ```shell
-nomad node-status -self
+kubectl exec -it nomad-pod-IDm -- nomad node-status -self
 ```
 
 Alternatively, you can drain a remote node with the following command, substituting the node ID:
+
 ```shell
-nomad node-drain -enable -yes <node-id>
+kubectl exec -it nomad-pod-IDm -- nomad node-drain -enable -yes <node-id>
 ```
 
 === Scaling Down the Client Cluster

--- a/jekyll/_cci2/server-3-operator-overview.adoc
+++ b/jekyll/_cci2/server-3-operator-overview.adoc
@@ -28,7 +28,7 @@ toc::[]
 
 ## Execution Environment
 
-CircleCI server 3.x uses Nomad as the primary job scheduler. Refer to our https://circleci.com/docs/2.0/nomad/[Introduction to Nomad Cluster Operation]
+CircleCI server 3.x uses Nomad as the primary job scheduler. Refer to our https://circleci.com/docs/2.0/server-3-operator-nomad/[Introduction to Nomad Cluster Operation]
 to learn more about the job scheduler and how to perform basic client and cluster operations.
 
 By default, CircleCI Nomad clients automatically provision compute resources according to the executors configured for each job in a project’s `.circleci/config.yml` file.

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -383,6 +383,8 @@ en:
           link: 2.0/server-3-operator-overview
         - name: Metrics and Monitoring
           link: 2.0/server-3-operator-metrics-and-monitoring
+        - name: Introduction to Nomad
+          link: 2.0/server-3-operator-nomad
         - name: Configuring a Proxy
           link: 2.0/server-3-operator-proxy
         - name: User Accounts


### PR DESCRIPTION
We have this doc in the ops guide for server 2.x: https://circleci.com/docs/2.0/nomad/
This PR adds a server 3 version :-)