### PR TITLE
Fix gpu executor image to supported ubuntu version

### DIFF
--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -182,7 +182,7 @@ jobs:
   build:
     machine:
       resource_class: gpu.nvidia.small
-      image: ubuntu-1604-cuda-10.1:201909-23
+      image: ubuntu-2004-cuda-11.4:202110-01
     steps:
       - run: nvidia-smi
 ```


### PR DESCRIPTION
# Description

Changed the deprecated  ubuntu version to supported one. 
The image is chosen from here : https://circleci.com/docs/2.0/configuration-reference/#available-linux-gpu-images

# Reasons

[Deprecating Ubuntu 14.04 and 16.04 images: stay secure with modern Ubuntu](https://circleci.com/blog/ubuntu-14-16-image-deprecation/)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
