### PR TITLE
[DD-465]  CircleCI-Docs: Add `Experiment Entry` event on docs onload

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -55,4 +55,6 @@ $(() => {
   Prism.highlightAll();
   // trackCopyCode service MUST be initialized after PrismJS is initialized
   services.trackCopyCode.init();
+
+  window.OptimizelyClient.getTrackExperimentEntry();
 });

--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -43,6 +43,15 @@ class OptimizelyClient {
       }
     });
   }
+
+  // Experiment entered tracking
+  getTrackExperimentEntry() {
+    let orgId = Cookies.get(COOKIE_KEY) ?? null;
+    this.getUserId().then((userId) => {
+      trackExperimentEntry(userId, orgId, 'docs');
+    });
+  }
+
   // getVariationName is always guaranteed to resolve with either "null" or a variation name.
   // This is consistent to what getVariation from the optimizely-sdk does.
   //
@@ -264,6 +273,19 @@ export const storeExperimentParticipation = (
     // Uglify /w browserlist force us to do catch (_)
     // We're deliberately ignoring it so that it doesn't break the app. It'll mean a few extra
     // events are emitted, but I think that's the lesser issue.
+  }
+};
+
+export const trackExperimentEntry = (userId, orgId, projectId) => {
+  if (userId && orgId) {
+    const properties = {
+      id: uuidv4(),
+      timestamp: Date.now().toISOString(),
+      userId,
+      orgId,
+      projectId,
+    };
+    window.AnalyticsClient.trackAction('Experiment Entry', properties);
   }
 };
 


### PR DESCRIPTION
# Description
We need to add a trackAction on the docs onload to understand incoming activity

# Reason
Request from engagement team

# Testing
Looker [link](https://circleci.looker.com/dashboards/662?Page+Name=job)