### PR TITLE
Add Sign Up page to side nav

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -6,6 +6,8 @@ en:
       children:
         - name: Welcome
           link: /
+        - name: Sign Up and Try
+          link: 2.0/first-steps/  
         - name: About CircleCI
           link: 2.0/about-circleci/
         - name: Concepts

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -7,7 +7,7 @@ en:
         - name: Welcome
           link: /
         - name: Sign Up and Try
-          link: 2.0/first-steps/  
+          link: /first-steps
         - name: About CircleCI
           link: 2.0/about-circleci/
         - name: Concepts


### PR DESCRIPTION
# Description
Add [Sign Up](https://circleci.com/docs/first-steps) to **Getting Started** section, under **Overview**

# Reasons
The Sign Up page was only navigable from the docs homepage and not the sidenav. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
