### PR TITLE
Update asciidoc attributes

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -84,7 +84,7 @@ asciidoctor:
   base_dir: :docdir
   safe: unsafe
   attributes:
-    imagesdir: /assets/img/docs/
+    imagesdir: jekyll/assets/img/docs/
     relfileprefix: ../
     outfilesuffix: /index.html
     serverversion: 3.3.1

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -84,7 +84,7 @@ asciidoctor:
   base_dir: :docdir
   safe: unsafe
   attributes:
-    imagesdir: @baseurl/assets/img/docs/
+    imagesdir: /docs/assets/img/docs/
     relfileprefix: ../
     outfilesuffix: /index.html
     serverversion: 3.3.1

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -84,7 +84,7 @@ asciidoctor:
   base_dir: :docdir
   safe: unsafe
   attributes:
-    imagesdir: docs/assets/img/docs/
+    imagesdir: /docs/assets/img/docs/
     relfileprefix: ../
     outfilesuffix: /index.html
     serverversion: 3.3.1

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -84,7 +84,7 @@ asciidoctor:
   base_dir: :docdir
   safe: unsafe
   attributes:
-    imagesdir: /docs/assets/img/docs/
+    imagesdir: @baseurl/assets/img/docs/
     relfileprefix: ../
     outfilesuffix: /index.html
     serverversion: 3.3.1

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -81,10 +81,10 @@ asciidoc:
       kotsversion: 1.64.0
 
 asciidoctor:
-  base_dir: _cci2/
+  base_dir: :docdir
   safe: unsafe
   attributes:
-    imagesdir: /docs/assets/img/docs/
+    imagesdir: /assets/img/docs/
     relfileprefix: ../
     outfilesuffix: /index.html
     serverversion: 3.3.1

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -84,7 +84,7 @@ asciidoctor:
   base_dir: :docdir
   safe: unsafe
   attributes:
-    imagesdir: jekyll/assets/img/docs/
+    imagesdir: docs/assets/img/docs/
     relfileprefix: ../
     outfilesuffix: /index.html
     serverversion: 3.3.1


### PR DESCRIPTION
Update base directory for asciidoc content to widen the scope of content outside `_cci2`. We already have a style guide, and soon "Vamp" docs will live outside the `_cci2` dir.

Reference here: https://github.com/asciidoctor/jekyll-asciidoc/tree/v2.1.x#specifying-the-base-directory

(ignore the other commits, I was playing around with the images path and previews)