### PR TITLE
Remove non build params link

### DIFF
--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -174,7 +174,7 @@ All CircleCI API endpoints begin with `https://circleci.com/api/v1.1/`
 /project/:vcs-type/:username/:project/:build\_num/retry | Retries the build, returns a summary of the new build.
 /project/:vcs-type/:username/:project/:build\_num/cancel | Cancels the build, returns a summary of the build.
 /project/:vcs-type/:username/:project/:build_num/ssh-users | Adds a user to the build's SSH permissions.
-/project/:vcs-type/:username/:project/tree/:branch | Triggers a new build, returns a summary of the build. Optional 1.0 [build parameters](https://circleci.com/docs/2.0/parallelism-faster-jobs/) can be set as well and Optional 2.0 [build parameters](https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-api-v1).
+/project/:vcs-type/:username/:project/tree/:branch | Triggers a new build, returns a summary of the build. Optional [build parameters](https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-api-v1) can be set.
 /project/:vcs-type/:username/:project/ssh-key | Creates an ssh key used to access external systems that require SSH key-based authentication.
 /project/:vcs-type/:username/:project/checkout-key | Creates a new checkout key.
 


### PR DESCRIPTION
# Description
* Removes "build parameters" link that pointed to [test splitting and parallelism](https://circleci.com/docs/2.0/parallelism-faster-jobs/)
* Removes mention of different 1.0 and 2.0 build parameters
 
# Reasons
The [test splitting and parallelism](https://circleci.com/docs/2.0/parallelism-faster-jobs/) link did not seem at all relevant to build parameters. There does not seem to be documentation on any difference between 1.0 and 2.0 build parameters (1.0 /2.0 is not the same as v1/v2 of the api)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Include relevant backlinks to other CircleCI docs/pages.
