### PR TITLE
[DD-498] User Printing Preference & User Darkmode Preference Teardown 

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -7,7 +7,6 @@ import Prism from 'prismjs';
 
 import services from './services';
 import '../styles/main.scss';
-import { trackDarkModePreference, checkIfUsersPrint } from './site/main';
 
 // adding "Clients" to the window object so they can be accessed by other js inside Jekyll
 window.Cookie = Cookie;
@@ -20,10 +19,6 @@ import site from './site';
 Prism.manual = true;
 
 services.rum.init();
-// Temporary service to check if user dark mode preferences
-trackDarkModePreference();
-// Temporary service to check if users are printing a page
-checkIfUsersPrint();
 
 $(() => {
   services.instantsearch.init();

--- a/src/js/site/main.js
+++ b/src/js/site/main.js
@@ -312,39 +312,6 @@ $(function () {
   });
 });
 
-/*
-  Check if users have dark mode enabled
-  Set key if user response has not already been tracked to ensure we dont get multiple events from the same user
- */
-export function trackDarkModePreference() {
-  try {
-    const storageKey = 'provided-dark-mode-response';
-    if (localStorage.getItem(storageKey)) {
-      return;
-    } else {
-      localStorage.setItem(storageKey, true);
-      window.AnalyticsClient.trackAction('User Dark Mode Preference', {
-        darkModeEnabled:
-          window.matchMedia &&
-          window.matchMedia('(prefers-color-scheme: dark)').matches,
-      });
-    }
-  } catch (_) {
-    return false;
-  }
-}
-
-/*
-  Checking if users are attempting to print docs pages to gauge interest of print button
- */
-export function checkIfUsersPrint() {
-  window.onbeforeprint = () => {
-    window.AnalyticsClient.trackAction('User Attempting to Print', {
-      page: window.location.pathname,
-    });
-  };
-}
-
 // Used to call functions on document on ready
 $(function () {
   // Currently this function is only used for the insights table


### PR DESCRIPTION
Ticket
Original PRs: #6272 & #6221 

# Changes

- remove tracking logic from `main.js`
- remove import from `app.js`

# Description
We have enough data for user printing and dark mode preferences, we are cleaning up our code base in terms of best practice and also reducing our overall bundle size and amplitude calls. 

# Considerations
No new data will be gathered for our amplitude charts for both User Printing Preferences and Dark Mode preferences from when this PR is merged.

# Screenshots
No visual changes