### PR TITLE
[DD-439] Regenerate the code snippets spreadsheet

### DIFF
--- a/jekyll/_cci2_ja/migration.md
+++ b/jekyll/_cci2_ja/migration.md
@@ -155,4 +155,5 @@ ssh -p PORT ubuntu@IP_ADDRESS -L 5902:localhost:5901 # SSH で接続します
           print(sys.version)
 ```
 
-- ``` - bash を上手に活用することで、何でも実行可能です。 `for i in {1..5}; do curl -v $ENDPOINT_URL && break || sleep 10; done`
+- bash を上手に活用することで、何でも実行可能です。 
+            `for i in {1..5}; do curl -v $ENDPOINT_URL && break || sleep 10; done`

--- a/scripts/snippets_csv/index.js
+++ b/scripts/snippets_csv/index.js
@@ -1,215 +1,22 @@
-const ObjectsToCsv = require('objects-to-csv');
-const fs = require('fs');
+import ObjectsToCsv from 'objects-to-csv'
+import fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
-const path = require('path');
-const glob = require('glob-promise');
-const search = require('search-in-file');
-const { gitlogPromise } = require('gitlog');
+import { exploreSingle } from './runSnippetTracking.js'
+import { exploreTotal } from './runArticleTracking.js'
 
-const repoPath = path.join(__dirname, '../../');
-const directories = ['__glossary', '_cci2', '_cci2_ja'];
-
-const log = (message) => {
+export const log = (message) => {
   // eslint-disable-next-line no-console
   console.log('=>', message);
 };
 
-
-/* Single */
-const addToData = async (filePath, lineStart, lineStop) => {
-  let info = {
-    file: filePath,
-    lines: `${lineStart}-${lineStop}`,
-    snippetSize: lineStop - lineStart - 1,
-  };
-
-  const logData = await gitlogPromise({
-    repo: repoPath,
-    fileLineRange: {
-      file: filePath,
-      startLine: lineStart,
-      endLine: lineStop,
-    },
-    number: 100,
-  }).then();
-
-  if (logData.length) {
-    const creationDate = logData[logData.length - 1].authorDate.split(' ')[0];
-
-    // calculate the age of the snippet
-    const today = new Date();
-    const snippetDate = new Date(creationDate);
-    const ageInMonths =
-      today.getFullYear() * 12 +
-      today.getMonth() -
-      (snippetDate.getFullYear() * 12 + snippetDate.getMonth());
-
-    info = {
-      ...info,
-      creationDate,
-      createdBy: logData[logData.length - 1].authorName,
-      lastUpdatedDate: logData[0].authorDate.split(' ')[0],
-      lastUpdatedBy: logData[0].authorName,
-      updatesCount: logData.length,
-      ageInMonths,
-    };
-  }
-
-  // add a link to github at the very end
-  info = {
-    ...info,
-    link: `https://github.com/circleci/circleci-docs/blob/master/${filePath}?plain=1#L${lineStart}-L${lineStop}`,
-  };
-
-  return info;
-};
-  
-const exploreSingle = async () => {
-  const files = await glob(
-    `${repoPath}/jekyll/@(${directories.join('|')})/*.@(md|adoc)`,
-  );
-  log(`Found ${files.length} files`);
-
-  const results = await search.fileSearch(files, '```', {
-    searchResults: 'lineNo',
-  });
-  let promises = [];
-
-  results.forEach((lines) => {
-    if (lines.length) {
-      // cleanup file path
-      const file = lines[0].filePath.replace(repoPath, '');
-      log(`${file} has ${lines.length} snippets`);
-
-      for (let i = 0; i < lines.length; i++) {
-        const hit = lines[i];
-        const isSingleLineCode = (hit.line.match(/```/g) || []).length === 2;
-
-        if (isSingleLineCode) {
-          promises.push(addToData(file, hit.lineNo, hit.lineNo));
-        } else {
-          promises.push(addToData(file, hit.lineNo, lines[i + 1].lineNo));
-          i++;
-        }
-      }
-    }
-  });
-
-  return await Promise.all(promises);
-};
-
-/* Total */
-const addToDataTotal = async (filePath, lineStart, lineStop, numSnippets) => {
-  let pageName = (filePath.substring(filePath.lastIndexOf("/") + 1, filePath.length - 1)).split('.')[0];
-  let info = {
-    pageName: pageName,
-    numSnippets: numSnippets,
-    linkToDocs: 'https://circleci.com/docs/2.0/' + pageName,
-    file: filePath,
-    lines: `${lineStart}-${lineStop}`,
-    snippetSize: lineStop - lineStart - 1,
-  };
-
-  const logData = await gitlogPromise({
-    repo: repoPath,
-    fileLineRange: {
-      file: filePath,
-      startLine: lineStart,
-      endLine: lineStop,
-    },
-    number: 100,
-  }).then();
-
-  if (logData.length) {
-    const creationDate = logData[logData.length - 1].authorDate.split(' ')[0];
-
-    // calculate the age of the snippet
-    const today = new Date();
-    const snippetDate = new Date(creationDate);
-    const ageInMonths =
-      today.getFullYear() * 12 +
-      today.getMonth() -
-      (snippetDate.getFullYear() * 12 + snippetDate.getMonth());
-
-    info = {
-      ...info,
-      creationDate,
-      createdBy: logData[logData.length - 1].authorName,
-      lastUpdatedDate: logData[0].authorDate.split(' ')[0],
-      lastUpdatedBy: logData[0].authorName,
-      updatesCount: logData.length,
-      ageInMonths,
-      linkToDocs: 'https://circleci.com/docs/2.0/'
-    };
-  }
-
-  // add a link to github at the very end
-  info = {
-    ...info,
-    link: `https://github.com/circleci/circleci-docs/blob/master/${filePath}?plain=1#L${lineStart}-L${lineStop}`,
-  };
-
-  return info;
-};
-/* end exploreSingle */
-
-const exploreTotal = async () => {
-  const files = await glob(
-    `${repoPath}/jekyll/@(${directories.join('|')})/*.@(md|adoc)`,
-  );
-  log(`Found ${files.length} files`);
-
-  const results = await search.fileSearch(files, '```', {
-    searchResults: 'lineNo',
-  });
-  let promises = [];
-
-  results.forEach((lines) => {
-    if (lines.length) {
-      // cleanup file path
-      let file = lines[0].filePath.replace(repoPath, '');
-      log(`${file} has ${lines.length} snippets`);
-
-      // have to count how many snippits need remove to know how many you have
-      let numberOfValidSnippits = 0;
-      for (let i = 0; i < lines.length; i++) {
-        let hit = lines[i];
-        let skip = (hit.line.match(/```shell/g) || []).length === 1;
-        if(!skip) {
-          numberOfValidSnippits++;
-        } else {
-          i++;
-        }
-      }
-
-      for (let i = 0; i < lines.length; i++) {
-        let hit = lines[i];
-        let isSingleLineCode = (hit.line.match(/```/g) || []).length === 2;
-        // Don't record snippits that are CLI/API commands and responses
-        let skip = (hit.line.match(/```shell/g) || []).length === 1;
-        
-        if(!skip) {
-          if (isSingleLineCode) {
-            promises.push(addToDataTotal(file, hit.lineNo, hit.lineNo, numberOfValidSnippits));
-          } else {
-            promises.push(addToDataTotal(file, hit.lineNo, lines[i + 1].lineNo, numberOfValidSnippits));
-            i++;
-          }
-        } else {
-          // If you are skipping need to increment past the end of shell script ```
-          i++;
-        }
-      }
-    }
-  });
-
-  return await Promise.all(promises);
-};
-/* end exporeTotal */
-const runSingleSnippetInfo = async () => {
+const runSnippetTracking = async () => {
   // first we remove the ouput file to clear it
-  if (fs.existsSync(`${__dirname}/snippets.csv`)) {
-    fs.unlinkSync(`${__dirname}/snippets.csv`);
+  if (fs.existsSync(`${__dirname}/snippetsTracking.csv`)) {
+    fs.unlinkSync(`${__dirname}/snippetsTracking.csv`);
   }
 
   // get the data
@@ -221,14 +28,14 @@ const runSingleSnippetInfo = async () => {
   // with the CSV library
   while (data.length > 0) {
     const csv = new ObjectsToCsv(data.splice(0, 500));
-    csv.toDisk('./snippets.csv', { append: true });
+    csv.toDisk('./snippetsTracking.csv', { append: true });
   }
 }
 
-const runTotalSnippetInfo = async () => {
+const runArticleTracking = async () => {
     // first we remove the ouput file to clear it
-    if (fs.existsSync(`${__dirname}/snippetsTotal.csv`)) {
-      fs.unlinkSync(`${__dirname}/snippetsTotal.csv`);
+    if (fs.existsSync(`${__dirname}/articleTracking.csv`)) {
+      fs.unlinkSync(`${__dirname}/articleTracking.csv`);
     }
 
     // get the data
@@ -240,14 +47,15 @@ const runTotalSnippetInfo = async () => {
     // with the CSV library
     while (data.length > 0) {
       const csv = new ObjectsToCsv(data.splice(0, 500));
-      csv.toDisk('./snippetsTotal.csv', { append: true });
+      csv.toDisk('./articleTracking.csv', { append: true });
     }
 }
 
 const start = async () => {
   // commented out to save on runtime
-  // await runSingleSnippetInfo();
-  await runTotalSnippetInfo();
+
+  // await runSnippetTracking();
+  await runArticleTracking();
 
   log('Done');
 };

--- a/scripts/snippets_csv/index.js
+++ b/scripts/snippets_csv/index.js
@@ -1,9 +1,10 @@
 const ObjectsToCsv = require('objects-to-csv');
+const fs = require('fs');
+
+const path = require('path');
 const glob = require('glob-promise');
 const search = require('search-in-file');
 const { gitlogPromise } = require('gitlog');
-const path = require('path');
-const fs = require('fs');
 
 const repoPath = path.join(__dirname, '../../');
 const directories = ['__glossary', '_cci2', '_cci2_ja'];
@@ -13,6 +14,8 @@ const log = (message) => {
   console.log('=>', message);
 };
 
+
+/* Single */
 const addToData = async (filePath, lineStart, lineStop) => {
   let info = {
     file: filePath,
@@ -60,8 +63,8 @@ const addToData = async (filePath, lineStart, lineStop) => {
 
   return info;
 };
-
-const explore = async () => {
+  
+const exploreSingle = async () => {
   const files = await glob(
     `${repoPath}/jekyll/@(${directories.join('|')})/*.@(md|adoc)`,
   );
@@ -95,14 +98,122 @@ const explore = async () => {
   return await Promise.all(promises);
 };
 
-const start = async () => {
+/* Total */
+const addToDataTotal = async (filePath, lineStart, lineStop, numSnippets) => {
+  let pageName = (filePath.substring(filePath.lastIndexOf("/") + 1, filePath.length - 1)).split('.')[0];
+  let info = {
+    pageName: pageName,
+    numSnippets: numSnippets,
+    linkToDocs: 'https://circleci.com/docs/2.0/' + pageName,
+    file: filePath,
+    lines: `${lineStart}-${lineStop}`,
+    snippetSize: lineStop - lineStart - 1,
+  };
+
+  const logData = await gitlogPromise({
+    repo: repoPath,
+    fileLineRange: {
+      file: filePath,
+      startLine: lineStart,
+      endLine: lineStop,
+    },
+    number: 100,
+  }).then();
+
+  if (logData.length) {
+    const creationDate = logData[logData.length - 1].authorDate.split(' ')[0];
+
+    // calculate the age of the snippet
+    const today = new Date();
+    const snippetDate = new Date(creationDate);
+    const ageInMonths =
+      today.getFullYear() * 12 +
+      today.getMonth() -
+      (snippetDate.getFullYear() * 12 + snippetDate.getMonth());
+
+    info = {
+      ...info,
+      creationDate,
+      createdBy: logData[logData.length - 1].authorName,
+      lastUpdatedDate: logData[0].authorDate.split(' ')[0],
+      lastUpdatedBy: logData[0].authorName,
+      updatesCount: logData.length,
+      ageInMonths,
+      linkToDocs: 'https://circleci.com/docs/2.0/'
+    };
+  }
+
+  // add a link to github at the very end
+  info = {
+    ...info,
+    link: `https://github.com/circleci/circleci-docs/blob/master/${filePath}?plain=1#L${lineStart}-L${lineStop}`,
+  };
+
+  return info;
+};
+/* end exploreSingle */
+
+const exploreTotal = async () => {
+  const files = await glob(
+    `${repoPath}/jekyll/@(${directories.join('|')})/*.@(md|adoc)`,
+  );
+  log(`Found ${files.length} files`);
+
+  const results = await search.fileSearch(files, '```', {
+    searchResults: 'lineNo',
+  });
+  let promises = [];
+
+  results.forEach((lines) => {
+    if (lines.length) {
+      // cleanup file path
+      let file = lines[0].filePath.replace(repoPath, '');
+      log(`${file} has ${lines.length} snippets`);
+
+      // have to count how many snippits need remove to know how many you have
+      let numberOfValidSnippits = 0;
+      for (let i = 0; i < lines.length; i++) {
+        let hit = lines[i];
+        let skip = (hit.line.match(/```shell/g) || []).length === 1;
+        if(!skip) {
+          numberOfValidSnippits++;
+        } else {
+          i++;
+        }
+      }
+
+      for (let i = 0; i < lines.length; i++) {
+        let hit = lines[i];
+        let isSingleLineCode = (hit.line.match(/```/g) || []).length === 2;
+        // Don't record snippits that are CLI/API commands and responses
+        let skip = (hit.line.match(/```shell/g) || []).length === 1;
+        
+        if(!skip) {
+          if (isSingleLineCode) {
+            promises.push(addToDataTotal(file, hit.lineNo, hit.lineNo, numberOfValidSnippits));
+          } else {
+            promises.push(addToDataTotal(file, hit.lineNo, lines[i + 1].lineNo, numberOfValidSnippits));
+            i++;
+          }
+        } else {
+          // If you are skipping need to increment past the end of shell script ```
+          i++;
+        }
+      }
+    }
+  });
+
+  return await Promise.all(promises);
+};
+/* end exporeTotal */
+const runSingleSnippetInfo = async () => {
   // first we remove the ouput file to clear it
   if (fs.existsSync(`${__dirname}/snippets.csv`)) {
     fs.unlinkSync(`${__dirname}/snippets.csv`);
   }
 
   // get the data
-  const data = await explore();
+  const data = await exploreSingle();
   log(`Found ${data.length} snippets`);
 
   // write the data to the output CSV file in chuncks of 500
@@ -112,6 +223,31 @@ const start = async () => {
     const csv = new ObjectsToCsv(data.splice(0, 500));
     csv.toDisk('./snippets.csv', { append: true });
   }
+}
+
+const runTotalSnippetInfo = async () => {
+    // first we remove the ouput file to clear it
+    if (fs.existsSync(`${__dirname}/snippetsTotal.csv`)) {
+      fs.unlinkSync(`${__dirname}/snippetsTotal.csv`);
+    }
+
+    // get the data
+    const data = await exploreTotal();
+    log(`Found ${data.length} snippets`);
+  
+    // write the data to the output CSV file in chuncks of 500
+    // this is done to prevent writing to much data which can cause issues
+    // with the CSV library
+    while (data.length > 0) {
+      const csv = new ObjectsToCsv(data.splice(0, 500));
+      csv.toDisk('./snippetsTotal.csv', { append: true });
+    }
+}
+
+const start = async () => {
+  // commented out to save on runtime
+  // await runSingleSnippetInfo();
+  await runTotalSnippetInfo();
 
   log('Done');
 };

--- a/scripts/snippets_csv/index.js
+++ b/scripts/snippets_csv/index.js
@@ -5,8 +5,8 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-import { exploreSingle } from './runSnippetTracking.js'
-import { exploreTotal } from './runArticleTracking.js'
+import { snippetTracking } from './runSnippetTracking.js'
+import { articleTracking } from './runArticleTracking.js'
 
 export const log = (message) => {
   // eslint-disable-next-line no-console
@@ -20,7 +20,7 @@ const runSnippetTracking = async () => {
   }
 
   // get the data
-  const data = await exploreSingle();
+  const data = await snippetTracking();
   log(`Found ${data.length} snippets`);
 
   // write the data to the output CSV file in chuncks of 500
@@ -39,7 +39,7 @@ const runArticleTracking = async () => {
     }
 
     // get the data
-    const data = await exploreTotal();
+    const data = await articleTracking();
     log(`Found ${data.length} snippets`);
   
     // write the data to the output CSV file in chuncks of 500

--- a/scripts/snippets_csv/package.json
+++ b/scripts/snippets_csv/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "export": "node index.js"
   },

--- a/scripts/snippets_csv/runArticleTracking.js
+++ b/scripts/snippets_csv/runArticleTracking.js
@@ -1,0 +1,103 @@
+import * as path from 'path'
+import glob from 'glob-promise'
+import * as search from 'search-in-file'
+import { gitlogPromise } from 'gitlog'
+import { log } from './index.js'
+
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoPath = path.join(__dirname, '../../');
+const directories = ['__glossary', '_cci2', '_cci2_ja'];
+
+/* Total */
+const addToDataTotal = async (filePath, lineStart, lineStop) => {
+  let pageName = (filePath.substring(filePath.lastIndexOf("/") + 1, filePath.length - 1)).split('.')[0];
+  let linkToDocs = 'https://circleci.com/docs/2.0/' + pageName;
+  
+  let info = {
+    pageName: pageName,
+    lines: `${lineStart}-${lineStop}`,
+    snippetSize: lineStop - lineStart - 1,
+    linkToDocs: linkToDocs,
+  };
+
+  const logData = await gitlogPromise({
+    repo: repoPath,
+    fileLineRange: {
+      file: filePath,
+      startLine: lineStart,
+      endLine: lineStop,
+    },
+    number: 100,
+  }).then();
+
+  if (logData.length) {
+    const creationDate = logData[logData.length - 1].authorDate.split(' ')[0];
+
+    // calculate the age of the snippet
+    const today = new Date();
+    const snippetDate = new Date(creationDate);
+    const ageInMonths =
+      today.getFullYear() * 12 +
+      today.getMonth() -
+      (snippetDate.getFullYear() * 12 + snippetDate.getMonth());
+
+    info = {
+      ...info,
+      updatesCount: logData.length,
+      ageInMonths,
+    };
+  }
+
+  // add a link to github at the very end
+  info = {
+    ...info,
+    link: `https://github.com/circleci/circleci-docs/blob/master/${filePath}?plain=1#L${lineStart}-L${lineStop}`,
+  };
+
+  return info;
+};
+/* end exploreSingle */
+
+export const exploreTotal = async () => {
+  const files = await glob(
+    `${repoPath}/jekyll/@(${directories.join('|')})/*.@(md|adoc)`,
+  );
+  log(`Found ${files.length} files`);
+
+  const results = await search.fileSearch(files, '```', {
+    searchResults: 'lineNo',
+  });
+  let promises = [];
+
+  results.forEach((lines) => {
+    if (lines.length) {
+      // cleanup file path
+      let file = lines[0].filePath.replace(repoPath, '');
+      log(`${file} has ${lines.length} snippets`);
+
+      for (let i = 0; i < lines.length; i++) {
+        let hit = lines[i];
+        let isSingleLineCode = (hit.line.match(/```/g) || []).length === 2;
+        // Don't record snippits that are CLI/API commands and responses
+        let skip = (hit.line.match(/```shell/g) || []).length === 1;
+        
+        if(!skip) {
+          if (isSingleLineCode) {
+            promises.push(addToDataTotal(file, hit.lineNo, hit.lineNo));
+          } else {
+            promises.push(addToDataTotal(file, hit.lineNo, lines[i + 1].lineNo));
+            i++;
+          }
+        } else {
+          // If you are skipping need to increment past the end of shell script ```
+          i++;
+        }
+      }
+    }
+  });
+
+  return await Promise.all(promises);
+};
+/* end exporeTotal */

--- a/scripts/snippets_csv/runArticleTracking.js
+++ b/scripts/snippets_csv/runArticleTracking.js
@@ -53,14 +53,14 @@ const addToDataTotal = async (filePath, lineStart, lineStop) => {
   // add a link to github at the very end
   info = {
     ...info,
-    link: `https://github.com/circleci/circleci-docs/blob/master/${filePath}?plain=1#L${lineStart}-L${lineStop}`,
+    link: `https://github.com/circleci/circleci-docs/blob/master/${filePath}`,
   };
 
   return info;
 };
 /* end exploreSingle */
 
-export const exploreTotal = async () => {
+export const articleTracking = async () => {
   const files = await glob(
     `${repoPath}/jekyll/@(${directories.join('|')})/*.@(md|adoc)`,
   );

--- a/scripts/snippets_csv/runArticleTracking.js
+++ b/scripts/snippets_csv/runArticleTracking.js
@@ -61,16 +61,20 @@ const addToDataTotal = async (filePath, lineStart, lineStop) => {
 /* end exploreSingle */
 
 export const articleTracking = async () => {
-  const files = await glob(
+  let files = await glob(
     `${repoPath}/jekyll/@(${directories.join('|')})/*.@(md|adoc)`,
   );
   log(`Found ${files.length} files`);
+
+  // we want to filter out the ja files
+  files = files.filter(function(s) {
+      return s.indexOf("_cci2_ja") === -1;
+  });
 
   const results = await search.fileSearch(files, '```', {
     searchResults: 'lineNo',
   });
   let promises = [];
-
   results.forEach((lines) => {
     if (lines.length) {
       // cleanup file path

--- a/scripts/snippets_csv/runArticleTracking.js
+++ b/scripts/snippets_csv/runArticleTracking.js
@@ -12,7 +12,8 @@ const directories = ['__glossary', '_cci2', '_cci2_ja'];
 
 /* Total */
 const addToDataTotal = async (filePath, lineStart, lineStop) => {
-  let pageName = (filePath.substring(filePath.lastIndexOf("/") + 1, filePath.length - 1)).split('.')[0];
+  // We need to be careful to not have our file names use .md or .adoc in them except as file extensions
+  let pageName = (filePath.substring(filePath.lastIndexOf("/") + 1, filePath.length)).replace('.md', '').replace('.adoc', '');
   let linkToDocs = 'https://circleci.com/docs/2.0/' + pageName;
   
   let info = {

--- a/scripts/snippets_csv/runSnippetTracking.js
+++ b/scripts/snippets_csv/runSnippetTracking.js
@@ -60,7 +60,7 @@ const addToData = async (filePath, lineStart, lineStop) => {
   return info;
 };
     
-export const exploreSingle = async () => {
+export const snippetTracking = async () => {
   console.log('exploreSingle')
   const files = await glob(
     `${repoPath}/jekyll/@(${directories.join('|')})/*.@(md|adoc)`,

--- a/scripts/snippets_csv/runSnippetTracking.js
+++ b/scripts/snippets_csv/runSnippetTracking.js
@@ -1,0 +1,96 @@
+import * as path from 'path'
+import glob from 'glob-promise'
+import * as search from 'search-in-file'
+import { gitlogPromise } from 'gitlog'
+import { log } from './index.js'
+
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoPath = path.join(__dirname, '../../');
+const directories = ['__glossary', '_cci2', '_cci2_ja'];
+
+
+/* Single */
+const addToData = async (filePath, lineStart, lineStop) => {
+  let info = {
+    file: filePath,
+    lines: `${lineStart}-${lineStop}`,
+    snippetSize: lineStop - lineStart - 1,
+  };
+
+  const logData = await gitlogPromise({
+    repo: repoPath,
+    fileLineRange: {
+      file: filePath,
+      startLine: lineStart,
+      endLine: lineStop,
+    },
+    number: 100,
+  }).then();
+
+  if (logData.length) {
+    const creationDate = logData[logData.length - 1].authorDate.split(' ')[0];
+
+    // calculate the age of the snippet
+    const today = new Date();
+    const snippetDate = new Date(creationDate);
+    const ageInMonths =
+      today.getFullYear() * 12 +
+      today.getMonth() -
+      (snippetDate.getFullYear() * 12 + snippetDate.getMonth());
+
+    info = {
+      ...info,
+      creationDate,
+      createdBy: logData[logData.length - 1].authorName,
+      lastUpdatedDate: logData[0].authorDate.split(' ')[0],
+      lastUpdatedBy: logData[0].authorName,
+      updatesCount: logData.length,
+      ageInMonths,
+    };
+  }
+
+  // add a link to github at the very end
+  info = {
+    ...info,
+    link: `https://github.com/circleci/circleci-docs/blob/master/${filePath}?plain=1#L${lineStart}-L${lineStop}`,
+  };
+
+  return info;
+};
+    
+export const exploreSingle = async () => {
+  console.log('exploreSingle')
+  const files = await glob(
+    `${repoPath}/jekyll/@(${directories.join('|')})/*.@(md|adoc)`,
+  );
+  log(`Found ${files.length} files`);
+
+  const results = await search.fileSearch(files, '```', {
+    searchResults: 'lineNo',
+  });
+  let promises = [];
+
+  results.forEach((lines) => {
+    if (lines.length) {
+      // cleanup file path
+      const file = lines[0].filePath.replace(repoPath, '');
+      log(`${file} has ${lines.length} snippets`);
+
+      for (let i = 0; i < lines.length; i++) {
+        const hit = lines[i];
+        const isSingleLineCode = (hit.line.match(/```/g) || []).length === 2;
+
+        if (isSingleLineCode) {
+          promises.push(addToData(file, hit.lineNo, hit.lineNo));
+        } else {
+          promises.push(addToData(file, hit.lineNo, lines[i + 1].lineNo));
+          i++;
+        }
+      }
+    }
+  });
+
+  return await Promise.all(promises);
+};


### PR DESCRIPTION
# Description
Regenerate the code snippets spreadsheet. Over time, the links we generated to specific lines of content that contain code snippets have drifted.  Since this will always be a problem, let's change the output to include:
-fileName
-lines
-snippetSize
-link to Docs Article,
-updatesCount
-age
-link to github

# Reasons
Provide stakeholders with valuable information about code snippets

# Todo
Right now it cuts off at the first . need to cut off .md or .adoc