### PR TITLE
Add circleci-launch-agent version for Server 3.4

### DIFF
--- a/jekyll/_cci2/runner-installation-cli.adoc
+++ b/jekyll/_cci2/runner-installation-cli.adoc
@@ -225,7 +225,7 @@ Each minor version of server is compatible with a specific version of `circleci-
 | 1.0.33818-051c2fc
 |===
 
-== Additional Resources
+== Additional Resources 
 
 - https://hub.docker.com/r/circleci/runner[CircleCI Runner Image on Docker Hub]
 - https://github.com/CircleCI-Public/circleci-runner-docker[CircleCI Runner Image on Github]

--- a/jekyll/_cci2/runner-installation-cli.adoc
+++ b/jekyll/_cci2/runner-installation-cli.adoc
@@ -169,6 +169,9 @@ For *server v3.1.0 and up*, use the table below to find the compatible launch ag
 
 | 3.3
 | 1.0.29477-605777e
+
+| 3.4
+| 1.0.33818-051c2fc
 |===
 +
 Substitute `<launch-agent-version>` with your launch agent version for server and run the following:
@@ -217,6 +220,9 @@ Each minor version of server is compatible with a specific version of `circleci-
 
 | 3.3
 | 1.0.29477-605777e
+
+| 3.4
+| 1.0.33818-051c2fc
 |===
 
 == Additional Resources


### PR DESCRIPTION
# Description
We are missing the Runner `circleci-launch-agent` for Server 3.4. 

This PR adds the correct version to both:
1. Continued for Linux, macOS, and Server
2. Self-hosted runners for server compatibility

# Reasons
There is a different version for Server 3.4. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [N/A] Break up walls of text by adding paragraph breaks.
- [N/A] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [N/A] Keep the title between 20 and 70 characters.
- [N/A] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [N/A] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [N/A] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [N/A] Include relevant backlinks to other CircleCI docs/pages.
