### PR TITLE
Update windows docs to latest orb for consistency

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -543,7 +543,7 @@ jobs:
 version: 2.1 # Use version 2.1 to enable orb usage.
 
 orbs:
-  win: circleci/windows@4.1 # The Windows orb give you everything you need to start using the Windows executor.
+  win: circleci/windows@4.1.1 # The Windows orb give you everything you need to start using the Windows executor.
 
 jobs:
   build: # name of your job
@@ -565,6 +565,7 @@ jobs:
   build: # name of your job
     machine:
       image: 'windows-server-2022-gui:current'
+      shell: 'powershell.exe -ExecutionPolicy Bypass'
     resource_class: windows.medium # can be medium, large, xlarge, 2xlarge
     steps:
       # Commands are run in a Windows virtual machine environment
@@ -634,7 +635,7 @@ See the [Available Linux GPU images](#available-linux-gpu-images) section for th
 ```yaml
 version: 2.1
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@4.1.1
 
 jobs:
   build:

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -106,7 +106,7 @@ To access the Windows execution environment, either use the Windows orb and then
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0 # The Windows orb gives you everything you need to start using the Windows executor
+  win: circleci/windows@4.1.1 # The Windows orb gives you everything you need to start using the Windows executor
 
 jobs:
   build: # name of your job
@@ -124,9 +124,10 @@ version: 2.1
 
 jobs:
   build: # name of your job
+    resource_class: 'windows.medium'
     machine:
       image: 'windows-server-2022-gui:current'   
-
+      shell: 'powershell.exe -ExecutionPolicy Bypass'
     steps:
       # Commands are run in a Windows virtual machine environment
       - checkout
@@ -201,7 +202,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@4.1.1
 
 jobs:
   build:

--- a/jekyll/_cci2/hello-world-windows.md
+++ b/jekyll/_cci2/hello-world-windows.md
@@ -45,7 +45,7 @@ Above, we start by declaring that we will use version `2.1` of CircleCI, giving 
 
 ```yaml
 orbs:
-  win: circleci/windows@2.4.0
+  win: circleci/windows@4.1.1
 ```
 
 Next, we declare orbs that we will be using in our build. We will only use the [Windows orb](https://circleci.com/developer/orbs/orb/circleci/windows) to help us get started. This example uses the 2.4.0 version of the orb, but you may consider using a more recent version.

--- a/jekyll/_cci2/hello-world.md
+++ b/jekyll/_cci2/hello-world.md
@@ -95,7 +95,7 @@ Using the basics from the Linux example above, you can add a job that uses the W
 version: 2.1 # Use version 2.1 to enable orb usage.
 
 orbs:
-  win: circleci/windows@2.2.0 # The Windows orb give you everything you need to start using the Windows executor.
+  win: circleci/windows@4.1.1 # The Windows orb give you everything you need to start using the Windows executor.
 
 jobs:
   build: # name of your job

--- a/jekyll/_cci2/using-gpu.md
+++ b/jekyll/_cci2/using-gpu.md
@@ -30,7 +30,7 @@ To use the Windows GPU execution environment, you can either choose to use the w
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1.0
+  win: circleci/windows@4.1.1
 
 jobs:
   build:

--- a/jekyll/_cci2/using-windows.md
+++ b/jekyll/_cci2/using-windows.md
@@ -26,7 +26,7 @@ Both options are shown in the example below. The configuration for CircleCI serv
 version: 2.1 # Use version 2.1 to enable Orb usage.
 
 orbs:
-  win: circleci/windows@4.1 # The Windows orb give you everything you need to start using the Windows executor.
+  win: circleci/windows@4.1.1 # The Windows orb give you everything you need to start using the Windows executor.
 
 jobs:
   build: # name of your job
@@ -44,8 +44,10 @@ version: 2
 
 jobs:
   build: # name of your job
+    resource_class: 'windows.medium'
     machine:
       image: 'windows-server-2022-gui:current'
+      shell: 'powershell.exe -ExecutionPolicy Bypass'
     steps:
       # Commands are run in a Windows virtual machine environment
         - checkout
@@ -87,7 +89,7 @@ Note that in order to use a specific image with the Windows orb, for example, Wi
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
@@ -110,7 +112,7 @@ workflows:
 version: 2.1 # Use version 2.1 to enable Orb usage.
 
 orbs:
-  win: circleci/windows@4.1 # The Windows orb give you everything you need to start using the Windows executor.
+  win: circleci/windows@4.1.1 # The Windows orb give you everything you need to start using the Windows executor.
 
 jobs:
   build: # name of your job
@@ -203,7 +205,7 @@ You can configure the shell at the job level or at the step level. It is possibl
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
@@ -272,7 +274,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
@@ -323,7 +325,7 @@ Please note that it is possible to run Windows Docker containers on the Windows 
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1
+  win: circleci/windows@4.1.1
 
 jobs:
   build:

--- a/jekyll/_cci2_ja/configuration-reference.md
+++ b/jekyll/_cci2_ja/configuration-reference.md
@@ -418,7 +418,7 @@ CircleCI は、Windows 上でのジョブ実行をサポートしています。
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
@@ -564,7 +564,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
@@ -620,7 +620,7 @@ jobs:
 ```yaml
 version: 2.1
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@4.1.1
 
 jobs:
   build:

--- a/jekyll/_cci2_ja/executor-intro.md
+++ b/jekyll/_cci2_ja/executor-intro.md
@@ -97,7 +97,7 @@ Windows 実行環境を使用するには、Windows Orb を使って Orb から�
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0 # The Windows orb gives you everything you need to start using the Windows executor
+  win: circleci/windows@4.1.1 # The Windows orb gives you everything you need to start using the Windows executor
 
 jobs:
   build: # name of your job
@@ -115,9 +115,10 @@ version: 2.1
 
 jobs:
   build: # name of your job
+    resource_class: 'windows.medium'
     machine:
       image: 'windows-server-2022-gui:current'   
-
+      shell: 'powershell.exe -ExecutionPolicy Bypass'
     steps:
       # Commands are run in a Windows virtual machine environment
       - checkout
@@ -193,7 +194,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@4.1.1
 
 jobs:
   build:

--- a/jekyll/_cci2_ja/executor-types.md
+++ b/jekyll/_cci2_ja/executor-types.md
@@ -343,7 +343,7 @@ macOS VM のストレージ容量は、リソースクラスや使用される X
 version: 2.1 # バージョン 2.1 を指定して Orb の使用を有効化します
 
 orbs:
-  win: circleci/windows@2.2.0 # Windows Orb には Windows Executor の使用に必要なすべてが揃っています
+  win: circleci/windows@4.1.1 # Windows Orb には Windows Executor の使用に必要なすべてが揃っています
 
 jobs:
   build: # ジョブの名前
@@ -397,7 +397,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@4.1.1
 
 jobs:
   build:

--- a/jekyll/_cci2_ja/hello-world-windows.md
+++ b/jekyll/_cci2_ja/hello-world-windows.md
@@ -72,7 +72,7 @@ Windows イメージは約 30 日ごとにアップデートされます。 Wind
 version: 2.1 # バージョン 2.1 を指定して Orb の使用を有効化します
 
 orbs:
-  win: circleci/windows@4.1 # The Windows orb give you everything you need to start using the Windows executor.
+  win: circleci/windows@4.1.1 # The Windows orb give you everything you need to start using the Windows executor.
 
 jobs:
   build: # name of your job
@@ -106,7 +106,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
@@ -134,7 +134,7 @@ Windows では 3 種類のシェルを使用してジョブステップを実行
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
@@ -160,7 +160,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
@@ -181,7 +181,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@4.1
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
@@ -216,7 +216,7 @@ version: 2.1
 
 ```yaml
 orbs:
-  win: circleci/windows@2.4.0
+  win: circleci/windows@4.1.1
 ```
 
 次に、ビルドで使用する Orb を宣言します。 最初は [Windows Orb](https://circleci.com/developer/orbs/orb/circleci/windows) のみを使用します。 このサンプルでは、2.4.0 バージョンの Orb を使用していますが、それ以降のバージョンも使用していただけます。

--- a/jekyll/_cci2_ja/hello-world.md
+++ b/jekyll/_cci2_ja/hello-world.md
@@ -95,7 +95,7 @@ jobs:
 version: 2.1 # バージョン 2.1 を指定して Orb の使用を有効化します
 
 orbs:
-  win: circleci/windows@2.2.0 # Windows Orb には Windows Executor の使用に必要なすべてが揃っています
+  win: circleci/windows@4.1.1 # Windows Orb には Windows Executor の使用に必要なすべてが揃っています
 
 jobs:
   build: # ジョブの名前

--- a/jekyll/_cci2_ja/troubleshooting-common-issues.md
+++ b/jekyll/_cci2_ja/troubleshooting-common-issues.md
@@ -1454,7 +1454,7 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@4.1.1
 
 workflows:
   btd:

--- a/jekyll/_cci2_ja/using-gpu.md
+++ b/jekyll/_cci2_ja/using-gpu.md
@@ -30,11 +30,11 @@ jobs:
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.3.0
+  win: circleci/windows@4.1.1
 
 jobs:
   build:
-    executor: win/gpu-nvidia
+    executor: win/server-2019-cuda
     steps:
       - run: '&"C:\Program Files\NVIDIA Corporation\NVSMI\nvidia-smi.exe"'
 ```

--- a/jekyll/_cci2_ja/using-windows.md
+++ b/jekyll/_cci2_ja/using-windows.md
@@ -19,7 +19,7 @@ version:
 version: 2.1 # バージョン 2.1 を指定して Orb の使用を有効化します
 
 orbs:
-  win: circleci/windows@2.2.0 # Windows Orb には Windows Executor の使用に必要なすべてが揃っています
+  win: circleci/windows@4.1.1 # Windows Orb には Windows Executor の使用に必要なすべてが揃っています
 
 jobs:
   build: # ジョブの名前


### PR DESCRIPTION
`win/server-2022` isn't supported in `windows@2.2.0` so just make everything consistently the latest.

Also, set resource class and shell for non-orb configs.