### PR TITLE
Remove macOS coming soon alert

### DIFF
--- a/jekyll/_cci2/plan-free.adoc
+++ b/jekyll/_cci2/plan-free.adoc
@@ -22,8 +22,6 @@ The Free plan offers *unlimited users* - there is no limit to the number of user
 
 Below are the features you can use on the Free plan. Refer to the https://circleci.com/pricing/[Pricing] page for more detailed information on credit amounts, included resource classes, key features, and support. Refer to the https://circleci.com/product/features/resource-classes/[Resource class features] page for details on CPU, memory, network and storage, and credit usage for compute type on execution environments.
 
-NOTE: Please note, for the Free plan, resource classes on macOS are *coming soon*.
-
 === Available resource classes 
 A wide array of resource classes on Docker, Linux, Windows, and macOS are available to use. This flexibility helps ensure that you choose the right compute resources. To view examples, or find more information about these executors, please refer to the the <<executor-intro#,Executors and Images>> page.
 


### PR DESCRIPTION
# Description
* Remove macOS coming soon alert

# Reasons
* [macOS resource classes](https://circleci.com/product/features/resource-classes/#macos) are available on the [free plan](https://circleci.com/pricing/#comparison-table). 
* The [last commit](https://github.com/circleci/circleci-docs/commit/1a9dfa467e95abd9c07f4c90382bbdb26e01a98a) to this file removed "(coming soon)" after macOS in the following paragraph, but this alert was not removed then.
* The alert was quite prominent and could be scaring off those looking for macOS support, causing them to think it's not available, when it actually is.

# Screenshots
## Before 
![Screen Shot 2022-05-10 at 2 29 19 PM](https://user-images.githubusercontent.com/5113432/167697742-0f27c77c-9968-4d9f-a98a-028c3c7b20a5.png)

## After
![Screen Shot 2022-05-10 at 2 29 48 PM](https://user-images.githubusercontent.com/5113432/167697757-3bc01330-5b83-4ed5-9e93-d6d9201e4523.png)

