### PR TITLE
Mention change in config file storage destination from CCIE 3.4.0

### DIFF
--- a/jekyll/_cci2/server-3-whats-new.adoc
+++ b/jekyll/_cci2/server-3-whats-new.adoc
@@ -70,6 +70,7 @@ application to indicate the cause of the issue. If a build is run on your instal
 CircleCI application, users should be directed to use the https://circleci.com/docs/2.0/local-cli/[CircleCI CLI] to validate the project configuration
 and get details of the possible cause of the issue.
 * The KOTS admin console cannot be upgraded if your installation is set up to be behind a proxy. The proxy settings will be deleted and cause the KOTS admin console to break.
+* Config files will now be stored in the https://circleci.com/docs/2.0/server-3-install-prerequisites/#object-storage-and-permissions[chosen object store] (e.g., AWS S3, Google Cloud Storage or Minio). Users can run into errors accessing certain pipelines, if these config files are deleted due to retention policies (e.g., AWS S3 Lifecycle).
 
 == Release 3.3.1
 


### PR DESCRIPTION
# Description

This is a follow-up from https://github.com/circleci/circleci.com/pull/5996

We noted that since 3.4.0, for newer pipelines, the config files are now stored on S3 rather than Postgres.
As such, some customers were seeing errors when accessing certain pipelines due to the fact that they had retention policy set for their S3.
This change caused the config files for newer pipelines to be deleted (due to lifecycle rule on their S3), and thus errors on the UI.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
