### PR TITLE
update admonition styles in asciidoc content

### DIFF
--- a/docs/server-docs.adoc
+++ b/docs/server-docs.adoc
@@ -1,8 +1,8 @@
-= CircleCI Server Documentation
+= Asciidoc
 
-Server documentation is written in ASCIIDOC and built for the web and PDF using https://github.com/asciidoctor/jekyll-asciidoc[jekyll-asciidoc] and https://github.com/asciidoctor/asciidoctor-pdf[asciidoctor-pdf] plugins.
+Some CircleCI documentation is written in asciidoc and built into the site using https://github.com/asciidoctor/jekyll-asciidoc[jekyll-asciidoc]. Server documentation is also converted to PDF using https://github.com/asciidoctor/asciidoctor-pdf[asciidoctor-pdf] plugins.
 
-== Document Structure
+== Server Document Structure
 Server documentation is provided in two formats:
 
 * HTML on the main CircleCI docs site showing the current docs for server 2.x 

--- a/jekyll/_cci2/server-3-overview.adoc
+++ b/jekyll/_cci2/server-3-overview.adoc
@@ -11,6 +11,26 @@ version:
 :toc: macro
 :toc-title:
 
+NOTE: This is a very long note with a link http://circleci.com/docs[Link text]. This is a very long note with a link. This is a very long note with a link. This is a very long note with a link. This is a very long note with a link
+
+TIP: This is a tip with some **bold text**.
+
+IMPORTANT: This bit is important you should definitely _pay attention_.
+
+CAUTION: This is a caution. **Do not do this!!**
+
+WARNING: This is a warning. Don't!
+
+[IMPORTANT] 
+.Feeding the Werewolves
+==== 
+While werewolves are hardy community members, keep in mind the following dietary concerns:
+
+. They are allergic to cinnamon.
+. More than two glasses of orange juice in 24 hours makes them howl in harmony with alarms and sirens.
+. Celery makes them sad.
+====
+
 toc::[]
 
 == Introduction

--- a/jekyll/_cci2/server-3-overview.adoc
+++ b/jekyll/_cci2/server-3-overview.adoc
@@ -11,26 +11,6 @@ version:
 :toc: macro
 :toc-title:
 
-NOTE: This is a very long note with a link http://circleci.com/docs[Link text]. This is a very long note with a link. This is a very long note with a link. This is a very long note with a link. This is a very long note with a link
-
-TIP: This is a tip with some **bold text**.
-
-IMPORTANT: This bit is important you should definitely _pay attention_.
-
-CAUTION: This is a caution. **Do not do this!!**
-
-WARNING: This is a warning. Don't!
-
-[IMPORTANT] 
-.Feeding the Werewolves
-==== 
-While werewolves are hardy community members, keep in mind the following dietary concerns:
-
-. They are allergic to cinnamon.
-. More than two glasses of orange juice in 24 hours makes them howl in harmony with alarms and sirens.
-. Celery makes them sad.
-====
-
 toc::[]
 
 == Introduction

--- a/jekyll/_style/style-formatting.adoc
+++ b/jekyll/_style/style-formatting.adoc
@@ -13,3 +13,86 @@
 
 // * Use italics for technical terms and to refer to a specific guide within docs, for example:
 // ** TBC
+
+== Using notes, tips, important information, cautions and warnings
+
+To add an admonition - note, tip, important information, caution, warning – use the following syntax:
+
+[source,adoc]
+NOTE: This is a note.
+
+The result of this is:
+
+NOTE: This is a note.
+
+---
+
+[source,adoc]
+TIP: This is a tip.
+
+The result of this is:
+
+TIP: This is a tip.
+
+---
+
+[source,adoc]
+IMPORTANT: This is some important information.
+
+The result of this is:
+
+IMPORTANT: This is some important information.
+
+---
+
+[source,adoc]
+CAUTION: This is a note.
+
+The result of this is:
+
+CAUTION: This is a note.
+
+---
+
+[source,adoc]
+WARNING: This is a note.
+
+The result of this is:
+
+WARNING: This is a note.
+
+---
+
+You can also make a longer admonition block for any of the types listed above:
+
+[source,adoc]
+----
+[IMPORTANT] 
+==== 
+[.important]#While werewolves are hardy community members, keep in mind the following dietary concerns:#
+
+. [.important]#They are allergic to cinnamon.#
+. [.important]#More than two glasses of orange juice in 24 hours makes them howl in harmony with alarms and sirens.#
+. [.important]#Celery makes them sad.#
+====
+----
+
+[IMPORTANT] 
+====  
+[.important]#While werewolves are hardy community members, keep in mind the following dietary concerns:#
+
+. [.important]#They are allergic to cinnamon.#
+. [.important]#More than two glasses of orange juice in 24 hours makes them howl in harmony with alarms and sirens.#
+. [.important]#Celery makes them sad.#
+====
+
+NOTE: If the paragraph text is not styled using `[.style]##` as shown here, it will still work but the text colour will be black rather that matching the colour of the admonition.
+
+=== Things to avoid
+
+Try not to use links in warnings at this time due to the blue on red style:
+
+[source.adoc]
+WARNING: A warning with a link:circleci.com[CircleCI] looks bad!
+
+WARNING: A warning with a link:circleci.com[CircleCI] looks bad!

--- a/jekyll/_style/style-formatting.adoc
+++ b/jekyll/_style/style-formatting.adoc
@@ -93,6 +93,6 @@ NOTE: If the paragraph text is not styled using `[.style]##` as shown here, it w
 Try not to use links in warnings at this time due to the blue on red style:
 
 [source.adoc]
-WARNING: A warning with a link:circleci.com[CircleCI] is hard to read.
+WARNING: A warning with a link:https://circleci.com/[CircleCI] is hard to read.
 
-WARNING: A warning with a link:circleci.com[CircleCI] is hard to read.
+WARNING: A warning with a link:https://circleci.com/[CircleCI] is hard to read.

--- a/jekyll/_style/style-formatting.adoc
+++ b/jekyll/_style/style-formatting.adoc
@@ -11,8 +11,8 @@
 ** Select **VCS** in the **Project Settings** window
 ** Select **Projects** from the sidebar and click **Set Up Project** for the project you want to follow
 
-// * Use italics for technical terms and to refer to a specific guide within docs, for example:
-// ** TBC
+* Use italics for technical terms, for example:
+** _Continuous Integration_
 
 == Using notes, tips, important information, cautions and warnings
 
@@ -93,6 +93,6 @@ NOTE: If the paragraph text is not styled using `[.style]##` as shown here, it w
 Try not to use links in warnings at this time due to the blue on red style:
 
 [source.adoc]
-WARNING: A warning with a link:circleci.com[CircleCI] looks bad!
+WARNING: A warning with a link:circleci.com[CircleCI] is hard to read.
 
-WARNING: A warning with a link:circleci.com[CircleCI] looks bad!
+WARNING: A warning with a link:circleci.com[CircleCI] is hard to read.

--- a/src/styles/_asciidoc.scss
+++ b/src/styles/_asciidoc.scss
@@ -15,7 +15,6 @@
   margin-bottom:20px;
   border:1px solid transparent;
   border-radius:4px
-
 }
 
 .note{
@@ -60,8 +59,6 @@
   margin-right: auto;
   margin-bottom: 10px;
 }
-
-
 
 .green{
   color: #43C78A;

--- a/src/styles/_asciidoc.scss
+++ b/src/styles/_asciidoc.scss
@@ -1,3 +1,8 @@
+table{
+  margin-top: 0px;
+}
+
+/*
 .admonitionblock>table td.icon{
   vertical-align: top;
   text-align:center;
@@ -9,6 +14,7 @@
 .admonitionblock td.icon .icon-warning:before{content:"\f071";color:#a94442}
 .admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#8a6d3b}
 .admonitionblock td.icon .icon-important:before{content:"\f06a";color:#3c763d}
+*/
 
 .admonitionblock {
   padding:15px;

--- a/src/styles/_asciidoc.scss
+++ b/src/styles/_asciidoc.scss
@@ -1,36 +1,53 @@
-span.icon>.fa {
-  cursor: default;
+.admonitionblock>table td.icon{
+  vertical-align: top;
+  text-align:center;
+  width:70px}
+
+.admonitionblock td.icon [class^="fa icon-"]{font-size:1.8em;cursor:default}
+.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#31708f}
+.admonitionblock td.icon .icon-tip:before{content:"\f0eb";color:#555555}
+.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#a94442}
+.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#8a6d3b}
+.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#3c763d}
+
+.admonitionblock {
+  padding:15px;
+  margin-bottom:20px;
+  border:1px solid transparent;
+  border-radius:4px
+
 }
-.admonitionblock td.icon {
-  text-align: center;
-  width: 80px;
+
+.note{
+  background-color:#d9edf7;
+  border-color:#bce8f1;
+  color:#31708f
 }
-.admonitionblock td.icon [class^="fa icon-"] {
-  font-size: 2.5em;
-  /* text-shadow: 1px 1px 2px rgba(0,0,0,.5); */
-  cursor: default;
+
+.tip{
+  background-color:#f9f9f9;
+  border-color:#dddddd;
+  color:#555555
 }
-.admonitionblock td.icon .icon-note:before {
-  content: "\f05a";
-  color: #19407c;
+
+.important{
+  background-color:#dff0d8;
+  border-color:#d6e9c6;
+  color:#3c763d
 }
-.admonitionblock td.icon .icon-tip:before {
-  content: "\f0eb";
-  /*text-shadow: 1px 1px 2px rgba(155,155,0,.8);*/
-  color: #111;
+
+.caution{
+  background-color:#fcf8e3;
+  border-color:#faebcc;
+  color:#8a6d3b
 }
-.admonitionblock td.icon .icon-warning:before {
-  content: "\f071";
-  color: #bf6900;
+
+.warning{
+  background-color:#f2dede;
+  border-color:#ebccd1;
+  color:#a94442
 }
-.admonitionblock td.icon .icon-caution:before {
-  content: "\f06d";
-  color: #bf3400;
-}
-.admonitionblock td.icon .icon-important:before {
-  content: "\f06a";
-  color: #bf0000;
-}
+
 .title{
   font-style: italic;
   text-align: center;
@@ -44,9 +61,7 @@ span.icon>.fa {
   margin-bottom: 10px;
 }
 
-.admonitionblock {
-  margin-bottom: 10px;
-}
+
 
 .green{
   color: #43C78A;

--- a/src/styles/_asciidoc.scss
+++ b/src/styles/_asciidoc.scss
@@ -10,7 +10,7 @@ table{
   width:70px
 }
 
-.admonitionblock td.icon [class^="fa icon-"]{font-size:1.8em;cursor:default}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:1.8em;cursor:default;padding-right: 15px;}
 .admonitionblock td.icon .icon-note:before{content:"\f05a";color:#31708f}
 .admonitionblock td.icon .icon-tip:before{content:"\f0eb";color:#555555}
 .admonitionblock td.icon .icon-warning:before{content:"\f071";color:#a94442}
@@ -57,6 +57,7 @@ table{
 .title{
   font-style: italic;
   text-align: center;
+  padding-bottom: 10px;
 }
 
 .imageblock{

--- a/src/styles/_asciidoc.scss
+++ b/src/styles/_asciidoc.scss
@@ -2,11 +2,13 @@ table{
   margin-top: 0px;
 }
 
-/*
+
 .admonitionblock>table td.icon{
-  vertical-align: top;
+  vertical-align: middle;
   text-align:center;
-  width:70px}
+  margin-left: -100px;
+  width:70px
+}
 
 .admonitionblock td.icon [class^="fa icon-"]{font-size:1.8em;cursor:default}
 .admonitionblock td.icon .icon-note:before{content:"\f05a";color:#31708f}
@@ -14,7 +16,7 @@ table{
 .admonitionblock td.icon .icon-warning:before{content:"\f071";color:#a94442}
 .admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#8a6d3b}
 .admonitionblock td.icon .icon-important:before{content:"\f06a";color:#3c763d}
-*/
+
 
 .admonitionblock {
   padding:15px;
@@ -52,7 +54,6 @@ table{
   border-color:#ebccd1;
   color:#a94442
 }
-
 .title{
   font-style: italic;
   text-align: center;
@@ -63,6 +64,10 @@ table{
   display: block;
   margin-left: auto;
   margin-right: auto;
+  margin-bottom: 10px;
+}
+
+.admonitionblock {
   margin-bottom: 10px;
 }
 


### PR DESCRIPTION
Update asciidoc admonitions with to look like html alerts.

This is how they looked before:
<img width="1299" alt="Screenshot 2022-04-05 at 14 29 05" src="https://user-images.githubusercontent.com/24589403/162164561-641c5c3e-9843-4d09-8b68-d36ec7252d00.png">

This is how they look now:

<img width="1420" alt="Screenshot 2022-04-06 at 23 30 42" src="https://user-images.githubusercontent.com/24589403/162164656-c35af8c8-448e-4701-9a34-f1e6ae3bb692.png">

I have updated the style guide section on formatting too, to include info on how to use them.