### PR TITLE
[EXT-271] Clarify webhook duplicates

### DIFF
--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -38,6 +38,8 @@ A webhook is sent using an HTTP POST to the URL that was registered when the web
 
 CircleCI expects that the server that responds to a webhook will return a 2xx response code. If a non-2xx response is received, CircleCI will retry at a later time. If CircleCI does not receive a response to the webhook within a short period of time, CircleCI will assume that delivery has failed, and will retry at a later time. The timeout period is currently 5 seconds, but is subject to change during the preview period. The exact details of the retry policy are not currently documented, and are subject to change during the preview period. 
 
+CircleCI provides at-least-once delivery guarantees, which means that you could get duplicate webhook requests for various reasons, including your server taking more time to send a response than our defined timeout. To de-duplicate requests, there is an `id` property in the webhook payload that can be used to identify the event
+
 If you have feedback about timeouts and retries, please get [get in touch](https://circleci.canny.io/webhooks) with our team.
 
 ### Webhook headers

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -38,7 +38,7 @@ A webhook is sent using an HTTP POST to the URL that was registered when the web
 
 CircleCI expects that the server that responds to a webhook will return a 2xx response code. If a non-2xx response is received, CircleCI will retry at a later time. If CircleCI does not receive a response to the webhook within a short period of time, CircleCI will assume that delivery has failed, and will retry at a later time. The timeout period is currently 5 seconds, but is subject to change during the preview period. The exact details of the retry policy are not currently documented, and are subject to change during the preview period. 
 
-CircleCI provides at-least-once delivery guarantees. To deduplicate requests, there is an `id` property in the webhook payload that can be used to identify the event
+Webhook requests may be duplicated. To deduplicate requests, there is an [`id` property](#common-top-level-keys) in the webhook payload that can be used to identify the event
 
 If you have feedback about timeouts and retries, please get [get in touch](https://circleci.canny.io/webhooks) with our team.
 

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -38,7 +38,7 @@ A webhook is sent using an HTTP POST to the URL that was registered when the web
 
 CircleCI expects that the server that responds to a webhook will return a 2xx response code. If a non-2xx response is received, CircleCI will retry at a later time. If CircleCI does not receive a response to the webhook within a short period of time, CircleCI will assume that delivery has failed, and will retry at a later time. The timeout period is currently 5 seconds, but is subject to change during the preview period. The exact details of the retry policy are not currently documented, and are subject to change during the preview period. 
 
-CircleCI provides at-least-once delivery guarantees, which means that you could get duplicate webhook requests for various reasons, including your server taking more time to send a response than our defined timeout. To deduplicate requests, there is an `id` property in the webhook payload that can be used to identify the event
+CircleCI provides at-least-once delivery guarantees. To deduplicate requests, there is an `id` property in the webhook payload that can be used to identify the event
 
 If you have feedback about timeouts and retries, please get [get in touch](https://circleci.canny.io/webhooks) with our team.
 

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -38,7 +38,7 @@ A webhook is sent using an HTTP POST to the URL that was registered when the web
 
 CircleCI expects that the server that responds to a webhook will return a 2xx response code. If a non-2xx response is received, CircleCI will retry at a later time. If CircleCI does not receive a response to the webhook within a short period of time, CircleCI will assume that delivery has failed, and will retry at a later time. The timeout period is currently 5 seconds, but is subject to change during the preview period. The exact details of the retry policy are not currently documented, and are subject to change during the preview period. 
 
-CircleCI provides at-least-once delivery guarantees, which means that you could get duplicate webhook requests for various reasons, including your server taking more time to send a response than our defined timeout. To de-duplicate requests, there is an `id` property in the webhook payload that can be used to identify the event
+CircleCI provides at-least-once delivery guarantees, which means that you could get duplicate webhook requests for various reasons, including your server taking more time to send a response than our defined timeout. To deduplicate requests, there is an `id` property in the webhook payload that can be used to identify the event
 
 If you have feedback about timeouts and retries, please get [get in touch](https://circleci.canny.io/webhooks) with our team.
 

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -38,7 +38,7 @@ A webhook is sent using an HTTP POST to the URL that was registered when the web
 
 CircleCI expects that the server that responds to a webhook will return a 2xx response code. If a non-2xx response is received, CircleCI will retry at a later time. If CircleCI does not receive a response to the webhook within a short period of time, CircleCI will assume that delivery has failed, and will retry at a later time. The timeout period is currently 5 seconds, but is subject to change during the preview period. The exact details of the retry policy are not currently documented, and are subject to change during the preview period. 
 
-Webhook requests may be duplicated. To deduplicate requests, there is an [`id` property](#common-top-level-keys) in the webhook payload that can be used to identify the event
+Webhook requests may be duplicated. To deduplicate (prevent requests from being duplicated for a specific event), there is an [`id` property](#common-top-level-keys) in the webhook payload that can be used to identify the event for this purpose.
 
 If you have feedback about timeouts and retries, please get [get in touch](https://circleci.canny.io/webhooks) with our team.
 


### PR DESCRIPTION
# Description
Clarify webhook duplicates and how to deduplicate requests

# Reasons
Jira ticket [EXT-271](https://circleci.atlassian.net/browse/EXT-271)

This comes from a support ticket where the customer was confused why they were seeing duplicate requests

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
