### PR TITLE
Update link from Discuss to Dev Hub

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -427,4 +427,4 @@ Also, consider reading documentation on some of CircleCI’s features:
 ## Software pre-installed on the Windows image
 {: #software-pre-installed-on-the-windows-image }
 
-To find information on what software is pre-installed on the Windows image, please visit the [Developer Hub](https://circleci.com/developer/machine/image/windows-server). The Windows image page on the Developer Hub will list links to the most recent updates.
+To find information on what software is pre-installed on the Windows image, please visit the [Developer Hub](https://circleci.com/developer/machine/image/windows-server). The Windows image page on the Developer Hub lists links to the most recent updates.

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -427,4 +427,4 @@ Also, consider reading documentation on some of CircleCI’s features:
 ## Software pre-installed on the Windows image
 {: #software-pre-installed-on-the-windows-image }
 
-To find information on what software is pre-installed on the Windows image, please visit the [Developer Hub](https://circleci.com/developer/machine/image/windows-server). The links to the newest updates will be listed here.
+To find information on what software is pre-installed on the Windows image, please visit the [Developer Hub](https://circleci.com/developer/machine/image/windows-server). The Windows image page on the Developer Hub will list links to the most recent updates.

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -427,4 +427,4 @@ Also, consider reading documentation on some of CircleCI’s features:
 ## Software pre-installed on the Windows image
 {: #software-pre-installed-on-the-windows-image }
 
-To find information on what software is pre-installed on the Windows image, please visit the [Discuss](https://discuss.circleci.com/) page.
+To find information on what software is pre-installed on the Windows image, please visit the [Developer Hub](https://circleci.com/developer/machine/image/windows-server). The links to the newest updates will be listed here.


### PR DESCRIPTION
# Description
Link to Dev Hub for image software.

# Reasons
Currently there is no good resource for someone to find what software is pre-installed on the windows image. The most relevant link we have is the Dev Hub, which links out to some discuss posts.