### PR TITLE
update snippet to correct RAM values

### DIFF
--- a/jekyll/_includes/snippets/machine-resource-table.md
+++ b/jekyll/_includes/snippets/machine-resource-table.md
@@ -1,7 +1,7 @@
-| Class            | vCPUs | RAM   |
-| ---------------- | ----- | ----- |
-| medium           | 2     | 100GB |
-| large            | 4     | 100GB  |
-| xlarge           | 8     | 100GB  |
-| 2xlarge          | 16    | 100GB  |
+Class | vCPUs | RAM | Disk Size
+--- | --- | --- | ---
+medium | 2 | 7.5 GB | 100GB
+large | 4 | 15 GB | 100GB
+xlarge | 8 | 32 GB | 100GB
+2xlarge | 16 | 64 GB | 100GB
 {: class="table table-striped"}


### PR DESCRIPTION
# Description
Update RAM column in machine executor table in config ref

# Reasons
Values were in fact disc size.

