### PR TITLE
Fix: add `getAnonymousId` to guarantee a consistent userId

### DIFF
--- a/src/js/services/optimizely.js
+++ b/src/js/services/optimizely.js
@@ -14,24 +14,26 @@ class OptimizelyClient {
       datafile: window.optimizelyDatafile,
     });
   }
-  getUserId(isGuestExperiment) {
+  getAnonymousId() {
+    let anonymousId = null;
+    try {
+      // Analytics.js generates a universally unique ID (UUID) for the viewer during the library’s initialization phase
+      // and sets this as anonymousId for each new visitor.
+      // This call is always valid and will never return null. From the docs:
+      // If the user’s anonymousId is null (meaning not set) when you call this function, Analytics.js automatically generated and sets a new anonymousId for the user.
+      anonymousId = analytics.user().anonymousId();
+    } catch (_) {
+      return null;
+    }
+    return anonymousId;
+  }
+  getUserId() {
     return new Promise((resolve) => {
       if (window.userData) {
         // if we already have userData
         resolve(
           window.userData.analytics_id ? window.userData.analytics_id : null,
         );
-      } else if (isGuestExperiment) {
-        let anonymousId = null;
-        try {
-          // Analytics.js generates a universally unique ID (UUID) for the viewer during the library’s initialization phase
-          // and sets this as anonymousId for each new visitor.
-          // This call is always valid and will never return null. From the docs:
-          // If the user’s anonymousId is null (meaning not set) when you call this function, Analytics.js automatically generated and sets a new anonymousId for the user.
-          anonymousId = analytics.user().anonymousId();
-        } finally {
-          resolve(anonymousId);
-        }
       } else {
         // If we are here it means we are still waiting on getting notified
         // that the call to /api/v1/me has resolved and the new userData is available
@@ -90,7 +92,10 @@ class OptimizelyClient {
       }
 
       // once we have the userId
-      this.getUserId(isGuestExperiment).then((userId) => {
+      this.getUserId().then((userId) => {
+        // if we don't have a userId but we are in a guest experiment, we can request the anonymousId
+        userId = !userId && isGuestExperiment ? this.getAnonymousId() : userId;
+
         if (!userId) {
           return resolve(null);
         }

--- a/src/js/services/optimizely.test.js
+++ b/src/js/services/optimizely.test.js
@@ -54,31 +54,11 @@ describe('Optimizely Service logged-in users', () => {
     });
   });
 
-  describe('getUserId() in a Guest Experiment', () => {
+  describe('getAnonymousId()', () => {
     glob.analytics.user().anonymousId.mockReturnValue(anonymousId);
 
-    it('returns anonymousId when userData is not here', async () => {
-      glob.userData = null;
-      await expect(client.getUserId(true)).resolves.toBe(anonymousId);
-    });
-
-    it('returns analytics_id when userData has a valid analytics_id', async () => {
-      glob.userData = {
-        analytics_id: '00000000-0000-0000-0000-000000000000',
-      };
-      await expect(client.getUserId(true)).resolves.toBe(
-        glob.userData.analytics_id,
-      );
-    });
-
-    it('returns null when userData is empty', async () => {
-      glob.userData = {};
-      await expect(client.getUserId(true)).resolves.toBe(null);
-    });
-
-    it("returns null when analytics doesn't exist", async () => {
-      glob.analytics = null;
-      await expect(client.getUserId(true)).resolves.toBe(null);
+    it('returns anonymousId when no error', async () => {
+      expect(client.getAnonymousId()).toBe(anonymousId);
     });
   });
 


### PR DESCRIPTION
# Description
- Add `getAnonymousId` to guarantee a consistent userId while experiment resolving

# Reasons
It was a little confusing to attempt to do both resolvings of `userId` and `anonymousId` in the same function. This created side effects where the `anonymousId` will be used while the call to the API was still resolving. 