### PR TITLE
Use cimg/* images for example on /adv-config/

### DIFF
--- a/jekyll/_cci2/adv-config.md
+++ b/jekyll/_cci2/adv-config.md
@@ -185,7 +185,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:buster-browsers
+      - image: cimg/node:lts-browsers
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -305,7 +305,7 @@ jobs:
 
     # Primary container image where all commands run
     docker:
-      - image: circleci/python:3.6.2-stretch-browsers
+      - image: cimg/python:3.6
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -313,7 +313,7 @@ jobs:
           TEST_DATABASE_URL: postgresql://root@localhost/circle_test
 
     # Service container image
-      - image: cimg/postgres:9.6.5
+      - image: cimg/postgres:12
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -321,7 +321,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update
-      - run: sudo apt-get install postgresql-client-9.6
+      - run: sudo apt-get install postgresql-client-12
       - run: whoami
       - run: |
           psql \


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Use `cimg/*` images for example on [/adv-config/](https://circleci.com/docs/2.0/adv-config/).

# Reasons
`circleci/node` and `circleci/python` images are legacy and has been deprecated on 2021-12-31.

> Legacy images with the prefix "circleci/" were [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) on December 31, 2021.


# Appendix
```
$ docker run --rm -it cimg/node:lts-browsers cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.3 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.3 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

```
$ docker run --rm -it cimg/python:3.6.15 cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.2 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.2 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

cf. Ubuntu 20.04, the base image of `cimg/python:3.6`, has `psql` command in [postgresql-client-12](https://packages.ubuntu.com/focal/postgresql-client-12) instead of [postgreql-client-9.6](https://packages.debian.org/stretch/postgresql-client-9.6).