### PR TITLE
oss: Relay does not use CircleCI any more

### DIFF
--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -114,9 +114,8 @@ Following are a few examples of projects (big and small) that build on CircleCI:
 - **[React](https://github.com/facebook/react)** - Facebook’s JavaScript based React is built with CircleCI (as well as other CI tools).
 - **[React Native](https://github.com/facebook/react-native/)** - Build native mobile apps using JavaScript and React.
 - **[Flow](https://github.com/facebook/flow/)** - Adds static typing to JavaScript to improve developer productivity and code quality.
-- **[Relay](https://github.com/facebook/relay)** - JavaScript framework for building data-driven React applications.
 - **[Vue](https://github.com/vuejs/vue)** -  Vue.js is a progressive, incrementally-adoptable JavaScript framework for building UI on the web.
-- **[StoryBook](https://github.com/storybooks/storybook)** - Interactive UI component dev & test: React, React Native, Vue, Angular, Ember.
+- **[Storybook](https://github.com/storybookjs/storybook)** - Interactive UI component dev & test: React, React Native, Vue, Angular, Ember.
 - **[Electron](https://github.com/electron/electron)** - Build cross-platform desktop apps with JavaScript, HTML, and CSS.
 - **[Angular](https://github.com/angular/angular)** - Framework for building browser and desktop web applications.
 - **[Apollo](https://github.com/apollographql)** - A community building flexible open source tools for GraphQL.


### PR DESCRIPTION

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
- Remove [`facebook/relay`](https://github.com/facebook/relay) repo from Example open source projects on [/oss/](https://circleci.com/docs/2.0/oss/).
- Storybook is not `StoryBook` (https://github.com/storybookjs/storybook).
- Org rename in storybook: https://github.com/storybookjs/storybook/pull/6954

# Reasons
- https://github.com/facebook/relay/pull/2892