### PR TITLE
docs: update definition of CIRCLE_PREVIOUS_BUILD_NUM env var

### DIFF
--- a/jekyll/_includes/snippets/built-in-env-vars.md
+++ b/jekyll/_includes/snippets/built-in-env-vars.md
@@ -12,7 +12,7 @@ Variable | Type | Value
 `CIRCLE_PR_NUMBER`{:.env_var} | Integer | The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
 `CIRCLE_PR_REPONAME`{:.env_var} | String | The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
 `CIRCLE_PR_USERNAME`{:.env_var} | String | The GitHub or Bitbucket username of the user who created the pull request. Only available on forked PRs.
-`CIRCLE_PREVIOUS_BUILD_NUM`{:.env_var} | Integer | The number of previous builds on the current branch. Note: This variable is not set on runner executors.
+`CIRCLE_PREVIOUS_BUILD_NUM`{:.env_var} | Integer | The largest job number in a given branch that is less than the current job number. **Note**: The variable is not always set, and is not deterministic. It is also not set on runner executors. We would like to deprecate this variable, and recommend users to avoid using it.
 `CIRCLE_PROJECT_REPONAME`{:.env_var} | String | The name of the repository of the current project.
 `CIRCLE_PROJECT_USERNAME`{:.env_var} | String | The GitHub or Bitbucket username of the current project.
 `CIRCLE_PULL_REQUEST`{:.env_var} | String | The URL of the associated pull request. If there are multiple associated pull requests, one URL is randomly chosen.

--- a/jekyll/_includes/snippets/built-in-env-vars.md
+++ b/jekyll/_includes/snippets/built-in-env-vars.md
@@ -12,7 +12,7 @@ Variable | Type | Value
 `CIRCLE_PR_NUMBER`{:.env_var} | Integer | The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
 `CIRCLE_PR_REPONAME`{:.env_var} | String | The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
 `CIRCLE_PR_USERNAME`{:.env_var} | String | The GitHub or Bitbucket username of the user who created the pull request. Only available on forked PRs.
-`CIRCLE_PREVIOUS_BUILD_NUM`{:.env_var} | Integer | The largest job number in a given branch that is less than the current job number. **Note**: The variable is not always set, and is not deterministic. It is also not set on runner executors. We would like to deprecate this variable, and recommend users to avoid using it.
+`CIRCLE_PREVIOUS_BUILD_NUM`{:.env_var} | Integer | The largest job number in a given branch that is less than the current job number. **Note**: The variable is not always set, and is not deterministic. It is also not set on runner executors. This variable is likely to be deprecated, and CircleCI recommends users to avoid using it.
 `CIRCLE_PROJECT_REPONAME`{:.env_var} | String | The name of the repository of the current project.
 `CIRCLE_PROJECT_USERNAME`{:.env_var} | String | The GitHub or Bitbucket username of the current project.
 `CIRCLE_PULL_REQUEST`{:.env_var} | String | The URL of the associated pull request. If there are multiple associated pull requests, one URL is randomly chosen.


### PR DESCRIPTION
# Description

After checking in with our Engineering team, we noticed that the definition of this CIRCLE_PREVIOUS_BUILD_NUM built-in environment variable (env var) was incorrect.

# Reasons

A customer has reached out, observing this CIRCLE_PREVIOUS_BUILD_NUM env var is not present in their builds.
We need to update the doc to say that this env var is not always present and depends on the workflow which the job is running in.

Importantly, we want to alert users that this env var is not necessarily present, and not deterministic.
Ideally, we would like to ask users to avoid using it, as our goal would be to deprecate it.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
