### PR TITLE
Added link to Creating a Project doc

### DIFF
--- a/jekyll/_cci2/projects.md
+++ b/jekyll/_cci2/projects.md
@@ -13,8 +13,9 @@ version:
 
 A CircleCI project shares the name of the associated code repository and is visible on the **Projects** page of the [CircleCI web app](https://app.circleci.com/). Projects are added by using the **Set Up Project** button.
 
-On the **Projects** page, you can either set up any project that you are the owner of on your VCS, or follow any project in your organization to gain access to its pipelines and to subscribe to [email notifications]({{site.baseurl}}/2.0/notifications/) for the project's status.
+On the **Projects** page, you can either set up any project you own in your Version Control System (VCS), or follow any project in your organization to access its pipelines and to subscribe to [email notifications]({{site.baseurl}}/2.0/notifications/) for the project's status.
 
+For step-by-step guidance, see [Creating a Project in CircleCI]({{site.baseurl}}/2.0/create-project/).
 ## Projects dashboard
 {: #projects-dashboard }
 


### PR DESCRIPTION
# Description
Added a link to the new Creating a Project tutorial that was merged yesterday.

# Reasons
Linked to https://circleci.atlassian.net/browse/DOCSTEAM-235