### PR TITLE
Docsteam 371 move content out of execution envs

### DIFF
--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -36,7 +36,6 @@ When `setup_remote_docker` executes, a remote environment will be created, and y
 
 ### Specifications
 {: #specifications }
-{:.no_toc}
 
 The Remote Docker Environment has the following technical specifications (for CircleCI server installations, contact the systems administrator for specifications):
 
@@ -47,7 +46,6 @@ CPUs | Processor                 | RAM | HD
 
 ### Example
 {: #example }
-{:.no_toc}
 
 The example below shows how you can build a Docker image using the `machine` executor with the default image - this does not require the use of remote Docker:
 
@@ -147,7 +145,6 @@ The job and [remote docker]({{ site.baseurl }}/2.0/glossary/#remote-docker) run 
 
 ### Accessing services
 {: #accessing-services }
-{:.no_toc}
 
 It is **not** possible to start a service in remote docker and ping it directly from a primary container or to start a primary container that can ping a service in remote docker. To solve that, you’ll need to interact with a service from remote docker, as well as through the same container:
 
@@ -173,7 +170,6 @@ A different way to do this is to use another container running in the same netwo
 
 ### Mounting folders
 {: #mounting-folders }
-{:.no_toc}
 
 It is **not** possible to mount a volume from your job space into a container in Remote Docker (and vice versa). You may use the `docker cp` command to transfer files between these two environments. For example, to start a container in Remote Docker using a config file from your source code:
 

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -10,7 +10,7 @@ version:
 - Server v2.x
 ---
 
-This document explains how to build Docker images for deployment elsewhere or further testing, and how to start services in a remote docker environment when using the Docker execution environment.
+This page explains how to build Docker images for deployment and further testing. The examples on this page that use the Docker execution environment show how to start services in a remote docker environment.
 
 * TOC
 {:toc}
@@ -102,7 +102,7 @@ jobs:
           docker push CircleCI-Public/circleci-demo-docker:$TAG
 ```
 
-Let’s break down what’s happening during this build’s execution:
+Below is a break down of what is happening during this build’s execution:
 
 1. All commands are executed in the [primary-container]({{ site.baseurl }}/2.0/glossary/#primary-container). (line 5)
 2. Once `setup_remote_docker` is called, a new remote environment is created, and your primary container is configured to use it. All docker-related commands are also executed in your primary container, but building/pushing images and running containers happens in the remote Docker Engine. (line 10)

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -10,7 +10,7 @@ version:
 - Server v2.x
 ---
 
-This document explains how to build Docker images for deployment elsewhere or further testing, and how to start services in a remote docker environment.
+This document explains how to build Docker images for deployment elsewhere or further testing, and how to start services in a remote docker environment when using the Docker execution environment.
 
 * TOC
 {:toc}
@@ -18,14 +18,15 @@ This document explains how to build Docker images for deployment elsewhere or fu
 ## Overview
 {: #overview }
 
-To build Docker images for deployment, you must use a special `setup_remote_docker` key which creates a separate environment for each build for security. This environment is remote, fully-isolated and has been configured to execute Docker commands. If your job requires `docker` or `docker-compose` commands, add the `setup_remote_docker` step into your `.circleci/config.yml`:
+To build Docker images for deployment using the Docker execution environment, you must use a special `setup_remote_docker` key which creates a separate environment for each build for security. This environment is remote, fully-isolated and has been configured to execute Docker commands. If your job requires `docker` or `docker-compose` commands, add the `setup_remote_docker` step into your `.circleci/config.yml`:
 
 ```yaml
 jobs:
   build:
+    docker:
+      - image: cimg/base:2022.06
     steps:
       # ... steps for building/testing app ...
-
       - setup_remote_docker:
           version: 20.10.14
 ```
@@ -34,7 +35,7 @@ When `setup_remote_docker` executes, a remote environment will be created, and y
 
 **Note:** The use of the `setup_remote_docker` key is reserved for configs in which your primary executor _is_ a docker container. If your executor is `machine` (and you want to use docker commands in your config) you do **not** need to use the `setup_remote_docker` key.
 
-### Specifications
+## Specifications
 {: #specifications }
 
 The Remote Docker Environment has the following technical specifications (for CircleCI server installations, contact the systems administrator for specifications):
@@ -44,16 +45,18 @@ CPUs | Processor                 | RAM | HD
 2    | Intel(R) Xeon(R) @ 2.3GHz | 8GB | 100GB
 {: class="table table-striped"}
 
-### Example
-{: #example }
+## Run Docker commands using the machine executor
+{: #run-docker-commands-using-the-machine-executor }
 
 The example below shows how you can build a Docker image using the `machine` executor with the default image - this does not require the use of remote Docker:
 
 ```yaml
-version: 2
+version: 2.1
+
 jobs:
  build:
-   machine: true
+   machine:
+    image: ubuntu-2204:2022.04.2
    steps:
      - checkout
      # start proprietary DB using private Docker image
@@ -68,6 +71,9 @@ jobs:
      # deploy the image
      - run: docker push company/app:$CIRCLE_BRANCH
 ```
+
+## Run Docker commands using the Docker executor
+{: #run-docker-commands-using-the-docker-executor }
 
 The example below shows how you can build and deploy a Docker image for our [demo docker project](https://github.com/CircleCI-Public/circleci-demo-docker) using the Docker executor, with remote Docker:
 
@@ -96,6 +102,13 @@ jobs:
           docker push CircleCI-Public/circleci-demo-docker:$TAG
 ```
 
+Let’s break down what’s happening during this build’s execution:
+
+1. All commands are executed in the [primary-container]({{ site.baseurl }}/2.0/glossary/#primary-container). (line 5)
+2. Once `setup_remote_docker` is called, a new remote environment is created, and your primary container is configured to use it. All docker-related commands are also executed in your primary container, but building/pushing images and running containers happens in the remote Docker Engine. (line 10)
+3. We enable [Docker Layer Caching]({{ site.baseurl }}/2.0/glossary/#docker-layer-caching) (DLC) here to speed up image building.
+4. We use project environment variables to store credentials for Docker Hub. (line 17)
+
 **Note:** The [CircleCI convenience images]({{site.baseurl}}/2.0/circleci-images/) for the Docker executor come with the Docker CLI pre-installed. If you are using a third-party image for your primary container that doesn't already have the Docker CLI installed, then [you will need to install it](https://docs.docker.com/install/#supported-platforms) as part of your job before calling any `docker` commands.
 
 ```yml
@@ -105,14 +118,7 @@ jobs:
           command: apk add docker-cli
 ```
 
-Let’s break down what’s happening during this build’s execution:
-
-1. All commands are executed in the [primary-container]({{ site.baseurl }}/2.0/glossary/#primary-container). (line 5)
-2. Once `setup_remote_docker` is called, a new remote environment is created, and your primary container is configured to use it. All docker-related commands are also executed in your primary container, but building/pushing images and running containers happens in the remote Docker Engine. (line 10)
-3. We enable [Docker Layer Caching]({{ site.baseurl }}/2.0/glossary/#docker-layer-caching) (DLC) here to speed up image building.
-4. We use project environment variables to store credentials for Docker Hub. (line 17)
-
-## Docker version
+## Specify a Docker version for remote docker
 {: #docker-version }
 
 To specify the Docker version, you can set it as a `version` attribute:

--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -86,7 +86,7 @@ See the [Example docker-compose Project](https://github.com/circleci/cci-demo-do
 ## Using Docker Compose with machine executor
 {: #using-docker-compose-with-machine-executor }
 
-If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `config.yml` file and use `docker-compose` as you would normally (see Linux VM execution environment documentation [here]({{site.baseurl}}/2.0/using-linuxvm) for more details). That is, if you have a Docker Compose file that shares local directories with a container, this will work as expected. Refer to Docker's documentation of [Your first docker-compose.yml file](https://docs.docker.com/get-started/part3/#your-first-docker-composeyml-file) for details.
+If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `.circleci/config.yml` file and use `docker-compose` as you would normally (see Linux VM execution environment documentation [here]({{site.baseurl}}/2.0/using-linuxvm) for more details). That is, if you have a Docker Compose file that shares local directories with a container, this will work as expected. Refer to Docker's documentation of [Your first docker-compose.yml file](https://docs.docker.com/get-started/part3/#your-first-docker-composeyml-file) for details.
 
 
 ## Using Docker Compose with docker executor

--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -1,10 +1,7 @@
 ---
 layout: classic-docs
 title: "Installing and Using Docker Compose"
-short-title: "Installing and Using Docker Compose"
 description: "How to enable Docker Compose in your primary container"
-categories: [containerization]
-order: 40
 version:
 - Cloud
 - Server v3.x
@@ -19,12 +16,11 @@ If you are new to Docker Compose, do consider reviewing the [official Docker Com
 {:toc}
 
 The `docker-compose` utility is [pre-installed in the CircleCI convenience
-images][pre-installed] and machine executors. If you are using another image, you
-can install it into your [primary container][primary-container] during the job
-execution with the Remote Docker Environment activated by adding the following
-to your [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file:
+images]({{ site.baseurl }}/2.0/circleci-images/#pre-installed-tools) and machine executor images. 
 
-```yml
+If you are using the Docker executor and **are not** using a convenience image, you can install Docker Compose into your [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) during the job execution with the Remote Docker Environment activated by adding the following to your [`.circleci/config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file:
+
+```yaml
       - run:
           name: Install Docker Compose
           environment:
@@ -38,9 +34,6 @@ to your [`config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file:
 The above code example assumes that you will also have `curl` available in your
 executor. If you are constructing your own docker images, consider reading the
 [custom docker images document]({{site.baseurl}}/2.0/custom-images/).
-
-[pre-installed]: {{ site.baseurl }}/2.0/circleci-images/#pre-installed-tools
-[primary-container]: {{ site.baseurl }}/2.0/glossary/#primary-container
 
 Then, to activate the Remote Docker Environment, add the `setup_remote_docker` step:
 
@@ -93,7 +86,7 @@ See the [Example docker-compose Project](https://github.com/circleci/cci-demo-do
 ## Using Docker Compose with machine executor
 {: #using-docker-compose-with-machine-executor }
 
-If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `config.yml` file and use `docker-compose` as you would normally (see Linux VM execution environment documentation [here]({{site.baseurl}}/2.0/using-linuxvm) for more details). That is, if you have a Docker Compose file that shares local directories with a container, this will work as expected. Refer to Docker's documentation of [Your first docker-compose.yml file](https://docs.docker.com/get-started/part3/#your-first-docker-composeyml-file) for details. **Note: There is an overhead for provisioning a machine executor as a result of spinning up a private Docker server. Use of the `machine` key may require additional fees in a future pricing update.**
+If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `config.yml` file and use `docker-compose` as you would normally (see Linux VM execution environment documentation [here]({{site.baseurl}}/2.0/using-linuxvm) for more details). That is, if you have a Docker Compose file that shares local directories with a container, this will work as expected. Refer to Docker's documentation of [Your first docker-compose.yml file](https://docs.docker.com/get-started/part3/#your-first-docker-composeyml-file) for details.
 
 
 ## Using Docker Compose with docker executor

--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -20,7 +20,7 @@ images]({{ site.baseurl }}/2.0/circleci-images/#pre-installed-tools) and machine
 
 If you are using the Docker executor and **are not** using a convenience image, you can install Docker Compose into your [primary container]({{ site.baseurl }}/2.0/glossary/#primary-container) during the job execution with the Remote Docker Environment activated by adding the following to your [`.circleci/config.yml`]({{ site.baseurl }}/2.0/configuration-reference/) file:
 
-```yaml
+```yml
       - run:
           name: Install Docker Compose
           environment:

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -142,6 +142,8 @@ en:
           link: 2.0/custom-images/
         - name: Docker authenticated pulls
           link: 2.0/private-images/
+        - name: Running docker commands
+          link: 2.0/building-docker-images/
     - name: Linux VM
       children:
         - name: Using Linux VM
@@ -252,8 +254,6 @@ en:
           link: 2.0/selecting-a-workflow-to-run-using-pipeline-parameters/
         - name: Installing and using docker-compose
           link: 2.0/docker-compose/
-        - name: Running docker commands
-          link: 2.0/building-docker-images/
 
 - name: Orbs
   icon: icons/sidebar/orbs.svg

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -138,12 +138,6 @@ en:
           link: 2.0/circleci-images/
         - name: Migrating to Next-Gen Images
           link: 2.0/next-gen-migration-guide/
-        - name: Docker compose
-          link: 2.0/docker-compose/
-        - name: Docker layer caching
-          link: 2.0/docker-layer-caching/
-        - name: Running docker commands
-          link: 2.0/building-docker-images/
         - name: Using custom images
           link: 2.0/custom-images/
         - name: Docker authenticated pulls
@@ -256,6 +250,10 @@ en:
           link: 2.0/using-dynamic-configuration/
         - name: Selecting a Workflow to Run
           link: 2.0/selecting-a-workflow-to-run-using-pipeline-parameters/
+        - name: Installing and using docker-compose
+          link: 2.0/docker-compose/
+        - name: Running docker commands
+          link: 2.0/building-docker-images/
 
 - name: Orbs
   icon: icons/sidebar/orbs.svg


### PR DESCRIPTION
# Description
* moved the docker compose docs out of the execution environments section and into the configuration how-to section
* Removed the DLC page from the execution environments section - it's an optimization feature rather than executor usage
* updated the building-docker-images page because there were some obvious issues and the flow of the doc was confusing

# Reasons
[A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.](https://circleci.atlassian.net/browse/DOCSTEAM-371?atlOrigin=eyJpIjoiYWQ1NmFlYWZlN2VlNDIzNzk1N2U5YWUzMDRkM2E2OWMiLCJwIjoiaiJ9)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
