### PR TITLE
[FLEETS-763] Re-arrange valid IPs based on current infrastructure

### DIFF
--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -63,35 +63,27 @@ workflows:
 
 Jobs that have been opted into the IP ranges feature will have one of the following IP address ranges associated with them:
 
-- 107.22.40.20
-- 18.215.226.36
-- 3.228.208.40
 - 3.228.39.90
-- 3.91.130.126
-- 34.194.144.202
+- 18.213.67.41
 - 34.194.94.201
+- 34.194.144.202
+- 34.197.6.234
 - 35.169.17.173
 - 35.174.253.146
-- 52.20.179.68
-- 52.21.153.129
-- 52.22.187.0
 - 52.3.128.216
 - 52.4.195.249
 - 52.5.58.121
+- 52.21.153.129
 - 52.72.72.233
-- 52.72.73.201
-- 54.144.204.41
-- 54.161.182.76
-- 54.162.196.253
-- 54.164.161.41
-- 54.167.72.230
-- 54.205.138.102
-- 54.209.115.53
-- 54.211.118.70
-- 54.226.126.177
-- 54.81.162.133
-- 54.83.41.200
 - 54.92.235.88
+- 54.161.182.76
+- 54.164.161.41
+- 54.166.105.113
+- 54.167.72.230
+- 54.172.26.132
+- 54.205.138.102
+- 54.208.72.234
+- 54.209.115.53
 
 **Note:** Jobs can use any of the address ranges above. It is also important to note that the address ranges are shared by all CircleCI customers who have opted into using the feature.
 {: class="alert alert-info"}


### PR DESCRIPTION
# Description
Remove no-longer-used IP addresses and add newly allocated IP addresses for IP ranges

# Reasons
[Jira issue](https://circleci.atlassian.net/browse/FLEETS-763)