### PR TITLE
updated sample setup_remote_docker version to latest

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -27,7 +27,7 @@ jobs:
       # ... steps for building/testing app ...
 
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.12
 ```
 
 When `setup_remote_docker` executes, a remote environment will be created, and your current [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) will be configured to use it. Then, any docker-related commands you use will be safely executed in this new environment.
@@ -87,7 +87,7 @@ jobs:
       # ... steps for building/testing app ...
 
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.12
           docker_layer_caching: true
 
       # build and push Docker image

--- a/jekyll/_cci2_ja/building-docker-images.md
+++ b/jekyll/_cci2_ja/building-docker-images.md
@@ -27,7 +27,7 @@ jobs:
       # ... アプリのビルド・テストに関する記述 ...
 
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.12
 ```
 
 `setup_remote_docker` が実行されるとリモート環境が作成され、現在の[プライマリ コンテナ]({{ site.baseurl }}/2.0/glossary/#primary-container)は、それを使用するように構成されます。 これで、使用するすべての Docker 関連コマンドが、この新しい環境で安全に実行されます。
@@ -87,7 +87,7 @@ jobs:
       # ... steps for building/testing app ...
 
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.12
           docker_layer_caching: true
 
       # build and push Docker image


### PR DESCRIPTION
# Description
The latest version of docker that can be set to setup_remote_docker seems to be 20.10.12, so I have updated it.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.