### PR TITLE
Update clarity around example app config

### DIFF
--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -46,8 +46,9 @@ As a user getting to know the macOS execution environment, our ideal scenario is
 - Run tests using XCode on the macOS VM whenever we push code.
 - Create and upload the compiled application as an artifact after tests have run successfully.
 
-You can checkout the example application's repo on
-[GitHub](https://github.com/CircleCI-Public/circleci-demo-macos).
+You can checkout the example application's repo on [GitHub](https://github.com/CircleCI-Public/circleci-demo-macos).
+
+Please note, if you would like to test running the code in the example configuration file (below) yourself, you should either fork, or duplicate the example application from GitHub. The example configuration file is not guaranteed to work on any/all Xcode projects.
 
 ## Example configuration file
 {: #example-configuration-file }


### PR DESCRIPTION
# Description
Clarity on how a user can test the example config.

# Reasons
macOS example application presents a config file, but to run/test this file successfully, a user will need to fork or duplicate the repo as the example config can't be guaranteed to work on any one Xcode project. The example config is specific to the example application.
[Jira Ticket](https://circleci.atlassian.net/jira/software/projects/DOCSTEAM/boards/412?selectedIssue=DOCSTEAM-204)