### PR TITLE
Update PHP code coverage example

### DIFF
--- a/jekyll/_cci2/code-coverage.md
+++ b/jekyll/_cci2/code-coverage.md
@@ -583,6 +583,8 @@ jobs:
       - run:
           name: "Run tests"
           command: phpdbg -qrr vendor/bin/phpunit --coverage-html build/coverage-report
+          environment:
+            XDEBUG_MODE: coverage
       - store_artifacts:
           path:  build/coverage-report
 ```
@@ -605,6 +607,8 @@ jobs:
       - run:
           name: "Run tests"
           command: phpdbg -qrr vendor/bin/phpunit --coverage-html build/coverage-report
+          environment:
+            XDEBUG_MODE: coverage
       - store_artifacts:
           path:  build/coverage-report
 ```
@@ -628,6 +632,8 @@ jobs:
       - run:
           name: "Run tests"
           command: phpdbg -qrr vendor/bin/phpunit --coverage-html build/coverage-report
+          environment:
+            XDEBUG_MODE: coverage
       - store_artifacts:
           path:  build/coverage-report
 ```


### PR DESCRIPTION
# Description
Add environment variable `XDEBUG_MODE=coverage`

# Reasons
https://github.com/circleci/circleci-docs/issues/6144
The env var needs to be set for the latest Xdebug to generate coverage reports.