### PR TITLE
[CHORE]: Add Tracking for Old Signup CTA when Users are in Control

### DIFF
--- a/src/js/experiments/signUpCTA.js
+++ b/src/js/experiments/signUpCTA.js
@@ -5,11 +5,19 @@ window.OptimizelyClient.getVariationName({
   experimentContainer: '.global-nav--footer',
   guestExperiment: true,
 }).then((variation) => {
+  const ctaBtn = document.getElementById('signup-cta');
   if (variation === 'treatment') {
-    const ctaBtn = document.getElementById('signup-cta');
     ctaBtn.innerHTML = 'Start Building for Free';
     ctaBtn.addEventListener('click', () => {
-      window.AnalyticsClient.trackAction('Clicked New Signup CTA');
+      window.AnalyticsClient.trackAction('Clicked New Signup CTA', {
+        ctaText: 'Start Building for Free',
+      });
+    });
+  } else if (variation === 'control') {
+    ctaBtn.addEventListener('click', () => {
+      window.AnalyticsClient.trackAction('Clicked Old Signup CTA', {
+        ctaText: 'Signup',
+      });
     });
   }
 });


### PR DESCRIPTION
Optimizely: [here](https://analytics.amplitude.com/circleci/chart/74xr9av)
Original PR: #6396 

# Changes

- add new event to track when users click the old signup CTA

# Reasons
We want to see specifically the user engagement with the old signup CTA when they are in the control group versus the engagement for the new signup CTA when they are in the treatment group.

# Events

-  `Clicked New Signup CTA`
- `Clicked Old Signup CTA`

# Amplitude 
<img width="337" alt="Screen Shot 2022-03-10 at 2 27 47 PM" src="https://user-images.githubusercontent.com/57234605/157765440-9d8d6a8d-e0e7-46fa-873b-00970f2ed167.png">

