### PR TITLE
Not to use web-ui-datadog context to void failures on forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,6 @@ workflows:
                 - master 
                 - /.*-preview/
       - datadog-synthetics-ci:
-          context:
-            - web-ui-datadog
           requires:
             - build
       - reindex-search:


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Not to use `web-ui-datadog` context in `datadog-synthetics-ci` job.

# Reasons
To void useless failures on forked repos.

Closes #6658