### PR TITLE
add 20.10.12 to list of available docker versions

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -126,6 +126,7 @@ To specify the Docker version, you can set it as a `version` attribute:
 
 CircleCI supports multiple versions of Docker. The following are the available versions:
 
+- `20.10.12`
 - `20.10.11`
 - `20.10.7`
 - `20.10.6`


### PR DESCRIPTION
# Description
Docker version `20.10.12` is available to use, so this adds it to the list of available versions
<img width="786" alt="Screen Shot 2022-04-05 at 1 27 21 PM" src="https://user-images.githubusercontent.com/11543636/161815021-d2d42913-4fbe-4896-bcfb-771dac0037bf.png">


# Reasons
Keeps the list of available Docker versions up-to-date