### PR TITLE
[DD-698] Fix: remove 2.0 from sidebar and link to /

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -5,7 +5,7 @@ en:
     - name: Overview
       children:
         - name: Welcome
-          link: 2.0/
+          link: /
         - name: About CircleCI
           link: 2.0/about-circleci/
         - name: Concepts


### PR DESCRIPTION
# Description
- on the new docs platform (deployed last night) we are running into an error where clicking "welcome" in the sidebar causes a too many redirects error. 
- This pr removes the `/2.0/` that we were linking to, and links directly where that would have redirected to `/`.

# Reasons

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
