### PR TITLE
Update concepts.md

### DIFF
--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -619,6 +619,7 @@ repository to CircleCI as a Project.
 * A *User* is an individual user within an organization, inherited from your VCS.
 * A CircleCI user is anyone who can log in to the CircleCI platform with a
 username and password. Users must be added to a [GitHub or Bitbucket org]({{site.baseurl }}/2.0/gh-bb-integration/) to view or follow associated CircleCI projects. Users may not view project data that is stored in environment variables.
+
 ## Workflows
 {: #workflows }
 


### PR DESCRIPTION
# Description
Added a line break before the Workflows heading.

# Reasons
The Workflows heading had attached itself to the previous paragraph and was indented.