### PR TITLE
updating referrences from traefik to kong

### DIFF
--- a/jekyll/_cci2/server-3-install-hardening-your-cluster.adoc
+++ b/jekyll/_cci2/server-3-install-hardening-your-cluster.adoc
@@ -23,7 +23,9 @@ to control traffic between the different components of the system and isolate th
 
 As always, the rule is to make as many of the resources as private as possible, applies. If your users will access your
 CircleCI server installation via VPN, there is no need to assign any public IP addresses at all, as long as you have a
-working NAT gateway setup. Otherwise, you will need at least one public subnet for the CircleCI server Traefik load balancer.
+working NAT gateway setup. Otherwise, you will need at least one public subnet for the `circleci-server-traefik` load balancer.
+
+NOTE: From server v3.3.0, we have replaced https://github.com/traefik/traefik-helm-chart[Traefik] with https://github.com/Kong/charts[Kong] as our reverse proxy. However, in order to minimize disruption when upgrading, we chose not to rename the service used by kong. Therefore, you will see a service named `circleci-server-traefik`, however, this service is actually for Kong.
 
 However, in this case, it is also recommended to place Nomad clients and VMs in a public subnet to enable your users to
 SSH into jobs and scope access via networking rules.

--- a/jekyll/_cci2/server-3-install-hardening-your-cluster.adoc
+++ b/jekyll/_cci2/server-3-install-hardening-your-cluster.adoc
@@ -25,7 +25,7 @@ As always, the rule is to make as many of the resources as private as possible, 
 CircleCI server installation via VPN, there is no need to assign any public IP addresses at all, as long as you have a
 working NAT gateway setup. Otherwise, you will need at least one public subnet for the `circleci-server-traefik` load balancer.
 
-NOTE: From server v3.3.0, we have replaced https://github.com/traefik/traefik-helm-chart[Traefik] with https://github.com/Kong/charts[Kong] as our reverse proxy. However, in order to minimize disruption when upgrading, we chose not to rename the service used by kong. Therefore, you will see a service named `circleci-server-traefik`, however, this service is actually for Kong.
+NOTE: From server v3.3.0, we have replaced https://github.com/traefik/traefik-helm-chart[Traefik] with https://github.com/Kong/charts[Kong] as our reverse proxy. However, in order to minimize disruption when upgrading, we chose not to rename the service used by Kong. Therefore, you will see a service named `circleci-server-traefik` but this service is actually for Kong.
 
 However, in this case, it is also recommended to place Nomad clients and VMs in a public subnet to enable your users to
 SSH into jobs and scope access via networking rules.

--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -183,7 +183,7 @@ You can skip these sections unless you plan on using an existing Postgres, Mongo
 === Save and deploy
 Once you have completed the fields detailed above, it is time to deploy. The deployment will install the core services and provide you with an IP address for the Kong load balancer. That IP address will be critical in setting up a DNS record and completing the first phase of the installation.
 
-NOTE: From server v3.3.0, we have replaced https://github.com/traefik/traefik-helm-chart[Traefik] with https://github.com/Kong/charts[Kong] as our reverse proxy. However, in order to minimize disruption when upgrading, we chose not to rename the service used by kong. Therefore, you will see a service named `circleci-server-traefik`, however, this service is actually for Kong.
+NOTE: From server v3.3.0, we have replaced https://github.com/traefik/traefik-helm-chart[Traefik] with https://github.com/Kong/charts[Kong] as our reverse proxy. However, in order to minimize disruption when upgrading, we chose not to rename the service used by Kong. Therefore, you will see a service named `circleci-server-traefik` but this service is actually for Kong.
 
 NOTE: In this first stage we skipped a lot of fields in the config. We will revisit those in the next stages of installation.
 

--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -181,14 +181,16 @@ endif::env-aws[]
 You can skip these sections unless you plan on using an existing Postgres, MongoDB or Vault instance, in which case see the https://circleci.com/docs/2.0/server-3-operator-externalizing-services/[Externalizing Services doc]. By default, CirecleCI server will create its own Postgres, MongoDB and Vault instances within the CircleCI namespace. The instances inside the CircleCI namespace will be included in the CircleCI backup and restore process.
 
 === Save and deploy
-Once you have completed the fields detailed above, it is time to deploy. The deployment will install the core services and provide you with an IP address for the Traefik load balancer. That IP address will be critical in setting up a DNS record and completing the first phase of the installation.
+Once you have completed the fields detailed above, it is time to deploy. The deployment will install the core services and provide you with an IP address for the Kong load balancer. That IP address will be critical in setting up a DNS record and completing the first phase of the installation.
+
+NOTE: From server v3.3.0, we have replaced https://github.com/traefik/traefik-helm-chart[Traefik] with https://github.com/Kong/charts[Kong] as our reverse proxy. However, in order to minimize disruption when upgrading, we chose not to rename the service used by kong. Therefore, you will see a service named `circleci-server-traefik`, however, this service is actually for Kong.
 
 NOTE: In this first stage we skipped a lot of fields in the config. We will revisit those in the next stages of installation.
 
 === Create DNS entry
-Create a DNS entry for your Traefik load balancer, for example, `circleci.your.domain.com` and `app.circleci.your.domain.com`. The DNS entry should align with the DNS names used when creating your TLS certificate and GitHub OAuth app during the prerequisites steps. All traffic will be routed through this DNS record.
+Create a DNS entry for your Kong load balancer, for example, `circleci.your.domain.com` and `app.circleci.your.domain.com`. The DNS entry should align with the DNS names used when creating your TLS certificate and GitHub OAuth app during the prerequisites steps. All traffic will be routed through this DNS record.
 
-You will need the IP address or, if using AWS, the DNS name of the Traefik load balancer. You can find this with the following command:
+You will need the IP address or, if using AWS, the DNS name of the Kong load balancer. You can find this with the following command:
 
 ----
 kubectl get service circleci-server-traefik --namespace=<YOUR_CIRCLECI_NAMESPACE>
@@ -200,7 +202,7 @@ For more information on adding a new DNS record, see the following documentation
 
 * link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-creating.html[Creating records by using the Amazon Route 53 Console] (AWS)
 
-NOTE: The Traefik load balancer has a healthcheck that serves a JSON payload at https://loadbalancer-address/status.
+NOTE: The Kong load balancer has a healthcheck that serves a JSON payload at https://loadbalancer-address/status
 
 === Validation
 

--- a/jekyll/_cci2/server-3-whats-new.adoc
+++ b/jekyll/_cci2/server-3-whats-new.adoc
@@ -49,6 +49,7 @@ toc::[]
 * The Insights dashboard is now available.
 * IRSA (AWS) can now be used as an alternative to keys for object storage authentication.
 * The email address from which build notifications are sent is now configurable from the KOTS Admin Console.
+* We have replaced https://github.com/traefik/traefik-helm-chart[Traefik] with https://github.com/Kong/charts[Kong] as our reverse proxy. However, in order to minimize disruption when upgrading, we chose not to rename the service used by kong. Therefore, you will see a service named `circleci-server-traefik`, however, this service is actually for Kong.
 
 === Fixes
 


### PR DESCRIPTION
# Description
We currently have the "Traefik load balancer" documented for our customers, but we have since moved to Kong. The service name in Kubernetes did not change (`circleci-server-traefik`) in order to persist the existing load balancer. We are now updating our docs to reflect this change

# Reasons
https://circleci.atlassian.net/browse/SERVER-1622