### PR TITLE
fix KOTS cli Mac download link to 1.65.0

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -47,7 +47,7 @@ Download and install the following software before continuing:
 | Kubernetes Package Management
 |
 
-| KOTS: https://github.com/replicatedhq/kots/releases/download/v1.69.1/kots_darwin_all.tar.gz[Mac] or https://github.com/replicatedhq/kots/releases/download/v1.65.0/kots_linux_amd64.tar.gz[Linux].
+| KOTS: https://github.com/replicatedhq/kots/releases/download/v1.65.0/kots_darwin_all.tar.gz[Mac] or https://github.com/replicatedhq/kots/releases/download/v1.65.0/kots_linux_amd64.tar.gz[Linux].
 | {kotsversion} *
 | Replicated Kubernetes Application Management. KOTS is a `kubectl` https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/[plugin]. 
 | Once you have extracted `kots` from the tar.gz (`tar zxvf kots_linux_amd64.tar.gz`), run `sudo mv kots /usr/local/bin/kubectl-kots` to install it. Mac users will need to grant a security exception.


### PR DESCRIPTION
# Description
We are advocating customers to install v1.65.0 as can be seen on https://circleci.com/docs/2.0/server-3-install-prerequisites/#install-required-software

I noted [a previous PR](https://github.com/circleci/circleci-docs/commit/b8124b42f9eb170011d35abbdd26055b5145209f) addressed the earlier broken link.
However, as a customer noted, this is pointing to a different version @ 1.69.1 instead.

We can verify the updated link for Mac download in this PR here:
https://github.com/replicatedhq/kots/releases/tag/v1.65.0

# Reasons

Customer noted this link points to a different version (v1.69.1) which is not the same as the link for Linux (1.65.0).
Our docs recommend customers to use 1.65.0 as well. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
