### PR TITLE
chore(optimizations): replace baseURL to baseurl - 404 error

### DIFF
--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -73,7 +73,7 @@ If your project has a large test suite, you can configure your build to use [`pa
 
 Using `resource_class`, it is possible to configure CPU and RAM resources for each job. For Cloud, see [this table]({{site.baseurl}}/2.0/configuration-reference/#resourceclass) for a list of available classes, and for self hosted installations contact your system administrator for a list.
 
-* See the `resource_class` section of the [Configuration Reference]({{site.baseURL}}/2.0/configuration-reference/#resourceclass) for more information.
+* See the `resource_class` section of the [Configuration Reference]({{site.baseurl}}/2.0/configuration-reference/#resourceclass) for more information.
 
 ## See also
 {: #see-also }


### PR DESCRIPTION
# Description

Section `See the resource_class section of the Configuration Reference for more information.`

reference a bad link that causes a 404
❌  https://circleci.com/2.0/configuration-reference/#resourceclass

good link ✅ https://circleci.com/docs/2.0/configuration-reference/#resourceclass

# Reasons

404 error for customer 