### PR TITLE
[SERVER-1900] default regcred

### DIFF
--- a/jekyll/_cci2/server/Installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/Installation/phase-2-core-services.adoc
@@ -165,16 +165,6 @@ https://circleci.atlassian.net/browse/SERVER-1822
 === Global
 All values in this section are children of global.
 
-[#image-pull-secrets]
-==== Image pull secrets (required)
-This the name should match the `docker-registry` secret <<step-two-pull-image-from-dockerhub,created above>>.
-
-[source,yaml]
-----
-  imagePullSecrets:
-  - name: <regcredsecret>
-----
-
 [#circleci-domain-name]
 ==== CircleCI domain name (required)
 Enter the domain name you specified when creating your Frontend TLS key and certificate.


### PR DESCRIPTION
# Description
There is an opportunity to remove an install step for the customer.
We specify a specific secret name for the customer when creating the registry credential secret.  The[ values.yaml has been defaulted](https://github.com/circleci/server/pull/6603) to match that name.  So the customer no longer needs to add this section to their customer values.yaml file.

This will work for 99% of customers.  If customers want to do something different and that is still possible, they will need to look a little closer in the default values.yaml to see how.  And those customers are probably already familiar with how to set image pull secrets.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
