### PR TITLE
adding warning about supported kots version

### DIFF
--- a/jekyll/_cci2/server-3-operator-metrics-and-monitoring.adoc
+++ b/jekyll/_cci2/server-3-operator-metrics-and-monitoring.adoc
@@ -29,7 +29,9 @@ NOTE: Data is retained for a maximum of 15 days.
 NOTE: Prometheus Server is not limited to only scrape metrics from your CircleCI server install. It will scrape metrics from your entire cluster by default. You may disable Prometheus from within the KOTS Admin Console config if needed.
 
 === Prometheus
-https://prometheus.io/[Prometheus] is a leading monitoring and alerting system for Kubernetes. Server 3.x ships with basic implementation of monitoring common performance metrics. 
+https://prometheus.io/[Prometheus] is a leading monitoring and alerting system for Kubernetes. Server 3.x ships with basic implementation of monitoring common performance metrics.
+
+WARNING: this feature is broken in KOTS versions 1.65.0 - 1.67.0. If you rely on this feature we recommend not upgrading your KOTS version until this is resolved
 
 === KOTS Admin - Metrics Graphs
 By default, an instance of Prometheus is deployed with your CircleCI server install. Once deployed, you may provide the address for your Prometheus instance to the KOTS Admin Console. KOTS will use this address to generate graph data for the CPU and memory usage of containers in your cluster.

--- a/jekyll/_cci2/server-3-operator-metrics-and-monitoring.adoc
+++ b/jekyll/_cci2/server-3-operator-metrics-and-monitoring.adoc
@@ -29,7 +29,7 @@ NOTE: Data is retained for a maximum of 15 days.
 NOTE: Prometheus Server is not limited to only scrape metrics from your CircleCI server install. It will scrape metrics from your entire cluster by default. You may disable Prometheus from within the KOTS Admin Console config if needed.
 
 === Prometheus
-https://prometheus.io/[Prometheus] is a leading monitoring and alerting system for Kubernetes. Server 3.x ships with basic implementation of monitoring common performance metrics.
+https://prometheus.io/[Prometheus] is a leading monitoring and alerting system for Kubernetes. Server 3.x ships with a basic implementation of monitoring common performance metrics.
 
 WARNING: this feature is broken in KOTS versions 1.65.0 - 1.67.0. If you rely on this feature we recommend not upgrading your KOTS version until this is resolved
 

--- a/jekyll/_cci2/server-3-operator-metrics-and-monitoring.adoc
+++ b/jekyll/_cci2/server-3-operator-metrics-and-monitoring.adoc
@@ -31,7 +31,7 @@ NOTE: Prometheus Server is not limited to only scrape metrics from your CircleCI
 === Prometheus
 https://prometheus.io/[Prometheus] is a leading monitoring and alerting system for Kubernetes. Server 3.x ships with a basic implementation of monitoring common performance metrics.
 
-WARNING: this feature is broken in KOTS versions 1.65.0 - 1.67.0. If you rely on this feature we recommend not upgrading your KOTS version until this is resolved
+WARNING: This feature is broken in KOTS versions 1.65.0 - 1.67.0. If you rely on this feature, we recommend that you do not upgrade your KOTS version until this has been resolved.
 
 === KOTS Admin - Metrics Graphs
 By default, an instance of Prometheus is deployed with your CircleCI server install. Once deployed, you may provide the address for your Prometheus instance to the KOTS Admin Console. KOTS will use this address to generate graph data for the CPU and memory usage of containers in your cluster.


### PR DESCRIPTION
# Description
Prometheus graphs in the kots admin dashboard is broken for KOTS versions 1.65+
We need to make note of this with a warning

# Reasons
https://circleci.atlassian.net/browse/SERVER-1711