### PR TITLE
Avoid POSTGRES_USER=root env on /postgres-config

### DIFF
--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -48,7 +48,7 @@ jobs:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
         environment:
-          POSTGRES_USER: root
+          POSTGRES_USER: testuser
           POSTGRES_DB: circle-test_test
 
     steps:


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Avoids POSTGRES_USER=root environment variables and old images on [/postgres-config](https://circleci.com/docs/2.0/postgres-config/).

# Reasons
Part of #6700

# Content Checklist
n/a