### PR TITLE
Macos storage

### DIFF
--- a/jekyll/_cci2/dedicated-hosts-macos.adoc
+++ b/jekyll/_cci2/dedicated-hosts-macos.adoc
@@ -21,10 +21,10 @@ The identifier for the dedicated host resource is `macos.x86.metal.gen1`, and su
 [.table.table-striped]
 [cols=5*, options="header", stripes=even]
 |===
-| Resource Class Name
-| vCPU
+| Class
+| vCPUs
 | Memory
-| Storage
+| Total Storage
 | Cost
 
 | `macos.x86.metal.gen1`
@@ -80,4 +80,4 @@ workflows:
 
 *A:* Apple released an https://www.apple.com/legal/sla/docs/macOSBigSur.pdf[updated end-user license agreement (EULA)] along with the release of Big Sur in November 2020, which requires cloud providers to lease Apple hardware to no more than one customer for a minimum of 24 hours.
 
-NOTE: By using the Services, you represent and warrant that you have reviewed and agree to be bound by the terms of the Apple Software License Agreement as well as the terms applicable to any software preinstalled on the Apple Software, including, but not limited to Apple's Xcode developer software and any other Apple or third-party software.
+NOTE: By using the Services, you represent and warrant that you have reviewed and agree to be bound by the terms of the Apple Software License Agreement, as well as the terms applicable to any software preinstalled on the Apple Software, including, but not limited to, Apple's Xcode developer software and any other Apple or third-party software.

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -312,7 +312,25 @@ jobs:
       - run: xcodebuild -version
 ```
 
+### macOS VM Storage
+{: #macos-vm-storage }
+
+The amount of available storage on our macOS VMs depends on the resource class and Xcode image being used. The size Xcode images varies based on which tools are pre-installed.
+
+Xcode Version | Class                 | Minimum Available Storage
+--------------|-----------------------|--------------------------
+10.3.0        | medium, large         | 36GB
+10.3.0        | macos.x86.medium.gen2 | 36GB
+11.*          | medium, large         | 23GB
+11.*          | macos.x86.medium.gen2 | 23GB
+12.*          | medium, large         | 30GB
+12.*          | macos.x86.medium.gen2 | 30GB<sup>(2)</sup>
+13.*          | medium, large         | 23GB
+13.*          | macos.x86.medium.gen2 | 89GB
+
 <sup>(1)</sup> _This resource requires a minimum 24-hour lease. See the [Dedicated Host for macOS]({{ site.baseurl }}/2.0/dedicated-hosts-macos) page to learn more about this resource class._
+
+<sup>(2)</sup> _Exception: Xcode 12.0.1 and 12.5.1 have a minimum 100GB of available storage._
 
 ## Using the Windows executor
 {: #using-the-windows-executor }

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -315,7 +315,7 @@ jobs:
 ### macOS VM Storage
 {: #macos-vm-storage }
 
-The amount of available storage on our macOS VMs depends on the resource class and Xcode image being used. The size Xcode images varies based on which tools are pre-installed.
+The amount of available storage on our macOS VMs depends on the resource class and Xcode image being used. The size of the Xcode images varies based on which tools are pre-installed.
 
 Xcode Version | Class                 | Minimum Available Storage
 --------------|-----------------------|--------------------------

--- a/jekyll/_cci2/executor-types.md
+++ b/jekyll/_cci2/executor-types.md
@@ -308,7 +308,7 @@ jobs:
 
     steps:
       # Commands will execute in macOS container
-      # with Xcode 11.3 installed
+      # with Xcode 12.5.1 installed
       - run: xcodebuild -version
 ```
 


### PR DESCRIPTION
# Description
I'm updating the column headers for the Dedicated Hosts specs table to be more consistent with other spec tables and clarify that storage info is for total storage, rather than available. I'm also adding a section to the macOS docs with details about our available VM storage.

# Reasons
We get a lot of questions around macOS storage and want to provide an easy reference for customers in our docs.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
