### PR TITLE
Replace buildpack-deps with cimg/base:2022.04-20.04 on /env-vars

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -311,7 +311,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: buildpack-deps:trusty
+      - image: cimg/base:2022.04-20.04
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Replaces `buildpack-deps` (by `@docker`, not by `@circleci`) with the latest version of `cimg/base` on /env-vars.

# Reasons
Part of #6746

# Content Checklist
n/a