### PR TITLE
Fix broken links

### DIFF
--- a/jekyll/_cci2/concurrency.adoc
+++ b/jekyll/_cci2/concurrency.adoc
@@ -14,7 +14,7 @@ version:
 
 This page summarizes concurrency, and suggests ways to use concurrency to your advantage.
 
-In CircleCI, **concurrency** refers to utilizing multiple containers to run multiple jobs at the same time. This is different from CircleCI **parallelism**, which is test-splitting across multiple containers. If you would like information on parallelism, visit the <<parallelism-faster-jobs/#,Running Tests in Parallel>> page.
+In CircleCI, **concurrency** refers to utilizing multiple containers to run multiple jobs at the same time. This is different from CircleCI **parallelism**, which is test-splitting across multiple containers. If you would like information on parallelism, visit the <<parallelism-faster-jobs#,Running Tests in Parallel>> page.
 
 Every plan with CircleCI includes the ability to run jobs concurrently. However, the number of jobs you can run concurrently differs between plans. Please refer to the https://circleci.com/pricing/[pricing page] for up-to-date information on the number of concurrent job runs included in your plan.
 
@@ -28,7 +28,7 @@ Within CircleCI, concurrent jobs can be classified as one of two situations:
 
 This page discusses the first point, and will provide examples of how to configure concurrent jobs in a single workflow. Configuring concurrency in a workflow allows multiple jobs to be run at the same time, in a single workflow, through the use of multiple containers.
 
-To keep the system stable for all CircleCI customers, we implement different soft concurrency limits on each of the <<configuration-reference/#resourceclass,resource classes>> for different executors.
+To keep the system stable for all CircleCI customers, we implement different soft concurrency limits on each of the <<configuration-reference#resourceclass,resource classes>> for different executors.
 
 If jobs are queued, it is possible you are hitting these limits. Hitting your limit may depend on a few factors, such as how many people in your organization are running jobs at once, or if you have overlapping workflows.
 
@@ -118,5 +118,5 @@ workflows:
 Please note, if you are still using CircleCI Server 2 with `version: 2`, you will need to specify the version in the `workflows` section, as mentioned in the <<#concurrency-in-workflows,Concurrency in workflows>> section.
 
 == See also
-- <<workflows/#,Workflows>>
-- <<sample-config/#,Sample config.yml Files>>
+- <<workflows#,Workflows>>
+- <<sample-config#,Sample config.yml Files>>


### PR DESCRIPTION
# Description
Removing an extra `/` that made it into the URLs.

# Reasons
Some of the URLs are broken.