### PR TITLE
[SERVER-1666] update core install guide to use helm instead of KOTS

### DIFF
--- a/jekyll/_cci2/server/Installation/2-install-core.adoc
+++ b/jekyll/_cci2/server/Installation/2-install-core.adoc
@@ -13,7 +13,7 @@ version:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 
-Before you begin with the CircleCI server v4.x core services installation phase, ensure all xref:server-3-install-prerequisites.adoc[prerequisites] are met.
+Before you begin with the CircleCI server v4.x core services installation phase, ensure all <<1-install-prerequisites#,prerequisites>> are met.
 
 .Installation Experience Flow Chart Phase 2
 image::server-install-flow-chart-phase2.png[Flow chart showing the installation flow for server 3.x with phase 2 highlighted]

--- a/jekyll/_cci2/server/Installation/2-install-core.adoc
+++ b/jekyll/_cci2/server/Installation/2-install-core.adoc
@@ -23,215 +23,300 @@ NOTE: In the following sections replace any items or credentials displayed betwe
 toc::[]
 
 == Phase 2: Core services installation
-CircleCI server v4.x uses https://kots.io[KOTS] from https://www.replicated.com/[Replicated] for installation management and distribution.
 
-. Ensure you are running the minimum KOTS version ({kotsversion}) by running the command:
-+
-```bash
-kubectl kots version
+CircleCI server is installed as a helm chart.
+
+=== Namespace
+Create a namespace to install the application into.
 ```
-+
-NOTE: The KOTS command opens up a tunnel to the admin console. If running on Windows inside WSL2, the port is not available on the host machine. Turning WSL off and back on should resolve the issue. For more information, please see
-https://github.com/microsoft/WSL/issues/4199.
-
-. From the terminal, run (if you are installing behind a proxy see https://circleci.com/docs/2.0/server-3-install/#installing-behind-an-http-proxy[Installing behind HTTP Proxy]):
-+
-```bash
-kubectl kots install circleci-server
-```
-+
-You will be prompted for:
-+
-* namespace for the deployment
-* password for the KOTS Admin Console
-
-. When complete, you should be provided with a URL to access the KOTS admin console, usually `\http://localhost:8800`.
-
-TIP: If you need to get back to the KOTS admin console at a later date, run: `kubectl kots admin-console -n <YOUR_CIRCLECI_NAMESPACE>`
-
-TIP: Once you have created your namespace, we recommend setting your `kubectl` context too with the following command: `kubectl config set-context --current --namespace <namespace>`
-
-=== Installing behind an HTTP Proxy (optional)
-
-If you wish to install CircleCI server behind a proxy, use the following command structure should be used for step 2 above (for more information see the KOTS docs https://kots.io/kotsadm/installing/online-install/#proxies[here]):
-
-```bash
-kubectl kots install circleci-server --http-proxy <YOUR_HTTP_PROXY_URI> --https-proxy <https-proxy> --no-proxy <YOUR_NO_PROXY_LIST>
+kubectl create ns circleci-server
 ```
 
-The load balancer endpoints must be added to the no-proxy list for the following services: `output processor` and `vm-service`. This is because the no-proxy list is shared between the application and build-agent. The application and build-agent are assumed to be behind the same firewall and therefore cannot have a proxy between them.
+TIP: Once you have created your namespace, we recommend setting your `kubectl` context too, with the following command: `kubectl config set-context --current --namespace <namespace>`
 
-For further information see the https://circleci.com//docs/2.0/server-3-operator-proxy/index.html[Configuring a Proxy] guide.
+=== DockerHub
 
-=== Frontend Settings
-Frontend settings control the web-application-specific aspects of the CircleCI system.
+CircleCI's images are stored in a dockerhub repository.  Credentials to pull the images from CircleCI's dockerhub will be provided to you.  A `docker-registry` Kubernetes secret will be used to pull images from a docker repository.
 
-.Frontend Settings
-image::server-3-frontend-settings.png[Screenshot showing frontend settings]
+==== Option 1
 
-Complete the fields described below.
+If your application has access to the public internet, use the secret below.  The username and password will be provided to you.  This example pulls the images from CircleCI's repository directly.
+```
+kubectl create secret docker-registry regcred \
+  --docker-server=https://index.docker.io/v2/ \
+  --docker-username=<your-username> \
+  --docker-password=<your-access-token> \
+  --docker-email=<your-email>
+```
 
-* *CircleCI Domain Name (required)* - Enter the domain name you specified when creating your Frontend TLS key and certificate.
+==== Option 2
 
-* *Frontend Replicas* - Used to increase the amount of traffic that can be handled by the frontend.
+If your application does not have access to the public internet, you may pull and store the images in whatever docker repository you have available.  Credentials to pull the images from CircleCI's dockerhub will be provided to you.  The `docker-registry` kubernetes secret you will use will take the following form.
 
-* *Frontend TLS Private Key (required)* - You created this during your prerequisite steps. You can retrieve this value with the following command:
-+
+```
+kubectl create secret docker-registry regcred \
+  --docker-server=<your-docker-image-repo> \
+  --docker-username=<your-username> \
+  --docker-password=<your-access-token> \
+  --docker-email=<your-email>
+```
+
+=== Helm Values
+
+Before installing CircleCI, it is recommended to create a new values.yaml file unique to your installation.  The following describes the minimum required values to include in the values.yaml file.  Additional customizations are available, see the provided values.yaml for all possible options.
+
+For sensitive data there are 2 options, add them into the values.yaml file, or add them as Kubernetes secrets directly.  This flexibility allows customers to manage secrets with whatever in-house processes they prefer.  Regardless of which option is used, the sensitive information is stored as a kubernetes secret within CircleCI.
+
+==== API-Token
+
+The application requires a secret containing an API token. This API token is used to facilitate internal API communication to api-service.  Use a random string and store it securely, CircleCI will not be able to recover this value if lost.  There are 2 options:
+
+*Option 1 - Create the secret yourself*
+
+```
+kubectl create secret generic api-token \
+  --from-literal=api-token=<super-secret-random-value>
+```
+
+*Option 2 - CircleCI creates the secret*
+
+Add the value to values.yaml.  CircleCI will create the secret automatically.
+
+```
+apiToken: <super-secret-random-value>
+```
+
+==== Session Cookie
+
+The application requires a session cookie key secret. CircleCI uses this to sign session cookies.  This must be exactly 16 characters long. Use a random string and store it securely, CircleCI will not be able to recover this value if lost.  There are 2 options:
+
+*Option 1 - Create the Secret yourself*
+
+```
+kubectl create secret generic session-cookie \
+--from-literal=session-cookie-key=<secret-key-16-chars>
+```
+
+*Option 2 - CircleCI creates the secret*
+
+Add the value to values.yaml.  CircleCI will create the secret automatically. 
+
+```
+sessionCookieKey: <secret-key-16-chars>
+```
+
+==== Encryption
+
+The application requires a secret containing signing and encrpytion keysets. These keysets are used to encrypt and sign artifacts generated by CircleCI.  The keys were created during prerequisites phase. CircleCI will not be able to recover the values if lost.  Based on how you prefer to manage secrets there are 2 options.
+
+*Option 1 - Create the secret yourself*
+
+kubectl create secret generic signing-keys \
+  --from-literal=signing-key=<your-generated-signing-key> \
+  --from-literal=encryption-key=<your-generated-encryption-key> 
+
+*Option 2 - CircleCI creates the secret*
+
+Add the value to values.yaml.  CircleCI will create the secret automatically. 
+
+```
+keyset:
+  signing: <your-generated-signing-key>
+  encryption: <your-generated-encryption-key>
+```
+
+TODO: Put the rest of the secret instructions here
+
+https://circleci.atlassian.net/browse/SERVER-1823
+
+https://circleci.atlassian.net/browse/SERVER-1819
+
+https://circleci.atlassian.net/browse/SERVER-1821
+
+https://circleci.atlassian.net/browse/SERVER-1820
+
+https://circleci.atlassian.net/browse/SERVER-1822
+
+
+
+
+==== Global
+All values in this section are children of global.
+
+===== Image Pull Secrets (required)
+This the name should match the `docker-registry` secret <<DockerHub,created above>>
+```
+  imagePullSecrets:
+  - name: <regcredsecret>
+```
+
+===== CircleCI Domain Name (required)
+Enter the domain name you specified when creating your Frontend TLS key and certificate.
+
+```
+  domainName: <domain-name-for-circleci>
+```
+
+==== TLS
+For TLS, you have 4 options: 
+
+. Do nothing.  https://letsencrypt.org/[Let's Encrypt] will automatically request and manage certificates for you.  This is a good option for trials, it is not recommended for production use.
+
+. You can supply a private key and certificate
+
+You may have created this during the prerequisite steps. You can retrieve the values with the following commands:
 ```bash
 cat /etc/letsencrypt/live/<CIRCLECI_SERVER_DOMAIN>/privkey.pem
-```
-
-* *Frontend TLS Certificate (required)* - You created this during your prerequisite steps. You can retrieve this value with the following command:
-+
-```bash
 cat /etc/letsencrypt/live/<CIRCLECI_SERVER_DOMAIN>/fullchain.pem
 ```
 
-****
-For the **Frontend TLS private key and certificate** you have 4 options: 
+Add them to values.yaml:
+```
+tls:
+  certificate: "<full-chain>"
+  privateKey: "<private-key>"
+```
 
-* You can supply a private key and certificate
-* Check the box that allows https://letsencrypt.org/[Let's Encrypt] to automatically request and manage certificates for you. 
-* Check the box that allows https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html[AWS Certificate Manager (ACM)] to automatically request and manage certificates for you. For more information about using ACM see the [CircleCI Server v4.x Operator Certificates] guide.
-* You can also disable TLS termination at this point, but the system will still need to be accessed over HTTPS.
+[start=3]
+. Have https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html[AWS Certificate Manager (ACM)] automatically request and manage certificates for you.  Follow the https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html[ACM documentation] for instructions on how to generate ACM certificates.
 
-**Using ACM TLS Certificates**
-
-If you would like to use https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html[AWS Certificate Manager (ACM)] to manage your TLS certificates, follow the https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html[ACM documentation] for instructions on how to generate ACM certificates.
-
-Once you have generated your certificates, enable ACM from the KOTS admin console under the Frontend section. Check the ACM box and provide your ACM ARN (Amazon Resource Name).
+Enable `aws_acm` and add the `service.beta.kubernetes.io/aws-load-balancer-ssl-cert` annotation to point at the ACM ARN
+```
+nginx:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <acm-arn>
+  aws_acm:
+    enabled: false
+```
 
 [WARNING]
 ==== 
-If you have already deployed CircleCI server, enabling ACM is a destructive change to your frontend service. The service will have to be regenerated to allow the use of your ACM certificates and so the associated loadbalancer will also be regenerated. 
-You will need to reroute your DNS records to the new loadbalancer once you have redeployed CircleCI server.
+If you have already deployed CircleCI server, enabling ACM is a destructive change to the loadbalancer. The service will have to be regenerated to allow the use of your ACM certificates and so the associated loadbalancer will also be regenerated. 
+You will need to update your DNS records to the new loadbalancer once you have redeployed CircleCI server.
 ====
 
-****
+[start=4]
+. Disable TLS termination within CircleCI.  The system will still need to be accessed over HTTPS, so TLS termination will be required somewhere upstream of CircleCI.  Implement this by following step 1 (do nothing) and forward to CircleCI on port 80 after terminating TLS.
 
-* *Private Load Balancer (optional)* - Load balancer does not generate external IP addresses.
-+
-NOTE: If you are selecting the option to use private load balancers, the Let's Encrypt option will no longer work and become unavailable.
-
-=== Encryption
-
-Encryption and artifact signing keys were created during prerequisites phase. You can enter them here now.
-
-.Encryption Settings
-image::server-3-encryption-settings.png[Screenshot showing encryption settings]
-
-Complete the following fields:
-
-* *Artifact Signing Key (required)*
-
-* *Encryption Signing Key (required)*
 
 === GitHub
 
-You created your Github OAuth application in the prerequisite phase. Use the data to complete the following settings:
+You created your Github OAuth application in the prerequisite phase. Add the client ID and secret.
 
-.GitHub Settings
-image::server-3-github-settings.png[Screenshot showing GitHub settings]
+```
+github:
+  clientId: <client-id>
+  clientSecret: <client-secret>
+```
 
-* *GitHub Type (required)* -
-Select Cloud or Enterprise (on premises).
+==== GitHub Enterprise
 
-* *OAuth Client ID (required)* -
-The OAuth Client ID provided by GitHub.
+In the case of GitHub enterprise add the following to the `GitHub` section.
 
-* *OAuth Client Secret (required)* -
-The OAuth Client Secret provided by GitHub.
+Create the `defaultToken` by navigating to Settings > Developer Settings > Personal access tokens. The default token requires no scopes.
 
-* *Github Enterprise Fingerprint* -
-Required when using a proxy. Include the output of `ssh-keyscan github.example.com` in the text field.
+```
+  enterprise: true
+  hostname: <github-enterprise-hostname>
+  defaultToken: <token>
+```
 
-=== Object storage
+==== Object storage
 
-You created your Object Storage Bucket and Keys in the prerequisite steps. Use the data to complete the following settings depending on your platform.
+Regardless of your storage provider, a bucket name will need to be included.  It was created in the prerequisite steps.
 
-.Object Storage Settings
-image::server-3-object-storage.png[Screenshot showing object storage settings]
+```
+object_storage:
+  bucketName: <bucket-name>
+```
 
 // Don't include this section in the GCP PDF.
-
 ifndef::env-gcp[]
 
-==== S3 compatible
+===== S3 compatible
+Add an `s3` section as a child of `object_storage`.  The `endpoint` in the case of AWS S3 is the https://docs.aws.amazon.com/general/latest/gr/rande.html[regional endpoint].  Otherwise it is the API endpoint fo your object storage server
 
-* *Storage Bucket Name (required)* -
-The bucket used for server.
+```
+  s3:
+    enabled: true
+    endpoint: <storage-server-or-s3-endpoint>
+```
 
-* *AWS S3 Region (optional)* -
-AWS region of bucket if your provider is AWS. S3 Endpoint is ignored if this option is set.
+Under `object_storage.s3`, add either the `accessKey` and `secretKey` or `irsaRole`.  They were created in the prerequisite steps.
 
-* *S3 Endpoint (optional)* -
-API endpoint of S3 storage provider. Required if your provider is not AWS. AWS S3 Region is ignored if this option is set.
+*Option 1 - IAM access keys*
+Add the following to the `object_storage.s3` section:
 
-* *Storage Object Expiry (required)* -
-Number of days to retain your test results and artifacts. Set to 0 to disable and retain objects indefinitely.
+```
+    accessKey: <access-key>
+    secretKey: <secret-key>
+```
 
-===== Authentication
-One of the following is required. Either select IAM keys and provide:
+*Option 2 - IRSA*
+Add the following to the `object_storage.s3` section:
 
-* *Access Key ID (required)* -
-Access Key ID for S3 bucket access.
-
-* *Secret Key (required)* -
-Secret Key for S3 bucket access.
-
-Or select IAM role and provide:
-
-* *Role ARN* -
-https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[Role ARN for Service Accounts] (Amazon Resource Name) for S3 bucket access.
+```
+    region: <role-region>
+    irsaRole: <irsa-arn>
+```
 
 // Stop hiding from GCP PDF:
-
 endif::env-gcp[]
 
 // Don't include this section in the AWS PDF:
-
 ifndef::env-aws[]
 
-==== Google Cloud Storage
-You should have created your Google Cloud Storage bucket and service account during the prerequisite steps.
+===== Google Cloud Storage
 
-* *Storage Bucket Name (required)* -
-The bucket used for server.
+Under `object_storage` add the following.
 
-* *Storage Object Expiry (required)* -
-Number of days to retain your test results and artifacts. Set to 0 to disable and retain objects indefinitely.
+```
+gcs:
+    enabled: true
+```
 
-===== Authentication
+Under `object_storage.gcs` add either `service_account` or `workloadIdentity`.  They were created in the prerequisite steps.
 
-* You can choose one of the following:
-** *Service Account JSON (required)* - A JSON format key of the Service Account to use for bucket access.
-** *Service Account Email (required)* - Service Account Email id if using Google Workload Identity.
+*Option 1 - Service Account*
 
-endif::env-aws[]
+Add a JSON format key of the Service Account to use for bucket access.  Add the following to the `object_storage.gcs` section:
+
+```
+service_account: <service-account>
+```
+
+
+*Option 2 - Google Workload Identity*
+
+Add the Service Account Email of the workload identity.  Add the following to the `object_storage.gcs` section:
+
+```
+workloadIdentity: <workload-identity-service-account-email>
+```
 
 // Stop hiding from AWS PDF
+endif::env-aws[]
 
-****
-Skip over the next few sections - **Output Processor**, **Nomad** and **VM Service**. We will set these up in the next phase of the installation.
-****
-
-=== Postgres, MongoDB, Vault settings
-
-You can skip these sections unless you plan on using an existing Postgres, MongoDB or Vault instance, in which case, see the https://circleci.com/docs/2.0/server-3-operator-externalizing-services/[Externalizing Services doc]. By default, CircleCI server v4.x will create its own Postgres, MongoDB and Vault instances within the CircleCI namespace. The instances inside the CircleCI namespace will be included in the CircleCI backup and restore process.
 
 === Save and deploy
 Once you have completed the fields detailed above, you can deploy. The deployment installs the core services and provides you with an IP address for the Kong load balancer. That IP address is critical in setting up a DNS record and completing the first phase of the installation.
 
-NOTE: From server v4.3.0, we have replaced https://github.com/traefik/traefik-helm-chart[Traefik] with https://github.com/Kong/charts[Kong] as our reverse proxy. However, to minimize disruption when upgrading, we chose not to rename the service used by Kong. Although you will see a service named `circleci-server-traefik`, this service is actually for Kong.
+Pull all the helm dependencies:
+
+`helm dep update`
+
+Install CircleCI Server:
+
+`helm install server -f values.yaml <path-to-helm-chart>`
 
 === Create DNS entry
-Create a DNS entry for your Kong load balancer, for example, `circleci.your.domain.com` and `app.circleci.your.domain.com`. The DNS entry should align with the DNS names used when creating your TLS certificate and GitHub OAuth app during the prerequisites steps. All traffic will be routed through this DNS record.
+Create a DNS entry for your nginx load balancer, for example, `circleci.your.domain.com` and `app.circleci.your.domain.com`. The DNS entry should align with the DNS names used when creating your TLS certificate and GitHub OAuth app during the prerequisites steps. All traffic will be routed through this DNS record.
 
-You need the IP address or, if using AWS, the DNS name of the Kong load balancer. You can find this information with the following command:
+You need the IP address or, if using AWS, the DNS name of the nginx load balancer. You can find this information with the following command:
 
 [source, shell]
 ----
-kubectl get service circleci-server-traefik --namespace=<YOUR_CIRCLECI_NAMESPACE>
+kubectl get service circleci-proxy
 ----
 
 For more information on adding a new DNS record, see the following documentation:
@@ -239,8 +324,6 @@ For more information on adding a new DNS record, see the following documentation
 * link:https://cloud.google.com/dns/docs/records#adding_a_record[Managing Records] (GCP)
 
 * link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-creating.html[Creating records by using the Amazon Route 53 Console] (AWS)
-
-NOTE: The Kong load balancer has a healthcheck that serves a JSON payload at https://loadbalancer-address/status
 
 === Validation
 

--- a/jekyll/_cci2/server/Installation/2-install-core.adoc
+++ b/jekyll/_cci2/server/Installation/2-install-core.adoc
@@ -22,110 +22,137 @@ NOTE: In the following sections replace any items or credentials displayed betwe
 
 toc::[]
 
+[#phase-2-core-services-installation]
 == Phase 2: Core services installation
 
 CircleCI server is installed as a helm chart.
 
-=== Namespace
+[#step-one-create-a-namespace]
+=== Step one: Create a namespace
 Create a namespace to install the application into.
-```
+
+[source,shell]
+----
 kubectl create ns circleci-server
-```
+----
 
 TIP: Once you have created your namespace, we recommend setting your `kubectl` context too, with the following command: `kubectl config set-context --current --namespace <namespace>`
 
-=== DockerHub
+[#step-two-pull-image-from-dockerhub]
+=== Step two: Pull image from DockerHub
 
-CircleCI's images are stored in a dockerhub repository.  Credentials to pull the images from CircleCI's dockerhub will be provided to you.  A `docker-registry` Kubernetes secret will be used to pull images from a docker repository.
+CircleCI's images are stored in a dockerhub repository. Credentials to pull the images from CircleCI's dockerhub will be provided to you as part of the onboarding process. A `docker-registry` Kubernetes secret will be used to pull images from a docker repository.
 
-==== Option 1
-
-If your application has access to the public internet, use the secret below.  The username and password will be provided to you.  This example pulls the images from CircleCI's repository directly.
-```
+* **Option 1: Your application has access to the public internet**
++
+The username and password will be provided to you.  This example pulls the images from CircleCI's repository directly.
++
+[source,shell]
+----
 kubectl create secret docker-registry regcred \
   --docker-server=https://index.docker.io/v2/ \
   --docker-username=<your-username> \
   --docker-password=<your-access-token> \
   --docker-email=<your-email>
-```
+----
 
-==== Option 2
-
-If your application does not have access to the public internet, you may pull and store the images in whatever docker repository you have available.  Credentials to pull the images from CircleCI's dockerhub will be provided to you.  The `docker-registry` kubernetes secret you will use will take the following form.
-
-```
+* **Option 2: Your application does NOT have access to the public internet**
++
+Pull and store the images in whatever docker repository you have available.  Credentials to pull the images from CircleCI's dockerhub will be provided to you.  The `docker-registry` kubernetes secret you will use will take the following form.
++
+[source,shell]
+----
 kubectl create secret docker-registry regcred \
   --docker-server=<your-docker-image-repo> \
   --docker-username=<your-username> \
   --docker-password=<your-access-token> \
   --docker-email=<your-email>
-```
+----
 
-=== Helm Values
+[#step-three-create-helm-values]
+=== Step three: Create helm values
 
-Before installing CircleCI, it is recommended to create a new values.yaml file unique to your installation.  The following describes the minimum required values to include in the values.yaml file.  Additional customizations are available, see the provided values.yaml for all possible options.
+Before installing CircleCI, it is recommended to create a new `values.yaml` file unique to your installation. The following describes the minimum required values to include in `values.yaml`. Additional customizations are available, see the provided `values.yaml` for all available options.
 
-For sensitive data there are 2 options, add them into the values.yaml file, or add them as Kubernetes secrets directly.  This flexibility allows customers to manage secrets with whatever in-house processes they prefer.  Regardless of which option is used, the sensitive information is stored as a kubernetes secret within CircleCI.
+For sensitive data there are two options: 
 
-==== API-Token
+* add into the values.yaml file 
+* add them as Kubernetes secrets directly
 
-The application requires a secret containing an API token. This API token is used to facilitate internal API communication to api-service.  Use a random string and store it securely, CircleCI will not be able to recover this value if lost.  There are 2 options:
+This flexibility allows you to manage secrets using whichever process you prefer. 
 
-*Option 1 - Create the secret yourself*
+NOTE: Whichever option you choose, this sensitive information is stored as a kubernetes secret within CircleCI.
 
-```
+[#api-token]
+==== API token
+
+The application requires a secret containing an API token. This API token is used to facilitate internal API communication to api-service. Use a random string and store it securely, CircleCI will not be able to recover this value if lost. There are two options:
+
+* *Option 1 - Create the secret yourself*
++
+[source,shell]
+----
 kubectl create secret generic api-token \
   --from-literal=api-token=<super-secret-random-value>
-```
+----
 
-*Option 2 - CircleCI creates the secret*
-
-Add the value to values.yaml.  CircleCI will create the secret automatically.
-
-```
+* *Option 2 - CircleCI creates the secret*
++
+Add the value to `values.yaml`. CircleCI will create the secret automatically.
++
+[source,yaml]
+----
 apiToken: <super-secret-random-value>
-```
+----
 
-==== Session Cookie
+[#session-cookie]
+==== Session cookie
 
-The application requires a session cookie key secret. CircleCI uses this to sign session cookies.  This must be exactly 16 characters long. Use a random string and store it securely, CircleCI will not be able to recover this value if lost.  There are 2 options:
+The application requires a session cookie key secret, which CircleCI uses to sign session cookies. The key secret must be exactly 16 characters long. Use a random string and store it securely, CircleCI will not be able to recover this value if lost. There are 2 options:
 
-*Option 1 - Create the Secret yourself*
-
-```
+* *Option 1 - Create the Secret yourself*
++
+[source,shell]
+----
 kubectl create secret generic session-cookie \
 --from-literal=session-cookie-key=<secret-key-16-chars>
-```
+----
 
-*Option 2 - CircleCI creates the secret*
-
+* *Option 2 - CircleCI creates the secret*
++
 Add the value to values.yaml.  CircleCI will create the secret automatically. 
-
-```
++
+[source,yaml]
+----
 sessionCookieKey: <secret-key-16-chars>
-```
+----
 
+[#encryption]
 ==== Encryption
 
-The application requires a secret containing signing and encrpytion keysets. These keysets are used to encrypt and sign artifacts generated by CircleCI.  The keys were created during prerequisites phase. CircleCI will not be able to recover the values if lost.  Based on how you prefer to manage secrets there are 2 options.
+The application requires a secret containing signing and encrpytion keysets. These keysets are used to encrypt and sign artifacts generated by CircleCI. These keys were created during the prerequisites phase. CircleCI will not be able to recover the values if lost. Depending on how you prefer to manage secrets, there are 2 options.
 
-*Option 1 - Create the secret yourself*
-
+* *Option 1 - Create the secret yourself*
++
+[source,shell]
+----
 kubectl create secret generic signing-keys \
   --from-literal=signing-key=<your-generated-signing-key> \
   --from-literal=encryption-key=<your-generated-encryption-key> 
+----
 
-*Option 2 - CircleCI creates the secret*
-
+* *Option 2 - CircleCI creates the secret*
++
 Add the value to values.yaml.  CircleCI will create the secret automatically. 
-
-```
++
+[source,yaml]
+----
 keyset:
   signing: <your-generated-signing-key>
   encryption: <your-generated-encryption-key>
-```
+----
 
-TODO: Put the rest of the secret instructions here
+#TODO: Put the rest of the secret instructions here#
 
 https://circleci.atlassian.net/browse/SERVER-1823
 
@@ -137,128 +164,147 @@ https://circleci.atlassian.net/browse/SERVER-1820
 
 https://circleci.atlassian.net/browse/SERVER-1822
 
-
-
-
+[#global]
 ==== Global
 All values in this section are children of global.
 
-===== Image Pull Secrets (required)
-This the name should match the `docker-registry` secret <<DockerHub,created above>>
-```
+[#image-pull-secrets]
+===== Image pull secrets (required)
+This the name should match the `docker-registry` secret <<step-two-pull-image-from-dockerhub,created above>>.
+
+[source,yaml]
+----
   imagePullSecrets:
   - name: <regcredsecret>
-```
+----
 
-===== CircleCI Domain Name (required)
+[#circleci-domain-name]
+===== CircleCI domain name (required)
 Enter the domain name you specified when creating your Frontend TLS key and certificate.
 
-```
+[source,yaml]
+----
   domainName: <domain-name-for-circleci>
-```
+----
 
+[#tls]
 ==== TLS
 For TLS, you have 4 options: 
 
-. Do nothing.  https://letsencrypt.org/[Let's Encrypt] will automatically request and manage certificates for you.  This is a good option for trials, it is not recommended for production use.
+* Do nothing.  https://letsencrypt.org/[Let's Encrypt] will automatically request and manage certificates for you.  This is a good option for trials, it is not recommended for production use.
 
-. You can supply a private key and certificate
-
+* You can supply a private key and certificate
++
 You may have created this during the prerequisite steps. You can retrieve the values with the following commands:
-```bash
++
+[source,bash]
+----
 cat /etc/letsencrypt/live/<CIRCLECI_SERVER_DOMAIN>/privkey.pem
 cat /etc/letsencrypt/live/<CIRCLECI_SERVER_DOMAIN>/fullchain.pem
-```
-
-Add them to values.yaml:
-```
+----
++
+Add them to `values.yaml``:
++
+[source,yaml]
+----
 tls:
   certificate: "<full-chain>"
   privateKey: "<private-key>"
-```
+----
 
-[start=3]
-. Have https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html[AWS Certificate Manager (ACM)] automatically request and manage certificates for you.  Follow the https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html[ACM documentation] for instructions on how to generate ACM certificates.
-
+* Have https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html[AWS Certificate Manager (ACM)] automatically request and manage certificates for you.  Follow the https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html[ACM documentation] for instructions on how to generate ACM certificates.
++
 Enable `aws_acm` and add the `service.beta.kubernetes.io/aws-load-balancer-ssl-cert` annotation to point at the ACM ARN
-```
++
+[source,yaml]
+----
 nginx:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <acm-arn>
   aws_acm:
     enabled: false
-```
-
+----
++
 [WARNING]
 ==== 
 If you have already deployed CircleCI server, enabling ACM is a destructive change to the loadbalancer. The service will have to be regenerated to allow the use of your ACM certificates and so the associated loadbalancer will also be regenerated. 
 You will need to update your DNS records to the new loadbalancer once you have redeployed CircleCI server.
 ====
 
-[start=4]
-. Disable TLS termination within CircleCI.  The system will still need to be accessed over HTTPS, so TLS termination will be required somewhere upstream of CircleCI.  Implement this by following step 1 (do nothing) and forward to CircleCI on port 80 after terminating TLS.
+* Disable TLS termination within CircleCI.  The system will still need to be accessed over HTTPS, so TLS termination will be required somewhere upstream of CircleCI.  Implement this by following step 1 (do nothing) and forward to CircleCI on port 80 after terminating TLS.
 
-
-=== GitHub
+[#step-four-github-integration]
+=== Step four: GitHub integration
 
 You created your Github OAuth application in the prerequisite phase. Add the client ID and secret.
 
-```
+[source,yaml]
+----
 github:
   clientId: <client-id>
   clientSecret: <client-secret>
-```
+----
 
-==== GitHub Enterprise
+[#github-enterprise]
+==== GitHub enterprise
 
 In the case of GitHub enterprise add the following to the `GitHub` section.
 
-Create the `defaultToken` by navigating to Settings > Developer Settings > Personal access tokens. The default token requires no scopes.
+Create the `defaultToken` by navigating to **Settings > Developer Settings > Personal access tokens**. The default token requires no scopes.
 
-```
+[source,yaml]
+----
   enterprise: true
   hostname: <github-enterprise-hostname>
   defaultToken: <token>
-```
+----
 
+[#object-storage]
 ==== Object storage
 
-Regardless of your storage provider, a bucket name will need to be included.  It was created in the prerequisite steps.
+Regardless of your storage provider, a bucket name will need to be included. Your created this during the prerequisites phase.
 
-```
+[source,yaml]
+----
 object_storage:
   bucketName: <bucket-name>
-```
+----
 
 // Don't include this section in the GCP PDF.
 ifndef::env-gcp[]
 
+[#s3-compatible]
 ===== S3 compatible
 Add an `s3` section as a child of `object_storage`.  The `endpoint` in the case of AWS S3 is the https://docs.aws.amazon.com/general/latest/gr/rande.html[regional endpoint].  Otherwise it is the API endpoint fo your object storage server
 
-```
+[source,yaml]
+----
   s3:
     enabled: true
     endpoint: <storage-server-or-s3-endpoint>
-```
+----
 
-Under `object_storage.s3`, add either the `accessKey` and `secretKey` or `irsaRole`.  They were created in the prerequisite steps.
+Under `object_storage.s3`, add either the `accessKey` and `secretKey` or `irsaRole`.  They were created during the prerequisite steps.
 
-*Option 1 - IAM access keys*
+* *Option 1 - IAM access keys*
++
 Add the following to the `object_storage.s3` section:
-
-```
++
+[source,yaml]
+----
     accessKey: <access-key>
     secretKey: <secret-key>
-```
+----
 
-*Option 2 - IRSA*
+* *Option 2 - IRSA*
++
 Add the following to the `object_storage.s3` section:
-
-```
++
+[source,yaml]
+----
     region: <role-region>
     irsaRole: <irsa-arn>
-```
+----
 
 // Stop hiding from GCP PDF:
 endif::env-gcp[]
@@ -266,30 +312,32 @@ endif::env-gcp[]
 // Don't include this section in the AWS PDF:
 ifndef::env-aws[]
 
+[#google-cloud-storage]
 ===== Google Cloud Storage
 
 Under `object_storage` add the following.
 
-```
+[source,yaml]
+----
 gcs:
     enabled: true
-```
+----
 
-Under `object_storage.gcs` add either `service_account` or `workloadIdentity`.  They were created in the prerequisite steps.
+Under `object_storage.gcs` add either `service_account` or `workloadIdentity`. They were created during the prerequisite steps.
 
-*Option 1 - Service Account*
-
+* *Option 1 - Service Account*
++
 Add a JSON format key of the Service Account to use for bucket access.  Add the following to the `object_storage.gcs` section:
-
-```
++
+[source,yaml]
+----
 service_account: <service-account>
-```
+----
 
-
-*Option 2 - Google Workload Identity*
-
+* *Option 2 - Google Workload Identity*
++
 Add the Service Account Email of the workload identity.  Add the following to the `object_storage.gcs` section:
-
++
 ```
 workloadIdentity: <workload-identity-service-account-email>
 ```
@@ -297,24 +345,31 @@ workloadIdentity: <workload-identity-service-account-email>
 // Stop hiding from AWS PDF
 endif::env-aws[]
 
-
-=== Save and deploy
+[#step-five-save-and-deploy]
+=== Step five: Save and deploy
 Once you have completed the fields detailed above, you can deploy. The deployment installs the core services and provides you with an IP address for the Kong load balancer. That IP address is critical in setting up a DNS record and completing the first phase of the installation.
 
-Pull all the helm dependencies:
+. Pull all the helm dependencies:
++
+[source,shell]
+----
+helm dep update
+----
 
-`helm dep update`
+. Install CircleCI Server:
++
+[source,shell]
+----
+helm install server -f values.yaml <path-to-helm-chart>
+----
 
-Install CircleCI Server:
-
-`helm install server -f values.yaml <path-to-helm-chart>`
-
-=== Create DNS entry
+[#step-six-create-dns-entry]
+=== Step six: Create DNS entry
 Create a DNS entry for your nginx load balancer, for example, `circleci.your.domain.com` and `app.circleci.your.domain.com`. The DNS entry should align with the DNS names used when creating your TLS certificate and GitHub OAuth app during the prerequisites steps. All traffic will be routed through this DNS record.
 
-You need the IP address or, if using AWS, the DNS name of the nginx load balancer. You can find this information with the following command:
+You need the IP address, or, if using AWS, the DNS name of the nginx load balancer. You can find this information with the following command:
 
-[source, shell]
+[source,shell]
 ----
 kubectl get service circleci-proxy
 ----
@@ -325,12 +380,14 @@ For more information on adding a new DNS record, see the following documentation
 
 * link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-creating.html[Creating records by using the Amazon Route 53 Console] (AWS)
 
-=== Validation
+[#step-seven-validation]
+=== Step seven: Validation
 
 You should now be able to navigate to your CircleCI server installation and log in to the application successfully.
 
 Now we will move on to build services. It may take a while for all your services to be up. You can periodically check by running the following command (you are looking for the “frontend” pod to show a status of _running_ and **ready** should show 1/1):
 
+[source,shell]
 ----
 kubectl get pods -n <YOUR_CIRCLECI_NAMESPACE>
 ----

--- a/jekyll/_cci2/server/Installation/2-install-core.adoc
+++ b/jekyll/_cci2/server/Installation/2-install-core.adoc
@@ -393,7 +393,8 @@ kubectl get pods -n <YOUR_CIRCLECI_NAMESPACE>
 ----
 
 ifndef::pdf[]
-## What to read next
+[#next-steps]
+## Next steps
 
-* https://circleci.com/docs/2.0/server-3-install-build-services/[Server 3.x Phase 3: Execution Environment Installation]
+* <<3-install-execution-environment#,Server 4.x Phase 3: Execution Environment Installation>>
 endif::[]

--- a/jekyll/_cci2/server/Installation/3-install-execution-environment.adoc
+++ b/jekyll/_cci2/server/Installation/3-install-execution-environment.adoc
@@ -12,7 +12,7 @@ version:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 
-Before you begin with the CircleCI server v4.x execution installation phase, ensure you have run through xref:server-3-install-prerequisites.adoc[Phase 1 – Prerequisites] and xref:server-3-install.adoc[Phase 2 - Core services installation].
+Before you begin with the CircleCI server v4.x execution installation phase, ensure you have run through xref:1-install-prerequisites.adoc[Phase 1 – Prerequisites] and xref:server-3-install.adoc[Phase 2 - Core services installation].
 
 .Installation Experience Flow Chart Phase 3
 image::server-install-flow-chart-phase3.png[Flow chart showing the installation flow for server 3.x with phase 3 highlighted]

--- a/jekyll/_cci2/server/Installation/3-install-execution-environment.adoc
+++ b/jekyll/_cci2/server/Installation/3-install-execution-environment.adoc
@@ -12,7 +12,7 @@ version:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 
-Before you begin with the CircleCI server v4.x execution installation phase, ensure you have run through xref:1-install-prerequisites.adoc[Phase 1 – Prerequisites] and xref:server-3-install.adoc[Phase 2 - Core services installation].
+Before you begin with the CircleCI server v4.x execution installation phase, ensure you have run through <<1-install-prerequisites#,Phase 1 – Prerequisites>> and <<2-install-core#,Phase 2 - Core services installation>>.
 
 .Installation Experience Flow Chart Phase 3
 image::server-install-flow-chart-phase3.png[Flow chart showing the installation flow for server 3.x with phase 3 highlighted]

--- a/jekyll/_cci2/server/Installation/4-install-post.adoc
+++ b/jekyll/_cci2/server/Installation/4-install-post.adoc
@@ -12,7 +12,7 @@ version:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 
-Before you begin with the CircleCI server v4.x post installation phase, ensure you have run through xref:server-3-install-prerequisites.adoc[Phase 1 – Prerequisites], xref:server-3-install.adoc[Phase 2 - Core services installation] and xref:server-3-install-build-services.adoc[Phase 3 - Build services installation].
+Before you begin with the CircleCI server v4.x post installation phase, ensure you have run through <<1-install-prerequisites#,Phase 1 – Prerequisites>>, <<2-install-core#,Phase 2 - Core services installation>> and <<3-install-execution-environment#,Phase 3 - Execution environment installation>>.
 
 .Installation Experience Flow Chart Phase 4
 image::server-install-flow-chart-phase4.png[Flow chart showing the installation flow for server 3.x with phase 4 highlighted]

--- a/jekyll/_cci2/server/Installation/7-install-migration.adoc
+++ b/jekyll/_cci2/server/Installation/7-install-migration.adoc
@@ -21,7 +21,7 @@ toc::[]
 
 . Your current CircleCI Server installation is 2.19.
 . You have taken a backup of the 2.19 instance. If you are using external datastores, they need to be backed up separately.
-. You have a new CircleCI Server 3.x xref:server-3-install.adoc[installation].
+. You have a new CircleCI Server 3.x <<1-install-prerequisites#,installation>>.
 . You have successfully run https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[realitycheck] with contexts before starting.
 . The migration script must be run from a machine with:
 - `kubectl` configured for the server 3.x instance

--- a/jekyll/_cci2/server/Operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/Operator/operator-overview.adoc
@@ -13,7 +13,7 @@ version:
 
 The following guide contains information useful for CircleCI server Operators, or those responsible for ensuring CircleCI server 3.x is running properly through maintenance and monitoring.
 
-It is assumed that you have already read the https://circleci.com/docs/2.0/server-3-overview[Server 3.x Overview].
+It is assumed that you have already read the https://circleci.com/docs/2.0/server/overview/overview[Server 3.x Overview].
 
 CircleCI server schedules CI jobs using the https://www.nomadproject.io/[Nomad] scheduler. The Nomad control plane runs inside of Kubernetes, while the Nomad clients are provisioned outside the cluster. The Nomad clients need access to the Nomad control plane, output processor,
 and VM service.
@@ -36,7 +36,7 @@ By default, CircleCI Nomad clients automatically provision compute resources acc
 ### Nomad Clients
 Nomad Clients run without storing state, allowing you to increase or decrease the number of containers as needed.
 
-To ensure enough Nomad clients are running to handle all builds, track the queued builds and then increase the number of Nomad client machines as needed to balance the load. For more on tracking metrics see the xref:server-3-operator-metrics-and-monitoring.adoc[Metrics and Monitoring] section.
+To ensure enough Nomad clients are running to handle all builds, track the queued builds and then increase the number of Nomad client machines as needed to balance the load. For more on tracking metrics see the <<metrics-and-monitoring#,Metrics and Monitoring>> section.
 
 If a job's resource class requires more resources than the Nomad client's instance type has available, it will remain in a pending state. Choosing a smaller instance type for Nomad clients is a way to reduce cost, but limits the Docker resource classes CircleCI can use. Review the https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes[available resource classes] to decide what is best for you. The default instance type will run up to `xlarge` resource classes.
 


### PR DESCRIPTION
# Description
Update core service docs to reference helm instead of KOTS

# Reasons
4.0 will be KOTS free

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
