### PR TITLE
Remove caching of /usr/local/bin in stepthrough

### DIFF
--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -166,7 +166,7 @@ consider [caching dependencies or source code]({{ site.baseurl }}/2.0/caching/).
 Use the [`save_cache`]({{ site.baseurl }}/2.0/configuration-reference/#save_cache) step
 to cache certain files or directories.
 In this example,
-the virtual environment and installed packages are cached.
+the virtual environment is cached.
 
 Use the [`restore_cache`]({{ site.baseurl }}/2.0/configuration-reference/#restore_cache) step
 to restore cached files or directories.
@@ -191,9 +191,7 @@ jobs:
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:
-            - ".venv"
-            - "/usr/local/bin"
-            - "/usr/local/lib/python3.6/site-packages"
+            - "venv"
 ```
 
 {% endraw %}


### PR DESCRIPTION
This had been previously removed in the full config example at the end of the
page but not in the stepthrough in the doc.

# Reasons
Resolve inconsistency around caching as pointed out in [this issue](https://github.com/circleci/circleci-docs/issues/6409#issuecomment-1085922457).