### PR TITLE
Add orb dev kit section

### DIFF
--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -20,18 +20,30 @@ This orb authoring guide assumes you have read the [Introduction to orbs]({{site
 
 Whether you are writing your first orb or getting ready for production level, we recommend using our [Orb Development Kit](#orb-development-kit) to get started. Alternatively, as orbs are packages of [reusable configuration]({{site.baseurl}}/2.0/reusing-config), they can be written [manually]({{site.baseurl}}/2.0/orb-author-validate-publish), as singular `yaml` files, and published using our [circleci orb cli]({{site.baseurl}}/2.0/local-cli/#installation).
 
-## Create, test and publish an orb
-{: #create-test-and-publish-an-orb }
 
-Follow the steps below to create, test and publish your own orb, using the Orb Development Kit.
+## Orb Development Kit
+{: #orb-development-kit }
 
-The Orb Development Kit refers to a suite of tools that work together to simplify the orb development process, with automatic testing and deployment on CircleCI. The Orb Development Kit is made up of the following components:
+The Orb Development Kit refers to a suite of tools that work together to simplify the orb development process, with automatic testing and deployment on CircleCI. The `orb init` command is the key to using the Orb Development Kit. This command initiates a new orb project based on a template, and that template uses the other tools in the kit to automatically test and deploy your orb.
+
+The Orb Development Kit is made up of the following components:
 
 * [Orb Template](https://github.com/CircleCI-Public/Orb-Template)
 * [CircleCI CLI](https://circleci-public.github.io/circleci-cli/)
     * [Orb Pack Command]({{site.baseurl}}/2.0/orb-concepts/#orb-packing)
     * [Orb Init Command](https://circleci-public.github.io/circleci-cli/circleci_orb_init.html)
 * [Orb Tools Orb](https://circleci.com/developer/orbs/orb/circleci/orb-tools)
+
+The **orb template** is a repository with CircleCi's orb project template, which is automatically ingested and modified by the `orb init` command.
+
+The **CircleCI CLI** contains two commands which are designed to work with the kit. The **orb init command** initializes a new orb project, and the **orb pack command** packs the orb source into a single `orb.yml` file.
+
+The **orb tools orb** is an orb for creating orbs.
+
+## Create, test and publish an orb
+{: #create-test-and-publish-an-orb }
+
+Follow the steps below to create, test and publish your own orb, using the Orb Development Kit.
 
 ### Getting started
 {: #getting-started }


### PR DESCRIPTION
# Description

- Add orb dev kit section to orb author page.
- Clarify what the kit actually is.


# Reasons
[Jira](https://circleci.atlassian.net/jira/software/projects/DOCSTEAM/boards/412?selectedIssue=DOCSTEAM-353)

We have a bunch of places in our docs that were linking to a section on the orb authoring page that did not exist. I created this section both to have a valid link as well as expand on what the orb dev kit actually is as the definition was fairly convoluted.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
