### PR TITLE
separate sections for server 2 and 3 in sidebar

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -458,7 +458,7 @@ en:
     
 - name: Server Administration v2.x
   icon: icons/sidebar/admin.svg
-  - children:
+  children:
     - name: Server v2.19.x Install
       link: 2.0/install-overview/
       children:

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -349,7 +349,7 @@ en:
       - name: Help and Support
         link: 2.0/help-and-support/
 
-- name: Server Administration
+- name: Server Administration v3.x
   icon: icons/sidebar/admin.svg
   children:
     - name: Server v3.x Overview
@@ -455,6 +455,10 @@ en:
           link: 2.0/CircleCI-Server-3.0.1-Installation-Guide.pdf
         - name: v3.0 Operations Guide
           link: 2.0/CircleCI-Server-3.0.1-Operations-Guide.pdf
+    
+- name: Server Administration v2.x
+  icon: icons/sidebar/admin.svg
+  - children:
     - name: Server v2.19.x Install
       link: 2.0/install-overview/
       children:


### PR DESCRIPTION
As there are more releases the server admin section in the side bar is becoming unmanageable. This PR splits out the versions to make things easier to find. 