### PR TITLE
Remove solo intro section

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -184,23 +184,20 @@ en:
 - name: Configuration
   icon: icons/sidebar/configure.svg
   children:
-    - name: Introduction
+    - name: Configuration Introduction
       link: 2.0/config-intro/
-      children:
-        - name: Configuration Introduction
-          link: 2.0/config-intro/
-        - name: Configuration Reference
-          link: 2.0/configuration-reference/
-        - name: Sample Configuration
-          link: 2.0/sample-config/
-        - name: Reusing Configuration
-          link: 2.0/reusing-config/
-        - name: Dynamic Configuration
-          link: 2.0/dynamic-config
-        - name: Using the CircleCI CLI
-          link: 2.0/local-cli/
-        - name: Using the CircleCI Configuration Editor
-          link: 2.0/config-editor/
+    - name: Configuration Reference
+      link: 2.0/configuration-reference/
+    - name: Sample Configuration
+      link: 2.0/sample-config/
+    - name: Reusing Configuration
+      link: 2.0/reusing-config/
+    - name: Dynamic Configuration
+      link: 2.0/dynamic-config
+    - name: Using the CircleCI CLI
+      link: 2.0/local-cli/
+    - name: Using the CircleCI Configuration Editor
+      link: 2.0/config-editor/
     
 - name: Orbs
   icon: icons/sidebar/orbs.svg


### PR DESCRIPTION
# Description
Removing the "Introduction" link of Configuration in the side nav.

# Reasons
There is only one section now and that page is repetitive to the page directly under it. This is how we've gone about organizing in other sections, like Insights.