### PR TITLE
[CHORE] Remove Readtime for Config Ref

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -4,6 +4,7 @@ title: Configuring CircleCI
 short-title: Configuring CircleCI
 description: Reference for .circleci/config.yml
 order: 20
+readtime: false
 version:
 - Cloud
 - Server v3.x


### PR DESCRIPTION
Preview: [here](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/chore/remove-config-ref-readtime-preview/2.0/configuration-reference/?force-all)
Original Request Thread: [here](https://circleci.slack.com/archives/C021NCSEM44/p1646911591991159)

# Changes

- set `readtime` variable to `false` in config reference markdown

# Reasons
As Configuration Reference is a reference doc it is not meant for reading "cover to cover" and in its current form with the long read time might overwhelm users.

# Screenshots

**Before:**

![Screen Shot 2022-03-10 at 2 02 56 PM](https://user-images.githubusercontent.com/57234605/157762310-f4796113-d40d-426d-ac17-9e2ad53b669c.png)

**After:**
![Screen Shot 2022-03-10 at 2 02 35 PM](https://user-images.githubusercontent.com/57234605/157762320-08c30850-34d7-4a5f-904e-2abe5b13f6a5.png)

