### PR TITLE
Update runner-faqs.adoc

### DIFF
--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -82,3 +82,7 @@ Once the tokens have been deleted, you can delete the resource class.
 ```bash
 circleci runner resource-class delete <resource-class>
 ```
+
+== Can I let jobs from forks of my OSS project that are not a part of my organization use my organization's self-hosted runners?
+
+No, runner resource classes cannot be used by jobs that are not associated with the organization that owns the runner resource classes.

--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -83,6 +83,6 @@ Once the tokens have been deleted, you can delete the resource class.
 circleci runner resource-class delete <resource-class>
 ```
 
-== Can I let jobs from forks of my OSS project that are not a part of my organization use my organization's self-hosted runners?
+== Can jobs on forks of my OSS project use my organization's self-hosted runners if the fork is not a part of my organization?
 
-No, runner resource classes cannot be used by jobs that are not associated with the organization that owns the runner resource classes.
+No, runner resource classes cannot be used by jobs that are not associated with the organization that owns the runner resource classes. Only forks of your OSS project that _are_ a part of your organization may use the organization's self-hosted runners.


### PR DESCRIPTION
i may have made this language really confusing, so i'd appreciate any feedback to make it more clear.  i'm struggling myself to not add in a bunch of double negatives or make it confusing.

basically:

you have to be a part of the organization that owns the resource class to use the runners in that resource class.

we get questions from OSS customers that want to let forks of their project use OSS customer's runner resource classes.  you cant do that right now 