### PR TITLE
docs(using-arm): fix typo in canny link

### DIFF
--- a/jekyll/_cci2/using-arm.md
+++ b/jekyll/_cci2/using-arm.md
@@ -13,7 +13,7 @@ This document will walk you through the setup steps required to use an Arm
 resource on CircleCI. Arm resources are available on cloud and server 3.x.
 
 
-**CircleCI does not currently support ARM with our Docker executor.** If you would like to follow updates on this functionality, please refer to the following Canny post: [Support ARM resource class on Docker executor](https://circleci.canny.io/cloud-feature-requests/p/support-arm-resource-class-on-docker-executor").
+**CircleCI does not currently support ARM with our Docker executor.** If you would like to follow updates on this functionality, please refer to the following Canny post: [Support ARM resource class on Docker executor](https://circleci.canny.io/cloud-feature-requests/p/support-arm-resource-class-on-docker-executor).
 {: class="alert alert-warning"}
 
 ## Overview


### PR DESCRIPTION
# Description

Fixed broken Canny link for Arm Docker executor support.

# Reasons

Previously this 404'd.

# Content Checklist


- [na] Break up walls of text by adding paragraph breaks.
- [na] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [na] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [na] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [na] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
