### PR TITLE
Ensure all images have alt text

### DIFF
--- a/docs/WIDGETS.md
+++ b/docs/WIDGETS.md
@@ -12,10 +12,10 @@ Here's how this would look in Jekyll's Markdown:
 
 ```md
 {:.tab.jobscreenshot.Cloud}
-![]({{ site.baseurl }}/assets/img/docs/new-job-page.png)
+![Some alt text]({{ site.baseurl }}/assets/img/docs/new-job-page.png)
 
 {:.tab.jobscreenshot.Server}
-![]({{ site.baseurl }}/assets/img/docs/old-job-page.png)
+![Some alt text]({{ site.baseurl }}/assets/img/docs/old-job-page.png)
 ```
 
 Using the example line `{:.tab.jobscreenshot.Cloud}`, let's look at how usage of tabs is broken down.

--- a/jekyll/_cci2/aws.adoc
+++ b/jekyll/_cci2/aws.adoc
@@ -211,7 +211,7 @@ NOTE: If you get an "Unknown error authenticating via GitHub. Try again, or cont
 
 .. Copy the Client ID and Secret from GitHub and paste it into the relevant fields, then click Test Authentication.
 
-.. If you are using GitHub.com, move on to step 6. If using Github Enterprise, you will also need to follow some suplementary steps and supply an API Token so we can verify your organization. To provide this, complete the following from your GitHub Enterprise dashboard:
+.. If you are using GitHub.com, move on to step 6. If using Github Enterprise, you will also need to follow some supplementary steps and supply an API Token so we can verify your organization. To provide this, complete the following from your GitHub Enterprise dashboard:
 ... Navigate to Personal Settings (top right) > Developer Settings > Personal Access Tokens.
 ... Click “generate new token”. Name the token appropriately to prevent accidental deletion. Do not tick any of the checkboxes, we only require the default public read-level access so no extra permissions are required. We recommend this token should be shared across your organization rather than being owned by a single user.
 ... Copy the new token and paste it into the GitHub Enterprise Default API Token field.
@@ -219,17 +219,17 @@ NOTE: If you get an "Unknown error authenticating via GitHub. Try again, or cont
 .Enter Github Enterprise Token
 image::ghe_token.png[Github Integration]
 
-. **LDAP** – if you wish to use LDAP authentication for your installation, enter the required details in the LDAP section. For a detailed runthrough of LDAP settings, read our https://circleci.com/docs/2.0/authentication/#ldap[LDAP authentication guide]
+. **LDAP** – if you wish to use LDAP authentication for your installation, enter the required details in the LDAP section. For a detailed run-through of LDAP settings, read our https://circleci.com/docs/2.0/authentication/#ldap[LDAP authentication guide]
 
 . **Privacy** – We recommend using an SSL certificate and key for your install. You can submit these in the Privacy section if this step was missed during the installation.
 +
 .Privacy Settings
-image::privacy.png[]
+image::privacy.png[Privacy settings]
 
 . **Storage** – We recommend using S3 for storage and all required fields for Storage are pre-populated. The IAM user, as referred to in the <<aws-prereq#planning,planning>> section of this document, is used here.
 +
 .Storage Options
-image::storage.png[]
+image::storage.png[Storage options]
 
 . **Enhanced AWS Integration** – Complete this section if you are using 1.0 builders.
 // explain enhanced AWS integration 1.0 or just say ignore
@@ -247,7 +247,7 @@ CAUTION: If Docker Layer Caching (DLC) is to be used, VM preallocation should be
 . **AWS Cloudwatch or Datadog Metrics** can be configured for your installation. Set either of these up in the relevant sections. For more information read our https://circleci.com/docs/2.0/monitoring/[Monitoring guidance]:
 +
 .Metrics
-image::metrics_setup.png[]
+image::metrics_setup.png[AWS Cloudwatch and Datadog metrics]
 
 . **Custom Metrics** are an alternative to Cloudwatch and Datadog metrics, you can also customize the metrics you receive through Telegraf. For more on this read our https://circleci.com/docs/2.0/monitoring/#custom-metrics[Custom Metics] guide.
 
@@ -265,7 +265,7 @@ NOTE: If the Management Console reports `Failure reported from operator: no such
 //<!--add info on making users administrators etc. to user management section of ops guide and put a link here-->
 +
 .Start CircleCI from your Dashboard
-image::dashboard.png[]
+image::dashboard.png[CircleCI server dashboard]
 
 . After build containers have started and images have been downloaded, the first build should begin immediately. If there are no updates after around **15 minutes**, and you have clicked the Refresh button, contact https://support.circleci.com/hc/en-us[CircleCI support] for assistance.
 

--- a/jekyll/_cci2/customizations.adoc
+++ b/jekyll/_cci2/customizations.adoc
@@ -224,10 +224,11 @@ You can add a banner to your login screen as follows:
 . Access the file: `/etc/circleconfig/frontend/customizations` on the Services machine
 . Add the following line, substituting the text you wish to display in the banner:
 +
-```shell
-export CIRCLE__OUTER__LOGIN_BANNER_MESSAGE="<insert-your-message-here>
-```
+[source,shell]
+----
+export CIRCLE__OUTER__LOGIN_BANNER_MESSAGE="<insert-your-message-here>"
+----
 . Restart CircleCI from the Management Console (your-circleci-hostname.com:8800)
 
 .Login Screen Banner Example
-image::banner.png[]
+image::banner.png[Example of banner]

--- a/jekyll/_cci2/gh-bb-integration.md
+++ b/jekyll/_cci2/gh-bb-integration.md
@@ -263,15 +263,15 @@ Bitbucket does not currently provide CircleCI with an API to create user keys. H
 2. Navigate to the **SSH Keys** page and scroll down to the **User Key** section.
 
 3. Right-click the **Add User Key** button and select the **Inspect** option to open the browser inspector.
-![]({{site.baseurl}}/assets/img/docs/bb_user_key.png)
+![Project settings Add User Key button]({{site.baseurl}}/assets/img/docs/bb_user_key.png)
 
 4. In the browser inspector, select the **Network** tab, and clear the console.
 
 5. Click **Add User Key** and confirm the user is a machine user by clicking **Confirm User** in the modal. _Please note that creating a machine user is strongly advised, though not mandatory_.
-![]({{site.baseurl}}/assets/img/docs/bb_confirm_user.png)
+![Machine user modal]({{site.baseurl}}/assets/img/docs/bb_confirm_user.png)
 
 6. In the filter box, type in "checkout" (without the quotes). This will help you locate the `checkout-key`. Click the `checkout-key` with a 201 status, then select the **Preview** tab. and copy the `public_key` (without the quotes) to your clipboard.
-![]({{site.baseurl}}/assets/img/docs/bb_user_key2.png)
+![Finding the public key]({{site.baseurl}}/assets/img/docs/bb_user_key2.png)
 
 7. Add the key to Bitbucket by following Bitbucket's guide on [setting up SSH keys](https://support.atlassian.com/bitbucket-cloud/docs/set-up-an-ssh-key/).
 

--- a/jekyll/_cci2/insights-glossary.md
+++ b/jekyll/_cci2/insights-glossary.md
@@ -38,7 +38,7 @@ count of workflow executions or jobs, depending on the context.
 ## Organization-level metrics
 {: #organization-level-metrics }
 
-![]({{ site.baseurl }}/assets/img/docs/insights-org-metrics.png)
+![Organization-level metrics example]({{ site.baseurl }}/assets/img/docs/insights-org-metrics.png)
 
 Organization-level metrics allow you to analyze your organization’s performance.
 
@@ -54,7 +54,7 @@ Organization-level metrics allow you to analyze your organization’s performanc
 ## Workflow Metrics
 {: #workflow-metrics }
 
-![]({{ site.baseurl }}/assets/img/docs/insights-workflow-metrics.png)
+![Workflow metrics example]({{ site.baseurl }}/assets/img/docs/insights-workflow-metrics.png)
 
 | Term                    | Definition     |
 |-------------------------|----------------|
@@ -108,7 +108,7 @@ are calculated by taking the median of the daily P50 values as a benchmark.
 
 This section describes how your trend data may appear across various metrics.
 
-![]({{ site.baseurl }}/assets/img/docs/insights_trend_data.png)
+![Trends data example]({{ site.baseurl }}/assets/img/docs/insights_trend_data.png)
 
 - **Green**: The metric is trending in the right direction.
 - **Red**: The metric is trending in the wrong direction.

--- a/jekyll/_cci2/insights-tests.md
+++ b/jekyll/_cci2/insights-tests.md
@@ -23,7 +23,7 @@ The summary section displays test suite performance across your most recent 100 
 - failure counts
 - slow run times in test suite
 
-![]({{ site.baseurl }}/assets/img/docs/test-insights-performance-summary.png)
+![Performance summary example]({{ site.baseurl }}/assets/img/docs/test-insights-performance-summary.png)
 
 ### Most Recent Runs
 {: #most-recent-runs }
@@ -33,7 +33,7 @@ The most recent runs chart displays the most recent 100 executions of the test s
 - skipped tests
 - success rate of tests
 
-![]({{ site.baseurl }}/assets/img/docs/test-insights-recent-runs.png)
+![Recent runs example]({{ site.baseurl }}/assets/img/docs/test-insights-recent-runs.png)
 
 ### Flaky Tests
 {: #flaky-tests }
@@ -42,7 +42,7 @@ Flaky tests are tests that fail non-deterministically; they pass and fail due to
 
 Test insights detect flaky tests by identifying tests that failed and passed on the same commit in a 14-day window. Deterministic tests rely on the state of the repository and demonstrate the same behavior on re-runs. Additionally, these types of tests are labeled “FLAKY” throughout the CircleCI app making them easy to identify and fix.
 
-![]({{ site.baseurl }}/assets/img/docs/test-insights-flaky.png)
+![Flakey tests insights example]({{ site.baseurl }}/assets/img/docs/test-insights-flaky.png)
 
 ### Most Failed Tests
 {: #most-failed-tests }
@@ -53,7 +53,7 @@ You can view the 100 tests with the lowest success rates in their most recent pi
 - run time
 - success rate
 
-![]({{ site.baseurl }}/assets/img/docs/test-insights-failed.png)
+![Most failed tests examples]({{ site.baseurl }}/assets/img/docs/test-insights-failed.png)
 
 ### Slowest Tests
 {: #slowest-tests }
@@ -64,4 +64,4 @@ You can view the 100 tests with the longest run times in their most recent pipel
 - run time
 - success rate
 
-![]({{ site.baseurl }}/assets/img/docs/test-insights-slowest.png)
+![Slowest tests example]({{ site.baseurl }}/assets/img/docs/test-insights-slowest.png)

--- a/jekyll/_cci2/insights.md
+++ b/jekyll/_cci2/insights.md
@@ -32,13 +32,13 @@ To access a specific project's insights, view a pipeline's workflow and click
  clicking on the **actions** button while viewing the _pipelines dashboard_.
 
 {:.tab.insight-access.Access_by_sidebar}
-![]({{ site.baseurl }}/assets/img/docs/screen_insights_access-3.png)
+![Access insights from the CircleCI web app sidebar]({{ site.baseurl }}/assets/img/docs/screen_insights_access-3.png)
 
 {:.tab.insight-access.Access_by_pipeline}
-![]({{ site.baseurl }}/assets/img/docs/screen_insights_access-1.png)
+![Access insights from a pipeline in the CircleCI web app]({{ site.baseurl }}/assets/img/docs/screen_insights_access-1.png)
 
 {:.tab.insight-access.Access_by_workflow}
-![]({{ site.baseurl }}/assets/img/docs/screen_insights_access-2.png)
+![Access insights from a workflow in the CircleCI web app]({{ site.baseurl }}/assets/img/docs/screen_insights_access-2.png)
 
 
 ### Workflow overview

--- a/jekyll/_cci2/jira-plugin.md
+++ b/jekyll/_cci2/jira-plugin.md
@@ -14,12 +14,12 @@ the CircleCI JIRA plugin, you can display your build statuses in JIRA.
 {: #installation-steps }
 
 1. Navigate to project settings and select `JIRA integration`
-![]({{ site.baseurl }}/assets/img/docs/jira_plugin_1.png)
+![CircleCI web app Project Settings Jira integration options]({{ site.baseurl }}/assets/img/docs/jira_plugin_1.png)
 2. Go to the Atlassian Marketplace to get the [CircleCI JIRA Plugin](https://marketplace.atlassian.com/apps/1215946/circleci-for-jira?hosting=cloud&tab=overview)
-![]({{ site.baseurl }}/assets/img/docs/jira_plugin_2.png)
+![Atlassian marketplace showing CircleCI Jira plugin]({{ site.baseurl }}/assets/img/docs/jira_plugin_2.png)
 3. Install the plugin and follow the prompts to set it up.
-![]({{ site.baseurl }}/assets/img/docs/jira_plugin_3.png)
-![]({{ site.baseurl }}/assets/img/docs/jira_plugin_4.png)
+![Setting up the plugin 1]({{ site.baseurl }}/assets/img/docs/jira_plugin_3.png)
+![Setting up the plugin 2]({{ site.baseurl }}/assets/img/docs/jira_plugin_4.png)
 4. Return to the CircleCI JIRA Integration settings page and add the generated token.
 
 ---

--- a/jekyll/_cci2/notifications.md
+++ b/jekyll/_cci2/notifications.md
@@ -54,9 +54,9 @@ Use the [Notifications](https://app.circleci.com/settings/user/notifications){:r
 
 Email notifications will look like the following:
 
-![]({{ site.baseurl }}/assets/img/docs/notification-email-success.png)
+![Example success email notification]({{ site.baseurl }}/assets/img/docs/notification-email-success.png)
 
-![]({{ site.baseurl }}/assets/img/docs/notification-email-failure.png)
+![Example failure email notification]({{ site.baseurl }}/assets/img/docs/notification-email-failure.png)
 
 ## Enable web notifications
 {: #enable-web-notifications }
@@ -67,7 +67,7 @@ Perform the following steps to enable web notifications:
 
 2. Your browser will ask you to confirm that you want to allow notifications. Click `Allow`. See the screenshot below for additional details:
 
-![]({{ site.baseurl }}/assets/img/docs/notifications-enable-web.png)
+![Screenshots showing how to enable web notifications in your browser]({{ site.baseurl }}/assets/img/docs/notifications-enable-web.png)
 
 If you've previously denied CircleCI permission to send you web notifications
 you will need to manually turn those permissions on in your browser, as CircleCI cannot

--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -336,7 +336,7 @@ You can categorize your orb for better discoverability in the [Orb Registry](htt
 #### Listing categories
 {: #listing-categories }
 
-![](  {{ site.baseurl }}/assets/img/docs/orb-categories-list-categories.png)
+![Example of showing listing categories using the CLI](  {{ site.baseurl }}/assets/img/docs/orb-categories-list-categories.png)
 
 You can select up to two categories for your orb. These are the available categories:
 
@@ -361,21 +361,21 @@ The list of categories can also be obtained by running the `circleci orb list-ca
 #### Add an orb to a category
 {: #add-an-orb-to-a-category }
 
-![](  {{ site.baseurl }}/assets/img/docs/orb-categories-add-to-category.png)
+![Adding an orb category](  {{ site.baseurl }}/assets/img/docs/orb-categories-add-to-category.png)
 
 Add your orb to your chosen category by running `circleci orb add-to-category <namespace>/<orb> "<category-name>"`. You can view the detailed docs for this command [here](https://circleci-public.github.io/circleci-cli/circleci_orb_add-to-category.html).
 
 #### Remove an orb from a category
 {: #remove-an-orb-from-a-category }
 
-![](  {{ site.baseurl }}/assets/img/docs/orb-categories-remove-from-category.png)
+![Removing an orb from a category](  {{ site.baseurl }}/assets/img/docs/orb-categories-remove-from-category.png)
 
 Remove an orb from a category by running `circleci orb remove-from-category <namespace>/<orb> "<category-name>"`. You can view the detailed docs for this command [here](https://circleci-public.github.io/circleci-cli/circleci_orb_remove-from-category.html).
 
 #### Viewing an orb's categorizations
 {: #viewing-an-orbs-categorizations }
 
-![](  {{ site.baseurl }}/assets/img/docs/orb-categories-orb-info.png)
+![Show which categorizations have been added to an orb](  {{ site.baseurl }}/assets/img/docs/orb-categories-orb-info.png)
 
 To see which categorizations have been applied an orb, check the output of `circleci orb info <namespace>/<orb>` for a list. You can view the detailed docs for this command [here](https://circleci-public.github.io/circleci-cli/circleci_orb_info.html).
 

--- a/jekyll/_cci2/pipelines.md
+++ b/jekyll/_cci2/pipelines.md
@@ -54,8 +54,8 @@ TBC
 
 A pipeline is composed of workflows, which are composed of jobs. By navigating from a pipeline to a specific job, you can access your job output, test results and artifacts through several tabs.
 
-![]({{ site.baseurl }}/assets/img/docs/pipelines-job-step-test-artifact.png)
+![Job tab options in the CircleCI web app]({{ site.baseurl }}/assets/img/docs/pipelines-job-step-test-artifact.png)
 
 Further, the output of each job can be opened in a new tab (in either raw or formatted styling) with a unique link, making it share-able between team members.
 
-![]({{ site.baseurl }}/assets/img/docs/pipelines-job-output.png)
+![Download and share job step output]({{ site.baseurl }}/assets/img/docs/pipelines-job-output.png)

--- a/jekyll/_cci2/webhooks-airtable.md
+++ b/jekyll/_cci2/webhooks-airtable.md
@@ -79,7 +79,7 @@ Click "Add Webhook" and enter a name for the webhook, the webhook URL we copied
 earlier, and select the "Job Completed" event, before saving by pressing "Add
 Webhook" again.
 
-![]({{site.baseurl}}/assets/img/docs/webhooks/webhook_airtable_6.png)
+![Entering details for a webhook]({{site.baseurl}}/assets/img/docs/webhooks/webhook_airtable_6.png)
 
 ### 5. Trigger a test webhook
 {: #trigger-a-test-webhook }


### PR DESCRIPTION
For accessibility, we should always include alt text when including images in our docs. This PR adds those that were missing.