### PR TITLE
Remove reference to CIRCLE_COMPARE_URL as a built in env var. [TASKS-855]

### DIFF
--- a/jekyll/_cci2/build-processing.md
+++ b/jekyll/_cci2/build-processing.md
@@ -30,14 +30,6 @@ The following features are available for use in your pipelines:
 
 When migrating from a server v2.x to a v3.x installation you will have project configurations made before the introduction of pipelines. Pipelines are automatically enabled for server v3.x installations so all you need to do is change your project configurations (`.circleci/_config.yml`) to `version: 2.1` to access all the features described in the section above.
 
-### Pipelines with 2.0 configuration
-{: #pipelines-with-20-configuration }
-{:.no_toc}
-
-When using CircleCI cloud or server v3.x the CircleCI pipelines engine is automatically enabled. If, for whatever reason, you continue to use a 2.0 config, CircleCI will inject the `CIRCLE_COMPARE_URL` environment variable into all jobs for backwards compatibility.
-
-This environment variable is generated in a different way compared to the version available in legacy jobs, and is not always available – it is not injected when there is no meaningful previous revision, for example, on the first push of commits to an empty repository, or when a new branch is created/pushed without any additional commits.
-
 ## See also
 {: #see-also }
 {:.no_toc}

--- a/jekyll/_includes/snippets/built-in-env-vars.md
+++ b/jekyll/_includes/snippets/built-in-env-vars.md
@@ -26,5 +26,4 @@ Variable | Type | Value
 `CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var} | String | An identifier for the [workspace]({{site.baseurl}}/2.0/glossary/#workspace) of the current job. This identifier is the same for every job in a given workflow.
 `CIRCLE_WORKING_DIRECTORY`{:.env_var} | String | The value of the `working_directory` key of the current job.
 `CIRCLE_INTERNAL_TASK_DATA`{:.env_var} | String | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.
-`CIRCLE_COMPARE_URL`{:.env_var} | String | **Deprecated**. The GitHub or Bitbucket URL to compare commits of a build. Available in config v2 and below. For v2.1 we will introduce ["pipeline values"]({{site.baseurl}}/2.0/pipeline-variables/) as an alternative.
 {: class="table table-striped"}

--- a/jekyll/_includes/snippets/ja/built-in-env-vars.md
+++ b/jekyll/_includes/snippets/ja/built-in-env-vars.md
@@ -26,5 +26,4 @@
 | `CIRCLE_WORKFLOW_WORKSPACE_ID`{:.env_var} | 文字列型  | 現在のジョブの[ワークスペース]({{site.baseurl}}/2.0/glossary/#workspace)の識別子。 この識別子は、特定のワークスペース内のすべてのジョブで同じです。                                                                |
 | `CIRCLE_WORKING_DIRECTORY`{:.env_var}     | 文字列型  | 現在のジョブの `working_directory` キーの値。                                                                                                                               |
 | `CIRCLE_INTERNAL_TASK_DATA`{:.env_var}    | 文字列型  | **内部用**。 ジョブ関連の内部データが格納されるディレクトリ。 データ スキーマは変更される可能性があるため、このディレクトリのコンテンツは文書化されていません。                                                                             |
-| `CIRCLE_COMPARE_URL`{:.env_var}           | 文字列型  | **非推奨**。 同じビルドのコミットどうしを比較するための GitHub または Bitbucket URL。 v2 以下の設定ファイルで使用可能です。 v2.1 では、この変数に代わり "[パイプライン値]({{site.baseurl}}/2.0/pipeline-variables/)" が導入されています。 |
 {: class="table table-striped"}

--- a/jekyll/archived/_archive/environment-variables.md
+++ b/jekyll/archived/_archive/environment-variables.md
@@ -53,10 +53,6 @@ The SHA1 of the commit being tested.
 
 A link to the homepage for the current repository, for example, `https://github.com/circleci/frontend`.
 
-`CIRCLE_COMPARE_URL`
-
-A link to GitHub's comparison view for this push. Not present for builds that are triggered by GitHub pushes.
-
 `CIRCLE_BUILD_URL`
 
 A permanent link to the current build, for example, `https://circleci.com/gh/circleci/frontend/933`.

--- a/jekyll/archived/_cci1/environment-variables.md
+++ b/jekyll/archived/_cci1/environment-variables.md
@@ -53,10 +53,6 @@ The SHA1 of the commit being tested.
 
 A link to the homepage for the current repository, for example, `https://github.com/circleci/frontend`.
 
-`CIRCLE_COMPARE_URL`
-
-A link to GitHub's comparison view for this push. Not present for builds that are triggered by GitHub pushes.
-
 `CIRCLE_BUILD_URL`
 
 A permanent link to the current build, for example, `https://circleci.com/gh/circleci/frontend/933`.


### PR DESCRIPTION
# Description
remove references to the built-in CIRCLE_COMPARE_URL

# Reasons
CIRCLE_COMPARE_URL has been hard coded to the empty string since 2018
and has good of references online wrt the alternatives.
(https://discuss.circleci.com/t/is-circle-compare-url-still-a-thing/33366)

We include the above advice elsewhere in our documentation wrt using
pipeline values as an alternative is still valid

(part of https://circleci.atlassian.net/browse/TASKS-855)


# Content Checklist

Deletions only :)

