### PR TITLE
Remove unsupported key 'when' from store_artifacts

### DIFF
--- a/jekyll/_cci2/language-java.md
+++ b/jekyll/_cci2/language-java.md
@@ -91,7 +91,6 @@ jobs: # a collection of steps
           path: build/test-results/test
       - store_artifacts: # Upload test results for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
           path: build/test-results/test
-          when: always
       - run:
           name: Assemble JAR
           command: |
@@ -239,7 +238,6 @@ Next `store_test_results` uploads the JUnit test metadata from the `build/test-r
           path: build/test-results/test
       - store_artifacts:
           path: build/test-results/test
-          when: always
 ```
 {% endraw %}
 


### PR DESCRIPTION
# Description
Remove an unsupported key 'when' from store_artifacts step.

# Reasons
The key has no effect since this step is always executed according to [docs](https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute).