### PR TITLE
fix link tag in doc to fix link from app

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1496,7 +1496,7 @@ Note the following distinctions between Artifacts, Workspaces, and Caches:
 Refer to the [Persisting Data in Workflows: When to Use Caching, Artifacts, and Workspaces](https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/) for additional conceptual information about using workspaces, caching, and artifacts.
 
 ##### **`add_ssh_keys`**
-{: #addsshkeys }
+{: #add-ssh-keys }
 
 Special step that adds SSH keys from a project's settings to a container. Also configures SSH to use these keys.
 


### PR DESCRIPTION
There is a link from the app project settings > ssh keys to the config reference. The link was broken. This PR fixes the link

<img width="716" alt="Screenshot 2022-03-17 at 11 48 15" src="https://user-images.githubusercontent.com/24589403/158802413-35e8d59d-ea8c-4d3e-ad58-2e84621d8785.png">
.