### PR TITLE
Fix: Signup experiment on JA

### DIFF
--- a/src/js/experiments/signupLinksCta.js
+++ b/src/js/experiments/signupLinksCta.js
@@ -1,7 +1,10 @@
 /**
  * This experiment adds CTA signup buttons to the docs/2.0/first-steps document.
  * */
-const isFirstStepsPage = window.location.pathname == '/docs/2.0/first-steps/' || window.location.pathname == '/docs/ja/2.0/first-steps/';
+const isFirstStepsPage =
+  window.location.pathname == '/docs/2.0/first-steps/' ||
+  window.location.pathname == '/docs/ja/2.0/first-steps/';
+
 
 function handleGithubDropdownClick() {
   const dropdown = $('.gh-signup-dropdown');

--- a/src/js/experiments/signupLinksCta.js
+++ b/src/js/experiments/signupLinksCta.js
@@ -1,7 +1,7 @@
 /**
  * This experiment adds CTA signup buttons to the docs/2.0/first-steps document.
  * */
-const isFirstStepsPage = window.location.pathname == '/docs/2.0/first-steps/';
+const isFirstStepsPage = window.location.pathname == '/docs/2.0/first-steps/' || window.location.pathname == '/docs/ja/2.0/first-steps/';
 
 function handleGithubDropdownClick() {
   const dropdown = $('.gh-signup-dropdown');

--- a/src/js/experiments/signupLinksCta.js
+++ b/src/js/experiments/signupLinksCta.js
@@ -5,7 +5,6 @@ const isFirstStepsPage =
   window.location.pathname == '/docs/2.0/first-steps/' ||
   window.location.pathname == '/docs/ja/2.0/first-steps/';
 
-
 function handleGithubDropdownClick() {
   const dropdown = $('.gh-signup-dropdown');
   // toggle the popup

--- a/src/styles/_first_steps_cta.scss
+++ b/src/styles/_first_steps_cta.scss
@@ -2,7 +2,7 @@
 $btn-breakpoint: 967px;
 $btn-breakpoint-sm: 360px;
 
-.sign-up-and-try-circleci {
+.sign-up-and-try-circleci, .circleci-のユーザー登録 {
   .signup-and-try-experiment-block {
     display: none;
     &.show {


### PR DESCRIPTION
# Description
The content of `/first-steps` got translated into Japanese, but the styling and javascript were not built to run on the japanese page. This makes the experiment run on `docs/ja/2.0/first-steps`/


