### PR TITLE
update codeowners so docs team own sidebar and snippets etc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,10 @@
 *.adoc @circleci/docs
 *.pdf @circleci/docs
 
+/jekyll/_cci2/ @circleci/docs
+/jekyll/_data/ @circleci/docs
+/jekyll/_includes/ @circleci/docs
+
 /jekyll/_cci2_ja/ @circleci/translations
 /jekyll/_data/ja/ @circleci/translations
 /jekyll/_includes/ja/ @circleci/translations


### PR DESCRIPTION
I realised docs team weren't listed as code owners for the `_data` and `_includes` dirs. This fixes it!
