### PR TITLE
FIx Crowdin's bug

### DIFF
--- a/jekyll/_cci2_ja/dedicated-hosts-macos.adoc
+++ b/jekyll/_cci2_ja/dedicated-hosts-macos.adoc
@@ -46,6 +46,7 @@ version:
 
 == macOS 専有ホストリソースを使ったサンプル設定ファイル
 
+```yaml
 # .circleci/config.yml
 version: 2.1
 jobs:
@@ -68,6 +69,7 @@ workflows:
   build-test:
     jobs:
       - build-and-test
+```
 
 == よくあるご質問
 


### PR DESCRIPTION
Adding ```yaml, which was removed by Crowdin in the translation process.