### PR TITLE
Use cimg/* images for example on /variables/

### DIFF
--- a/jekyll/_cci2/variables.md
+++ b/jekyll/_cci2/variables.md
@@ -35,7 +35,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:latest
+      - image: cimg/node:latest
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Use `cimg/*` images for example on [/variables/](https://circleci.com/docs/2.0/variables/).

# Reasons
The `circleci/node` image is legacy and has been deprecated on 2021-12-31.

> Legacy images with the prefix "circleci/" were [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) on December 31, 2021.