### PR TITLE
Update retry a build command in API v1

### DIFF
--- a/jekyll/_data/api.yml
+++ b/jekyll/_data/api.yml
@@ -311,7 +311,7 @@ artifacts_latest:
     } ]
 
 retry_build:
-  url: "/api/v1.1/project/:vcs-type/:username/:project/:build_num/retry"
+  url: "/api/v1.1/project/:vcs-type/:org_name/:project/:build_num/retry"
   description: "Retries the build, returns a summary of the new build."
   method: "POST"
   response: |

--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -94,7 +94,7 @@ This is also the payload for the notification webhooks, in which case this objec
 ## Retry a Build
 
 ```sh
-curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/retry -H "Circle-Token: <circle-token>"
+curl -X POST https://circleci.com/api/v1.1/project/:vcs-type/:org_name/:project/:build_num/retry -H "Circle-Token: <circle-token>"
 
 ```
 

--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -171,7 +171,7 @@ All CircleCI API endpoints begin with `https://circleci.com/api/v1.1/`
 **API** | **Description**
 ------- | -------------
 /project/:vcs-type/:username/:project/follow | Follow a new project on CircleCI.
-/project/:vcs-type/:username/:project/:build\_num/retry | Retries the build, returns a summary of the new build.
+/project/:vcs-type/:org_name/:project/:build\_num/retry | Retries the build, returns a summary of the new build.
 /project/:vcs-type/:username/:project/:build\_num/cancel | Cancels the build, returns a summary of the build.
 /project/:vcs-type/:username/:project/:build_num/ssh-users | Adds a user to the build's SSH permissions.
 /project/:vcs-type/:username/:project/tree/:branch | Triggers a new build, returns a summary of the build. Optional [build parameters](https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-api-v1) can be set.


### PR DESCRIPTION
# Description
Update the retry build command to change from `username` to `org_name`

# Reasons
This was requested by a support engineer
[Jira Ticket](https://circleci.atlassian.net/jira/software/projects/DOCSTEAM/boards/412?selectedIssue=DOCSTEAM-328)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
