### PR TITLE
Avoid POSTGRES_USER=root env on /project-walkthrough

### DIFF
--- a/jekyll/_cci2/project-walkthrough.md
+++ b/jekyll/_cci2/project-walkthrough.md
@@ -71,12 +71,12 @@ jobs:
         environment:
           FLASK_CONFIG: testing
           TEST_DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
-      - image: cimg/postgres:9.6.5
+      - image: cimg/postgres:14.2
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
         environment:
-          POSTGRES_USER: root
+          POSTGRES_USER: testuser
           POSTGRES_DB: circle_test
           POSTGRES_PASSWORD: ""
 ```
@@ -102,12 +102,12 @@ jobs:
         environment:
           FLASK_CONFIG: testing
           TEST_DATABASE_URL: postgresql://ubuntu@localhost/circle_test?sslmode=disable
-      - image: cimg/postgres:9.6.5
+      - image: cimg/postgres:14.2
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
         environment:
-          POSTGRES_USER: ubuntu
+          POSTGRES_USER: testuser
           POSTGRES_DB: circle_test
           POSTGRES_PASSWORD: ""
     steps:


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Avoids POSTGRES_USER=root environment variables and old images on [/project-walkthrough/](https://circleci.com/docs/2.0/project-walkthrough/). Also the deprecated images (PostgreSQL 9.6 was already EOL'd) are updated to the latest minor.

# Reasons
Last part of #6700

# Content Checklist
n/a