### PR TITLE
add content checklist items to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Please follow our style when contributing to CircleCI docs. Our style guide is h
 Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:
 
 - [ ] Break up walls of text by adding paragraph breaks.
-- [ ] Consider if the content could benefit from more structure like lists or tables to make it easier to consume.
+- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
 - [ ] Keep the title between 20 and 70 characters.
 - [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
 - [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,6 @@ Please take a moment to check through the following items when submitting your P
 - [ ] Consider if the content could benefit from more structure like lists or tables to make it easier to consume.
 - [ ] Keep the title between 20 and 70 characters.
 - [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
-- [ ] Check all headings h1-h6 are in sentence case.
+- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
 - [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
 - [ ] Include relevant backlinks to other CircleCI docs/pages.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,3 +4,16 @@ A brief description of the changes.
 # Reasons
 A link to a GitHub and/or JIRA issue (if applicable).
 Otherwise, a brief sentence about why you made these changes.
+
+# Content Checklist
+Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.
+
+Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:
+
+- [ ] Break up walls of text by adding paragraph breaks.
+- [ ] Consider if the content could benefit from more structure like lists or tables to make it easier to consume.
+- [ ] Keep the title between 20 and 70 characters.
+- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
+- [ ] Check all headings h1-h6 are in sentence case.
+- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
+- [ ] Include relevant backlinks to other CircleCI docs/pages.


### PR DESCRIPTION
# Description
The PR adds a link to the style guide, plus a content checklist to the PR template.

# Reasons
To help contributors check for things that will improve our content for consistency, SEO and so they are easier to consume.