### PR TITLE
include 3.4.1 in list for supported k8s versions

### DIFF
--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -126,7 +126,7 @@ CircleCI server installs into an existing Kubernetes cluster. The application us
 | 3.2.2 - 3.3.0
 | 1.16 - 1.21
 
-| 3.4.0
+| 3.4.0 - 3.4.1
 | 1.16 - 1.23
 |===
 


### PR DESCRIPTION


# Description
Updated the table to account for Server 3.4.1

# Reasons

3.4.1 has been released.
Specifically, we noted that 3.4.1 supports k8s version of the same range (1.16 - 1.23), as seen here:
https://circleci.com/docs/2.0/server-3-whats-new/#known-issues

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
