### PR TITLE
Update KOTS installation links for v1.64.0

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -45,7 +45,7 @@ Download and install the following software before continuing:
 | {helmversion} or greater
 | Kubernetes Package Management
 
-| KOTS: https://github.com/replicatedhq/kots/releases/download/v1.47.3/kots_darwin_amd64.tar.gz[Mac] or https://github.com/replicatedhq/kots/releases/download/v1.47.3/kots_linux_amd64.tar.gz[Linux].
+| KOTS: https://github.com/replicatedhq/kots/releases/download/v1.64.0/kots_darwin_all.tar.gz[Mac] or https://github.com/replicatedhq/kots/releases/download/v1.64.0/kots_linux_amd64.tar.gz[Linux].
 | {kotsversion} *
 | Replicated Kubernetes Application Management
 


### PR DESCRIPTION
# Description

Updated the links since we are now recommending v1.64.0 (previously v1.47.3)
> You can confirm the download links here https://github.com/replicatedhq/kots/releases/tag/v1.64.0


It seems we use the `{kotsversion}` template to declare the latest supported version.
(see https://github.com/circleci/circleci-docs/pull/6450)

I wanted to use the same `{kotsversion}` template on these links so that we can skip manual link updates too.
However, I noted that the Mac (Darwin) release URL pattern from v.1.47.3 to v.1.64.0 has changed:

```diff
- https://github.com/replicatedhq/kots/releases/download/v1.47.3/kots_darwin_amd64.tar.gz
+ https://github.com/replicatedhq/kots/releases/download/v1.64.0/kots_darwin_all.tar.gz
```

Hence, I decided for this commit, I'll skip using the `{kotsversion}` template for now.
We can revisit using the `{kotsversion}` template for the next bump then.

# Reasons

A customer reached out and shared that our link seems to be stale :)