### PR TITLE
Fix: only show "reading time" in tooltip if it exists for doc.

### DIFF
--- a/jekyll/_includes/quick-info-list.html
+++ b/jekyll/_includes/quick-info-list.html
@@ -1,7 +1,9 @@
 {% if page.page-type != "index" and page.page-type != "homepage" %}
 <div id="tooltip" role="tooltip" class="tooltip-popover"></div>
 <div id="tooltip-time" role="tooltip" class="tooltip-popover">
-  Last updated • Reading time
+  <span>
+    <span>Last updated</span> {% if page.readtime %} <span>• Reading time</span>{% endif %}
+  </span>
   <div id='arrow' data-popper-arrow></div>
 </div>
 <div class="quick-info-list">


### PR DESCRIPTION
[Ticket](https://circleci.atlassian.net/browse/DD-497)

# Description
- Fix: conditionally show "reading time" popper text if reading time is enabled for that document.

# Reasons
Original bug: 
<img width="400" alt="image" src="https://user-images.githubusercontent.com/12987958/160913789-cdfd859e-0f06-47a1-9d0a-3aa45a671928.png">
