### PR TITLE
server-1733/GCP_WI_update | update link and GCP WI detail

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -225,7 +225,7 @@ https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workloa
     --region="<REGION>"
 ```
 
-You must repeat Step 2 for all the existing node pools. Follow these links for steps to enable Workload Identity for your Kubernetes service accounts: link:https://circleci.com/docs/2.0/server-3-install-build-services/#gcp-2[Nomad Autoscaler], link:https://circleci.com/docs/2.0/server-3-install-build-services/#gcp-3[VM] and link:https://circleci.com/docs/2.0/server-3-install-prerequisites/#create-a-google-cloud-storage-bucket[Object-Storage]
+You must repeat Step 3 for all the existing node pools. Follow these links for steps to enable Workload Identity for your Kubernetes service accounts: link:https://circleci.com/docs/2.0/server-3-install-build-services/#gcp-2[Nomad Autoscaler], link:https://circleci.com/docs/2.0/server-3-install-build-services/#gcp-3[VM] and link:https://circleci.com/docs/2.0/server-3-install-prerequisites/#create-a-google-cloud-storage-bucket[Object-Storage]
 
 === Create a new GitHub OAuth app
 

--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -609,10 +609,9 @@ You will need the following details when you configure CircleCI server.
 
 * *Storage Bucket Name* - The bucket used for server.
 
-You can choose one of the following:
-
-  * *Service Account JSON* - A JSON format key of the Service Account to use for bucket access.
-  * *Service Account Email* - Service Account Email id if using Google Workload Identity.
+* You can choose one of the following:
+** *Service Account JSON* - A JSON format key of the Service Account to use for bucket access.
+** *Service Account Email* - Service Account Email id if using Google Workload Identity.
 
 A dedicated service account is recommended. Add to it the Storage Object Admin role, with a condition on the resource name limiting access to only the bucket specified above. For example, enter the following into the Google’s Condition Editor in the IAM console:
 

--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -225,7 +225,7 @@ https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workloa
     --region="<REGION>"
 ```
 
-You must repeat Step 2 for all the existing node pools. Follow these links for steps to enable Workload Identity for your Kubernetes service accounts: link:https://circleci.com/docs/2.0/server-3-install-build-services/#gcp-2[Nomad Autoscaler], link:https://circleci.com/docs/2.0/server-3-install-build-services/#gcp-3[VM] and link:https://circleci.com/docs/2.0/server-3-install-prerequisites/#step-5-enable-workload-identity[Object-Storage]
+You must repeat Step 2 for all the existing node pools. Follow these links for steps to enable Workload Identity for your Kubernetes service accounts: link:https://circleci.com/docs/2.0/server-3-install-build-services/#gcp-2[Nomad Autoscaler], link:https://circleci.com/docs/2.0/server-3-install-build-services/#gcp-3[VM] and link:https://circleci.com/docs/2.0/server-3-install-prerequisites/#create-a-google-cloud-storage-bucket[Object-Storage]
 
 === Create a new GitHub OAuth app
 
@@ -609,7 +609,10 @@ You will need the following details when you configure CircleCI server.
 
 * *Storage Bucket Name* - The bucket used for server.
 
-* *Service Account JSON* - A JSON format key of the Service Account to use for bucket access.
+You can choose one of the following:
+
+  * *Service Account JSON* - A JSON format key of the Service Account to use for bucket access.
+  * *Service Account Email* - Service Account Email id if using Google Workload Identity.
 
 A dedicated service account is recommended. Add to it the Storage Object Admin role, with a condition on the resource name limiting access to only the bucket specified above. For example, enter the following into the Google’s Condition Editor in the IAM console:
 

--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -203,8 +203,10 @@ Number of days to retain your test results and artifacts. Set to 0 to disable an
 
 ===== Authentication
 
-* *Service Account JSON (required)* -
-A JSON format key of the Service Account to use for bucket access.
+You can choose one of the following:
+
+  * *Service Account JSON (required)* - A JSON format key of the Service Account to use for bucket access.
+  * *Service Account Email (required)* - Service Account Email id if using Google Workload Identity.
 
 endif::env-aws[]
 

--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -203,10 +203,9 @@ Number of days to retain your test results and artifacts. Set to 0 to disable an
 
 ===== Authentication
 
-You can choose one of the following:
-
-  * *Service Account JSON (required)* - A JSON format key of the Service Account to use for bucket access.
-  * *Service Account Email (required)* - Service Account Email id if using Google Workload Identity.
+* You can choose one of the following:
+** *Service Account JSON (required)* - A JSON format key of the Service Account to use for bucket access.
+** *Service Account Email (required)* - Service Account Email id if using Google Workload Identity.
 
 endif::env-aws[]
 


### PR DESCRIPTION
# Description
* Added missing GCP Workload Identity information
* Updated doc link 

# Reasons
[SERVER-1733](https://circleci.atlassian.net/browse/SERVER-1733)