### PR TITLE
Fix: Do not alter jekyll internal objects directly

### DIFF
--- a/jekyll/_plugins/json_data.rb
+++ b/jekyll/_plugins/json_data.rb
@@ -4,13 +4,13 @@ def data_to_json(site)
   # add sidenav
   output = output.push({
     name: 'sidenav',
-    content: site.data['sidenav']
+    content: site.data['sidenav'].dup
   });
 
   # add sitemap
   output = output.push({
     name: 'sitemap',
-    content: site.pages
+    content: site.pages.dup
   });
 
   # process data and write to json files

--- a/jekyll/_plugins/json_pages.rb
+++ b/jekyll/_plugins/json_pages.rb
@@ -5,7 +5,7 @@ def doc_to_json(document, site)
   compressor = HtmlCompressor::Compressor.new
 
   # compile data + content
-  output = document.data
+  output = document.data.dup
   output['content'] = compressor.compress(document.content)
   output['file_name'] = document.relative_path
 


### PR DESCRIPTION
# Description
- Use `dup` to copy the jekyll objects

# Reasons
https://github.com/circleci/circleci-docs/pull/7000 introduced a minor bug that directly alters the jekyll internal objects rather than copying them beforehand. This was introducing a lot of unnecessary extra metadata that was not needed. This is explaining why Algolia refused to `index` our content because the data will be too large:

![Screen Shot 2022-06-24 at 3 38 33 PM](https://user-images.githubusercontent.com/1449325/175719463-3c393f8c-9049-4f7a-b97f-5260fafe5cfe.png)
