### PR TITLE
Update testing-macos.md

### DIFF
--- a/jekyll/_cci2/testing-macos.md
+++ b/jekyll/_cci2/testing-macos.md
@@ -69,7 +69,7 @@ jobs:
     steps:
         - checkout
         - run: echo 'chruby ruby-2.7' >> ~/.bash_profile
-        - mac-permissions/add-mac-uitest-permissions
+        - mac-permissions/add-uitest-permissions
         - run: bundle install
         - run: bundle exec fastlane testandbuild
 


### PR DESCRIPTION
# Description

I noticed and thus added a fix here on a typo in the example of using the `add-uitest-permissions` command from the macOS orb.
As seen on https://circleci.com/developer/orbs/orb/circleci/macos?version=2.1.0#commands-add-uitest-permissions
