### PR TITLE
Fix: incorrect yml for JA sidenav

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -772,7 +772,7 @@ ja:
           link: ja/2.0/using-shell-scripts/
           i18n_name: シェルスクリプトを使う
     - name: Tutorials
-    - i18n_name: チュートリアル
+      i18n_name: チュートリアル
       children:
         - name: Test splitting
           link: ja/2.0/test-splitting-tutorial/


### PR DESCRIPTION
# Description

- Remove extra `-` in front of `i18n_name`

# Reasons
A `-` was prepending a `i18n_name` attribute which resulted in breaking the JA sidebar 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
