### PR TITLE
Update copy on warning message to refer to Prometheus explicitly

### DIFF
--- a/jekyll/_cci2/server-3-operator-metrics-and-monitoring.adoc
+++ b/jekyll/_cci2/server-3-operator-metrics-and-monitoring.adoc
@@ -31,7 +31,7 @@ NOTE: Prometheus Server is not limited to scraping metrics from your CircleCI se
 === Prometheus
 https://prometheus.io/[Prometheus] is a leading monitoring and alerting system for Kubernetes. Server 3.x ships with a basic implementation of monitoring common performance metrics.
 
-WARNING: This feature is broken in KOTS versions 1.65.0 - 1.67.0. If you rely on this feature, we recommend that you do not upgrade your KOTS version until this has been resolved.
+WARNING: The Prometheus feature is broken in KOTS versions 1.65.0 - 1.67.0. If you rely on this feature, we recommend that you do not upgrade your KOTS version until this has been resolved.
 
 === KOTS Admin - Metrics Graphs
 By default, an instance of Prometheus is deployed with your CircleCI server install. Once deployed, you may provide the address for your Prometheus instance to the KOTS Admin Console. KOTS uses this address to generate graph data for the CPU and memory usage of containers in your cluster.


### PR DESCRIPTION

# Description

This updates the warning message to mention the Prometheus feature explicity, to reduce any potential ambiguity.

# Reasons

I noted that due to the spacing afforded between sections, the warning message around Prometheus not available on KOTS v1.65 - v.167 may be ambiguous (low risk I think, but some readers may think this refers to the section below instead).

Current:
<img width="742" alt="Screen Shot 2022-06-13 at 10 50 08" src="https://user-images.githubusercontent.com/2164346/173265558-ad4e358b-7267-4a95-aaa6-5ec68e2fbe36.png">

Original PR adding this warning message can be found here:
https://github.com/circleci/circleci-docs/pull/6581

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
