### PR TITLE
Update Xcode image policy document

### DIFF
--- a/jekyll/_cci2/xcode-policy.md
+++ b/jekyll/_cci2/xcode-policy.md
@@ -25,65 +25,67 @@ You will find the most up to date information on these images on the [CircleCI D
 
 We aim to retain 4 major versions of Xcode, with more recent versions having a larger number of images to choose from.
 
-For example, with Xcode 13 being the latest major version being released:
+For example, with Xcode 14 being the latest major version being released:
 
 Xcode Version  | Action
 ----------------|---------------------------------
-Xcode 13 | We will keep all `major.minor` versions at the latest patch version
-Xcode 12 | We will keep all `major.minor` versions at the latest patch version
-Xcode 11 | As further Xcode 13 releases are announced, we will begin deprecating older versions of Xcode 11 in stages
-Xcode 10 | We retain a single image which will be the last stable release of Xcode 10
-Xcode 9 | Removed entirely
+Xcode 14 | We will retain all `major.minor` versions at the latest patch version
+Xcode 13 | We will retain the 4 latest `major.minor` versions at the latest patch version
+Xcode 12 | We retain a single image which will be the last stable release of Xcode 12
+Xcode 11 | We retain a single image which will be the last stable release of Xcode 11
+Xcode 10 | Removed entirely
 {: class="table table-striped"}
 
-Future example when Xcode 14 enters Beta:
+Future example, when Xcode 15 enters Beta:
 
 Xcode Version | Action
 ----------------|---------------------------------
-Xcode 14 | Beta image will be released and updated as per the beta image policy
-Xcode 13 | We will keep all `major.minor` versions at the latest patch version
-Xcode 12 | We will keep all `major.minor` versions at the latest patch version during the beta period and begin to flag images for deprecation during the Xcode 14 release cycle
-Xcode 11 | All images except for the final release will be flagged for deprecation and removed when Xcode 14 reaches GM
-Xcode 10 | Flagged for deprecation, removed when Xcode 14 reaches GM
+Xcode 15 | Beta image will be released and updated as per the beta image policy
+Xcode 14 | The latest 4 `major.minor` versions will be retained at the latest patch version, older images will be flagged for deprecation and removed when Xcode 15 reaches RC
+Xcode 13 | All images except for the final release will be flagged for deprecation and removed when Xcode 15 reaches RC
+Xcode 12 | All images except for the final release will be flagged for deprecation and removed when Xcode 15 reaches RC
+Xcode 11 | Flagged for deprecation, removed entirely when Xcode 15 reaches RC
 {: class="table table-striped"}
 
-When an image is selected for deprecation and removal, we will create an announcement on our [Discuss forum](https://discuss.circleci.com/c/announcements/39), along with reaching out via email to developers who have requested one of the deprecated images in their recent jobs. We will always aim to provide four weeks' notice.
+When an image is selected for deprecation and removal, we will create an announcement on our [Discuss forum](https://discuss.circleci.com/c/announcements/39), along with reaching out via email to developers who have requested one of the deprecated images in their recent jobs. We will always aim to provide four weeks notice where possible.
 
 We will never automatically redirect requests for images to different `major.minor` versions, so when one of these images is removed, jobs will start to fail if the `.circleci/config.yml` has not been updated.
 
 ## Xcode patches
 {: #xcode-patches }
 
-We retain the latest patch version of each Xcode `major.minor` version we support. Once a new patch version has been released, we will deprecate the previous patch version and redirect all requests to the new patch.
+We retain the latest patch version of each Xcode `major.minor` version we support. Once a new patch version has been released, we will deprecate the previous patch version and automatically redirect all requests to the new patch version.
 
-As patches are generally backwards compatible, redirects will be put in place within 24 hours of a new patch release. If any major issues are discovered, we will issue a rollback and make both versions temporarily available.
+As patches are generally backwards compatible, redirects will be put in place within 24 hours of a new patch release. If any major issues are discovered, we retain the ability to issue a rollback and make both versions temporarily available.
 
 **Example:**
 
-When Xcode `12.0.1` was released, we removed the previous patch version, `12.0.0`, and automatically redirected all requests for `12.0.0` to `12.0.1`.
+When Xcode `13.2.1` was released, we removed the previous patch version, `13.2.0`, and automatically redirected all requests for `13.2.0` to `13.2.1`.
 
 ## Beta image support
 {: #beta-image-support }
 
 We aim to make beta Xcode versions available on the macOS executor as soon as we can, to allow developers to test their apps ahead of the next stable Xcode release.
 
-Unlike our stable images (which are frozen and will not change), once a new beta image is released it will overwrite the previous beta image until a GM (stable) image is released, at which point the image is frozen and no longer updated. If you are requesting an image using an Xcode version that is currently in beta, please expect it to change when Apple releases a new Xcode beta with minimal notice. This can include breaking changes in Xcode and associated tooling which are beyond our control.
+Unlike our stable images (which are frozen once released and do not change), once a new beta image is released it will overwrite the previous beta image until an RC/Stable image is released, at which point the image is frozen and no longer updated. If you are requesting an image using an Xcode version that is currently in beta, please take into consideration that it will change when Apple releases a new Xcode beta with minimal notice. This can include breaking changes in Xcode and associated tooling which are beyond our control. We do not recommend using beta images for production pipelines.
 
 To read about our customer support policy regarding beta images, please check out this [support center article](https://support.circleci.com/hc/en-us/articles/360046930351-What-is-CircleCI-s-Xcode-Beta-Image-Support-Policy-).
 
 ## Xcode image releases
 {: #xcode-image-releases }
 
-We closely track and monitor Apple’s Xcode releases and always aim to release new images as quickly as possible. We can not provide an official SLA turnaround time for this, as it is highly dependent on any changes made in Xcode and macOS.
+We closely track and monitor Apple’s Xcode releases and always aim to release new images as quickly as possible. Typically we aim to support a new Xcode image within a couple of days, however please note that this is not an SLA. We can not, and do not, provide an official SLA turnaround time for new Xcode images.
 
 New images are always announced on our [Discuss site](https://discuss.circleci.com/c/announcements/39) along with release notes, and will be added to the table of [Xcode versions in the documentation]({{site.baseurl}}/2.0/testing-ios/#supported-xcode-versions).
 
 ## macOS versions
 {: #macos-versions }
 
-Each Xcode image is built on top of a clean macOS install. We aim to keep the macOS version as stable as possible by only updating it when the minimum version requirement for Xcode is increased. When this occurs, we will update the macOS version to the latest stable version that is available.
+Each Xcode image is built on top of a clean macOS install. We aim to keep the macOS version reasonably up to date with the latest version available. Generally our images can be up to 2 minor/patch versions behind the latest stable version.
 
-When a new major version of macOS (e.g., `11.0` or `12.0`) is released, we will usually start to use this version after a minimum of two minor Xcode releases have passed to allow for any major bugs and issues to be resolved. The release timing for this is entirely dependent on Apple’s own release cycle, but will always be announced ahead of time on our [Discuss forum](https://discuss.circleci.com/c/announcements/39).
+We aim to keep the macOS version aligned across our different macOS executors (e.g., VM and Metal), however this may not always be the case. Please check the [Software Manifest]({{site.baseurl}}/2.0/testing-ios/#supported-xcode-versions) file for the image for the most accurate information.
+
+When a new major version of macOS (e.g., `12.0` or `13.0`) is released, we will usually start to use this version after a minimum of two minor Xcode releases have passed to allow for any major bugs and issues to be resolved. The release timing for this is entirely dependent on Apple’s own release cycle, but will always be announced on our [Discuss forum](https://discuss.circleci.com/c/announcements/39).
 
 ## Exceptions
 {: #exceptions }

--- a/jekyll/_cci2/xcode-policy.md
+++ b/jekyll/_cci2/xcode-policy.md
@@ -47,7 +47,7 @@ Xcode 12 | All images except for the final release will be flagged for deprecati
 Xcode 11 | Flagged for deprecation, removed entirely when Xcode 15 reaches RC
 {: class="table table-striped"}
 
-When an image is selected for deprecation and removal, we will create an announcement on our [Discuss forum](https://discuss.circleci.com/c/announcements/39), along with reaching out via email to developers who have requested one of the deprecated images in their recent jobs. We will always aim to provide four weeks notice where possible.
+When an image is selected for deprecation and removal, we will create an announcement on our [Discuss forum](https://discuss.circleci.com/c/announcements/39), along with reaching out via email to developers who have requested one of the deprecated images in their recent jobs. We will always aim to provide four weeks' notice where possible.
 
 We will never automatically redirect requests for images to different `major.minor` versions, so when one of these images is removed, jobs will start to fail if the `.circleci/config.yml` has not been updated.
 
@@ -83,9 +83,9 @@ New images are always announced on our [Discuss site](https://discuss.circleci.c
 
 Each Xcode image is built on top of a clean macOS install. We aim to keep the macOS version reasonably up to date with the latest version available. Generally our images can be up to 2 minor/patch versions behind the latest stable version.
 
-We aim to keep the macOS version aligned across our different macOS executors (e.g., VM and Metal), however this may not always be the case. Please check the [Software Manifest]({{site.baseurl}}/2.0/testing-ios/#supported-xcode-versions) file for the image for the most accurate information.
+We aim to keep the macOS version aligned across our different macOS executors (for example, VM and Metal), however this may not always be the case. Please check the [Software Manifest]({{site.baseurl}}/2.0/testing-ios/#supported-xcode-versions) file for the image for the most accurate information.
 
-When a new major version of macOS (e.g., `12.0` or `13.0`) is released, we will usually start to use this version after a minimum of two minor Xcode releases have passed to allow for any major bugs and issues to be resolved. The release timing for this is entirely dependent on Apple’s own release cycle, but will always be announced on our [Discuss forum](https://discuss.circleci.com/c/announcements/39).
+When a new major version of macOS (for example, `12.0` or `13.0`) is released, we will usually start to use this version after a minimum of two minor Xcode releases have passed to allow for any major bugs and issues to be resolved. The release timing for this is entirely dependent on Apple’s own release cycle, but will always be announced on our [Discuss forum](https://discuss.circleci.com/c/announcements/39).
 
 ## Exceptions
 {: #exceptions }


### PR DESCRIPTION
# Description
Update Xcode image policy document

# Reasons
CPE-496 as a result of the policy review to manage image disk usage

cc @alexazl for additional review (please do not merge until Alexa has reviewed)