### PR TITLE
Fix broken link to CircleCI

### DIFF
--- a/jekyll/_cci2/language-php.md
+++ b/jekyll/_cci2/language-php.md
@@ -22,7 +22,7 @@ This document provides a walkthrough of the [`.circleci/config.yml`]({{ site.bas
 We maintain a reference PHP Laravel project to show how to build PHP on CircleCI:
 
 - <a href="https://github.com/CircleCI-Public/circleci-demo-php-laravel" target="_blank">Demo PHP Laravel Project on GitHub</a>
-- [Demo PHP Laravel Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-php-laravel){:rel="nofollow"}
+- [Demo PHP Laravel Project building on CircleCI](https://app.circleci.com/pipelines/github/CircleCI-Public/sample-php-laravel){:rel="nofollow"}
 
 In the project you will find a commented CircleCI configuration file <a href="https://github.com/CircleCI-Public/circleci-demo-php-laravel/blob/circleci-2.0/.circleci/config.yml" target="_blank">`.circleci/config.yml`</a>. This file shows best practice for using CircleCI with PHP projects.
 


### PR DESCRIPTION
# Description

Fixes broken link here:

[Demo PHP Laravel Project building on CircleCI](https://circleci.com/gh/CircleCI-Public/circleci-demo-php-laravel){:rel="nofollow"}

# Reasons

Link was broken, gave a HTTP 404 error. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ x ] Break up walls of text by adding paragraph breaks.
- [ x ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ x ] Keep the title between 20 and 70 characters.
- [ x ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ x ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ x ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ x ] Include relevant backlinks to other CircleCI docs/pages.
