### PR TITLE
Fix docker image name in note

### DIFF
--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -93,7 +93,7 @@ jobs:
 ```
 
 **Note:**
-`circleci/python:3.6.4` is a [convenience image]({{ site.baseurl }}/2.0/circleci-images/) provided by CircleCI.
+`cimg/python:3.10.1` is a [convenience image]({{ site.baseurl }}/2.0/circleci-images/) provided by CircleCI.
 These images are extensions of official Docker images
 and include tools useful for CI/CD environments.
 


### PR DESCRIPTION
# Description

The note references the legacy circle CI image for python and a version which does not match the code example above.

# Reasons

Let's make the doc consistent