### PR TITLE
Avoid POSTGRES_USER=root env and old postgres image tags

### DIFF
--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -386,7 +386,7 @@ jobs:
        auth:
          username: mydockerhub-user
          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-     - image: postgres:9.4.1 # Specifies the database image
+     - image: postgres:14.2 # Specifies the database image
        auth:
          username: mydockerhub-user
          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -396,14 +396,14 @@ jobs:
        environment: # Specifies the POSTGRES_USER authentication
         # environment variable, see circleci.com/docs/2.0/env-vars/
         # for instructions about using environment variables.
-         POSTGRES_USER: root
+         POSTGRES_USER: user
 #...
  build2:
    machine: # Specifies a machine image that uses
-   # an Ubuntu version 20.04 image with Docker 19.03.13
-   # and docker-compose 1.27.4, follow CircleCI Discuss Announcements
+   # an Ubuntu version 20.04 image with Docker 20.10.12
+   # and docker-compose 1.29.2, follow CircleCI Discuss Announcements
    # for new image releases.
-     image: ubuntu-2004:202010-01
+     image: ubuntu-2004:202201-02
 #...
  build3:
    macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
@@ -422,7 +422,7 @@ jobs:
        auth:
          username: mydockerhub-user
          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-     - image: postgres:9.4.1 # Specifies the database image
+     - image: postgres:14.2 # Specifies the database image
        auth:
          username: mydockerhub-user
          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -432,7 +432,7 @@ jobs:
        environment: # Specifies the POSTGRES_USER authentication
         # environment variable, see circleci.com/docs/2.0/env-vars/
         # for instructions about using environment variables.
-         POSTGRES_USER: root
+         POSTGRES_USER: user
 #...
  build2:
    machine: true
@@ -451,7 +451,7 @@ jobs:
        auth:
          username: mydockerhub-user
          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-     - image: postgres:9.4.1 # Specifies the database image
+     - image: postgres:14.2 # Specifies the database image
        auth:
          username: mydockerhub-user
          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -461,7 +461,7 @@ jobs:
        environment: # Specifies the POSTGRES_USER authentication
         # environment variable, see circleci.com/docs/2.0/env-vars/
         # for instructions about using environment variables.
-         POSTGRES_USER: root
+         POSTGRES_USER: user
 #...
  build2:
    machine: true # Specifies a machine image.
@@ -498,7 +498,7 @@ See the [Choosing an Executor Type]({{ site.baseurl }}/2.0/executor-types/) docu
            username: mydockerhub-user
            password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 
-       - image: postgres:9.4.1 # Specifies the database image
+       - image: postgres:14.2 # Specifies the database image
          auth:
            username: mydockerhub-user
            password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
@@ -508,7 +508,7 @@ See the [Choosing an Executor Type]({{ site.baseurl }}/2.0/executor-types/) docu
          environment: # Specifies the POSTGRES_USER authentication
           # environment variable, see circleci.com/docs/2.0/env-vars/
           # for instructions about using environment variables.
-           POSTGRES_USER: root
+           POSTGRES_USER: user
 ...
    build2:
      machine: # Specifies a machine image that uses


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Avoids `POSTGRES_USER`=`root` environment variables and old `postgres` image tag on [/concepts](https://circleci.com/docs/2.0/concepts/).

# Reasons
Part of #6700

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
