### PR TITLE
ja: Update circleci/node images to latest

### DIFF
--- a/jekyll/_cci2_ja/code-coverage.md
+++ b/jekyll/_cci2_ja/code-coverage.md
@@ -524,7 +524,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.0-browsers
+      - image: circleci/node:14.17-browsers
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # コンテキスト/プロジェクト UI 環境変数を参照します。


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

# Description
Just sync en->ja to update circleci/node images to latest.

# Reasons
- #5554 port to ja