### PR TITLE
Update built-in-env-vars.md

### DIFF
--- a/jekyll/_includes/snippets/built-in-env-vars.md
+++ b/jekyll/_includes/snippets/built-in-env-vars.md
@@ -22,6 +22,7 @@ Variable | Type | Value
 `CIRCLE_TAG`{:.env_var} | String | The name of the git tag, if the current build is tagged. For more information, see the [Git Tag Job Execution]({{site.baseurl}}/2.0/workflows/#executing-workflows-for-a-git-tag).
 `CIRCLE_USERNAME`{:.env_var} | String | The GitHub or Bitbucket username of the user who triggered the pipeline (only if the user has a CircleCI account).
 `CIRCLE_WORKFLOW_ID`{:.env_var} | String | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
+`CIRCLE_WORKFLOW_JOB_ID`{:.env_var} | String | A unique identifier for the current job.
 `CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var} | String | An identifier for the [workspace]({{site.baseurl}}/2.0/glossary/#workspace) of the current job. This identifier is the same for every job in a given workflow.
 `CIRCLE_WORKING_DIRECTORY`{:.env_var} | String | The value of the `working_directory` key of the current job.
 `CIRCLE_INTERNAL_TASK_DATA`{:.env_var} | String | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.


### PR DESCRIPTION
# Description

Included the `CIRCLE_WORKFLOW_JOB_ID` which identifies the current job (UUID string).

We can see this [populated in action here](https://app.circleci.com/pipelines/github/kelvintaywl-cci/generating-artifacts-url/4/workflows/9fce5e28-fb62-434e-9e21-e049077f3fb3/jobs/4/parallel-runs/0?filterBy=ALL&invite=true#step-99-21) for example, and this may be useful right now for [users trying to generate artifacts' URL in advance](https://support.circleci.com/hc/en-us/articles/5034956515355-How-to-Programmatically-Construct-the-URLs-for-Artifacts).

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.