### PR TITLE
[RT-344] Document missing runner env vars

### DIFF
--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -149,9 +149,10 @@ NOTE: A namespace is a unique identifier claimed by a user or organization. Each
 Almost all standard CircleCI features are available for use with runner jobs, however, a few features are not yet supported. If these features are important for you to make use of runner jobs, please let us know via the relevant canny page.
 
 - https://circleci.canny.io/runner-feature-requests/p/support-addsshkey-on-self-hosted-runners[`add_ssh_keys`]
+- The following built in environment variables are not populated within runner executors:
+-- CIRCLE_PREVIOUS_BUILD_NUM
+-- All deprecated cloud environment variables 
 
 == Learn more
 
 Take the https://academy.circleci.com/runner-course?access_code=public-2021[runner course] with CircleCI Academy to learn more about running jobs on your infrastructure.
-
-

--- a/jekyll/_includes/snippets/built-in-env-vars.md
+++ b/jekyll/_includes/snippets/built-in-env-vars.md
@@ -12,7 +12,7 @@ Variable | Type | Value
 `CIRCLE_PR_NUMBER`{:.env_var} | Integer | The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
 `CIRCLE_PR_REPONAME`{:.env_var} | String | The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
 `CIRCLE_PR_USERNAME`{:.env_var} | String | The GitHub or Bitbucket username of the user who created the pull request. Only available on forked PRs.
-`CIRCLE_PREVIOUS_BUILD_NUM`{:.env_var} | Integer | The number of previous builds on the current branch. Note: This variable is not set on runner executors
+`CIRCLE_PREVIOUS_BUILD_NUM`{:.env_var} | Integer | The number of previous builds on the current branch. Note: This variable is not set on runner executors.
 `CIRCLE_PROJECT_REPONAME`{:.env_var} | String | The name of the repository of the current project.
 `CIRCLE_PROJECT_USERNAME`{:.env_var} | String | The GitHub or Bitbucket username of the current project.
 `CIRCLE_PULL_REQUEST`{:.env_var} | String | The URL of the associated pull request. If there are multiple associated pull requests, one URL is randomly chosen.

--- a/jekyll/_includes/snippets/built-in-env-vars.md
+++ b/jekyll/_includes/snippets/built-in-env-vars.md
@@ -12,7 +12,7 @@ Variable | Type | Value
 `CIRCLE_PR_NUMBER`{:.env_var} | Integer | The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
 `CIRCLE_PR_REPONAME`{:.env_var} | String | The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
 `CIRCLE_PR_USERNAME`{:.env_var} | String | The GitHub or Bitbucket username of the user who created the pull request. Only available on forked PRs.
-`CIRCLE_PREVIOUS_BUILD_NUM`{:.env_var} | Integer | The number of previous builds on the current branch.
+`CIRCLE_PREVIOUS_BUILD_NUM`{:.env_var} | Integer | The number of previous builds on the current branch. Note: This variable is not set on runner executors
 `CIRCLE_PROJECT_REPONAME`{:.env_var} | String | The name of the repository of the current project.
 `CIRCLE_PROJECT_USERNAME`{:.env_var} | String | The GitHub or Bitbucket username of the current project.
 `CIRCLE_PULL_REQUEST`{:.env_var} | String | The URL of the associated pull request. If there are multiple associated pull requests, one URL is randomly chosen.


### PR DESCRIPTION
# Description

Document environment variables that are not set on runner executors

# Reasons

[RT-344](https://circleci.atlassian.net/jira/software/c/projects/RT/boards/485?modal=detail&selectedIssue=RT-344)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
