### PR TITLE
Add: two-up include for new quick start guide

### DIFF
--- a/jekyll/_includes/two-up.html
+++ b/jekyll/_includes/two-up.html
@@ -1,0 +1,18 @@
+{% comment %}
+twoup is a jekyll include for rendering "two-pane" content: an image and text side by side.
+  * Params: @title    - section title
+  *         @content  - dynamic paragraph content
+  *         @imageURL - string pointing to image asset
+  *         @imageAlt = Alt text for the image.
+{% endcomment %}
+
+<div class="include-two-up">
+  <div class="left-side">
+    <div class="section-heading">{{include.title}}</div>
+    {{include.content}}
+  </div>
+
+  <div class="right-side">
+    <img class="right-img" src="{{include.imageURL}}" alt="{{include.imageAlt}}" />
+  </div>
+</div>

--- a/src/styles/includes/two-up.scss
+++ b/src/styles/includes/two-up.scss
@@ -1,0 +1,42 @@
+// markup here: jekyll/_includes/two-up.html
+
+.include-two-up {
+  background: white;
+  display: flex;
+  padding: 32px 0;
+
+  @media(max-width: $screen-sm) {
+    flex-direction: column;
+  }
+
+  .right-img {
+    margin: 0px;
+  }
+
+  .section-heading {
+    font-family: Roboto;
+    font-size: 18px;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 16px;
+    letter-spacing: 0px;
+    text-align: left;
+  }
+
+  .right-side {
+    flex: 1;
+    padding-left: 32px;
+    align-self: center;
+  }
+
+  .left-side {
+    flex: 1;
+    padding-right: 32px;
+  }
+
+  .right-side, .left-side {
+    @media(max-width: $screen-sm) {
+      padding: 12px 0 !important;
+    }
+  }
+}

--- a/src/styles/includes/two-up.scss
+++ b/src/styles/includes/two-up.scss
@@ -3,7 +3,7 @@
 .include-two-up {
   background: white;
   display: flex;
-  padding: 0 0 16px 0;
+  padding: 0 0 32px 0;
 
   @media(max-width: $screen-sm) {
     flex-direction: column;

--- a/src/styles/includes/two-up.scss
+++ b/src/styles/includes/two-up.scss
@@ -3,7 +3,7 @@
 .include-two-up {
   background: white;
   display: flex;
-  padding: 32px 0;
+  padding: 0 0 16px 0;
 
   @media(max-width: $screen-sm) {
     flex-direction: column;
@@ -18,7 +18,7 @@
     font-size: 18px;
     font-style: normal;
     font-weight: 500;
-    margin-bottom: 16px;
+    color: #000000;
     letter-spacing: 0px;
     text-align: left;
   }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -23,6 +23,9 @@
 @import 'prism/theme';
 @import 'prism/copy-code-button';
 
+// includes
+@import 'includes/two-up';
+
 // General
 body {
 	color: $body-text-color;


### PR DESCRIPTION
# Description
[Ticket](https://circleci.atlassian.net/browse/DD-451)

- add a new include for a "two-up" component where the left side is text and the right side is an image.
- this PR adds no content - just the structure for the include.
  - however, one can view an example of it implemented at [this preview link](http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/DD-451-two-up-preview/2.0/workflows/)

## Screenshots &tc

Here is a screen-recording representing breakpoints. I think it should change sooner, but I just used the standard mobile breakpoint we use everywhere.

https://user-images.githubusercontent.com/12987958/159349694-fc5855ae-093c-4d7f-aa38-c002fc45cd2c.mp4


