### PR TITLE
change server pdf build syntax to allow -preview

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
       - build_server_pdfs:
           filters:
             branches:
-              only: /.*/server/
+              only: /.*/server/*
       - build_api_docs
       - build:
           requires:


### PR DESCRIPTION
# Description
Allow rendering previews for branches that also build server PDFs.

# Reasons
We need to do both these things in single branches and I've just realised we can't.