### PR TITLE
server-1701 | Updated mtls value in nomad gcp example

### DIFF
--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -232,7 +232,7 @@ module "nomad" {
   enable_workload_identity  = var.enable_workload_identity
   k8s_namespace             = var.k8s_namespace
 
-  unsafe_disable_mtls    = true
+  unsafe_disable_mtls    = false
   assign_public_ip       = true
   preemptible            = true
   target_cpu_utilization = 0.50


### PR DESCRIPTION
# Description
* Default value updated as `false` for variable `unsafe_disable_mtls` in nomad gcp example. 


# Reasons
[SERVER-1701](https://circleci.atlassian.net/browse/SERVER-1701) 
