### PR TITLE
Update available linux machine images list

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -375,8 +375,10 @@ jobs:
 ##### Available `machine` images
 {: #available-machine-images }
 
-**Specifying an image in your config file is strongly recommended.** CircleCI supports multiple machine images that can be specified in the `image` field. For a full list of images see the [Ubuntu 20.04 page in the developer hub](https://circleci.com/developer/machine/image/ubuntu-2004). And for up to date lists of what is available in each image see [Discuss](https://discuss.circleci.com/t/linux-machine-executor-images-october-q4-update/37847).
+**Specifying an image in your config file is strongly recommended.** CircleCI supports multiple machine images that can be specified in the `image` field. For a full list of supported images, refer to the [Ubuntu 20.04 page in the Developer Hub](https://circleci.com/developer/machine/image/ubuntu-2004). More information on what software is available in each image can be found in our [Discuss forum](https://discuss.circleci.com/tag/machine-images).
 
+* `ubuntu-2004:202201-02` - Ubuntu 20.04, Docker v20.10.12, Docker Compose v1.29.2, Google Cloud SDK updates
+* `ubuntu-2004:202201-01` - Ubuntu 20.04, Docker v20.10.12, Docker Compose v1.29.2
 * `ubuntu-2004:202111-02` - Ubuntu 20.04, Docker v20.10.11, Docker Compose v1.29.2, log4j updates
 * `ubuntu-2004:202111-01` - Ubuntu 20.04, Docker v20.10.11, Docker Compose v1.29.2,
 * `ubuntu-2004:202107-02` - Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2,


### PR DESCRIPTION
# Description
Add most recent Ubuntu images to config reference's list of available machine images. 

# Reasons
Resolves issue [#6570](https://github.com/circleci/circleci-docs/issues/6570)

Ideally, we would just either link to the Developer Hub, or wherever the single source of truth is, and not maintain a separate list of images in other docs pages such as the Config Reference. However, for now we want to keep the list in the config reference that includes the Ubuntu 16.04 images because they are technically still available, albeit deprecated. 

This also means that with the upcoming release of the new 22.04 images, following this pattern we'd have to do at least another addition to the list before May of this year.

When the 14.04 and 16.04 images are EOL in May, we should remove the list entirely from the Config Reference.