### PR TITLE
Chore: Add `src-shared/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,8 @@ jekyll/_config_override.yml
 markdownlint-results.json
 .tool-versions
 
+# former submodule
+src-shared/
+
 # output for docs-platform
 json/


### PR DESCRIPTION
# Description
- Add `src-shared/` to `.gitignore`

# Reasons
`src-shared/` is a submodule we used to have but we don't need anymore. We want to add it to the `.gitignore` so it doesn't make its way back to the repo.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
