### PR TITLE
updates to standardise execution env use pages - linux VM

### DIFF
--- a/jekyll/_cci2/android-machine-image.md
+++ b/jekyll/_cci2/android-machine-image.md
@@ -32,13 +32,6 @@ below for more details.
 
 Please view the quarterly update announcement on our [Discuss](https://discuss.circleci.com/t/android-images-2022-january-q1-update/42842) page for a list of current pre-installed software.
 
-## Pricing
-{: #pricing }
-
-For pricing information, refer to the Linux machine executors under the “Linux
-VM" section on the [pricing page](https://circleci.com/pricing/).
-
-
 ## Examples
 {: #examples }
 

--- a/jekyll/_cci2/docker-to-machine.md
+++ b/jekyll/_cci2/docker-to-machine.md
@@ -1,10 +1,7 @@
 ---
 layout: classic-docs
-title: "Executor Migration from Docker to Machine"
-short-title: "Migrating Executor from Docker to `machine`"
-description: "Best practices and considerations when migrating executor"
-categories: [migration]
-order:  1
+title: "Migrating from Docker to Machine"
+description: "Best practices and considerations when migrating your executor from Docker to machine"
 version:
 - Cloud
 - Server v3.x

--- a/jekyll/_cci2/using-linuxvm.md
+++ b/jekyll/_cci2/using-linuxvm.md
@@ -8,9 +8,9 @@ version:
 - Server v2.x
 ---
 
-Your can run your jobs in the linux VM (virtual machine) execution environment by using the machine executor and specifying a Linux image. Using the machine executor runs your jobs in a dedicated, ephemeral VM.
+You can run your jobs in the linux VM (virtual machine) execution environment by using the machine executor and specifying a Linux image. Using the machine executor runs your jobs in a dedicated, ephemeral VM.
 
-Using the `machine` executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack; for example, to listen on a network interface, or to modify the system with `sysctl` commands.
+Using the machine executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack; for example, to listen on a network interface, or to modify the system with `sysctl` commands.
 
 To use the machine executor, use the [`machine` key]({{ site.baseurl }}/2.0/configuration-reference/#machine) in your job configuration and specify an image:
 
@@ -43,14 +43,14 @@ You can view the list of available images [in the docs Configuration Reference](
 ## Pre-installed software
 {: #pre-installed-software }
 
-The most up to date list of pre-installed software can be found on the [image builder](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh) page. You can also visit the [Discuss](https://discuss.circleci.com/) page for more information.
+The most up to date list of pre-installed software can be found on the [image builder](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh) page. You can also visit the [Discuss](https://discuss.circleci.com/tag/machine-images) page for more information.
 
 Additional packages can be installed with `sudo apt-get install <package>`. If the package in question is not found, `sudo apt-get update` may be required before installing it.
 
 ## Use machine with Docker
 {:  #use-machine-with-docker }
 
-Using the `machine` executor also means that you get full access to the Docker process. This allows you to run privileged Docker containers and build new Docker images.
+Using the machine executor also means that you get full access to the Docker process. This allows you to run privileged Docker containers and build new Docker images.
 
 The following example uses an image and enables [Docker layer caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or workflow.
 
@@ -60,7 +60,7 @@ machine:
   docker_layer_caching: true    # default - false
 ```
 
-## Using machine and IP ranges 
+## Using machine and IP ranges
 {: #using-machine-and-ip-ranges }
 
 The IP range `192.168.53.0/24` is reserved by CircleCI for internal use on the machine executor. This range should not be used in your jobs.

--- a/jekyll/_cci2/using-linuxvm.md
+++ b/jekyll/_cci2/using-linuxvm.md
@@ -8,16 +8,10 @@ version:
 - Server v2.x
 ---
 
-The `machine` option runs your jobs in a dedicated, ephemeral VM that has the following specifications:
-
-{% include snippets/machine-resource-table.md %}
-
-Using the `machine` executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack; for example, to listen on a network interface, or to modify the system with `sysctl` commands. To find out about migrating a project from using the Docker executor to using `machine`, see the [Executor Migration from Docker to Machine]({{ site.baseurl }}/2.0/docker-to-machine) document.
-
-Using the `machine` executor also means that you get full access to the Docker process. This allows you to run privileged Docker containers and build new Docker images.
+Your can run your jobs in the linux VM (virtual machine) execution environment by using the `machine` and specifying a Linux image. Using the `machine` executor runs your jobs in a dedicated, ephemeral VM.
 
 To use the machine executor,
-set the [`machine` key]({{ site.baseurl }}/2.0/configuration-reference/#machine) in `.circleci/config.yml`:
+use the [`machine` key]({{ site.baseurl }}/2.0/configuration-reference/#machine) in your job configuration and specify an image:
 
 {:.tab.machineblock.Cloud}
 ```yaml
@@ -37,7 +31,25 @@ jobs:
     machine: true
 ```
 
-You can view the list of available images [here]({{ site.baseurl }}/2.0/configuration-reference/#available-linux-machine-images).
+You can view the list of available images [in the docs Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#available-linux-machine-images), or on the [Developer Hub](https://circleci.com/developer/images?imageType=machine). If you are working on an installation of CircleCI server, the syntax is slightly different, and the available Linux images are managed by your system administrator.
+
+## Available LinuxVM resource classes
+{: Available LinuxVM resource classes } 
+
+{% include snippets/machine-resource-table.md %}
+
+Using the `machine` executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack; for example, to listen on a network interface, or to modify the system with `sysctl` commands.
+
+## Pre-installed software
+{: #pre-installed-software }
+
+The most up to date list of pre-installed software can be found on the [image builder](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh) page. You can also visit the [Discuss](https://discuss.circleci.com/) page for more information.
+
+Additional packages can be installed with `sudo apt-get install <package>`. If the package in question is not found, `sudo apt-get update` may be required before installing it.
+
+## Use `machine` with Docker
+
+Using the `machine` executor also means that you get full access to the Docker process. This allows you to run privileged Docker containers and build new Docker images.
 
 The following example uses an image and enables [Docker layer caching]({{ site.baseurl }}/2.0/docker-layer-caching) (DLC) which is useful when you are building Docker images during your job or workflow.
 
@@ -47,4 +59,11 @@ machine:
   docker_layer_caching: true    # default - false
 ```
 
+## `machine` and IP ranges 
+
 The IP range `192.168.53.0/24` is reserved by CircleCI for internal use on the machine executor. This range should not be used in your jobs.
+
+## Next steps
+{: Next steps }
+
+To find out about migrating a project from using the Docker executor to using `machine`, see the [Executor Migration from Docker to Machine]({{ site.baseurl }}/2.0/docker-to-machine) document.

--- a/jekyll/_cci2/using-linuxvm.md
+++ b/jekyll/_cci2/using-linuxvm.md
@@ -36,7 +36,7 @@ jobs:
 You can view the list of available images [in the docs Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#available-linux-machine-images), or on the [Developer Hub](https://circleci.com/developer/images?imageType=machine). If you are working on an installation of CircleCI server, you will notice in the example above the syntax is slightly different, and the available Linux images are managed by your system administrator.
 
 ## Available LinuxVM resource classes
-{: Available LinuxVM resource classes } 
+{: #available-linuxvm-resource-classes } 
 
 {% include snippets/machine-resource-table.md %}
 
@@ -48,6 +48,7 @@ The most up to date list of pre-installed software can be found on the [image bu
 Additional packages can be installed with `sudo apt-get install <package>`. If the package in question is not found, `sudo apt-get update` may be required before installing it.
 
 ## Use machine with Docker
+{:  #use-machine-with-docker }
 
 Using the `machine` executor also means that you get full access to the Docker process. This allows you to run privileged Docker containers and build new Docker images.
 
@@ -60,10 +61,11 @@ machine:
 ```
 
 ## Using machine and IP ranges 
+{: #using-machine-and-ip-ranges }
 
 The IP range `192.168.53.0/24` is reserved by CircleCI for internal use on the machine executor. This range should not be used in your jobs.
 
 ## Next steps
-{: Next steps }
+{: #next-steps }
 
 To find out about migrating a project from using the Docker executor to using `machine`, see the [Executor Migration from Docker to Machine]({{ site.baseurl }}/2.0/docker-to-machine) document.

--- a/jekyll/_cci2/using-linuxvm.md
+++ b/jekyll/_cci2/using-linuxvm.md
@@ -1,23 +1,24 @@
 ---
 layout: classic-docs
 title: "Using the Linux VM execution environment"
-description: "Learn how to configure a your jobs to run in the Linux VM execution environment."
+description: "Learn how to configure a your jobs to run in the Linux VM execution environment using the machine executor."
 version:
 - Cloud
 - Server v3.x
 - Server v2.x
 ---
 
-Your can run your jobs in the linux VM (virtual machine) execution environment by using the `machine` and specifying a Linux image. Using the `machine` executor runs your jobs in a dedicated, ephemeral VM.
+Your can run your jobs in the linux VM (virtual machine) execution environment by using the machine executor and specifying a Linux image. Using the machine executor runs your jobs in a dedicated, ephemeral VM.
 
-To use the machine executor,
-use the [`machine` key]({{ site.baseurl }}/2.0/configuration-reference/#machine) in your job configuration and specify an image:
+Using the `machine` executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack; for example, to listen on a network interface, or to modify the system with `sysctl` commands.
+
+To use the machine executor, use the [`machine` key]({{ site.baseurl }}/2.0/configuration-reference/#machine) in your job configuration and specify an image:
 
 {:.tab.machineblock.Cloud}
 ```yaml
 version: 2.1
 jobs:
-  build:
+  my-job:
     machine:
       image: ubuntu-2004:current
     resource_class: large
@@ -27,18 +28,17 @@ jobs:
 ```yaml
 version: 2.1
 jobs:
-  build:
+  my-job:
     machine: true
+    resource_class: large
 ```
 
-You can view the list of available images [in the docs Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#available-linux-machine-images), or on the [Developer Hub](https://circleci.com/developer/images?imageType=machine). If you are working on an installation of CircleCI server, the syntax is slightly different, and the available Linux images are managed by your system administrator.
+You can view the list of available images [in the docs Configuration Reference]({{ site.baseurl }}/2.0/configuration-reference/#available-linux-machine-images), or on the [Developer Hub](https://circleci.com/developer/images?imageType=machine). If you are working on an installation of CircleCI server, you will notice in the example above the syntax is slightly different, and the available Linux images are managed by your system administrator.
 
 ## Available LinuxVM resource classes
 {: Available LinuxVM resource classes } 
 
 {% include snippets/machine-resource-table.md %}
-
-Using the `machine` executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack; for example, to listen on a network interface, or to modify the system with `sysctl` commands.
 
 ## Pre-installed software
 {: #pre-installed-software }
@@ -47,7 +47,7 @@ The most up to date list of pre-installed software can be found on the [image bu
 
 Additional packages can be installed with `sudo apt-get install <package>`. If the package in question is not found, `sudo apt-get update` may be required before installing it.
 
-## Use `machine` with Docker
+## Use machine with Docker
 
 Using the `machine` executor also means that you get full access to the Docker process. This allows you to run privileged Docker containers and build new Docker images.
 
@@ -59,7 +59,7 @@ machine:
   docker_layer_caching: true    # default - false
 ```
 
-## `machine` and IP ranges 
+## Using machine and IP ranges 
 
 The IP range `192.168.53.0/24` is reserved by CircleCI for internal use on the machine executor. This range should not be used in your jobs.
 

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -122,6 +122,8 @@ en:
       children:
         - name: Introduction
           link: 2.0/executor-intro/
+        - name: Migrating from Docker to Machine
+          link: 2.0/docker-to-machine/
     - name: Docker
       children:
         - name: Using Docker
@@ -144,9 +146,6 @@ en:
       children:
         - name: Using Linux VM
           link: 2.0/using-linuxvm/
-        - name: Pre-installed software
-          link: 2.0/docker-to-machine/
-          hash: pre-installed-software
         - name: Android Machine Image
           link: 2.0/android-machine-image
 

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -122,7 +122,7 @@ en:
       children:
         - name: Introduction
           link: 2.0/executor-intro/
-        - name: Migrating from Docker to Machine
+        - name: Migrating Docker to Machine
           link: 2.0/docker-to-machine/
     - name: Docker
       children:


### PR DESCRIPTION
# Description
Updating "Using ..." pages for all execution environments to standardise how this information is formatted and presented. This is the Linux VM PR, there will be a PR for each execution environment.

# Reasons
[A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.](https://circleci.atlassian.net/browse/DOCSTEAM-326?atlOrigin=eyJpIjoiYmYxYzVkNDRiZTlkNGQxOWJhYTIzMDIxMzgyNjJkODAiLCJwIjoiaiJ9)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
