### PR TITLE
Update Deprecated Flag Name

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -152,7 +152,7 @@ eksctl create cluster --name=circleci-server --nodes 4 --node-type m5.xlarge
 . Once the cluster has been created, you can use the following command to configure `kubectl` access:
 +
 ```shell
-eksctl utils write-kubeconfig --name circleci-server
+eksctl utils write-kubeconfig --cluster circleci-server
 ```
 
 NOTE: You may see the following error `AWS STS Access - cannot get role ARN for current session: InvalidClientTokenID`. This means your AWS credentials are invalid, or your IAM user does not have permission to create an EKS cluster. Proper IAM permissions are necessary in order to use `eksctl`. See the AWS documentation regarding https://aws.amazon.com/iam/features/manage-permissions/[IAM permissions].


### PR DESCRIPTION
# Description
Update flag `--name` to `--cluster`

# Reasons
eksctl version 0.80.0 states `Flag --name has been deprecated, use --cluster`
<img width="969" alt="Screen Shot 2022-03-19 at 10 54 06 AM" src="https://user-images.githubusercontent.com/24261530/159128520-412eeeae-52cc-45dc-8f7c-71f119e38b14.png">
