### PR TITLE
Add banners for machine images deprecation

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -392,8 +392,10 @@ jobs:
 * `ubuntu-1604:201903-01` - Ubuntu 16.04, Docker v18.09.3, Docker Compose v1.23.1
 
 ***Note:*** *Ubuntu 16.04 has reached the end of its LTS window as of April 2021 and will no longer be supported by Canonical.
-As a result, `ubuntu-1604:202104-01` is the final Ubuntu 16.04 image released by CircleCI.
-We suggest upgrading to the latest Ubuntu 20.04 image for continued releases and support past April 2021.*
+As a result, `ubuntu-1604:202104-01` is the final Ubuntu 16.04 image released by CircleCI.*
+
+Ubuntu 14.04 and 16.04 machine images [are deprecated and will be removed permanently May 31, 2022](https://circleci.com/blog/ubuntu-14-16-image-deprecation/). These images will be temporarily unavailable March 29 and April 26, 2022. Migrate from [14.04]({{ site.baseurl }}/2.0/images/linux-vm/14.04-to-20.04-migration/) or [16.04]({{ site.baseurl }}/2.0/images/linux-vm/16.04-to-20.04-migration/).
+{: class="alert alert-warning"}
 
 The machine executor supports [Docker Layer Caching]({{ site.baseurl }}/2.0/docker-layer-caching) which is useful when you are building Docker images during your job or Workflow.
 

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -37,7 +37,7 @@ Find out more about the `docker` executor in the [Using Docker]({{ site.baseurl 
 ## Machine
 {: #machine }
 
-Ubuntu 14.04 and 16.04 machine images [are deprecated and will be removed permanently May 31, 2022](https://circleci.com/blog/ubuntu-14-16-image-deprecation/). These images will be temporarily unavailable March 29 and April 26, 2022. Migrate from [14.04]({{ site.baseurl }}/2.0/images/linux-vm/14.04-to-20.04-migration/) or [16.04]({{ site.baseurl }}https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/).
+Ubuntu 14.04 and 16.04 machine images [are deprecated and will be removed permanently May 31, 2022](https://circleci.com/blog/ubuntu-14-16-image-deprecation/). These images will be temporarily unavailable March 29 and April 26, 2022. Migrate from [14.04]({{ site.baseurl }}/2.0/images/linux-vm/14.04-to-20.04-migration/) or [16.04]({{ site.baseurl }}/2.0/images/linux-vm/16.04-to-20.04-migration/).
 {: class="alert alert-warning"}
 
 {:.tab.machine.Cloud}

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -37,6 +37,9 @@ Find out more about the `docker` executor in the [Using Docker]({{ site.baseurl 
 ## Machine
 {: #machine }
 
+Ubuntu 14.04 and 16.04 machine images [are deprecated and will be removed permanently May 31, 2022](https://circleci.com/blog/ubuntu-14-16-image-deprecation/). These images will be temporarily unavailable March 29 and April 26, 2022. Migrate from [14.04]({{ site.baseurl }}/2.0/images/linux-vm/14.04-to-20.04-migration/) or [16.04]({{ site.baseurl }}https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/).
+{: class="alert alert-warning"}
+
 {:.tab.machine.Cloud}
 ```yml
 jobs:

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -241,6 +241,8 @@ jobs:
 
 ## Using machine
 {: #using-machine }
+Ubuntu 14.04 and 16.04 machine images [are deprecated and will be removed permanently May 31, 2022](https://circleci.com/blog/ubuntu-14-16-image-deprecation/). These images will be temporarily unavailable March 29 and April 26, 2022. Migrate from [14.04]({{ site.baseurl }}/2.0/images/linux-vm/14.04-to-20.04-migration/) or [16.04]({{ site.baseurl }}/2.0/images/linux-vm/16.04-to-20.04-migration/).
+{: class="alert alert-warning"}
 
 The `machine` option runs your jobs in a dedicated, ephemeral VM that has the following specifications:
 


### PR DESCRIPTION
# Description
Similar to the legacy convenience images deprecation, we are adding banners to warn users of Ubuntu 14.04 and 16.04 images deprecation (first upcoming brownout in two weeks, EOL end of May). This change adds banners to the following docs:
https://circleci.com/docs/2.0/executor-intro/
https://circleci.com/docs/2.0/executor-types/#using-machine
https://circleci.com/docs/2.0/configuration-reference/#available-machine-images

# Reasons
Part of communications out to CircleCI users to make the appropriate changes to their pipelines in advance of the image brownouts/EOL.