### PR TITLE
[DD-452] Jekyll include for the section header + illustration + paragraph

### DIFF
--- a/jekyll/_includes/getting-started-section-header.html
+++ b/jekyll/_includes/getting-started-section-header.html
@@ -1,0 +1,9 @@
+<div class='section-header-wrapper'>
+  <h2 class='section-title'>{Placeholder for dynamic section title}</h2>
+  <span class='section-banner'>{Placeholder to include dynamic image}</span>
+  <div class='content-wrapper'>
+    <p>
+      {Placeholder for content here}
+    </p>
+  </div>
+</div>

--- a/jekyll/_includes/getting-started-section-header.html
+++ b/jekyll/_includes/getting-started-section-header.html
@@ -2,8 +2,8 @@
   <h2 class='section-title'>{{include.title}}</h2>
   <img class='image-banner' src="{{include.imagePath}}" alt="header banner" />
   <div class='content-wrapper'>
-    <p>
+    <span>
       {{include.content}}
-    </p>
+    </span>
   </div>
 </div>

--- a/jekyll/_includes/getting-started-section-header.html
+++ b/jekyll/_includes/getting-started-section-header.html
@@ -1,9 +1,9 @@
 <div class='section-header-wrapper'>
-  <h2 class='section-title'>{Placeholder for dynamic section title}</h2>
-  <span class='section-banner'>{Placeholder to include dynamic image}</span>
+  <h2 class='section-title'>{{include.title}}</h2>
+  <img class='image-banner' src="{{include.imagePath}}" alt="header banner" />
   <div class='content-wrapper'>
     <p>
-      {Placeholder for content here}
+      {{include.content}}
     </p>
   </div>
 </div>

--- a/jekyll/assets/img/docs/quick-start--first-step.svg
+++ b/jekyll/assets/img/docs/quick-start--first-step.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1097" height="180" viewBox="0 0 1097 180" fill="none">
+<rect width="366" height="180" fill="#003740"/>
+<rect x="365" width="366" height="180" fill="#008647"/>
+<rect x="731" width="366" height="180" fill="#C7E8D7"/>
+<path d="M365 144C285.471 144 221 79.529 221 0" stroke="#04AA51" stroke-width="4"/>
+<path d="M365 90C315.294 90 275 49.7056 275 0" stroke="#04AA51" stroke-width="4"/>
+<path d="M365 36C345.118 36 329 19.8823 329 0" stroke="#04AA51" stroke-width="4"/>
+<path d="M731 36C810.529 36 875 100.471 875 180" stroke="#003740" stroke-width="4"/>
+<path d="M731 90C780.706 90 821 130.294 821 180" stroke="#003740" stroke-width="4"/>
+<path d="M731 144C750.882 144 767 160.118 767 180" stroke="#003740" stroke-width="4"/>
+<path d="M365 36H731" stroke="#C7E8D7" stroke-width="4"/>
+<path d="M365 90H731" stroke="#C7E8D7" stroke-width="4"/>
+<path d="M365 144H731" stroke="#C7E8D7" stroke-width="4"/>
+<circle cx="321" cy="44" r="19" fill="#04AA51"/>
+</svg>

--- a/jekyll/assets/img/docs/quick-start--second-step.svg
+++ b/jekyll/assets/img/docs/quick-start--second-step.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1097" height="180" viewBox="0 0 1097 180" fill="none">
+<rect width="366" height="180" fill="#003740"/>
+<rect x="365" width="366" height="180" fill="#008647"/>
+<rect x="731" width="366" height="180" fill="#C7E8D7"/>
+<path d="M365 144C285.471 144 221 79.529 221 0" stroke="#04AA51" stroke-width="4"/>
+<path d="M365 90C315.294 90 275 49.7056 275 0" stroke="#04AA51" stroke-width="4"/>
+<path d="M365 36C345.118 36 329 19.8823 329 0" stroke="#04AA51" stroke-width="4"/>
+<path d="M731 36C810.529 36 875 100.471 875 180" stroke="#003740" stroke-width="4"/>
+<path d="M731 90C780.706 90 821 130.294 821 180" stroke="#003740" stroke-width="4"/>
+<path d="M731 144C750.882 144 767 160.118 767 180" stroke="#003740" stroke-width="4"/>
+<path d="M365 36H731" stroke="#C7E8D7" stroke-width="4"/>
+<path d="M365 90H731" stroke="#C7E8D7" stroke-width="4"/>
+<path d="M365 144H731" stroke="#C7E8D7" stroke-width="4"/>
+<circle cx="548" cy="63" r="19" fill="#C7E8D7"/>
+</svg>

--- a/jekyll/assets/img/docs/quick-start--third-step.svg
+++ b/jekyll/assets/img/docs/quick-start--third-step.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1097" height="180" viewBox="0 0 1097 180" fill="none">
+<rect width="366" height="180" fill="#003740"/>
+<rect x="365" width="366" height="180" fill="#008647"/>
+<rect x="731" width="366" height="180" fill="#C7E8D7"/>
+<path d="M365 144C285.471 144 221 79.529 221 0" stroke="#04AA51" stroke-width="4"/>
+<path d="M365 90C315.294 90 275 49.7056 275 0" stroke="#04AA51" stroke-width="4"/>
+<path d="M365 36C345.118 36 329 19.8823 329 0" stroke="#04AA51" stroke-width="4"/>
+<path d="M731 36C810.529 36 875 100.471 875 180" stroke="#003740" stroke-width="4"/>
+<path d="M731 90C780.706 90 821 130.294 821 180" stroke="#003740" stroke-width="4"/>
+<path d="M731 144C750.882 144 767 160.118 767 180" stroke="#003740" stroke-width="4"/>
+<path d="M365 36H731" stroke="#C7E8D7" stroke-width="4"/>
+<path d="M365 90H731" stroke="#C7E8D7" stroke-width="4"/>
+<path d="M365 144H731" stroke="#C7E8D7" stroke-width="4"/>
+<circle cx="794" cy="82" r="19" fill="#003740"/>
+</svg>

--- a/src/styles/includes/_getting-started-section-header.scss
+++ b/src/styles/includes/_getting-started-section-header.scss
@@ -1,0 +1,37 @@
+.section-title {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 300;
+  font-size: 40px;
+  line-height: 48px;
+  text-align: left;
+  font-feature-settings: 'liga' off;
+  color: #000000;
+  
+  @media (max-width: $screen-sm) {
+    font-size: 30px;
+    line-height: 38px;
+    text-align: left;
+  }
+}
+
+.image-banner {
+  width: 100%;
+}
+
+.content-wrapper {
+  text-align: left;
+  > p {
+    color: #000000;
+    font-family: 'Roboto';
+    font-style: normal;
+    font-weight: 400;
+    font-size: 24px;
+    line-height: 32px;
+
+    @media (max-width: $screen-sm) {
+      font-size: 20px;
+      line-height: 30px;
+    }
+  }
+}

--- a/src/styles/includes/_getting-started-section-header.scss
+++ b/src/styles/includes/_getting-started-section-header.scss
@@ -1,37 +1,42 @@
-.section-title {
+.section-header-wrapper {
   font-family: 'Roboto';
   font-style: normal;
-  font-weight: 300;
-  font-size: 40px;
-  line-height: 48px;
-  text-align: left;
-  font-feature-settings: 'liga' off;
-  color: #000000;
-  
-  @media (max-width: $screen-sm) {
-    font-size: 30px;
-    line-height: 38px;
+
+  .section-title {
+    font-weight: 300;
+    font-size: 40px;
+    line-height: 48px;
     text-align: left;
-  }
-}
-
-.image-banner {
-  width: 100%;
-}
-
-.content-wrapper {
-  text-align: left;
-  > p {
+    font-feature-settings: 'liga' off;
     color: #000000;
-    font-family: 'Roboto';
-    font-style: normal;
-    font-weight: 400;
-    font-size: 24px;
-    line-height: 32px;
-
+    
     @media (max-width: $screen-sm) {
-      font-size: 20px;
-      line-height: 30px;
+      font-size: 30px;
+      line-height: 38px;
+      text-align: left;
+    }
+  }
+
+  .image-banner {
+    width: 100%;
+  }
+
+  .content-wrapper {
+    text-align: left;
+    > span {
+      color: #000000;
+      font-weight: 400;
+      font-size: 24px;
+      line-height: 32px;
+  
+      @media (max-width: $screen-sm) {
+        font-size: 20px;
+        line-height: 30px;
+      }
     }
   }
 }
+
+
+
+

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -18,6 +18,7 @@
 @import 'language-guide';
 @import 'first_steps_cta';
 @import 'popup';
+@import 'includes/getting-started-section-header';
 
 // prism related scss
 @import 'prism/theme';


### PR DESCRIPTION
[Ticket](https://circleci.atlassian.net/browse/DD-452)
[Preview](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-452/getting-started-experiment-header-preview/2.0/concepts/?force-all)
**NOTE:** The preview link is just demoing the section header on the concepts page as we currently dont have the layout in place for the Getting Started experiment yet. 


# Changes

- add includes HTML layout for section header
- add styles for section header
- import SVGs for header banner image

# Description
We need to create an include section that we can reuse for each section for the Getting Started experiment. The includes layout should accept the title, banner image and intro paragraph as per the design. The includes should also be responsive to window size changes. 

# Considerations
This PR is a part of the [Getting Started experiment epic](https://circleci.atlassian.net/browse/DD-449). The other associated PRs: #6564 & #6544 

# Screenshots 
**Desktop:**
<img width="926" alt="Screen Shot 2022-03-21 at 2 16 59 PM" src="https://user-images.githubusercontent.com/57234605/159365341-938e8f1f-6971-48c3-9c64-62093b434732.png">

**Mobile:** 
<img width="361" alt="Screen Shot 2022-03-21 at 2 17 15 PM" src="https://user-images.githubusercontent.com/57234605/159365366-23fcc6f0-4a48-4000-9e0a-702542681084.png">

