### PR TITLE
Add 20.10.14 remote Docker version

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -27,7 +27,7 @@ jobs:
       # ... steps for building/testing app ...
 
       - setup_remote_docker:
-          version: 20.10.12
+          version: 20.10.14
 ```
 
 When `setup_remote_docker` executes, a remote environment will be created, and your current [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) will be configured to use it. Then, any docker-related commands you use will be safely executed in this new environment.
@@ -87,7 +87,7 @@ jobs:
       # ... steps for building/testing app ...
 
       - setup_remote_docker:
-          version: 20.10.12
+          version: 20.10.14
           docker_layer_caching: true
 
       # build and push Docker image
@@ -126,6 +126,7 @@ To specify the Docker version, you can set it as a `version` attribute:
 
 CircleCI supports multiple versions of Docker. The following are the available versions:
 
+- `20.10.14`
 - `20.10.12`
 - `20.10.11`
 - `20.10.7`


### PR DESCRIPTION
New version of remote Docker was published this morning. This PR adds it to Docs.