### PR TITLE
Fix typo

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -377,7 +377,7 @@ images!
 
 **Recent Tags:**
 
-See [the tag list for circleci/{{ image[0] }} on Docker Hub](https://hub.docker.com/r/circleci/{{ image[0] }})/tags?ordering=last_updated).
+See [the tag list for circleci/{{ image[0] }} on Docker Hub](https://hub.docker.com/r/circleci/{{ image[0] }}/tags?ordering=last_updated).
 
 ---
 


### PR DESCRIPTION
# Description
Removed unnecessary parenthesis.

# Reasons
Checked locally👇

**Before**😿 
![スクリーンショット 2022-06-10 16 55 43](https://user-images.githubusercontent.com/87592312/173019580-9c67a47b-4dfd-4bed-b288-b32a01226d39.png)

**After**😸  
![スクリーンショット 2022-06-10 16 56 15](https://user-images.githubusercontent.com/87592312/173019603-bac265e1-2927-4922-b3ac-c3f54ccf258c.png)
 