### PR TITLE
Fix list nesting in self-hosted runner docs

### DIFF
--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -52,9 +52,9 @@ Once a CircleCI self-hosted runner is installed, the self-hosted runner polls `c
 
 Almost all standard CircleCI features are available for use with self-hosted runner jobs, however, a few features are not yet supported. If these features are important for you to make use of self-hosted runner jobs, please let us know via the relevant canny page.
 
-- The following built in environment variables are not populated within runner executors:
--- CIRCLE_PREVIOUS_BUILD_NUM
--- All deprecated cloud environment variables 
+* The following built in environment variables are not populated within runner executors:
+  ** `CIRCLE_PREVIOUS_BUILD_NUM`
+  ** All deprecated cloud environment variables 
 
 [#learn-more]
 == Learn more


### PR DESCRIPTION
# Description

I'm fairly sure this is wrong:

<img width="592" alt="image" src="https://user-images.githubusercontent.com/7998310/177131406-6bc25ab7-6d4e-41a2-806b-c0106099e76a.png">

from: https://circleci.com/docs/2.0/runner-overview

# Reasons

I believe my PR makes this part of the docs more readable.

# Content Checklist

Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
