### PR TITLE
Update dedicated hosts table header to match other executors

### DIFF
--- a/jekyll/_cci2/dedicated-hosts-macos.adoc
+++ b/jekyll/_cci2/dedicated-hosts-macos.adoc
@@ -23,7 +23,7 @@ The identifier for the dedicated host resource is `macos.x86.metal.gen1`, and su
 |===
 | Class
 | vCPUs
-| Memory
+| RAM
 | Total Storage
 | Cost
 


### PR DESCRIPTION
# Description
Update Dedicated Hosts table header from `Memory` to `RAM`.

# Reasons
The rest of our executor/resource class tables use `RAM` and this change will provide more consistency across the docs.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
