### PR TITLE
Clarity on macOS runner banner

### DIFF
--- a/jekyll/_cci2/runner-installation-mac.adoc
+++ b/jekyll/_cci2/runner-installation-mac.adoc
@@ -124,7 +124,8 @@ Now you can load the service:
 sudo launchctl load '/Library/LaunchDaemons/com.circleci.runner.plist'
 ```
 
-NOTE: If you are following these instructions for a second time, you should unload the following existing service:
+NOTE: If you are following these instructions for a second time, use the command below to unload the existing service. Once the existing service is unloaded, you can load the new service with the command above.
+
 ```shell
 sudo launchctl unload '/Library/LaunchDaemons/com.circleci.runner.plist'
 ```


### PR DESCRIPTION
# Description
Add clarity around installing runner on macOS for a second time.

# Reasons
The banner didn't make it clear you needed to run both commands, not just the second one.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
