### PR TITLE
add css to allow use of asciidoc sidebars

### DIFF
--- a/src/styles/_asciidoc.scss
+++ b/src/styles/_asciidoc.scss
@@ -53,7 +53,7 @@ span.icon>.fa {
 }
 
 .sidebarblock{
-  border-style:1px solid #dddddd;
+  border:1px solid #dddddd;
   margin-bottom:1.25em;
   padding:1.25em;
   background:#f9f9f9;

--- a/src/styles/_asciidoc.scss
+++ b/src/styles/_asciidoc.scss
@@ -51,3 +51,30 @@ span.icon>.fa {
 .green{
   color: #43C78A;
 }
+
+.sidebarblock{
+  border-style:solid;
+  border-width:1px;
+  border-color:#dddddd;
+  margin-bottom:1.25em;
+  padding:1.25em;
+  background:#f9f9f9;
+  -webkit-border-radius:4px;
+  border-radius:4px
+}
+
+.sidebarblock>:first-child{
+  margin-top:0
+}
+
+.sidebarblock>:last-child{
+  margin-bottom:0
+}
+
+.sidebarblock>.content>.title{
+  margin-top:0;
+  font-size: 1.4rem;
+  font-weight: 500;
+  font-style: normal;
+  text-align:center;
+}

--- a/src/styles/_asciidoc.scss
+++ b/src/styles/_asciidoc.scss
@@ -53,9 +53,7 @@ span.icon>.fa {
 }
 
 .sidebarblock{
-  border-style:solid;
-  border-width:1px;
-  border-color:#dddddd;
+  border-style:1px solid #dddddd;
   margin-bottom:1.25em;
   padding:1.25em;
   background:#f9f9f9;


### PR DESCRIPTION
* Some features of asciidoctor require additional CSS to work. 
* This PR is to add the CSS required to use sidebars: https://docs.asciidoctor.org/asciidoc/latest/blocks/sidebars/
* The admonitions look bad (as they do always!) but we can tackle that in another ticket :-D

They look like this - I just added some random content to show how they look - the whole "Interesting" box is a "sidebar":
<img width="1500" alt="Screenshot 2022-03-21 at 14 32 13" src="https://user-images.githubusercontent.com/24589403/159283838-d3ab08b8-2a39-4d91-afeb-0a1f99f2d892.png">

