### PR TITLE
Update machine image references to 20.04

### DIFF
--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -263,10 +263,10 @@ See the [Choosing an Executor Type]({{ site.baseurl }}/2.0/executor-types/) docu
 ...
    build2:
      machine: # Specifies a machine image that uses
-     # an Ubuntu version 16.04 image
+     # an Ubuntu version 20.04 image
      # follow CircleCI Discuss Announcements
      # for new image releases.
-       image: ubuntu-1604:202007-01
+       image: ubuntu-2004:current
 ...
    build3:
      macos: # Specifies a macOS virtual machine with Xcode version 12.5.1

--- a/jekyll/_cci2/faq.md
+++ b/jekyll/_cci2/faq.md
@@ -489,7 +489,7 @@ You can also configure Docker to assign IPv6 address to containers, to test serv
 jobs:
   ipv6_tests:
   machine:
-    image: ubuntu-1604:202007-01
+    image: ubuntu-2004:current
   steps:
     - checkout
     - run:

--- a/jekyll/_cci2/migrating-from-aws.adoc
+++ b/jekyll/_cci2/migrating-from-aws.adoc
@@ -201,7 +201,7 @@ a|
 jobs:
   ubuntuJob:
     machine:
-      image: ubuntu-1604:201903-01
+      ubuntu-2004:current
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-azuredevops.adoc
+++ b/jekyll/_cci2/migrating-from-azuredevops.adoc
@@ -202,7 +202,7 @@ a|
 jobs:
   ubuntuJob:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-buildkite.adoc
+++ b/jekyll/_cci2/migrating-from-buildkite.adoc
@@ -191,7 +191,7 @@ a|
 jobs:
   ubuntuJob:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -190,7 +190,7 @@ a|
 jobs:
   ubuntu-job:
     machine:
-      image: ubuntu-1604:201903-01
+      ubuntu-2004:current
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -725,7 +725,7 @@ jobs:
 
     build-docker-image:
         machine:
-            image: ubuntu-1604:202004-01
+            image: ubuntu-2004:current
         steps:
             - attach_workspace:
                   at: .
@@ -765,7 +765,7 @@ jobs:
 
     deploy-docker-image:
         machine:
-            image: ubuntu-1604:202004-01
+            image: ubuntu-2004:current
         steps:
             - attach_workspace:
                   at: .
@@ -869,7 +869,7 @@ jobs:
 
     build-docker-image:
         machine:
-            image: ubuntu-1604:202004-01
+            image: ubuntu-2004:current
         steps:
             - attach_workspace:
                   at: .
@@ -909,7 +909,7 @@ jobs:
 
     deploy-docker-image:
         machine:
-            image: ubuntu-1604:202004-01
+            image: ubuntu-2004:current
         steps:
             - attach_workspace:
                   at: .


### PR DESCRIPTION
# Description
Updating machine image references to reflect deprecation of Ubuntu 14.04 and 16.04 images.

# Reasons
Deprecated images EOL is on 5/31/2022.
Used the `current` tag for maintainability. 
