### PR TITLE
Fix default cache path for golang build

### DIFF
--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -86,7 +86,7 @@ jobs: # basic units of work in a run
       - save_cache:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg/mod"
+            - "/home/circleci/go/pkg/mod"
 
       - run:
           name: Start service


### PR DESCRIPTION
# Description
The path shown in the documentation does not work

Not working cache : 
<img width="607" alt="image" src="https://user-images.githubusercontent.com/4854264/160396697-25e819c9-0afb-49ea-a752-9d12ebb15b9e.png">

Working cache : 
<img width="623" alt="image" src="https://user-images.githubusercontent.com/4854264/160396812-def22a60-b405-4ea2-afc8-b25a08337d42.png">

