### PR TITLE
Add crowdin tags for o and p pages

### DIFF
--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -14,6 +14,7 @@ In jobs using a <<contexts#,context>>, CircleCI provides an OpenID Connect ID (O
 
 toc::[]
 
+[#openid-connect-id-token-availability]
 == OpenID Connect ID token availability
 
 In CircleCI jobs that use at least one context, the OpenID Connect ID token is available in the environment variable `CIRCLE_OIDC_TOKEN`.
@@ -29,6 +30,7 @@ workflows:
             - my-context
 ```
 
+[#setting-up-your-cloud-service]
 == Setting up your cloud service
 
 Consult your cloud service's documentation for how to add an identity provider. For example, AWS's https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html[Creating OpenID Connect (OIDC) identity providers], or Google Cloud Platform's https://cloud.google.com/iam/docs/configuring-workload-identity-federation#oidc[Configuring workload identity federation].
@@ -39,6 +41,7 @@ You can find your CircleCI organization ID by navigating to **Organization Setti
 
 The OpenID Connect ID tokens issued by CircleCI have a fixed audience (see `aud` in the table below), which is also the Organization ID.
 
+[#format-of-the-openid-connect-id-token]
 == Format of the OpenID Connect ID token
 
 The OpenID Connect ID token contains the following standard https://openid.net/specs/openid-connect-core-1_0.html#IDToken[claims]:
@@ -82,7 +85,7 @@ The OpenID Connect ID token also contains some https://openid.net/specs/openid-c
 | An array of strings containing UUIDs that identify the context(s) used in the job. Currently, just one context is supported.
 |===
 
-
+[#authenticate-jobs-with-cloud-providers]
 ==  Authenticate jobs with cloud providers
 
 The following instructions are for:
@@ -90,6 +93,7 @@ The following instructions are for:
 * A one-time configuration of your AWS account to trust CircleCI's OIDC tokens
 * Running a job that uses the OIDC token to interact with AWS
 
+[#setting-up-aws]
 === Setting up AWS
 
 You will need to allow your AWS account to trust CircleCI's OpenID Connect tokens. To do this, create an Identity and Access Management(IAM) identity provider, and an IAM role in AWS (this is a one time configuration).
@@ -106,6 +110,7 @@ For the trusted entity, select **Web Identity**, then choose the identity provid
 
 **Note:** You may find it useful to create your own policy.
 
+[#interacting-with-aws-from-a-circleci-job]
 === Interacting with AWS from a CircleCI job
 
 Now you are ready to choose the CircleCI jobs in your workflow that you want to receive an OpenID Connect token. Since the OpenID Connect token is only available to jobs that use at least one <<contexts#,context>>, make sure each of the jobs you want to receive an OIDC token uses a context (the context may have no environment variables). 
@@ -143,6 +148,7 @@ jobs:
             aws sts get-caller-identity
 ```
 
+[#advanced-usage]
 === Advanced Usage
 
 You can take advantage of the format of the claims in CircleCI's <<format-of-the-openid-connect-id-token,OIDC token>> to limit what your CircleCI jobs can do in AWS. For example, if certain projects should only be able to access certain AWS resources, you can restrict your IAM role so that only CircleCI jobs in a specific project can assume that role.

--- a/jekyll/_cci2/plan-free.adoc
+++ b/jekyll/_cci2/plan-free.adoc
@@ -13,6 +13,7 @@ version:
 
 This document describes the Free plan available to developers.
 
+[#free-plan]
 == Free plan
 As with the CircleCI legacy Container plan, CircleCI also supports a free-tier with the usage-based plan. By using the Free plan, you can take advantage of a large number of premium features that will allow your team to be more productive, efficient, and fast.
 
@@ -22,10 +23,12 @@ The Free plan offers *unlimited users* - there is no limit to the number of user
 
 Below are the features you can use on the Free plan. Refer to the https://circleci.com/pricing/[Pricing] page for more detailed information on credit amounts, included resource classes, key features, and support. Refer to the https://circleci.com/product/features/resource-classes/[Resource class features] page for details on CPU, memory, network and storage, and credit usage for compute type on execution environments.
 
+[#available-resource-classes]
 === Available resource classes 
 A wide array of resource classes on Docker, Linux, Windows, and macOS are available to use. This flexibility helps ensure that you choose the right compute resources. To view examples, or find more information about these executors, please refer to the the <<executor-intro#,Executors and Images>> page.
 
 {% include snippets/features-of-circleci.adoc %}
 
+[#support]
 === Support
 Support is available through the https://discuss.circleci.com/[community forums], https://support.circleci.com/hc/en-us[support portal], and our https://support.circleci.com/hc/en-us/requests/new[global ticket-based system].

--- a/jekyll/_cci2/plan-overview.adoc
+++ b/jekyll/_cci2/plan-overview.adoc
@@ -16,6 +16,7 @@ This document is an introduction to the plans CircleCI offers to developers.
 
 NOTE: If you are an existing customer currently on the legacy CircleCI Container-based plan, you may want to consider consulting the document on using <<containers#,containers>>. If you want to switch from using containers to using credits, please https://support.circleci.com/hc/en-us/requests/new[open a support ticket] requesting to do so.
 
+[#overview]
 == Overview
 The CircleCI credit-based usage plans enable you to only pay for what you use, while also providing flexibility in customizing and scaling your team's https://circleci.com/continuous-integration/#what-is-continuous-integration[CI/CD] solution. Credits are consumed by the second, at varying rates per minute, according to what build configuration you use.
 
@@ -32,6 +33,7 @@ For example, your team might use a `large` `resource_class` (4 CPUs and 8 GB of 
 
 The documents in this section cover what each plan offers developers for their CI/CD needs. Consider also taking a moment to look at the CircleCI https://circleci.com/pricing/[Pricing] page to learn about how credits are distributed across different machine types.
 
+[#our-plans]
 == Our plans
 Visit the pages below to learn about the features of CircleCI's plans.
 
@@ -40,8 +42,10 @@ Visit the pages below to learn about the features of CircleCI's plans.
 - <<plan-scale#,Scale Plan>>
 - <<plan-server#,Server Plan>>
 
+[#configuring-your-credit-plan]
 == Configuring your credit plan
 To set up a Free or Performance plan, go to **Plan > Plan Overview** in the CircleCI https://app.circleci.com/[web application]. From there, select the plan that best fits your needs. To set up a Scale or Server plan, https://circleci.com/talk-to-us/[contact us].
 
+[#managing-credit-usage]
 == Managing credit usage
 There are certain optimizations that can be implemented that can help lower your credit consumption, such as eliminating duplicate artifact uploads. Properly managing network and storage usage can potentially lower the amount of credits used per month. If you would like to find out more about managing network and storage usage, please see the <<persist-data#,Persisting Data>> page.

--- a/jekyll/_cci2/plan-performance.adoc
+++ b/jekyll/_cci2/plan-performance.adoc
@@ -13,36 +13,45 @@ version:
 
 This document describes the Performance plan available to developers.
 
+[#permformance-plan]
 == Performance plan
 The Performance plan offers a set amount of credits across a variety of resource classes, per month, which you can customize depending on your build configuration and execution environment.
 
 In addition to a higher amount of network usage included, the Performance plan offers several improvements over the Free plan:
 
+[#access-to-ip-ranges]
 === Access to IP ranges
 Configure IP-based access to restricted environments with IP ranges. Jobs that have this feature feature enabled will have their traffic routed through one of the defined IP address ranges during job execution.
 
 For more information about this features, please refer to the <<ip-ranges#,IP Ranges>> page.
 
+[#additional-resource-classes]
 === Additional resource classes
 Access to some of the larger machine sizes on Docker, Linux, Windows, and macOS. The additional resource classes on the compute type/execution environment give you access to higher CPU and memory limits.
 
 For more information about these resources, please refer to the the <<executor-intro#,Executors and Images>> page.
 
+[#less-queuing-with-more-concurrency]
 === Less queuing with more concurrency
 A larger amount of jobs that can run concurrently in your workflows, as described below in <<#concurrency,Concurrency>>.
 
+[#scalable-user-seat-count]
 === Scalable user seat count
 Included is a set number of active users. Additional users can be added by using your credits. If you need more credits, they can be purchased to cover additional users on a per month basis. This process allows you to scale your credit package to align with build activity.
 
+[#additional-self-hosted-runners]
 === Additional self-hosted runners
 A significant increase in the amount of self-hosted runners, allowing you to run more jobs on your own infrastructure. See <<#self-hosted-runners,Self-hosted Runners>> below for more information.
 
+[#custom-storage-retention]
 === Custom storage retention
 The https://app.circleci.com/[CircleCI web app] allows for the customization of the storage retention periods of artifact, workspace, and cache objects. This allows you to determine how to store each of these objects types in a way that best suits your project. Lowering storage retention periods can also reduce your monthly bill.
 
+[#additional-support-options]
 === Additional support options
 Additional support through SLAs (limited hours and days), and support package add-ons. The Performance plan also has access to the https://discuss.circleci.com/[community forums], https://support.circleci.com/hc/en-us[support portal], and our https://support.circleci.com/hc/en-us/requests/new[global ticket-based system].
 
+[#circleci-features]
 == CircleCI features
 In addition to the upgraded features listed above, the Performance plan also has access to the features listed below. Refer to the https://circleci.com/pricing/[Pricing] page for more detailed information on credit amounts, included resource classes, key features, and support. Refer to the https://circleci.com/product/features/resource-classes/[Resource class features] page for details on CPU, memory, network and storage, and credit usage for compute type/execution environment. The following features are available across all of CircleCI's plans.
 

--- a/jekyll/_cci2/plan-scale.adoc
+++ b/jekyll/_cci2/plan-scale.adoc
@@ -12,36 +12,45 @@ version:
 
 This document describes the Scale plan available to developers.
 
+[#scale-plan]
 == Scale plan
 The Scale plan grows with your team and your business, and offers a wide range of customizations. The Scale plan offers custom credit options that can be used across all CircleCI resource classes, per month, depending on your build configuration and execution environment. This plan provides access to the highest amount of network and storage usage that CircleCI offers.
 
 The Scale plan offers several improvements over the Free and Performance plans:
 
+[#access-to-ip-ranges]
 === Access to IP ranges
 Configure IP-based access to restricted environments with IP ranges. Jobs that have this feature feature enabled will have their traffic routed through one of the defined IP address ranges during job execution (the IP ranges feature is the same on the Performance and Scale plan).
 
 For more information about this features, please refer to the <<ip-ranges#,IP Ranges>> page.
 
+[#access-to-all-resource-classes]
 === Access to all resource classes
 Access to all of the machine sizes on Docker, Linux, Windows, and macOS. The additional resource classes on the compute type/execution environment give you access to higher CPU and memory limits.
 
 For more information about these resources, please refer to the the <<executor-intro#,Executors and Images>> page.
 
+[#custom-concurrency]
 === Custom concurrency
 Customize the amount of jobs you need to run concurrently. This customization is available on all build configurations and execution environments. See <<#concurrency,Concurrency>> below for more information.
 
+[#custom-user-seat-count]
 === Custom user seat count
 Customize the amount of active users based on your needs.
 
+[#unlimited-self-hosted-runners]
 === Unlimited self-hosted runners
 Unlimited self-hosted runners, allowing you to run more jobs on your own infrastructure. See <<#self-hosted-runners,Self-hosted Runners>> below for more information.
 
+[#custom-storage-retention]
 === Custom storage retention
 The https://app.circleci.com/[CircleCI web app] allows for the customization of the storage retention periods of artifact, workspace, and cache objects. This allows you to determine how to store each of these objects types in a way that best suits your project. Lowering storage retention periods can also reduce your monthly bill.
 
+[#additional-support-options]
 === Additional support options
 Additional support through expanded SLAs, an available account team, training and onboarding options, all of which are expandable with available support package add-ons. The Scale plan also has access to the https://discuss.circleci.com/[community forums], https://support.circleci.com/hc/en-us[support portal], and our https://support.circleci.com/hc/en-us/requests/new[global ticket-based system].
 
+[#circleci-features]
 == CircleCI features
 In addition to the upgraded features listed above, the Scale plan also has access to the features listed below. Refer to the https://circleci.com/pricing/[Pricing] page for more detailed information on credit amounts, included resource classes, key features, and support. Refer to the https://circleci.com/product/features/resource-classes/[Resource class features] page for details on CPU, memory, network and storage, and credit usage for compute type/execution environment. The following features are available across all of CircleCI's plans.
 

--- a/jekyll/_cci2/plan-server.adoc
+++ b/jekyll/_cci2/plan-server.adoc
@@ -15,6 +15,7 @@ version:
 
 This document describes the Server plan available to developers.
 
+[#server-plan]
 == Server plan
 CircleCI server is an on-premises CI/CD platform for enterprise customers who have compliance or security needs that require them to operate within their firewall, in a private cloud, or in a data center. Please see the <<server-3-overview#,Server documentation>> for more information.
 
@@ -22,16 +23,19 @@ The Server plan offers custom credit options that can be used across all CircleC
 
 The Server plan gives you access to a few additional upgrades over some of the other plans:
 
+[#custom-user-seat-count]
 === Custom user seat count
 Customize the amount of active users based on your needs.
 
+[#custom-storage-retention]
 === Custom storage retention
 The https://app.circleci.com/[CircleCI web app] allows for the customization of the storage retention periods of artifact, workspace, and cache objects. This allows you to determine how to store each of these objects types in a way that best suits your project. Lowering storage retention periods can also reduce your monthly bill.
 
+[#additional-support-options]
 === Additional support options
 Additional support through expanded SLAs, an available account team, training and onboarding options, all of which are expandable with available support package add-ons. The Server plan also has access to the https://discuss.circleci.com/[community forums], https://support.circleci.com/hc/en-us[support portal], and our https://support.circleci.com/hc/en-us/requests/new[global ticket-based system].
 
-
+[#circleci-features]
 == CircleCI features
 In addition to the upgraded features listed above, the Server plan also has access to the features listed below. Refer to the https://circleci.com/pricing/[Pricing] page for more detailed information on credit amounts, included resource classes, key features, and support. Refer to the https://circleci.com/product/features/resource-classes/[Resource class features] page for details on CPU, memory, network and storage, and credit usage for compute type/execution environment. The following features are available across all of CircleCI's plans.
 


### PR DESCRIPTION
# Description
Adding crowdin tags for O and P adoc pages.

I did not touch some server files because some of the syntax was weird and it wasn't accepting the tags as normal syntax. I will need to sort out whether or not this is an issue.

# Reasons
Adoc files missing crowdin tags.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.