### PR TITLE
[Draft] Add crowdin tags to c pages

### DIFF
--- a/jekyll/_cci2/concurrency.adoc
+++ b/jekyll/_cci2/concurrency.adoc
@@ -20,6 +20,7 @@ Every plan with CircleCI includes the ability to run jobs concurrently. However,
 
 toc::[]
 
+[#concurrency]
 == Concurrency
 Within CircleCI, concurrent jobs can be classified as one of two situations:
 
@@ -34,6 +35,7 @@ If jobs are queued, it is possible you are hitting these limits. Hitting your li
 
 Customers on a Performance or Scale plan can request an increase to those limits at no extra charge by contacting https://support.circleci.com/hc/en-us/requests/new[CircleCI support].
 
+[#concurrency-in-workflows]
 === Concurrency in workflows
 To run a set of concurrent jobs, you will need to add a `workflows` section to your existing `.circleci/config.yml` file.
 
@@ -81,6 +83,7 @@ workflows:
 ...
 ```
 
+[#fan-out-fan-in-workflow-example]
 === Fan-out/fan-in workflow example
 A more complex example of using concurrent workflows is running a common build job, fanning-out to run a set of acceptance test jobs concurrently, and then fanning-in to run a common deploy job. This flow is illustrated below.
 
@@ -117,6 +120,7 @@ workflows:
 
 Please note, if you are still using CircleCI Server 2 with `version: 2`, you will need to specify the version in the `workflows` section, as mentioned in the <<#concurrency-in-workflows,Concurrency in workflows>> section.
 
+[#see-also]
 == See also
 - <<workflows#,Workflows>>
 - <<sample-config#,Sample config.yml Files>>

--- a/jekyll/_cci2/config-intro.adoc
+++ b/jekyll/_cci2/config-intro.adoc
@@ -17,6 +17,7 @@ This guide gets you started with the CircleCI `config.yml` file.
 
 toc::[]
 
+[#getting-started-with-circleci-config]
 == Getting started with CircleCI config
 
 This guide covers the following topics:
@@ -31,6 +32,7 @@ This guide covers the following topics:
 
 CircleCI believes in *configuration as code*. Consequently, the entire delivery process from build to deploy is orchestrated through a single file called `config.yml`. The `config.yml` file is located in a folder called `.circleci` at the top of your repo project. CircleCI uses the YAML syntax for config. See the <<writing-yaml#,Writing YAML>> document for guidance on the basics.
 
+[#part-1-using-the-shell]
 == Part 1: Using the shell
 
 CircleCI provides an on-demand shell to run commands. In this first example, you will set up a build and execute a shell command.
@@ -89,6 +91,7 @@ image:config-first-step.png[Successful step within job]
 
 NOTE: Although the `config.yml` syntax itself is straightforward, the indentation is more complicated. Incorrect indentation is the most common error. If you are experiencing problems with this example, check your indentation carefully, or copy and paste the sample code.
 
+[#part-2-using-code-from-your-repo]
 == Part 2: Using code from your repo
 
 CircleCI provides several commands to simplify complex actions. In this example, you will use the `checkout` command. This command fetches the code from your git repo. Once you have retrieved that code, you can work with it in subsequent steps.
@@ -139,6 +142,7 @@ You should now see some additional steps on the CircleCI dashboard:
 
 image::config-second-step.png[Checking out your repo]
 
+[#part-3-using-different-environments-and-creating-workflows]
 == Part 3: Using different environments and creating workflows
 
 In Parts 1 and 2, you ran your job in basic Linux-based Docker containers.
@@ -231,6 +235,7 @@ In this example, you have:
 
 TIP: To increase your understanding, experiment with other <<circleci-images#,CircleCI images>>, or add some more jobs to your workflow.
 
+[#part-4-adding-a-manual-approval]
 == Part 4: Adding a manual approval
 
 The CircleCI workflow model is based on the orchestration of preceeding jobs. As you saw in Part 3, the `requires` statement specifies that a job should run only if the previous job has been successfully executed.
@@ -332,6 +337,7 @@ In this example, you have:
 
 Using what you have learned above, you are ready to create some powerful pipelines.
 
+[#see-also]
 == See also
 
 * <<configuration-reference#,Configuring CircleCI>>

--- a/jekyll/_cci2/create-project.adoc
+++ b/jekyll/_cci2/create-project.adoc
@@ -16,12 +16,14 @@ This guide gets you started with creating a project in CircleCI.
 
 toc::[]
 
+[#step-one-link-your-vcs-with-circleci]
 == Step One: Link your VCS with CircleCI
 
 If you have not done so already, <<first-steps#,sign up with CircleCI>> and select your Version Control System (VCS). You can also sign up with email.
 
 A CircleCI project must be linked with an existing repo in your VCS. Make sure you have a repo and that you have authorized CircleCI to access it (in GitHub, you have the option to block CircleCI from accessing your private repositories).
 
+[#step-two-create-a-project-in-circleci]
 == Step Two: Create a project in CircleCI
 
 Follow these steps to create a new project in CircleCI:
@@ -35,6 +37,7 @@ If you cannot see your project, check you have selected the correct organization
 +
 image::cci-organizations.png[Select Organization]
 
+[#step-three-specify-a-config-file]
 == Step Three: Specify a config file
 
 Once you have set up your project, you will be prompted to provide a `config.yml` file.
@@ -59,6 +62,7 @@ image::edit-config-file.png[Edit Configuration File]
 
 This opens the CircleCI Configuration Editor, from where you can edit and commit your `config.yml` file.
 
+[#see-also]
 == See also
 
 * <<config-intro#,Configuration Introduction>>

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -65,7 +65,7 @@ sudo chmod 600 /opt/circleci/launch-agent-config.yaml
 
 These will be used when executing the task agent. These commands must be run as a user with permissions to create other users (e.g. `root`). For information about GECOS, see the https://en.wikipedia.org/wiki/Gecos_field[wiki page].
 
-[# ubuntu-debian]
+[#ubuntu-debian]
 === Ubuntu/Debian
 
 ```shell


### PR DESCRIPTION
# Description
Add crowdin tags to asciidoc files - starting with pages that start with the letter C

# Reasons
A lot of asciidoc files are missing these tags

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
