### PR TITLE
Fix: search hits not clickable on chrome v101

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -76,12 +76,6 @@ a {
     text-decoration: none;
   }
 
-  &>* {
-    // to prevent the child elements inside a tag from registering
-    // as the target in event listeners (for analytics tracking)
-    pointer-events: none;
-  }
-
   &.active {
     color: $link-text-color !important;
   }


### PR DESCRIPTION
# Description
- Remove blanket `pointer-events: none;` on all link's child

# Reasons
It was reported to us that search results are not clickable on Chrome latest update. I was able to reproduce on `Chrome Version 101.0.4951.41`
