### PR TITLE
Fix typo in notifications (72e60d15)

### DIFF
--- a/jekyll/_cci2_ja/notifications.md
+++ b/jekyll/_cci2_ja/notifications.md
@@ -59,7 +59,7 @@ Slack 通知の例を以下に示します。
 ![失敗を通知するメールのサンプル]({{ site.baseurl }}/assets/img/docs/notification-email-failure.png)
 
 ## メール通知の設定と変更
-CircleCI アプリケーションの [[Notifications (通知)](https://circleci.com/account/notifications){:rel="nofollow"}] ページで、デフォルトの通知先メールアドレスの設定と変更、メール通知の停止、ビルドごとのメール通知の有効化などを行えます。
+CircleCI アプリケーションの [Notifications (通知)](https://circleci.com/account/notifications){:rel="nofollow"} ページで、デフォルトの通知先メールアドレスの設定と変更、メール通知の停止、ビルドごとのメール通知の有効化などを行えます。
 
 メール通知の例を以下に示します。
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Fixes a typo in notifications markdown (72e60d15 part of #5993)

- notifications (production URL): https://circleci.com/docs/ja/2.0/notifications/#set-or-change-email-notifications 

# Reasons
We do not need to wrap link text with an extra `[]`.