### PR TITLE
Update Launch-Agent Version for Server 3.4

### DIFF
--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -168,6 +168,9 @@ depending on your version of server:
 
 | 3.3
 | 1.0.29477-605777e
+
+| 3.4
+| 1.0.33818-051c2fc
 |===
 
 == Additional Resources


### PR DESCRIPTION
# Description
Update Launch-Agent Version for Server 3.4

This version is taken from the server-3.4 branch [here](https://github.com/circleci/server/blob/e54a984cf22f071cd9d56231aa811dcb77738843/tests/cypress/integration/runnerTests/launch-agent.sh#L3)

# Reasons
Server 3.4 is being released soon and we're updating the documentation to show the appropriate version