### PR TITLE
Update instructions for pinning launch agent versions in Helm chart

### DIFF
--- a/jekyll/_cci2/runner-on-kubernetes.adoc
+++ b/jekyll/_cci2/runner-on-kubernetes.adoc
@@ -79,13 +79,13 @@ Customizable parameters are left inside the `+values.yaml+` file. See the follow
 | Y
 | You can xref:runner-installation-docker.adoc[extend a custom Docker image] from the CircleCI default self-hosted runner and use that instead.
 
+For CircleCI Enterprise installations, you can use the `+image.tag+` to set a pinned version of launch agent. See xref:runner-installation-cli.adoc#self-hosted-runners-for-server-compatibility[here] for the compatible version tags.
+
 | `+replicaCount+`  | 1         | Y         | The number of replicas of this self-hosted runner you want in your cluster. Must currently be set and updated manually. See <<limitationspending-work,Pending Work>>.
 
 | `+resourceClass+` | -         | Y         | The resource class you created for your self-hosted runner. You can choose to fill it in the chart here or to pass it directly when applying the chart, as shown above.
 
 | `+runnerToken+`   | -         | Y         | The token you created for your self-hosted runner resource class. You can choose to fill it in the chart here or to pass it directly when applying the chart, as shown above.
-
-| `+agentVersion+`  | -         | N         | The `circleci-task-agent` version to pin. This is only used for CircleCI server installations.
 
 | `+env+`           | -         | N         | Environment variables to set in the `launch-agent` pod. Including values for xref:runner-config-reference.adoc[runner configuration] 
 
@@ -95,11 +95,11 @@ Customizable parameters are left inside the `+values.yaml+` file. See the follow
 
 == CircleCI server installation
 
-When installing the Helm chart for use with a CircleCI server installation, the `agentVersion` will need to be set to the pinned version specified in the  xref:runner-installation-cli.adoc#self-hosted-runners-for-server-compatibility[Self-hosted Runner Installation] instructions. The `LAUNCH_AGENT_API_URL` will also need to be set as an environment variable either via the `--set` flag or in the `env` section of the `values.yaml` file, specifying the hostname or address of the server installation.
+When installing the Helm chart for use with a CircleCI server installation, the `+image.tag+` will need to be set to the pinned launch agent version specified in the xref:runner-installation-cli.adoc#self-hosted-runners-for-server-compatibility[Self-hosted Runner Installation] instructions. The `LAUNCH_AGENT_API_URL` will also need to be set as an environment variable either via the `--set` flag or in the `env` section of the `values.yaml` file, specifying the hostname or address of the server installation.
 
 === Upgrading self-hosted runner deployment for server
 
-. Modify the `+values.yaml+` file to specify the new `agentVersion` to update to. Refer to the <<Chart Values>> section of this document for more details about the `+values.yaml+` file.
+. Modify the `+values.yaml+` file to specify the new `+image.tag+` to update to. Refer to the <<Chart Values>> section of this document for more details about the `+values.yaml+` file.
 . Deploy the changes to the cluster 
 +
 ....

--- a/jekyll/_cci2/runner-on-kubernetes.adoc
+++ b/jekyll/_cci2/runner-on-kubernetes.adoc
@@ -79,7 +79,7 @@ Customizable parameters are left inside the `+values.yaml+` file. See the follow
 | Y
 | You can xref:runner-installation-docker.adoc[extend a custom Docker image] from the CircleCI default self-hosted runner and use that instead.
 
-For CircleCI Enterprise installations, you can use the `+image.tag+` to set a pinned version of launch agent. See xref:runner-installation-cli.adoc#self-hosted-runners-for-server-compatibility[here] for the compatible version tags.
+For CircleCI Enterprise installations, you can use the `+image.tag+` to set a pinned version of launch agent. See the xref:runner-installation-cli.adoc#self-hosted-runners-for-server-compatibility[Self-hosted Runner Installation] page for the compatible version tags.
 
 | `+replicaCount+`  | 1         | Y         | The number of replicas of this self-hosted runner you want in your cluster. Must currently be set and updated manually. See <<limitationspending-work,Pending Work>>.
 
@@ -95,7 +95,7 @@ For CircleCI Enterprise installations, you can use the `+image.tag+` to set a pi
 
 == CircleCI server installation
 
-When installing the Helm chart for use with a CircleCI server installation, the `+image.tag+` will need to be set to the pinned launch agent version specified in the xref:runner-installation-cli.adoc#self-hosted-runners-for-server-compatibility[Self-hosted Runner Installation] instructions. The `LAUNCH_AGENT_API_URL` will also need to be set as an environment variable either via the `--set` flag or in the `env` section of the `values.yaml` file, specifying the hostname or address of the server installation.
+When installing the Helm chart for use with a CircleCI server installation, the `+image.tag+` will need to be set to the pinned launch agent version specified in the xref:runner-installation-cli.adoc#self-hosted-runners-for-server-compatibility[Self-hosted Runner Installation] instructions. The `LAUNCH_AGENT_API_URL` will also need to be set as an environment variable. This can be done with the `--set` flag, or in the `env` section of the `values.yaml` file, specifying the hostname or address of the server installation.
 
 === Upgrading self-hosted runner deployment for server
 


### PR DESCRIPTION
# Description
Updates the Runner Kubernetes docs on how to set a pinned launch agent version for server. The launch agent binary is now built into the image and the image tag is used for versioning.

See this related PR: https://github.com/CircleCI-Public/circleci-runner-k8s/pull/19

# Reasons
Jira: https://circleci.atlassian.net/browse/RT-578

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
