### PR TITLE
Fix which agent agentVersion is for in the Runner K8s docs

### DIFF
--- a/jekyll/_cci2/runner-on-kubernetes.adoc
+++ b/jekyll/_cci2/runner-on-kubernetes.adoc
@@ -85,7 +85,7 @@ Customizable parameters are left inside the `+values.yaml+` file. See the follow
 
 | `+runnerToken+`   | -         | Y         | The token you created for your self-hosted runner resource class. You can choose to fill it in the chart here or to pass it directly when applying the chart, as shown above.
 
-| `+agentVersion+`  | -         | N         | The `circleci-task-agent` version to pin. This is only used for CircleCI server installations.
+| `+agentVersion+`  | -         | N         | The `circleci-launch-agent` version to pin. This is only used for CircleCI server installations.
 
 | `+env+`           | -         | N         | Environment variables to set in the `launch-agent` pod. Including values for xref:runner-config-reference.adoc[runner configuration] 
 


### PR DESCRIPTION
# Description
The `agentVersion` in the Helm chart is actually for `launch-agent`. See [here](https://github.com/CircleCI-Public/circleci-runner-docker/blob/main/launch-agent/Dockerfile#L3).

# Reasons
See above.

# Content Checklist
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
