### PR TITLE
Deprecating container plans

### DIFF
--- a/jekyll/_cci2/containers.md
+++ b/jekyll/_cci2/containers.md
@@ -7,29 +7,21 @@ version:
 - Cloud
 ---
 
-This document describes the basics of containers and how to leverage the containers in your plan to speed up your job and workflow runs. Please note: container-based plans will soon be deprecated in favor of using CircleCI's new [usage plans](https://circleci.com/pricing/usage/). If your builds are queuing with a Container-based plan, consider signing up for a CircleCI usage-based plan to mitigate queuing and to enjoy other benefits.
+Container-based plans will be deprecated from July 18th 2022. For steps to migrate to a usage-based plan, see this [Discuss post](https://discuss.circleci.com/t/migrating-from-a-container-paid-plan-to-a-usage-based-plan/42938/1).
+{: class="alert alert-warning"}
 
-You can read about the new usage-based plans in detail [in this document]({{ site.baseurl }}/2.0/credits/).
+You can read about usage-based plans in detail [in this document]({{ site.baseurl }}/2.0/credits/).
 
 ## Overview
 {: #overview }
 
-Every change committed to your version control system triggers CircleCI to checkout your code and run your job workflow inside a fresh, on-demand, isolated container with access to the following, depending on your plan:
+Every change committed to your version control system triggers CircleCI to checkout your code and run your job workflow inside a fresh, on-demand, isolated container or virtual machine with access to the following, depending on your plan:
 
 - **Concurrency** - Utilizing multiple containers to run multiple builds at the same time. To take advantage of concurrency, configure your development workflow using the [Orchestrating Workflows document]({{ site.baseurl }}/2.0/workflows/) and run your jobs in parallel as shown in the [Sample Config Files document]({{ site.baseurl }}/2.0/sample-config/#concurrent-workflow).
 
 - **Parallelism** - Splitting tests across multiple containers, allowing you to dramatically speed up your test suite. Update your `.circleci/config.yml` file to run your tests in parallel as described in the [Configuring CircleCI]({{ site.baseurl }}/2.0/configuration-reference/#parallelism) document. Learn how to update your config file to parallelize and split tests to decrease your build time by reading the [Running Tests in Parallel]({{ site.baseurl }}/2.0/parallelism-faster-jobs/) documentation.
 
-## Getting started
-{: #getting-started }
+## Migrating to a usage-based plan
+{: #migrating-to-a-usage-based-plan }
 
-Linux plans start with the ability to run one workflow, without concurrency, at no charge. Purchasing a Linux plan enables you to use additional containers when you need them. Choose a paid or free plan during the signup process and change your plan in the CircleCI app Settings page later to meet changing business requirements.
-
-Most CircleCI customers use two to three containers per full-time developer. Increase the number of containers to any level of parallelism and concurrency as your team or the complexity of your workflow grows.
-
-Open source projects include three additional free containers to run jobs concurrently.
-
-## Upgrading
-{: #upgrading }
-
-Refer to the [FAQ about upgrading]({{ site.baseurl }}/2.0/faq/#how-do-i-upgrade-my-container-plan-with-more-containers-to-prevent-queuing) for step-by-step instructions to upgrade your plan.
+Refer to [this Discuss posts](https://discuss.circleci.com/t/migrating-from-a-container-paid-plan-to-a-usage-based-plan/42938/1) for step-by-step instructions to migrate your plan, or [contact customer support](mailto:cs@circleci.com).

--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -72,8 +72,6 @@ If your project has a large test suite, you can configure your build to use [`pa
 ## Resource class
 {: #resource-class }
 
-**Note:**  If you are on a container-based plan, you will need to [open a support ticket](https://support.circleci.com/hc/en-us/requests/new) to enable this feature on your account. Resource class options for self-hosted installations are set by system administrators.
-
 Using `resource_class`, it is possible to configure CPU and RAM resources for each job. For Cloud, see [this table]({{site.baseurl}}/2.0/configuration-reference/#resourceclass) for a list of available classes, and for self-hosted installations contact your system administrator for a list.
 
 Please note, if a `resource_class` is not explicitly declared, CircleCI will try to find the best default resource class for your organization.

--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -594,7 +594,7 @@ Executors define the environment in which the steps of a job will be run, allowi
 Key | Required | Type | Description
 ----|-----------|------|------------
 docker | Y <sup>(1)</sup> | List | Options for `docker` executor.
-resource_class | N | String | Amount of CPU and RAM allocated to each container in a job. (Only available with the `docker` executor) **Note:** A paid account is required to access this feature. Customers on paid container-based plans can request access by [opening a support ticket](https://support.circleci.com/hc/en-us/requests/new).
+resource_class | N | String | Amount of CPU and RAM allocated to each container in a job.
 machine | Y <sup>(1)</sup> | Map | Options for `machine` executor.
 macos | Y <sup>(1)</sup> | Map | Options for `macOS` executor.
 shell | N | String | Shell to use for execution command in all steps. Can be overridden by `shell` in each step.


### PR DESCRIPTION
# Description
* Removed references to the container plan as it is no longer an option.
* Updated the container plan page to push people to migration steps. Once fully deprecated this page will be archived.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
