### PR TITLE
New Windows Server 2022 image

### DIFF
--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -42,14 +42,14 @@ The Windows execution environment (or `executor`) gives users the tools to build
 **Notes:**
 
 - The Windows executor currently only supports Windows containers. Running Linux containers on Windows is not possible for now.
-- Orb usage is not supported on CircleCI Server v2.x (please view the "server" code samples for server usage.)
+- Orb usage is not supported on CircleCI Server v2.x (please view the [Using the Windows executor on CircleCI server](#windows-on-server) section for server usage.)
 
 ## Windows executor images
 {: #windows-executor-images }
 
-CircleCI supports Windows Server 2019 with Visual Studio 2019 and Windows Server 2022 with Visual Studio 2022. Contact your systems administrator for details of what is included in CircleCI Server Windows images, or visit the [Discuss](https://discuss.circleci.com/) page.
+CircleCI supports Windows Server 2019 with Visual Studio 2019 and Windows Server 2022 with Visual Studio 2022. For information on what software is pre-installed on the Windows image, please visit the [Developer Hub](https://circleci.com/developer/machine/image/windows-server), or the [Discuss forum](https://discuss.circleci.com/). The Windows image page on the Developer Hub lists links to the most recent updates.
 
-Details on the Windows Server 2022 image can be found on [Discuss](https://discuss.circleci.com/t/march-2022-support-for-new-operating-system-for-windows-executors-windows-server-2022/43198/1).
+Details on the Windows Server 2022 image can be found on this [Discuss post](https://discuss.circleci.com/t/march-2022-support-for-new-operating-system-for-windows-executors-windows-server-2022/43198/1).
 
 The Windows images are updated approximately every 30 days. If a tag is not specified when using the Windows image, by default the latest stable version will be applied. The tagging scheme for the Windows image is as follows:
 
@@ -106,7 +106,7 @@ version: 2.1
 
 orbs:
   win: circleci/windows@4.1
-  
+
 jobs:
   build:
     executor: win/server-2022
@@ -302,11 +302,6 @@ The available options are:
 
 You can read more about using SSH in your builds [here]({{site.baseurl}}/2.0/ssh-access-jobs).
 
-## Software pre-installed on the Windows image
-{: #software-pre-installed-on-the-windows-image }
-
-To find information on what software is pre-installed on the Windows image, please visit the [Developer Hub](https://circleci.com/developer/machine/image/windows-server). The Windows image page on the Developer Hub lists links to the most recent updates.
-
 ## Known issues
 {: #known-issues }
 
@@ -317,6 +312,8 @@ These are the issues with the Windows executor that we are aware of and will add
 
 ## Using the Windows executor on CircleCI server
 {: #windows-on-server }
+
+Contact your systems administrator for details of what is included in CircleCI server Windows images, or visit the [Discuss](https://discuss.circleci.com/) forum.
 
 {:.tab.windowsblocktwo.Server_3}
 ```yaml

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -95,7 +95,7 @@ version: 2.1
 jobs:
   build: # name of your job
     machine:
-      image: windows-default # Windows machine image
+      image: windows-server-2019-vs2019:current # Windows machine image
     resource_class: windows.medium
     steps:
       - checkout
@@ -178,7 +178,7 @@ version: 2.1
 jobs:
   build: # name of your job
     machine:
-      image: windows-default # Windows machine image
+      image: windows-server-2019-vs2019:current # Windows machine image
     resource_class: windows.medium
     steps:
       # Commands are run in a Windows virtual machine environment
@@ -193,7 +193,7 @@ version: 2
 jobs:
   build: # name of your job
     machine:
-      image: windows-default # Windows machine image
+      image: windows-server-2019-vs2019:current # Windows machine image
     resource_class: windows.medium
     steps:
       # Commands are run in a Windows virtual machine environment
@@ -246,7 +246,7 @@ version: 2.1
 jobs:
   build: # name of your job
     machine:
-      image: windows-default # Windows machine image
+      image: windows-server-2019-vs2019:current # Windows machine image
     resource_class: windows.medium
     steps:
       # default shell is Powershell
@@ -268,7 +268,7 @@ version: 2
 jobs:
   build: # name of your job
     machine:
-      image: windows-default # Windows machine image
+      image: windows-server-2019-vs2019:current # Windows machine image
     resource_class: windows.medium
     steps:
       # default shell is Powershell
@@ -311,7 +311,7 @@ version: 2.1
 jobs:
   build: # name of your job
     machine:
-      image: windows-default # Windows machine image
+      image: windows-server-2019-vs2019:current # Windows machine image
     resource_class: windows.medium
     steps:
       - checkout
@@ -326,7 +326,7 @@ version: 2
 jobs:
   build: # name of your job
     machine:
-      image: windows-default # Windows machine image
+      image: windows-server-2019-vs2019:current # Windows machine image
     resource_class: windows.medium
     steps:
       - checkout

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -104,19 +104,18 @@ Note that in order to use the Windows Server 2022 image in CircleCI cloud, it mu
 ```yaml
 version: 2.1
 
-workflows:
-  build-and-unittest:
-    jobs:
-      - build-windows
-
+orbs:
+  win: circleci/windows@4.1
+  
 jobs:
-  build-windows:
-    machine:
-      image: windows-server-2022-gui:current
-      resource_class: windows.medium
-      shell: powershell.exe -ExecutionPolicy Bypass
+  build:
+    executor: win/server-2022
     steps:
-      - run: echo 'test'
+      - run: Write-Host 'Hello, Windows'
+workflows:
+  my-workflow:
+    jobs:
+      - build
 ```
 
 From here we will use the version 2.1 syntax to discuss using the Windows executor, but if you're using Server, you can follow along with the executor definition syntax described above.

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -339,7 +339,7 @@ orbs:
   win: circleci/windows@2.4.0
 ```
 
-Next, we declare orbs that we will be using in our build. We will only use the [windows orb](https://circleci.com/developer/orbs/orb/circleci/windows) to help us get started. This example uses the 2.4.0 version of the orb, but you may consider using a more recent verion.
+Next, we declare orbs that we will be using in our build. We will only use the [windows orb](https://circleci.com/developer/orbs/orb/circleci/windows) to help us get started. This example uses the 2.4.0 version of the orb, but you may consider using a more recent version.
 
 ```yaml
 workflows:
@@ -357,7 +357,7 @@ jobs:
       name: win/default
 ```
 
-Under the `jobs` key, we define the `build` job, and set the executor via the orb we are using. 
+Under the `jobs` key, we define the `build` job, and set the executor via the orb we are using.
 
 ```yaml
     steps:

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -125,6 +125,22 @@ jobs:
             docker run hello-world:nanoserver-1809
 ```
 
+Note that in order to use the Windows Server 2022 image in CircleCI cloud, it must be specified as the `executor`, as shown in the following:
+
+```
+version: 2.1
+orbs:
+  win: circleci/windows@4.1
+jobs:
+  build:
+    executor: win/server-2022
+    steps:
+      - run: Write-Host 'Hello, Windows'
+workflows:
+  my-workflow:
+    jobs:
+      - build
+```
 
 ## Known issues
 {: #known-issues }

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -53,12 +53,12 @@ Details on the Windows Server 2022 image can be found on this [Discuss post](htt
 
 The Windows images are updated approximately every 30 days. If a tag is not specified when using the Windows image, by default the latest stable version will be applied. The tagging scheme for the Windows image is as follows:
 
-- Stable: This image tag points to the latest production ready Windows image. This image should be used by projects that want a decent level of stability, but would like to get occasional software updates. It is typically updated once a month.<br>
+- Current (formerly Stable): This image tag points to the latest production-ready Windows image. This image should be used by projects that want a decent level of stability, but would like to get occasional software updates. It is typically updated once a month.<br>
 
-The new `current` tag is available for Windows images and will eventually completely replace `stable`. Refer to the [Discuss forum](https://discuss.circleci.com/t/april-2022-windows-image-updates-available-for-stable-tags/43511) for more information.
+The new `current` tag is available for Windows images. The `current` and `stable` tags are equivalent, and are currently both supported. Refer to the [Discuss forum](https://discuss.circleci.com/t/april-2022-windows-image-updates-available-for-stable-tags/43511) for more information.
 {: class="alert alert-info"}
 
-- Previous: This image tag points to the previous ("stable") production ready Windows image. This image can be used in cases where there was a breaking change in the latest software updates. It is typically updated once a month.
+- Previous: This image tag points to the previous production-ready Windows image. This image can be used in cases where there was a breaking change in the latest software updates. It is typically updated once a month.
 
 - Edge: This image tag points to the latest version of the Windows image, and is built from the HEAD of the main branch. This tag is intended to be used as a testing version of the image with the most recent changes, and not guaranteed to be stable.
 

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -67,7 +67,7 @@ Please note that it is possible to run Windows Docker Containers on the Windows 
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@4.1
 
 jobs:
   build:
@@ -144,7 +144,7 @@ Get started with Windows on CircleCI with the following configuration snippet th
 version: 2.1 # Use version 2.1 to enable orb usage.
 
 orbs:
-  win: circleci/windows@2.2.0 # The Windows orb give you everything you need to start using the Windows executor.
+  win: circleci/windows@4.1 # The Windows orb give you everything you need to start using the Windows executor.
 
 jobs:
   build: # name of your job
@@ -207,7 +207,7 @@ You can configure the shell at the job level or at the step level. It is possibl
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@4.1
 
 jobs:
   build:
@@ -279,7 +279,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@4.1
 
 jobs:
   build:

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -120,7 +120,7 @@ workflows:
 
 From here we will use the version 2.1 syntax to discuss using the Windows executor, but if you're using Server, you can follow along with the executor definition syntax described above.
 
-## Specifying a Shell with the Windows executor
+## Specifying a shell with the Windows executor
 {: #specifying-a-shell-with-the-windows-executor }
 
 There are three shells that you can use to run job steps on Windows:
@@ -203,11 +203,11 @@ jobs:
 ## Example application
 {: #example-application }
 
-Let’s consider a more advanced (but still introductory) "hello world" application using the Windows executor. This [example application](https://github.com/CircleCI-Public/circleci-demo-windows) still prints "Hello World" to the console, but does so using .NET core to create an executable, uses dependency caching, and creates an artifact on every build. 
+Let us consider a more advanced (but still introductory) "hello world" application using the Windows executor. This [example application](https://github.com/CircleCI-Public/circleci-demo-windows) still prints "Hello World" to the console, but does so using .NET core to create an executable, uses dependency caching, and creates an artifact on every build.
 
 **Note:** If you are using Windows on CircleCI server, replace usage of orbs with a machine image, as described in the [Using the Windows executor on CircleCI server](#windows-on-server) section.
 
-You can view the entire configuration [here](https://github.com/CircleCI-Public/circleci-demo-windows/blob/master/.circleci/config.yml). It also includes browser and UI testing, but we'll focus on the `hello-world` workflow for now.
+You can view the entire configuration [here](https://github.com/CircleCI-Public/circleci-demo-windows/blob/master/.circleci/config.yml). It also includes browser and UI testing, but we will focus on the `hello-world` workflow for now.
 
 ```yaml
 version: 2.1
@@ -348,7 +348,7 @@ jobs:
         - run: Write-Host 'Hello, Windows'
 ```
 
-### Specifying a Shell
+### Specifying a shell
 {: #specifying-a-shell-server }
 {:.no_toc}
 

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -326,7 +326,7 @@ jobs:
 
 Let’s consider a more advanced (but still introductory) "hello world" application using the Windows executor. This [example application](https://github.com/CircleCI-Public/circleci-demo-windows) still prints "Hello World" to the console, but does so using .NET core to create an executable, uses dependency caching, and creates an artifact on every build. **Note:** If you are using Windows on CircleCI server, replace usage of orbs with a machine image as described in the previous code samples.
 
-You can view the entire configuration [here](https://github.com/CircleCI-Public/circleci-demo-windows/blob/master/.circleci/config.yml).
+You can view the entire configuration [here](https://github.com/CircleCI-Public/circleci-demo-windows/blob/master/.circleci/config.yml). It also includes browser and UI testing, but we'll focus on the `hello-world` workflow for now. 
 
 ```yaml
 version: 2.1
@@ -336,10 +336,19 @@ Above, we start by declaring that we will use version `2.1` of CircleCI, giving 
 
 ```yaml
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@2.4.0
 ```
 
-Next, we declare orbs that we will be using in our build. We will only use the [windows orb](https://circleci.com/developer/orbs/orb/circleci/windows) to help us get started.
+Next, we declare orbs that we will be using in our build. We will only use the [windows orb](https://circleci.com/developer/orbs/orb/circleci/windows) to help us get started. This example uses the 2.4.0 version of the orb, but you may consider using a more recent verion.
+
+```yaml
+workflows:
+  hello-world:
+    jobs:
+      - build
+```
+
+We define a `hello-world` workflow, in which we run a single job named `build`.
 
 ```yaml
 jobs:
@@ -349,7 +358,7 @@ jobs:
       shell: powershell.exe
 ```
 
-Under the `jobs` key, we set the executor via the orb we are using. We can also declare the default shell to be applied across future steps in the configuration. The default shell is `Powershell.exe`
+Under the `jobs` key, we define the `build` job, and set the executor via the orb we are using. We can also declare the default shell to be applied across future steps in the configuration. The default shell is `Powershell.exe`
 
 ```yaml
     steps:

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -126,6 +126,7 @@ jobs:
 ```
 
 Note that in order to use the Windows Server 2022 image in CircleCI cloud, it must be specified as the `executor`, as shown in the following:
+{: class="alert alert-info"}
 
 ```
 version: 2.1

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -108,40 +108,6 @@ jobs:
             docker run hello-world:nanoserver-1809
 ```
 
-Note that in order to use the Windows Server 2022 image in CircleCI cloud, it must be specified as the `executor`, as shown in the following:
-{: class="alert alert-info"}
-
-```yaml
-version: 2.1
-
-workflows:
-  build-and-unittest:
-    jobs:
-      - build-windows
-
-jobs:
-  build-windows:
-    machine:
-      image: windows-server-2022-gui:current
-      resource_class: windows.medium
-      shell: powershell.exe -ExecutionPolicy Bypass
-    steps:
-      - run: echo 'test'
-```
-
-Additionally, it is possible to access the Windows image directly in your jobs without using the orb:
-
-```yaml
-jobs:
-  build-windows:
-    machine:
-      image: windows-server-2022:current
-      resource_class: windows.medium
-      shell: powershell.exe -ExecutionPolicy Bypass
-```
-
-With that said, we strongly encourage using the orb as it helps simplify your configuration.
-
 ## Known issues
 {: #known-issues }
 
@@ -202,6 +168,40 @@ jobs:
       # Commands are run in a Windows virtual machine environment
         - checkout
         - run: Write-Host 'Hello, Windows'
+```
+
+Additionally, it is possible to access the Windows image directly in your jobs without using the orb:
+
+```yaml
+jobs:
+  build-windows:
+    machine:
+      image: windows-server-2022:current
+      resource_class: windows.medium
+      shell: powershell.exe -ExecutionPolicy Bypass
+```
+
+With that said, we strongly encourage using the orb as it helps simplify your configuration.
+
+Note that in order to use the Windows Server 2022 image in CircleCI cloud, it must be specified as the `executor`, as shown in the following:
+{: class="alert alert-info"}
+
+```yaml
+version: 2.1
+
+workflows:
+  build-and-unittest:
+    jobs:
+      - build-windows
+
+jobs:
+  build-windows:
+    machine:
+      image: windows-server-2022-gui:current
+      resource_class: windows.medium
+      shell: powershell.exe -ExecutionPolicy Bypass
+    steps:
+      - run: echo 'test'
 ```
 
 From here we will use the version 2.1 syntax to discuss using the Windows executor, but if you're using Server, you can follow along with the executor definition syntax described above.

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -113,17 +113,20 @@ Note that in order to use the Windows Server 2022 image in CircleCI cloud, it mu
 
 ```yaml
 version: 2.1
-orbs:
-  win: circleci/windows@4.1
-jobs:
-  build:
-    executor: win/server-2022
-    steps:
-      - run: Write-Host 'Hello, Windows'
+
 workflows:
-  my-workflow:
+  build-and-unittest:
     jobs:
-      - build
+      - build-windows
+
+jobs:
+  build-windows:
+    machine:
+      image: windows-server-2022-gui:current
+      resource_class: windows.medium
+      shell: powershell.exe -ExecutionPolicy Bypass
+    steps:
+      - run: echo 'test'
 ```
 
 Additionally, it is possible to access the Windows image directly in your jobs without using the orb:

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -85,20 +85,20 @@ jobs:
       - run: Write-Host 'Hello, Windows'
 ```
 
-Additionally, it is possible to access the Windows image directly in your jobs without using the orb:
+Additionally, it is possible to access the Windows image directly in your jobs without using orbs:
 
 ```yaml
 jobs:
   build-windows:
     machine:
-      image: windows-server-2022:current
+      image: windows-server-2019:stable
       resource_class: windows.medium
       shell: powershell.exe -ExecutionPolicy Bypass
 ```
 
-With that said, we strongly encourage using the orb as it helps simplify your configuration.
+With that said, we strongly encourage using the [Windows orb](https://circleci.com/developer/orbs/orb/circleci/windows) as it helps simplify your configuration.
 
-Note that in order to use the Windows Server 2022 image in CircleCI cloud, it must be specified as the `executor`, as shown in the following:
+Note that in order to use the Windows Server 2022 image with the Windows orb in CircleCI cloud, it must be specified in the `executor` type, as shown in the following:
 {: class="alert alert-info"}
 
 ```yaml
@@ -125,7 +125,7 @@ From here we will use the version 2.1 syntax to discuss using the Windows execut
 
 There are three shells that you can use to run job steps on Windows:
 
-* PowerShell (default in the Windows Orb)
+* PowerShell (default in the Windows orb)
 * Bash
 * Command
 
@@ -203,9 +203,11 @@ jobs:
 ## Example application
 {: #example-application }
 
-Let’s consider a more advanced (but still introductory) "hello world" application using the Windows executor. This [example application](https://github.com/CircleCI-Public/circleci-demo-windows) still prints "Hello World" to the console, but does so using .NET core to create an executable, uses dependency caching, and creates an artifact on every build. **Note:** If you are using Windows on CircleCI server, replace usage of orbs with a machine image as described in the previous code samples.
+Let’s consider a more advanced (but still introductory) "hello world" application using the Windows executor. This [example application](https://github.com/CircleCI-Public/circleci-demo-windows) still prints "Hello World" to the console, but does so using .NET core to create an executable, uses dependency caching, and creates an artifact on every build. 
 
-You can view the entire configuration [here](https://github.com/CircleCI-Public/circleci-demo-windows/blob/master/.circleci/config.yml). It also includes browser and UI testing, but we'll focus on the `hello-world` workflow for now. 
+**Note:** If you are using Windows on CircleCI server, replace usage of orbs with a machine image, as described in the [Using the Windows executor on CircleCI server](#windows-on-server) section.
+
+You can view the entire configuration [here](https://github.com/CircleCI-Public/circleci-demo-windows/blob/master/.circleci/config.yml). It also includes browser and UI testing, but we'll focus on the `hello-world` workflow for now.
 
 ```yaml
 version: 2.1
@@ -218,7 +220,7 @@ orbs:
   win: circleci/windows@2.4.0
 ```
 
-Next, we declare orbs that we will be using in our build. We will only use the [windows orb](https://circleci.com/developer/orbs/orb/circleci/windows) to help us get started. This example uses the 2.4.0 version of the orb, but you may consider using a more recent version.
+Next, we declare orbs that we will be using in our build. We will only use the [Windows orb](https://circleci.com/developer/orbs/orb/circleci/windows) to help us get started. This example uses the 2.4.0 version of the orb, but you may consider using a more recent version.
 
 ```yaml
 workflows:

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -120,7 +120,7 @@ workflows:
 
 From here we will use the version 2.1 syntax to discuss using the Windows executor, but if you're using Server, you can follow along with the executor definition syntax described above.
 
-## Specifying a Shell with the Windows Executor
+## Specifying a Shell with the Windows executor
 {: #specifying-a-shell-with-the-windows-executor }
 
 There are three shells that you can use to run job steps on Windows:
@@ -283,6 +283,7 @@ It is possible to SSH into a Windows build container. This is useful for trouble
 
 ### Steps
 {: #steps }
+{:.no_toc}
 
 1. Ensure that you have added an SSH key to your [GitHub](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/) or [Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html) account.
 

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -54,7 +54,10 @@ Details on the Windows Server 2022 image can be found on [Discuss](https://discu
 
 The Windows images are updated approximately every 30 days. If a tag is not specified when using the Windows image, by default the latest stable version will be applied. The tagging scheme for the Windows image is as follows:
 
-- Stable: This image tag points to the latest production ready Windows image. This image should be used by projects that want a decent level of stability, but would like to get occasional software updates. It is typically updated once a month.
+- Stable: This image tag points to the latest production ready Windows image. This image should be used by projects that want a decent level of stability, but would like to get occasional software updates. It is typically updated once a month.<br>
+
+The new `current` tag is available for Windows images and will eventually completely replace `stable`. Refer to the [Discuss forum](https://discuss.circleci.com/t/april-2022-windows-image-updates-available-for-stable-tags/43511) for more information.
+{: class="alert alert-info"}
 
 - Previous: This image tag points to the previous ("stable") production ready Windows image. This image can be used in cases where there was a breaking change in the latest software updates. It is typically updated once a month.
 

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -20,7 +20,6 @@ This document describes how to get started with continuous integration on **Wind
   <strong>A Windows Server 2022 image is now available to CircleCI Cloud customers, read more on <a href="https://discuss.circleci.com/t/march-2022-support-for-new-operating-system-for-windows-executors-windows-server-2022/43198">Discuss</a></strong>.
 </div>
 
-
 ## Prerequisites
 {: #prerequisites }
 
@@ -68,7 +67,6 @@ The new `current` tag is available for Windows images and will eventually comple
 
 Get started with Windows on CircleCI with the following configuration snippet that you can paste into your `.circleci/config.yml` file:
 
-{:.tab.windowsblocktwo.Cloud}
 ```yaml
 version: 2.1 # Use version 2.1 to enable orb usage.
 
@@ -85,36 +83,6 @@ jobs:
       # Commands are run in a Windows virtual machine environment
       - checkout
       - run: Write-Host 'Hello, Windows'
-```
-
-{:.tab.windowsblocktwo.Server_3}
-```yaml
-version: 2.1
-
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-server-2019-vs2019:current # Windows machine image
-    resource_class: windows.medium
-    steps:
-      # Commands are run in a Windows virtual machine environment
-        - checkout
-        - run: Write-Host 'Hello, Windows'
-```
-
-{:.tab.windowsblocktwo.Server_2}
-```yaml
-version: 2
-
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-server-2019-vs2019:current # Windows machine image
-    resource_class: windows.medium
-    steps:
-      # Commands are run in a Windows virtual machine environment
-        - checkout
-        - run: Write-Host 'Hello, Windows'
 ```
 
 Additionally, it is possible to access the Windows image directly in your jobs without using the orb:
@@ -164,8 +132,6 @@ There are three shells that you can use to run job steps on Windows:
 
 You can configure the shell at the job level or at the step level. It is possible to use multiple shells in the same job. Consider the example below, where we use Bash, Powershell, and Command by adding a `shell:` argument to our `job` and `step` declarations:
 
-
-{:.tab.windowsblockthree.Cloud}
 ```YAML
 version: 2.1
 
@@ -189,55 +155,9 @@ jobs:
          shell: cmd.exe
 ```
 
-{:.tab.windowsblockthree.Server_3}
-```YAML
-version: 2.1
+**Note:** It is possible to install updated or other Windows shell-tooling as well; for example, you could install the latest version of Powershell Core with the `dotnet` CLI and use it in a job's successive steps:
 
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-server-2019-vs2019:current # Windows machine image
-    resource_class: windows.medium
-    steps:
-      # default shell is Powershell
-      - run:
-         command: $(echo hello | Out-Host; $?) -and $(echo world | Out-Host; $?)
-         shell: powershell.exe
-      - run:
-         command: echo hello && echo world
-         shell: bash.exe
-      - run:
-         command: echo hello & echo world
-         shell: cmd.exe
-```
-
-{:.tab.windowsblockthree.Server_2}
-```YAML
-version: 2
-
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-server-2019-vs2019:current # Windows machine image
-    resource_class: windows.medium
-    steps:
-      # default shell is Powershell
-      - run:
-         command: $(echo hello | Out-Host; $?) -and $(echo world | Out-Host; $?)
-         shell: powershell.exe
-      - run:
-         command: echo hello && echo world
-         shell: bash.exe
-      - run:
-         command: echo hello & echo world
-         shell: cmd.exe
-```
-
-**Note:** It is possible to install updated or other Windows shell-tooling as well; for example, you could install the latest version of Powershell Core with the `dotnet` cli and use it in a job's successive steps:
-
-
-{:.tab.windowsblockfour.Cloud}
-```YAML
+```yaml
 
 version: 2.1
 
@@ -254,42 +174,11 @@ jobs:
 
 ```
 
-{:.tab.windowsblockfour.Server_3}
-```YAML
-version: 2.1
-
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-server-2019-vs2019:current # Windows machine image
-    resource_class: windows.medium
-    steps:
-      - checkout
-      - run: dotnet tool install --global PowerShell
-      - run: pwsh ./<my-script>.ps1
-```
-
-{:.tab.windowsblockfour.Server_2}
-```YAML
-version: 2
-
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-server-2019-vs2019:current # Windows machine image
-    resource_class: windows.medium
-    steps:
-      - checkout
-      - run: dotnet tool install --global PowerShell
-      - run: pwsh ./<my-script>.ps1
-```
-
 ## Running Windows Docker containers on the Windows executor
 {: #windows-docker-containers-on-windows-executor }
 
 Please note that it is possible to run Windows Docker Containers on the Windows executor like so:
 
-{:.tab.windowsblockone.Cloud}
 ```yaml
 version: 2.1
 
@@ -301,26 +190,6 @@ jobs:
     executor:
       name: win/default
       shell: powershell.exe
-    steps:
-      - checkout
-      - run: systeminfo
-      - run:
-          name: "Check docker"
-          shell: powershell.exe
-          command: |
-            docker info
-            docker run hello-world:nanoserver-1809
-```
-
-{:.tab.windowsblockone.Server_3}
-```yaml
-version: 2.1
-
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-server-2019-vs2019:current # Windows machine image
-    resource_class: windows.medium
     steps:
       - checkout
       - run: systeminfo
@@ -447,10 +316,149 @@ These are the issues with the Windows executor that we are aware of and will add
 * Connecting to a Windows job via SSH and using the `bash` shell results in an empty terminal prompt.
 * It is currently not possible to do nested virtualization (for example, using the `--platform linux` flag).
 
+## Using the Windows executor on CircleCI server
+{: #windows-on-server }
+
+{:.tab.windowsblocktwo.Server_3}
+```yaml
+version: 2.1
+
+jobs:
+  build: # name of your job
+    machine:
+      image: windows-server-2019-vs2019:current # Windows machine image
+    resource_class: windows.medium
+    steps:
+      # Commands are run in a Windows virtual machine environment
+        - checkout
+        - run: Write-Host 'Hello, Windows'
+```
+
+{:.tab.windowsblocktwo.Server_2}
+```yaml
+version: 2
+
+jobs:
+  build: # name of your job
+    machine:
+      image: windows-server-2019-vs2019:current # Windows machine image
+    resource_class: windows.medium
+    steps:
+      # Commands are run in a Windows virtual machine environment
+        - checkout
+        - run: Write-Host 'Hello, Windows'
+```
+
+### Specifying a Shell
+{: #specifying-a-shell-server }
+{:.no_toc}
+
+{:.tab.windowsblockthree.Server_3}
+```yaml
+version: 2.1
+
+jobs:
+  build: # name of your job
+    machine:
+      image: windows-server-2019-vs2019:current # Windows machine image
+    resource_class: windows.medium
+    steps:
+      # default shell is Powershell
+      - run:
+         command: $(echo hello | Out-Host; $?) -and $(echo world | Out-Host; $?)
+         shell: powershell.exe
+      - run:
+         command: echo hello && echo world
+         shell: bash.exe
+      - run:
+         command: echo hello & echo world
+         shell: cmd.exe
+```
+
+{:.tab.windowsblockthree.Server_2}
+```yaml
+version: 2
+
+jobs:
+  build: # name of your job
+    machine:
+      image: windows-server-2019-vs2019:current # Windows machine image
+    resource_class: windows.medium
+    steps:
+      # default shell is Powershell
+      - run:
+         command: $(echo hello | Out-Host; $?) -and $(echo world | Out-Host; $?)
+         shell: powershell.exe
+      - run:
+         command: echo hello && echo world
+         shell: bash.exe
+      - run:
+         command: echo hello & echo world
+         shell: cmd.exe
+```
+
+#### Install Powershell Core with the `dotnet` CLI
+{: #install-powershell-server }
+{:.no_toc}
+
+{:.tab.windowsblockfour.Server_3}
+```yaml
+version: 2.1
+
+jobs:
+  build: # name of your job
+    machine:
+      image: windows-server-2019-vs2019:current # Windows machine image
+    resource_class: windows.medium
+    steps:
+      - checkout
+      - run: dotnet tool install --global PowerShell
+      - run: pwsh ./<my-script>.ps1
+```
+
+{:.tab.windowsblockfour.Server_2}
+```yaml
+version: 2
+
+jobs:
+  build: # name of your job
+    machine:
+      image: windows-server-2019-vs2019:current # Windows machine image
+    resource_class: windows.medium
+    steps:
+      - checkout
+      - run: dotnet tool install --global PowerShell
+      - run: pwsh ./<my-script>.ps1
+```
+
+### Running Windows Docker containers
+{: #run-windows-container-server }
+{:.no_toc}
+
+{:.tab.windowsblockone.Server_3}
+```yaml
+version: 2.1
+
+jobs:
+  build: # name of your job
+    machine:
+      image: windows-server-2019-vs2019:current # Windows machine image
+    resource_class: windows.medium
+    steps:
+      - checkout
+      - run: systeminfo
+      - run:
+          name: "Check docker"
+          shell: powershell.exe
+          command: |
+            docker info
+            docker run hello-world:nanoserver-1809
+```
+
 ## Next steps
 {: #next-steps }
 
-Also, consider reading documentation on some of CircleCI’s features:
+Consider reading documentation on some of CircleCI’s features:
 
 * See the [Concepts]({{site.baseurl}}/2.0/concepts/) document for a summary of 2.0 configuration and the hierarchy of top-level keys in a .circleci/config.yml file.
 * Refer to the [Workflows]({{site.baseurl}}/2.0/workflows) document for examples of orchestrating job runs with concurrent, sequential, scheduled, and manual approval workflows.

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -355,10 +355,9 @@ jobs:
   build:
     executor:
       name: win/default
-      shell: powershell.exe
 ```
 
-Under the `jobs` key, we define the `build` job, and set the executor via the orb we are using. We can also declare the default shell to be applied across future steps in the configuration. The default shell is `Powershell.exe`
+Under the `jobs` key, we define the `build` job, and set the executor via the orb we are using. 
 
 ```yaml
     steps:

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -63,59 +63,6 @@ The new `current` tag is available for Windows images and will eventually comple
 
 - Edge: This image tag points to the latest version of the Windows image, and is built from the HEAD of the main branch. This tag is intended to be used as a testing version of the image with the most recent changes, and not guaranteed to be stable.
 
-Please note that it is possible to run Windows Docker Containers on the Windows executor like so:
-
-{:.tab.windowsblockone.Cloud}
-```yaml
-version: 2.1
-
-orbs:
-  win: circleci/windows@4.1
-
-jobs:
-  build:
-    executor:
-      name: win/default
-      shell: powershell.exe
-    steps:
-      - checkout
-      - run: systeminfo
-      - run:
-          name: "Check docker"
-          shell: powershell.exe
-          command: |
-            docker info
-            docker run hello-world:nanoserver-1809
-```
-
-{:.tab.windowsblockone.Server_3}
-```yaml
-version: 2.1
-
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-server-2019-vs2019:current # Windows machine image
-    resource_class: windows.medium
-    steps:
-      - checkout
-      - run: systeminfo
-      - run:
-          name: "Check docker"
-          shell: powershell.exe
-          command: |
-            docker info
-            docker run hello-world:nanoserver-1809
-```
-
-## Known issues
-{: #known-issues }
-
-These are the issues with the Windows executor that we are aware of and will address as soon as we can:
-
-* Connecting to a Windows job via SSH and using the `bash` shell results in an empty terminal prompt.
-* It is currently not possible to do nested virtualization (for example, using the `--platform linux` flag).
-
 ## Example configuration file
 {: #example-configuration-file }
 
@@ -337,6 +284,54 @@ jobs:
       - run: pwsh ./<my-script>.ps1
 ```
 
+## Running Windows Docker containers on the Windows executor
+{: #windows-docker-containers-on-windows-executor }
+
+Please note that it is possible to run Windows Docker Containers on the Windows executor like so:
+
+{:.tab.windowsblockone.Cloud}
+```yaml
+version: 2.1
+
+orbs:
+  win: circleci/windows@4.1
+
+jobs:
+  build:
+    executor:
+      name: win/default
+      shell: powershell.exe
+    steps:
+      - checkout
+      - run: systeminfo
+      - run:
+          name: "Check docker"
+          shell: powershell.exe
+          command: |
+            docker info
+            docker run hello-world:nanoserver-1809
+```
+
+{:.tab.windowsblockone.Server_3}
+```yaml
+version: 2.1
+
+jobs:
+  build: # name of your job
+    machine:
+      image: windows-server-2019-vs2019:current # Windows machine image
+    resource_class: windows.medium
+    steps:
+      - checkout
+      - run: systeminfo
+      - run:
+          name: "Check docker"
+          shell: powershell.exe
+          command: |
+            docker info
+            docker run hello-world:nanoserver-1809
+```
+
 ## Example application
 {: #example-application }
 
@@ -439,6 +434,19 @@ The available options are:
 
 You can read more about using SSH in your builds [here]({{site.baseurl}}/2.0/ssh-access-jobs).
 
+## Software pre-installed on the Windows image
+{: #software-pre-installed-on-the-windows-image }
+
+To find information on what software is pre-installed on the Windows image, please visit the [Developer Hub](https://circleci.com/developer/machine/image/windows-server). The Windows image page on the Developer Hub lists links to the most recent updates.
+
+## Known issues
+{: #known-issues }
+
+These are the issues with the Windows executor that we are aware of and will address as soon as we can:
+
+* Connecting to a Windows job via SSH and using the `bash` shell results in an empty terminal prompt.
+* It is currently not possible to do nested virtualization (for example, using the `--platform linux` flag).
+
 ## Next steps
 {: #next-steps }
 
@@ -447,8 +455,3 @@ Also, consider reading documentation on some of CircleCI’s features:
 * See the [Concepts]({{site.baseurl}}/2.0/concepts/) document for a summary of 2.0 configuration and the hierarchy of top-level keys in a .circleci/config.yml file.
 * Refer to the [Workflows]({{site.baseurl}}/2.0/workflows) document for examples of orchestrating job runs with concurrent, sequential, scheduled, and manual approval workflows.
 * Find complete reference information for all keys and pre-built Docker images in the [Configuring CircleCI]({{site.baseurl}}/2.0/configuration-reference/) and [CircleCI Images]({{site.baseurl}}/2.0/circleci-images/) documentation, respectively.
-
-## Software pre-installed on the Windows image
-{: #software-pre-installed-on-the-windows-image }
-
-To find information on what software is pre-installed on the Windows image, please visit the [Developer Hub](https://circleci.com/developer/machine/image/windows-server). The Windows image page on the Developer Hub lists links to the most recent updates.

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -108,30 +108,10 @@ jobs:
             docker run hello-world:nanoserver-1809
 ```
 
-{:.tab.windowsblockone.Server_2}
-```yaml
-version: 2
-
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-default # Windows machine image
-    resource_class: windows.medium
-    steps:
-      - checkout
-      - run: systeminfo
-      - run:
-          name: "Check docker"
-          shell: powershell.exe
-          command: |
-            docker info
-            docker run hello-world:nanoserver-1809
-```
-
 Note that in order to use the Windows Server 2022 image in CircleCI cloud, it must be specified as the `executor`, as shown in the following:
 {: class="alert alert-info"}
 
-```
+```yaml
 version: 2.1
 orbs:
   win: circleci/windows@4.1
@@ -148,7 +128,7 @@ workflows:
 
 Additionally, it is possible to access the Windows image directly in your jobs without using the orb:
 
-```
+```yaml
 jobs:
   build-windows:
     machine:

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -118,8 +118,6 @@ workflows:
       - build
 ```
 
-From here we will use the version 2.1 syntax to discuss using the Windows executor, but if you're using Server, you can follow along with the executor definition syntax described above.
-
 ## Specifying a shell with the Windows executor
 {: #specifying-a-shell-with-the-windows-executor }
 

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -143,6 +143,19 @@ workflows:
       - build
 ```
 
+Additionally, it is possible to access the Windows image directly in your jobs without using the orb:
+
+```
+jobs:
+  build-windows:
+    machine:
+      image: windows-server-2022:current
+      resource_class: windows.medium
+      shell: powershell.exe -ExecutionPolicy Bypass
+```
+
+With that said, we strongly encourage using the orb as it helps simplify your configuration.
+
 ## Known issues
 {: #known-issues }
 


### PR DESCRIPTION
# Description
Updates [Windows executor page](https://circleci.com/docs/2.0/hello-world-windows/) in docs to include example of using the new Windows 2022 image.

This also includes a change to the Windows orb version used, as well as a quick refresh of the [example application](https://circleci.com/docs/2.0/hello-world-windows/#example-application) since the example config had been previously updated.

# Reasons
https://discuss.circleci.com/t/march-2022-beta-support-for-new-operating-system-for-windows-executors-windows-server-2022/43198