### PR TITLE
[DD-589] Add Tracking for Quickstart Guide NEW Badge in Sidebar

### DIFF
--- a/src/js/experiments/gettingStartedGuide.js
+++ b/src/js/experiments/gettingStartedGuide.js
@@ -5,13 +5,11 @@ function addNewBadgeToSidebar() {
   const isGettingStartedPage =
     window.location.pathname == '/docs/2.0/getting-started/';
   const NEW_SIDEBAR_HTML = `
-    <a id="getting-started-guide" class="${
-      isGettingStartedPage ? 'active' : ''
-    }"
+    <a class="${isGettingStartedPage ? 'active' : ''}"
        style="display: flex; align-items: center"
        href="/docs/2.0/getting-started/"
        data-section="getting-started" data-proofer-ignore="">
-      <span id="getting-started-guide">Quickstart Guide</span>
+      <span>Quickstart Guide</span>
       <span class="getting-started-new-badge"> NEW </span>
     </a>
 `;
@@ -36,7 +34,7 @@ function setUpTracking(variation) {
     });
   }
 
-  // Since we are using this function for both variations, we only want to add tracking for elements if we are in treatment as they are unique for the experiment
+  // Since we are using this function for both variations, we only want to add tracking for these elements if we are in treatment as they are unique for the experiment
   if (variation === 'treatment') {
     const badges = Array.from($('.wrapper-link'));
     badges.forEach((badge) => {

--- a/src/js/experiments/gettingStartedGuide.js
+++ b/src/js/experiments/gettingStartedGuide.js
@@ -24,17 +24,27 @@ function showHomePageBadges() {
 }
 
 function setUpTracking(variation) {
+  if (window.location.pathname === '/docs/2.0/getting-started/') {
+    window.AnalyticsClient.trackAction('visited-gettingStarted-page', {
+      variation,
+      referrer: document.referrer,
+    });
+  }
+
   // Adding tracking to a tags that link to /docs/2.0/getting-started/
-  const newBadges = Array.from($("li > a[href='/docs/2.0/getting-started/']"));
-  newBadges?.forEach((link, i) => {
-    let location;
-    if (i === 0) location = 'mobile-sidebar';
-    if (i === 1) location = 'sidebar';
-    if (i === 2) location = 'homePage';
+  const linksToGettingStarted = Array.from(
+    $("li > a[href='/docs/2.0/getting-started/']"),
+  );
+  linksToGettingStarted?.forEach((link, i) => {
+    let linkLocation;
+    if (i === 0) linkLocation = 'mobile-sidebar';
+    if (i === 1) linkLocation = 'sidebar';
+    if (i === 2) linkLocation = 'homePage-section-link';
     link?.addEventListener('click', () => {
-      window.AnalyticsClient.trackAction('clicked-gettingStarted-link', {
+      window.AnalyticsClient.trackAction('clicked-link-to-gettingStarted', {
         variation,
-        location,
+        linkLocation,
+        referrer: document.referrer,
       });
     });
   });
@@ -42,13 +52,27 @@ function setUpTracking(variation) {
   // Since we are using setUpTracking for both variations, we only want to add tracking for these elements if we are in treatment as they are unique for the experiment
   if (variation === 'treatment') {
     const badges = Array.from($('.wrapper-link'));
-    badges.forEach((badge) => {
-      badge.addEventListener('click', () => {
-        window.AnalyticsClient.trackAction('clicked-landing-page-badge', {
-          badgeText: badge.innerText,
-          badgeHref: badge.href,
+    badges.forEach((badge, i) => {
+      // We are grabbing all the experimental badges from the landing page but the first element is unique as that links to /docs/2.0/getting-started/
+      // We are grouping that first badge with the same event name thats being used for linksToGettingStarted above as we want to track the total number of visits to the treatment page of the experiment and the link the user clicked to get there
+      if (i === 0) {
+        badge.addEventListener('click', () => {
+          window.AnalyticsClient.trackAction('clicked-link-to-gettingStarted', {
+            variation,
+            linkLocation: 'homePage-experiment-badge',
+            referrer: document.referrer,
+            badgeText: badge.innerText,
+            badgeHref: badge.href,
+          });
         });
-      });
+      } else {
+        badge.addEventListener('click', () => {
+          window.AnalyticsClient.trackAction('clicked-landing-page-badge', {
+            badgeText: badge.innerText,
+            badgeHref: badge.href,
+          });
+        });
+      }
     });
 
     const links = Array.from($('.treatment').find($('a')));

--- a/src/js/experiments/gettingStartedGuide.js
+++ b/src/js/experiments/gettingStartedGuide.js
@@ -5,11 +5,12 @@ function addNewBadgeToSidebar() {
   const isGettingStartedPage =
     window.location.pathname == '/docs/2.0/getting-started/';
   const NEW_SIDEBAR_HTML = `
-    <a class="${isGettingStartedPage ? 'active' : ''}"
+    <a id="getting-started-guide" class="${isGettingStartedPage ? 'active' : ''
+    }"
        style="display: flex; align-items: center"
        href="/docs/2.0/getting-started/"
        data-section="getting-started" data-proofer-ignore="">
-      <span>Quickstart Guide</span>
+      <span id="getting-started-guide">Quickstart Guide</span>
       <span class="getting-started-new-badge"> NEW </span>
     </a>
 `;
@@ -23,30 +24,44 @@ function showHomePageBadges() {
   }
 }
 
-function setUpTracking() {
-  const badges = Array.from($('.wrapper-link'));
-  badges.forEach((badge) => {
-    badge.addEventListener('click', () => {
-      window.AnalyticsClient.trackAction('clicked-landing-page-badge', {
-        badgeText: badge.innerText,
-        badgeHref: badge.href,
+function setUpTracking(variation) {
+  const newBadges = $("li > a[href='/docs/2.0/getting-started/']");
+  console.log(newBadges);
+  if (newBadges) {
+    const sidebarBadge = newBadges[1];
+    sidebarBadge.addEventListener('click', () => {
+      window.AnalyticsClient.trackAction('clicked-sidebar-getting-started', {
+        variation,
       });
     });
-  });
-  const links = Array.from($('.treatment').find($('a')));
-  links.forEach((link, i) => {
-    link.addEventListener('click', () => {
-      window.AnalyticsClient.trackAction(
-        'clicked-on-getting-started-guide-link',
-        {
-          linkText: link.innerText,
-          linkHref: link.href,
-          linkIndexOnPage: i + 1 + '/' + links.length,
-          page: window.location.pathname,
-        },
-      );
+  }
+
+  // Since we are using this function for both variations, we only want to add tracking for elements if we are in treatment as they are unique for the experiment
+  if (variation === 'treatment') {
+    const badges = Array.from($('.wrapper-link'));
+    badges.forEach((badge) => {
+      badge.addEventListener('click', () => {
+        window.AnalyticsClient.trackAction('clicked-landing-page-badge', {
+          badgeText: badge.innerText,
+          badgeHref: badge.href,
+        });
+      });
     });
-  });
+
+    const links = Array.from($('.treatment').find($('a')));
+    links.forEach((link, i) => {
+      link.addEventListener('click', () => {
+        window.AnalyticsClient.trackAction(
+          'clicked-on-getting-started-guide-link',
+          {
+            linkText: link.innerText,
+            linkIndexOnPage: i + 1 + '/' + links.length,
+            page: window.location.pathname,
+          },
+        );
+      });
+    });
+  }
 }
 
 function displayGettingStartedContent() {
@@ -93,21 +108,24 @@ window.OptimizelyClient.getVariationName({
 })
   .then((variation) => {
     if (variation === 'treatment') {
-      // Init new badges on landing page
-      showHomePageBadges();
-
       // Init NEW badge in sidebar
       addNewBadgeToSidebar();
+
+      // Init new badges on landing page
+      showHomePageBadges();
 
       // Display all content and layout for Quickstart Guide
       displayGettingStartedContent();
 
       // Init tracking for experiment links and landing page badges
-      setUpTracking();
+      setUpTracking(variation);
     } else {
       displayFirstGreenBuildContent();
+      setUpTracking(variation);
     }
   })
   .catch(() => {
+    // In case if users have ad blocker on which blocks optimizely, we will show content for control variation
     displayFirstGreenBuildContent();
+    setUpTracking('control');
   });

--- a/src/js/experiments/gettingStartedGuide.js
+++ b/src/js/experiments/gettingStartedGuide.js
@@ -53,7 +53,7 @@ function setUpTracking(variation) {
   if (variation === 'treatment') {
     const badges = Array.from($('.wrapper-link'));
     badges.forEach((badge, i) => {
-      // We are grabbing all the experimental badges from the landing page but the first element is unique as that links to /docs/2.0/getting-started/
+      // We are grabbing all 4 experimental badges from the landing page but the first element is unique as that links to /docs/2.0/getting-started/
       // We are grouping that first badge with the same event name thats being used for linksToGettingStarted above as we want to track the total number of visits to the treatment page of the experiment and the link the user clicked to get there
       if (i === 0) {
         badge.addEventListener('click', () => {

--- a/src/js/experiments/gettingStartedGuide.js
+++ b/src/js/experiments/gettingStartedGuide.js
@@ -5,7 +5,8 @@ function addNewBadgeToSidebar() {
   const isGettingStartedPage =
     window.location.pathname == '/docs/2.0/getting-started/';
   const NEW_SIDEBAR_HTML = `
-    <a id="getting-started-guide" class="${isGettingStartedPage ? 'active' : ''
+    <a id="getting-started-guide" class="${
+      isGettingStartedPage ? 'active' : ''
     }"
        style="display: flex; align-items: center"
        href="/docs/2.0/getting-started/"
@@ -26,7 +27,6 @@ function showHomePageBadges() {
 
 function setUpTracking(variation) {
   const newBadges = $("li > a[href='/docs/2.0/getting-started/']");
-  console.log(newBadges);
   if (newBadges) {
     const sidebarBadge = newBadges[1];
     sidebarBadge.addEventListener('click', () => {

--- a/src/js/experiments/gettingStartedGuide.js
+++ b/src/js/experiments/gettingStartedGuide.js
@@ -24,17 +24,22 @@ function showHomePageBadges() {
 }
 
 function setUpTracking(variation) {
-  const newBadges = $("li > a[href='/docs/2.0/getting-started/']");
-  if (newBadges) {
-    const sidebarBadge = newBadges[1];
-    sidebarBadge.addEventListener('click', () => {
-      window.AnalyticsClient.trackAction('clicked-sidebar-getting-started', {
+  // Adding tracking to a tags that link to /docs/2.0/getting-started/
+  const newBadges = Array.from($("li > a[href='/docs/2.0/getting-started/']"));
+  newBadges?.forEach((link, i) => {
+    let location;
+    if (i === 0) location = 'mobile-sidebar';
+    if (i === 1) location = 'sidebar';
+    if (i === 2) location = 'homePage';
+    link?.addEventListener('click', () => {
+      window.AnalyticsClient.trackAction('clicked-gettingStarted-link', {
         variation,
+        location,
       });
     });
-  }
+  });
 
-  // Since we are using this function for both variations, we only want to add tracking for these elements if we are in treatment as they are unique for the experiment
+  // Since we are using setUpTracking for both variations, we only want to add tracking for these elements if we are in treatment as they are unique for the experiment
   if (variation === 'treatment') {
     const badges = Array.from($('.wrapper-link'));
     badges.forEach((badge) => {


### PR DESCRIPTION
[Ticket](https://circleci.atlassian.net/browse/DD-589)
[Optimizely](https://app.optimizely.com/v2/projects/16812830475/experiments/21268663100/variations)

# Changes

- add event listener to track clicks on `getting-started` link for both control and treatment variations in sidebar
- make `setUpTracking` dynamic for both treatment and control variations

# Reasons
We didnt have tracking set up for the link to `docs/2.0/getting-started/` in the sidebar

# Considerations 
The `clicked-sidebar-getting-started` event will be fired when users click on either `Quickstart Guide`(treatment) or `Your First Green Build` (control). We can compare the click rate for both in amplitude by segmenting them with the `variation` property.

# Amplitude Events and Properties 

1. `clicked-link-to-gettingStarted`

- `variation`
- `linkLocation`
- `referrer`

**Link in sidebar:**
<img width="490" alt="Screen Shot 2022-04-29 at 4 47 14 PM" src="https://user-images.githubusercontent.com/57234605/166081457-3aade1de-952c-421a-8b3d-22ea5468710c.png">

**Link in mobile sidebar:**
<img width="350" alt="Screen Shot 2022-04-29 at 4 47 45 PM" src="https://user-images.githubusercontent.com/57234605/166081466-a07a6a29-f358-4d4c-97a2-e88d4f6341e5.png">

**Link in home page Get Started section**
<img width="496" alt="Screen Shot 2022-04-29 at 4 45 45 PM" src="https://user-images.githubusercontent.com/57234605/166081415-b34a407d-2aeb-4011-b99d-b7ddd9cc346e.png">


2. `visited-gettingStarted-page`

- `variation`
- `referrer`

<img width="345" alt="Screen Shot 2022-04-29 at 4 45 14 PM" src="https://user-images.githubusercontent.com/57234605/166081410-91844973-d7ba-4235-8894-839c2e0b1849.png">

