### PR TITLE
Merge Jenkins pages

### DIFF
--- a/jekyll/_cci2/introduction-to-circleci-migration.adoc
+++ b/jekyll/_cci2/introduction-to-circleci-migration.adoc
@@ -2,9 +2,8 @@
 version:
 - Cloud
 - Server v3.x
-- Server v2.x
 ---
-= Migrating to CircleCI
+= Introduction to CircleCI migration
 :page-layout: classic-docs
 :page-liquid:
 :page-description: This document provides an overview of the stages required to migrate your CI/CD pipelines to CircleCI.

--- a/jekyll/_cci2/migrate-from-aws.adoc
+++ b/jekyll/_cci2/migrate-from-aws.adoc
@@ -1,10 +1,9 @@
 ---
 version:
 - Cloud
-- Server 3
+- Server 3.x
 ---
-
-= Migrating from AWS
+= Migrate from AWS
 :page-layout: classic-docs
 :page-liquid:
 :page-description: This overview provides instructions for installing CircleCI Server on Amazon Web Services (AWS) with Terraform.

--- a/jekyll/_cci2/migrate-from-azure-devops.adoc
+++ b/jekyll/_cci2/migrate-from-azure-devops.adoc
@@ -1,27 +1,31 @@
 ---
 version:
 - Cloud
-- Server 3
+- Server 3.x
 ---
-
-= Migrating from Buildkite
+= Migrate from Azure DevOps
 :page-layout: classic-docs
 :page-liquid:
-:page-description: An overview of how to migrate from Buildkite to CircleCI.
+:page-description: An overview of how to migrate from Azure DevOps to CircleCI.
 :icons: font
 :toc: macro
 :toc-title:
 
-This document provides an overview of how to migrate from Buildkite to CircleCI.
+This document provides an overview of how to migrate from Azure DevOps to CircleCI.
 
 NOTE: **Tips provided by ImagineX Consulting**
 
 [#source-control-setup]
-== Source control setup
-First you will need to ensure your source code is located in either to GitHub or BitBucket. See the following for details on how to import your code:
+== Source Control Setup
+If you are using Azure DevOps Git or TFVC repositories, you will first need to migrate your source code to GitHub or BitBucket. For Azure DevOps Git repos, here are links on how to import into GitHub or BitBucket:
 
 * https://help.github.com/en/articles/importing-a-repository-with-github-importer[GitHub]
 * https://help.github.com/en/articles/importing-a-repository-with-github-importer[BitBucket]
+
+For TFVC repositories, we recommend using the git-tfs tool. Here is a link to the tool and steps for using it:
+
+* https://github.com/git-tfs/git-tfs[Git-tfs migration tool]
+* https://github.com/git-tfs/git-tfs/blob/master/doc/usecases/migrate_tfs_to_git.md[Git-tfs migration steps]
 
 [#github-enterprise]
 === GitHub Enterprise
@@ -46,18 +50,20 @@ git remote add enterprise git@[hostname]:[owner]/[repo-name].git
 git push enterprise --mirror
 ```
 
+If you need to export other Azure DevOps artifacts, you can download most of the data into Excel spreadsheets. Follow the Azure DevOps documentation on https://docs.microsoft.com/en-us/azure/devops/organizations/projects/save-project-data?view=azure-devops[saving project data].
+
 Once you have imported your code into GitHub or BitBucket, you can start creating a project in CircleCI using the https://circleci.com/docs/2.0/getting-started/[Getting Started guide].
 
 [#build-configuration]
-== Build configuration
+== Build Configuration
 
-Next, you will need to migrate your build configuration. On Buildkite, the build configuration is either defined in the web interface or in a file called `.pipeline.yml` in the root directory of your source code repository. If you use shell scripts to perform your build, you can reuse those scripts in CircleCI.
+If you are using Azure DevOps Pipelines or TFS Build and Release, you will need to migrate your build configuration. In Azure DevOps Pipelines, the build configuration is defined in a file called `azure-pipelines.yml` in the root directory of your source code repository. In TFS Build and Release, the build configuration is done through the web interface and can be exported to a json file. In either case, if you use shell scripts to perform your build, you can reuse those scripts in CircleCI.
 
-First, create a CircleCI build configuration file. In the root directory of your source code repository, create a folder named .circleci and create a file in that folder named config.yml. Next, follow the CircleCI documentation here to learn how to configure the .config.yml file.
+First, create a CircleCI build configuration file. In the root directory of your source code repository, create a folder named `.circleci` and create a file in that folder named `config.yml`. Next, follow the CircleCI documentation here to learn how to configure the `config.yml` file.
 
-The Buildkite and CircleCI configurations will be different. It may be helpful to have both Buildkite and CircleCI reference documentation open side-by-side to help with the conversion of the build steps:
+The Azure DevOps Pipelines and CircleCI configurations will be different. It may be helpful to have both Azure DevOps and CircleCI reference documentation open side-by-side to help with the conversion of the build steps:
 
-* https://buildkite.com/docs/pipelines/defining-steps[Buildkite Pipeline Reference]
+* https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema[Azure DevOps YML Reference]
 
 * https://circleci.com/docs/2.0/configuration-reference/[CircleCI YML Reference]
 
@@ -68,15 +74,18 @@ The Buildkite and CircleCI configurations will be different. It may be helpful t
 [cols=2*, options="header,unbreakable,autowidth", stripes=even]
 [cols="5,5"]
 |===
-| Buildkite | CircleCI
+| Azure DevOps | CircleCI
 
 2+| Define a job that executes a single build step.
 
 a|
 [source, yaml]
 ----
-steps:
-  - command: 'execute-script-for-job1.sh'
+jobs:
+  - job: job1
+    steps:
+      - script: chmod +x ./script.sh
+      - script: ./script.sh
 ----
 
 a|
@@ -94,12 +103,10 @@ jobs:
 a|
 [source, yaml]
 ----
-steps:
-  - label: 'job1'
-    plugins:
-      - docker#v3.2.0:
-          image: 'node:10'
-
+jobs:
+  - job: job1
+    container:
+      image: node:10
 ----
 
 a|
@@ -112,30 +119,32 @@ jobs:
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-
 ----
 
-2+| Define a multi-stage build pipeline. Job1 and Job2 run concurrently. Once they are done, Job3 runs. Once Job3 is done, Job4 runs.
+2+| Define a multi-stage build pipeline. Job1 and Job2 run in concurrently. Once they’re done, Job3 runs. Once Job3 is done, Job4 runs.
 
 a|
 [source, yaml]
 ----
-steps:
-  - label: 'job1'
-    command: 'make build dependencies'
-
-  - label: 'job2'
-    command: 'make build artifacts'
-
-  - wait
-
-  - label: 'job3'
-    command: 'make test'
-
-  - wait
-
-  - label: 'job4'
-    command: 'make deploy'
+stages:
+  - stage: build
+    jobs:
+    - job: job1
+      steps:
+        - script: make build dependencies
+    - job: job2
+      steps:
+        - script: make build artifacts
+  - stage: test
+    jobs:
+    - job: job3
+      steps:
+        - script: make test
+  - stage: deploy
+    jobs:
+    - job: job4
+      steps:
+        - script: make deploy
 ----
 
 a|
@@ -171,21 +180,23 @@ workflows:
           - job3
 ----
 
-2+| Execute jobs on multiple platforms. Buildkite uses tags to identify build agents. CircleCI provides executors for docker, Linux and MacOS.
+2+| Execute jobs on multiple platforms. Azure DevOps uses pools and demands to identify build runners. CircleCI provides executors for docker, Linux and MacOS.
 
 a|
 [source, yaml]
 ----
-steps:
-  - label: 'ubuntuJob'
-    agents:
-      ubuntu: '16.04'
-    command: 'echo "Hello, $USER!"'
+jobs:
+  - job: ubuntuJob
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+      - script: echo "Hello, $USER!"
+  - job: osxJob
+    pool:
+      vmImage: macOS-10.14
+    steps:
+      - script: echo "Hello, $USER!"
 
-  - label: 'osxJob'
-    agents:
-      osx: 'true'
-    command: 'echo "Hello, $USER!"'
 
 ----
 
@@ -198,7 +209,7 @@ jobs:
       # The image uses the current tag, which always points to the most recent
       # supported release. If stability and determinism are crucial for your CI
       # pipeline, use a release date tag with your image, e.g. ubuntu-2004:202201-02
-      image: ubuntu-2004:current
+      image: ubuntu-2004:current 
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrate-from-buildkite.adoc
+++ b/jekyll/_cci2/migrate-from-buildkite.adoc
@@ -1,32 +1,26 @@
 ---
 version:
 - Cloud
-- Server 3
+- Server 3.x
 ---
-
-= Migrating from Azure DevOps
+= Migrate from Buildkite
 :page-layout: classic-docs
 :page-liquid:
-:page-description: An overview of how to migrate from Azure DevOps to CircleCI.
+:page-description: An overview of how to migrate from Buildkite to CircleCI.
 :icons: font
 :toc: macro
 :toc-title:
 
-This document provides an overview of how to migrate from Azure DevOps to CircleCI.
+This document provides an overview of how to migrate from Buildkite to CircleCI.
 
 NOTE: **Tips provided by ImagineX Consulting**
 
 [#source-control-setup]
-== Source Control Setup
-If you are using Azure DevOps Git or TFVC repositories, you will first need to migrate your source code to GitHub or BitBucket. For Azure DevOps Git repos, here are links on how to import into GitHub or BitBucket:
+== Source control setup
+First you will need to ensure your source code is located in either to GitHub or BitBucket. See the following for details on how to import your code:
 
 * https://help.github.com/en/articles/importing-a-repository-with-github-importer[GitHub]
 * https://help.github.com/en/articles/importing-a-repository-with-github-importer[BitBucket]
-
-For TFVC repositories, we recommend using the git-tfs tool. Here is a link to the tool and steps for using it:
-
-* https://github.com/git-tfs/git-tfs[Git-tfs migration tool]
-* https://github.com/git-tfs/git-tfs/blob/master/doc/usecases/migrate_tfs_to_git.md[Git-tfs migration steps]
 
 [#github-enterprise]
 === GitHub Enterprise
@@ -51,20 +45,18 @@ git remote add enterprise git@[hostname]:[owner]/[repo-name].git
 git push enterprise --mirror
 ```
 
-If you need to export other Azure DevOps artifacts, you can download most of the data into Excel spreadsheets. Follow the Azure DevOps documentation on https://docs.microsoft.com/en-us/azure/devops/organizations/projects/save-project-data?view=azure-devops[saving project data].
-
 Once you have imported your code into GitHub or BitBucket, you can start creating a project in CircleCI using the https://circleci.com/docs/2.0/getting-started/[Getting Started guide].
 
 [#build-configuration]
-== Build Configuration
+== Build configuration
 
-If you are using Azure DevOps Pipelines or TFS Build and Release, you will need to migrate your build configuration. In Azure DevOps Pipelines, the build configuration is defined in a file called `azure-pipelines.yml` in the root directory of your source code repository. In TFS Build and Release, the build configuration is done through the web interface and can be exported to a json file. In either case, if you use shell scripts to perform your build, you can reuse those scripts in CircleCI.
+Next, you will need to migrate your build configuration. On Buildkite, the build configuration is either defined in the web interface or in a file called `.pipeline.yml` in the root directory of your source code repository. If you use shell scripts to perform your build, you can reuse those scripts in CircleCI.
 
-First, create a CircleCI build configuration file. In the root directory of your source code repository, create a folder named `.circleci` and create a file in that folder named `config.yml`. Next, follow the CircleCI documentation here to learn how to configure the `config.yml` file.
+First, create a CircleCI build configuration file. In the root directory of your source code repository, create a folder named .circleci and create a file in that folder named config.yml. Next, follow the CircleCI documentation here to learn how to configure the .config.yml file.
 
-The Azure DevOps Pipelines and CircleCI configurations will be different. It may be helpful to have both Azure DevOps and CircleCI reference documentation open side-by-side to help with the conversion of the build steps:
+The Buildkite and CircleCI configurations will be different. It may be helpful to have both Buildkite and CircleCI reference documentation open side-by-side to help with the conversion of the build steps:
 
-* https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema[Azure DevOps YML Reference]
+* https://buildkite.com/docs/pipelines/defining-steps[Buildkite Pipeline Reference]
 
 * https://circleci.com/docs/2.0/configuration-reference/[CircleCI YML Reference]
 
@@ -75,18 +67,15 @@ The Azure DevOps Pipelines and CircleCI configurations will be different. It may
 [cols=2*, options="header,unbreakable,autowidth", stripes=even]
 [cols="5,5"]
 |===
-| Azure DevOps | CircleCI
+| Buildkite | CircleCI
 
 2+| Define a job that executes a single build step.
 
 a|
 [source, yaml]
 ----
-jobs:
-  - job: job1
-    steps:
-      - script: chmod +x ./script.sh
-      - script: ./script.sh
+steps:
+  - command: 'execute-script-for-job1.sh'
 ----
 
 a|
@@ -104,10 +93,12 @@ jobs:
 a|
 [source, yaml]
 ----
-jobs:
-  - job: job1
-    container:
-      image: node:10
+steps:
+  - label: 'job1'
+    plugins:
+      - docker#v3.2.0:
+          image: 'node:10'
+
 ----
 
 a|
@@ -120,32 +111,30 @@ jobs:
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+
 ----
 
-2+| Define a multi-stage build pipeline. Job1 and Job2 run in concurrently. Once they’re done, Job3 runs. Once Job3 is done, Job4 runs.
+2+| Define a multi-stage build pipeline. Job1 and Job2 run concurrently. Once they are done, Job3 runs. Once Job3 is done, Job4 runs.
 
 a|
 [source, yaml]
 ----
-stages:
-  - stage: build
-    jobs:
-    - job: job1
-      steps:
-        - script: make build dependencies
-    - job: job2
-      steps:
-        - script: make build artifacts
-  - stage: test
-    jobs:
-    - job: job3
-      steps:
-        - script: make test
-  - stage: deploy
-    jobs:
-    - job: job4
-      steps:
-        - script: make deploy
+steps:
+  - label: 'job1'
+    command: 'make build dependencies'
+
+  - label: 'job2'
+    command: 'make build artifacts'
+
+  - wait
+
+  - label: 'job3'
+    command: 'make test'
+
+  - wait
+
+  - label: 'job4'
+    command: 'make deploy'
 ----
 
 a|
@@ -181,23 +170,21 @@ workflows:
           - job3
 ----
 
-2+| Execute jobs on multiple platforms. Azure DevOps uses pools and demands to identify build runners. CircleCI provides executors for docker, Linux and MacOS.
+2+| Execute jobs on multiple platforms. Buildkite uses tags to identify build agents. CircleCI provides executors for docker, Linux and MacOS.
 
 a|
 [source, yaml]
 ----
-jobs:
-  - job: ubuntuJob
-    pool:
-      vmImage: ubuntu-16.04
-    steps:
-      - script: echo "Hello, $USER!"
-  - job: osxJob
-    pool:
-      vmImage: macOS-10.14
-    steps:
-      - script: echo "Hello, $USER!"
+steps:
+  - label: 'ubuntuJob'
+    agents:
+      ubuntu: '16.04'
+    command: 'echo "Hello, $USER!"'
 
+  - label: 'osxJob'
+    agents:
+      osx: 'true'
+    command: 'echo "Hello, $USER!"'
 
 ----
 
@@ -210,7 +197,7 @@ jobs:
       # The image uses the current tag, which always points to the most recent
       # supported release. If stability and determinism are crucial for your CI
       # pipeline, use a release date tag with your image, e.g. ubuntu-2004:202201-02
-      image: ubuntu-2004:current 
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrate-from-github-actions.adoc
+++ b/jekyll/_cci2/migrate-from-github-actions.adoc
@@ -1,18 +1,17 @@
 ---
 version:
 - Cloud
-- Server 3
+- Server 3.x
 ---
-
-= Migrating from Github Actions
+= Migrate from Github Actions
 :page-layout: classic-docs
 :page-liquid:
-:page-description: An overview of how to migrate from Github Actions to CircleCI.
+:page-description: An overview of how to migrate from GitHub Actions to CircleCI.
 :icons: font
 :toc: macro
 :toc-title:
 
-This document provides an overview of how to migrate from Github Actions to CircleCI.
+This document provides an overview of how to migrate from GitHub Actions to CircleCI.
 
 [#why-migrate-to-circleci]
 == Why migrate to CircleCI?
@@ -24,7 +23,7 @@ CircleCI is a first-class CI tool. CI/CD has been our specialization since the c
 3. **Resource Classes** - you can use various different https://circleci.com/docs/2.0/optimizations/#resource-class[sizes of executor] on our platform, great for adjusting according to lighter or heavier workloads on a node.
 4. **Test Parallelism** - our platform provides not only https://circleci.com/docs/2.0/workflows/[concurrent job execution] but also the ability to split tests between parallel environments. You can dramatically cut build times by https://circleci.com/docs/2.0/parallelism-faster-jobs/#using-the-circleci-cli-to-split-tests[splitting workloads between different containers].
 
-We have various other features that set our solution apart. https://circleci.com/signup/[Sign up for a free account today] and try us out, or if you are interested in CircleCI for your team, https://circleci.com/talk-to-us/?source-button=MigratingFromGithubActionsDoc[contact our sales team] to set up a trial.
+We have various other features that set our solution apart. https://circleci.com/signup/[Sign up for a free account today] and try us out, or if you are interested in CircleCI for your team, https://circleci.com/talk-to-us/?source-button=MigratingFromGitHubActionsDoc[contact our sales team] to set up a trial.
 
 [#concepts]
 == Concepts
@@ -32,7 +31,7 @@ We have various other features that set our solution apart. https://circleci.com
 [#jobs-and-workflows]
 === Jobs and workflows
 
-Both Github Actions and CircleCI share similar concepts around "jobs" and "workflows". A workflow is an end-to-end flow of connected jobs, which in turn consist of commands to achieve an atomic task (e.g. "run unit tests" or "build a Docker image").
+Both GitHub Actions and CircleCI share similar concepts around "jobs" and "workflows". A workflow is an end-to-end flow of connected jobs, which in turn consist of commands to achieve an atomic task (e.g. "run unit tests" or "build a Docker image").
 
 CircleCI differs primarily in configuration syntax, setting up workflow and job dependencies in a separate section as opposed to inline in the job.
 
@@ -40,7 +39,7 @@ CircleCI differs primarily in configuration syntax, setting up workflow and job 
 [cols=2*, options="header", stripes=even]
 [cols="50%,50%"]
 |===
-| Github | CircleCI
+| GitHub | CircleCI
 
 a|
 [source, yaml]
@@ -86,11 +85,11 @@ workflows:
 
 [#actions-vs-orbs]
 === Actions vs. orbs
-"Actions" in Github are reusable commands or tasks to run inside a job. However, they are written for execution inside a Docker container or coded as individual steps using JavaScript. This adds additional work and limits the scope in which they can be applied.
+"Actions" in GitHub are reusable commands or tasks to run inside a job. However, they are written for execution inside a Docker container or coded as individual steps using JavaScript. This adds additional work and limits the scope in which they can be applied.
 
 CircleCI offers similar functionality in our https://circleci.com/docs/2.0/orb-intro/#section=configuration[orbs]. The primary difference is that CircleCI orbs are just packaged, reusable YAML, so you can orbify reusable jobs, executors, or commands, and use them however you see fit in any of your jobs or workflows.
 
-Github offers browsing of Actions in their Marketplace; CircleCI has an https://circleci.com/developer/orbs[Orb Registry] as well as an https://circleci.com/integrations/[Integrations Page] containing numerous Certified, Partner, and community orbs / integrations.
+GitHub offers browsing of Actions in their Marketplace; CircleCI has an https://circleci.com/developer/orbs[Orb Registry] as well as an https://circleci.com/integrations/[Integrations Page] containing numerous Certified, Partner, and community orbs / integrations.
 
 [#runners-vs-executors]
 === Runners vs. executors
@@ -109,9 +108,9 @@ See the table in the next section to compare configuration.
 [cols=2*, options="header,unbreakable,autowidth", stripes=even]
 [cols="5,5"]
 |===
-| Github Config | CircleCI Config
+| GitHub Config | CircleCI Config
 
-2+| Specifying execution environment. While container execution is specified separately in Github, +
+2+| Specifying execution environment. While container execution is specified separately in GitHub, +
 `docker` is its https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor[own class of executor] in CircleCI.
 
 a|
@@ -220,7 +219,7 @@ jobs:
           command: ./gradlew build
 ----
 
-2+| Using shared tasks (Actions for Github, orbs for CircleCI). In CircleCI, you declare orbs at the top level +
+2+| Using shared tasks (Actions for GitHub, orbs for CircleCI). In CircleCI, you declare orbs at the top level +
 and then https://circleci.com/docs/2.0/configuration-reference/#orbs-requires-version-21[refer to them by name in config], similar in concept to Python or JavaScript imports.
 
 a|
@@ -301,7 +300,7 @@ jobs:
 
 For more configuration examples on CircleCI, visit our <<examples-and-guides-overview#,Examples and Guides Overview>> and <<example-configs#,Example Projects>> pages.
 
-Since the configuration between Github Actions and CircleCI is similar, it should be fairly trivial to migrate your jobs and workflows. However, for best chances of success, we recommend migrating over items in the following order:
+Since the configuration between GitHub Actions and CircleCI is similar, it should be fairly trivial to migrate your jobs and workflows. However, for best chances of success, we recommend migrating over items in the following order:
 
 . https://circleci.com/docs/2.0/concepts/#section=getting-started[Jobs, Steps, and Workflows]
 . https://circleci.com/docs/2.0/workflows/[More Advanced Workflow and Job Dependency Configuration]

--- a/jekyll/_cci2/migrate-from-gitlab.adoc
+++ b/jekyll/_cci2/migrate-from-gitlab.adoc
@@ -1,10 +1,9 @@
 ---
 version:
 - Cloud
-- Server 3
+- Server 3.x
 ---
-
-= Migrating from GitLab
+= Migrate from GitLab
 :page-layout: classic-docs
 :page-liquid:
 :page-description: An overview of how to migrate from GitLab to CircleCI.

--- a/jekyll/_cci2/migrate-from-jenkins.md
+++ b/jekyll/_cci2/migrate-from-jenkins.md
@@ -1,12 +1,11 @@
 ---
 layout: classic-docs
-title: Migrating from Jenkins
+title: Migrate from Jenkins
 categories: [migration]
 description: Differences between CircleCI and Jenkins, with migration guide.
 version:
 - Cloud
 - Server v3.x
-- Server v2.x
 ---
 
 This document provides the basic concepts that a longtime Jenkins user needs to know when migrating from Jenkins to CircleCI.

--- a/jekyll/_cci2/migrate-from-teamcity.adoc
+++ b/jekyll/_cci2/migrate-from-teamcity.adoc
@@ -1,10 +1,9 @@
 ---
 version:
 - Cloud
-- Server 3
+- Server 3.x
 ---
-
-= Migrating from TeamCity
+= Migrate from TeamCity
 :page-layout: classic-docs
 :page-liquid:
 :description: An overview of how to migrate from TeamCity to CircleCI.

--- a/jekyll/_cci2/migrate-from-travis-ci.md
+++ b/jekyll/_cci2/migrate-from-travis-ci.md
@@ -1,8 +1,11 @@
 ---
 layout: classic-docs
-title: Migrating From Travis CI
+title: Migrate From Travis CI
 categories: [migration]
 description: An overview of how to migrate from Travis CI to CircleCI.
+version:
+- Cloud
+- Server 3.x
 ---
 
 This document provides an overview of how to migrate from Travis CI to CircleCI.

--- a/jekyll/_cci2/migrating-from-jenkins.md
+++ b/jekyll/_cci2/migrating-from-jenkins.md
@@ -1,22 +1,25 @@
 ---
 layout: classic-docs
-title: Differences from Jenkins
+title: Migrating from Jenkins
 categories: [migration]
-description: Differences between CircleCI and Jenkins.
+description: Differences between CircleCI and Jenkins, with migration guide.
+version:
+- Cloud
+- Server v3.x
+- Server v2.x
 ---
 
-This document provides the basic concepts that a longtime Jenkins user needs to know when migrating from Jenkins to CircleCI in the following sections:
+This document provides the basic concepts that a longtime Jenkins user needs to know when migrating from Jenkins to CircleCI.
 
 * TOC
 {:toc}
 
 ## Quick start
 {: #quick-start }
-{:.no_toc}
 
-CircleCI is a very different product from Jenkins with a lot of different concepts on how to manage CI and CD, but it won’t take long to migrate the basic functionality of your Jenkins build to CircleCI. To get started quickly, try one of these options:
+CircleCI is a very different product from Jenkins, with a lot of different concepts on how to manage CI/CD, but it will not take long to migrate the basic functionality of your Jenkins build to CircleCI. To get started quickly, try these steps:
 
-1. **Getting Started:** Run your first green build on CircleCI using the [getting started video and steps]({{ site.baseurl }}/).
+1. **Getting Started:** Run your first green build on CircleCI using the [guide]({{site.baseurl}}/getting-started).
 
 2. **Copy-paste your commands from Execute Shell:** To simply duplicate your project exactly as it is in Jenkins, add a file called `config.yml` to a `.circleci/` directory of your project with the following content:
 
@@ -29,72 +32,142 @@ CircleCI is a very different product from Jenkins with a lot of different concep
             echo "Copy-paste from 'Execute Shell' in Jenkins"
 ```
 
-Some programs and utilities are [pre-installed on CircleCI Images]( {{ site.baseurl }}/2.0/circleci-images/#pre-installed-tools), but anything else required by your build must be installed with a `run` `step`. Your project’s dependencies may be [cached]( {{ site.baseurl }}/2.0/caching/) for the next build using the `save_cache` and `restore_cache` `steps`, so that they only need to be fully downloaded and installed once.
+Some programs and utilities are [pre-installed on CircleCI Images]({{site.baseurl}}/2.0/circleci-images/#pre-installed-tools), but anything else required by your build must be installed with a `run` step. Your project’s dependencies may be [cached]({{site.baseurl}}/2.0/caching/) for the next build using the `save_cache` and `restore_cache` steps, so that they only need to be fully downloaded and installed once.
 
-**Manual configuration:** If you were using plugins or options other than Execute Shell in Jenkins to run your build steps, you may need to manually port your build from Jenkins. Use the [Configuring CircleCI]( {{ site.baseurl }}/2.0/configuration-reference/) document as a guide to the complete set of CircleCI configuration keys.
+**Manual configuration:** If you were using plugins or options other than Execute Shell in Jenkins to run your build steps, you may need to manually port your build from Jenkins. Use the [Configuring CircleCI]({{site.baseurl}}/2.0/configuration-reference/) document as a guide to the complete set of CircleCI configuration keys.
 
 ## Job configuration
 {: #job-configuration }
 
-Jenkins projects are generally configured in the Jenkins web UI and their settings are stored on the filesystem of the Jenkins server. This makes it difficult to share configuration information within a team or organization. Cloning a GitHub or Bitbucket repository doesn’t copy the information stored in Jenkins. Settings stored on the Jenkins server also make regular backup of all Jenkins servers required.
+Jenkins projects are generally configured in the Jenkins web UI, and the settings are stored on the filesystem of the Jenkins server. This makes it difficult to share configuration information within a team or organization. Cloning a repository from your VCS does not copy the information stored in Jenkins. Settings stored on the Jenkins server also make regular backups of all Jenkins servers required.
 
-Almost all configuration of CircleCI builds is stored in a file called `.circleci/config.yml` that goes in the root of each project. Treating CI configuration like any other source code makes it easier to back up and share. Just a few project settings, like secrets, that shouldn’t be stored in source code are stored (encrypted) in the CircleCI app.
+Almost all configuration for CircleCI builds are stored in a file called `.circleci/config.yml` that is located in the root directory of each project. Treating CI/CD configuration like any other source code makes it easier to back up and share. Just a few project settings, like secrets, that should not be stored in source code are stored (encrypted) in the CircleCI app.
 
 ### Access to build machines
 {: #access-to-build-machines }
-{:.no_toc}
 
-It’s often up to an Ops person or team to manage Jenkins servers. These people generally get involved with various CI maintenance tasks like installing dependencies and troubleshooting issues.
+It is often the responsibility of an ops person or team to manage Jenkins servers. These people generally get involved with various CI/CD maintenance tasks like installing dependencies and troubleshooting issues.
 
-It is never necessary to access a CircleCI environment to install dependencies because every build starts in a fresh environment where custom dependencies must be installed automatically (ensuring that the entire build process is truly automated). Troubleshooting in the execution environment can be done easily and securely by any developer using CircleCI’s [SSH feature]( {{ site.baseurl }}/2.0/ssh-access-jobs/).
+It is never necessary to access a CircleCI environment to install dependencies, because every build starts in a fresh environment where custom dependencies must be installed automatically, ensuring that the entire build process is truly automated. Troubleshooting in the execution environment can be done easily and securely by any developer using CircleCI’s [SSH feature]({{site.baseurl}}/2.0/ssh-access-jobs/).
 
-If you install CircleCI on your own hardware, the divide between the host OS (at the “metal”/VM level) and the containerized execution environments can be extremely useful for security and ops (see Your Builds in Containers below). Ops team members can do what they need to on the host OS without affecting builds, and they never need to give developers access. Developers, on the other hand, can use CircleCI’s SSH feature to debug builds at the container level as much as they like without affecting ops.
-
-## Web UI
-{: #web-ui }
-{:.no_toc}
-
-CircleCI is a single-page web app that makes the entire user experience fast and easy on the eyes. The CircleCI team also continually refreshes and improves its UI. CircleCI’s modern UI is very popular with users, so the team will keep investing in it as technology and user expectations change.
+If you install CircleCI on your own hardware, the divide between the host OS (at the "metal"/VM level) and the containerized execution environments can be extremely useful for security and ops (see [Your builds in containers](#your-builds-in-containers) below). Ops team members can do what they need to on the host OS without affecting builds, and they never need to give developers access. Developers, on the other hand, can use CircleCI’s SSH feature to debug builds at the container level as much as they like without affecting ops.
 
 ## Plugins
 {: #plugins }
 
-You’ve almost certainly worked with plugins if you’ve used Jenkins. These plugins are Java-based like Jenkins itself and a bit complicated. They interface with any of several hundred possible extension points in Jenkins and can generate web views using JSP-style tags and views. You also have to use plugins to do almost anything with Jenkins. Even checking out a Git repository requires a plugin.
+You have to use plugins to do almost anything with Jenkins, including checking out a Git repository. Like Jenkins itself, its plugins are Java-based, and a bit complicated. They interface with any of several hundred possible extension points in Jenkins and can generate web views using JSP-style tags and views.
 
-All core CI functionality is built into CircleCI. Features such as checking out source from GitHub or Bitbucket, running builds and tests with your favorite tools, parsing test output, and storing artifacts are first-class and plugin-free. When you do need to add custom functionality to your builds and deployments, you can do so with a couple snippets of bash in appropriate places.
+All core CI functionality is built into CircleCI. Features such as checking out source from a VCS, running builds and tests with your favorite tools, parsing test output, and storing artifacts are plugin-free. When you do need to add custom functionality to your builds and deployments, you can do so with a couple snippets of bash in appropriate places.
+
+Below is a table of supported plugins that you can convert using the [CircleCI Jenkins converter tool](https://circleci.com/developer/tools/jenkins-converter) ([see Jenkins converter section](#jenkinsfile-converter)). 
+
+**Jenkinsfiles relying on plugins not listed below cannot be converted**. Please remove stanzas relying on those unsupported plugins (for example `options`), otherwise you will see an error message saying something is `Unknown` or `Invalid`. Please submit a ticket with our support center if you have a request to add a plugin to the list.
+{: class="alert alert-info" }
+
+- Ant Plugin (`ant`)
+- Authentication Tokens API Plugin (`authentication-tokens`)
+- Bouncy Castle API Plugin (`bouncycastle-api`)
+- Branch API Plugin (`branch-api`)
+- Build Timeout (`build-timeout`)
+- Command Agent Launcher Plugin (`command-launcher`)
+- Config File Provider Plugin (`config-file-provider`)
+- Credentials Binding Plugin (`credentials-binding`)
+- Credentials Plugin (`credentials`)
+- Display URL API (`display-url-api`)
+- Docker Commons Plugin (`docker-commons`)
+- Docker Pipeline (`docker-workflow`)
+- Durable Task Plugin (`durable-task`)
+- Email Extension Plugin (`email-ext`)
+- Folders Plugin (`cloudbees-folder`)
+- GitHub API Plugin (`github-api`)
+- GitHub Branch Source Plugin (`github-branch-source`)
+- GitHub plugin (`github`)
+- Gradle Plugin (`gradle`)
+- H2 API Plugin (`h2-api`)
+- JUnit Plugin (`junit`)
+- Jackson 2 API Plugin (`jackson2-api`)
+- JavaScript GUI Lib: ACE Editor bundle plugin (`ace-editor`)
+- JavaScript GUI Lib: Handlebars bundle plugin (`handlebars`)
+- JavaScript GUI Lib: Moment.js bundle plugin (`momentjs`)
+- JavaScript GUI Lib: jQuery bundles (jQuery and jQuery UI) plugin (`jquery-detached`)
+- Jenkins Apache HttpComponents Client 4.x API Plugin (`apache-httpcomponents-client-4-api`)
+- Jenkins GIT server Plugin (`git-server`)
+- Jenkins Git client plugin (`git-client`)
+- Jenkins Git plugin (`git`)
+- Jenkins JSch dependency plugin (`jsch`)
+- Jenkins Mailer Plugin (`mailer`)
+- Jenkins Subversion Plug-in (`subversion`)
+- Jenkins Workspace Cleanup Plugin (`ws-cleanup`)
+- LDAP Plugin (`ldap`)
+- Lockable Resources plugin (`lockable-resources`)
+- MapDB API Plugin (`mapdb-api`)
+- Matrix Authorization Strategy Plugin (`matrix-auth`)
+- Matrix Project Plugin (`matrix-project`)
+- OWASP Markup Formatter Plugin (`antisamy-markup-formatter`)
+- Oracle Java SE Development Kit Installer Plugin (`jdk-tool`)
+- PAM Authentication plugin (`pam-auth`)
+- Pipeline (`workflow-aggregator`)
+- Pipeline Graph Analysis Plugin (`pipeline-graph-analysis`)
+- Pipeline Maven Integration Plugin (`pipeline-maven`)
+- Pipeline Utility Steps (`pipeline-utility-steps`)
+- Pipeline: API (`workflow-api`)
+- Pipeline: Basic Steps (`workflow-basic-steps`)
+- Pipeline: Build Step (`pipeline-build-step`)
+- Pipeline: Declarative (`pipeline-model-definition`)
+- Pipeline: Declarative Agent API (`pipeline-model-declarative-agent`)
+- Pipeline: Declarative Extension Points API (`pipeline-model-extensions`)
+- Pipeline: GitHub Groovy Libraries (`pipeline-github-lib`)
+- Pipeline: Groovy (`workflow-cps`)
+- Pipeline: Input Step (`pipeline-input-step`)
+- Pipeline: Job (`workflow-job`)
+- Pipeline: Milestone Step (`pipeline-milestone-step`)
+- Pipeline: Model API (`pipeline-model-api`)
+- Pipeline: Multibranch (`workflow-multibranch`)
+- Pipeline: Nodes and Processes (`workflow-durable-task-step`)
+- Pipeline: REST API Plugin (`pipeline-rest-api`)
+- Pipeline: SCM Step (`workflow-scm-step`)
+- Pipeline: Shared Groovy Libraries (`workflow-cps-global-lib`)
+- Pipeline: Stage Step (`pipeline-stage-step`)
+- Pipeline: Stage Tags Metadata (`pipeline-stage-tags-metadata`)
+- Pipeline: Stage View Plugin (`pipeline-stage-view`)
+- Pipeline: Step API (`workflow-step-api`)
+- Pipeline: Supporting APIs (`workflow-support`)
+- Plain Credentials Plugin (`plain-credentials`)
+- Resource Disposer Plugin (`resource-disposer`)
+- SCM API Plugin (`scm-api`)
+- SSH Build Agents plugin (`ssh-slaves`)
+- SSH Credentials Plugin (`ssh-credentials`)
+- Script Security Plugin (`script-security`)
+- Structs Plugin (`structs`)
+- Timestamper (`timestamper`)
+- Token Macro Plugin (`token-macro`)
+- Trilead API Plugin (`trilead-api`)
 
 ## Distributed builds
 {: #distributed-builds }
 
-It is possible to make a Jenkins server distribute your builds to a number of “agent” machines to execute the jobs, but this takes a fair amount of work to set up. According to Jenkins’ [docs on the subject](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds), “Jenkins is not a clustering middleware, and therefore it doesn't make this any easier.”
+It is possible to make a Jenkins server distribute your builds to a number of "agent" machines to execute the jobs, but this takes a fair amount of work to set up. According to Jenkins’ [docs](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds), “Jenkins is not a clustering middleware, and therefore it doesn't make this any easier.”
 
-CircleCI distributes builds to a large fleet of builder machines by default. If you use SaaS-based circleci.com, then this just happens for you, your builds don’t queue unless you are using all the build capacity in your plan, and that’s that. If you use CircleCI installed in your own environment, then you will appreciate that CircleCI does manage your cluster of builder machines without the need for any extra tools.
+CircleCI distributes builds to a large fleet of builder machines by default. If you use SaaS-based circleci.com, then this just happens for you - your builds do not queue unless you are using all the build capacity in your plan. If you use CircleCI installed in your own environment, then you will appreciate that CircleCI does manage your cluster of builder machines without the need for any extra tools.
 
 ## Containers and Docker
 {: #containers-and-docker }
 
-Talking about containerization in build systems can be complicated because arbitrary build and test commands can be run inside of containers as part of the implementation of the CI system, and some of these commands may themselves involve running containers. Both of these points are addressed below. Also note that Docker is an extremely popular tool for running containers, but it is not the only one. Both the terms “container” (general) and “Docker” (specific) will be used.
-
+Talking about containerization in build systems can be complicated, because arbitrary build and test commands can be run inside of containers as part of the implementation of the CI/CD system, and some of these commands may involve running containers. Both of these points are addressed below. Also note that Docker is an extremely popular tool for running containers, but it is not the only one. Both the terms "container" (general) and "Docker" (specific) will be used.
 
 ### Containers in your builds
 {: #containers-in-your-builds }
-{:.no_toc}
 
+If you use a tool like Docker in your workflow, you will likely also want to run it on CI/CD. Jenkins does not provide any built-in support for this, and it is up to you to make sure it is installed and available within your execution environment.
 
-If you use a tool like Docker in your workflow, you will likely also want to run it on CI. Jenkins does not provide any built-in support for this, and it is up to you to make sure it is installed and available within your execution environment.
-
-Docker has long been one of the tools that is pre-installed on CircleCI, so you can access Docker in your builds by adding `docker` as an executor in you `config.yml` file. See the [Introduction to Execution Environments]( {{ site.baseurl }}/2.0/executor-intro/) page for more info.
+Docker has long been one of the tools that is pre-installed on CircleCI, so you can access Docker in your builds by adding `docker` as an executor in your `.circleci/config.yml` file. See the [Introduction to Execution Environments]({{site.baseurl}}/2.0/executor-intro/) page for more info.
 
 ### Your builds in containers
 {: #your-builds-in-containers }
-{:.no_toc}
-
 
 Jenkins normally runs your build in an ordinary directory on the build server, which can cause lots of issues with dependencies, files, and other state gathering on the server over time. There are plugins that offer alternatives, but they must be manually installed.
 
-
 CircleCI runs all Linux and Android builds in dedicated containers, which are destroyed immediately after use (macOS builds run in single-use VMs). This creates a fresh environment for every build, preventing unwanted cruft from getting into builds. One-off environments also promote a disposable mindset that ensures all dependencies are documented in code and prevents “snowflake” build servers.
-
 
 If you run builds on your own hardware with [CircleCI](https://circleci.com/enterprise/), running all builds in containers allows you to heavily utilize the hardware available to run builds.
 
@@ -107,8 +180,89 @@ CircleCI lets you increase the parallelism in any project’s settings so that e
 
 ## Jenkinsfile converter
 {: #jenkinsfile-converter }
-CircleCI manages a Jenkinsfile Converter, a web tool that allows you to easily convert a Jenkinsfile to a CircleCI ```config.yml``` file, to help you get started with CircleCI quickly and easily. Access [Jenkins Converter](https://circleci.com/developer/tools/jenkins-converter).
 
-**Note:** The converter only supports declarative Jenkinsfiles. The number of supported plug-ins and steps will be expanded, this preview of the converter may help you to convert half of the Jenkinsfile to make it easier for you to get started with CircleCI.
+The CircleCI [Jenkins Converter](https://circleci.com/developer/tools/jenkins-converter) is a web tool that allows you to easily convert a Jenkinsfile to a `.circleci/config.yml` file, helping you to get started building on CircleCI quickly and easily.
 
-Instructions on how to use the Jenkinsfile converter, its features, and limitations are located in the [Introduction to Jenkins Converter documentation]({{site.baseurl}}/2.0/jenkins-converter/).
+**The converter only supports declarative Jenkinsfiles**. While the number of supported plug-ins and steps continue to be expanded, the hope is that this tool gets you started at least 50% of the way, and makes it easier for you to get started building on CircleCI.
+
+### Supported syntax
+{: #supported-syntax }
+
+Only declarative (pipeline) `Jenkinsfile`s are currently supported.
+
+Jenkinsfile Syntax | Approx. CircleCI Syntax | Status
+--- | --- | ---
+agent | [executor]({{site.baseurl}}/2.0/configuration-reference/#executors-requires-version-21) | Static
+post | [when attribute]({{site.baseurl}}/2.0/configuration-reference/#the-when-attribute) | See [when]({{site.baseurl}}/2.0/configuration-reference/#the-when-attribute)
+stages | [workflows]({{site.baseurl}}/2.0/workflows/) | Supported |
+steps | [step]({{site.baseurl}}/2.0/jobs-steps/#steps-overview) | Limited
+environment | [environment]({{site.baseurl}}/2.0/env-vars/) | [Unsupported](https://github.com/circleci/jenkinsfile-converter/issues/26)
+options | N/A | See [Supported Jenkins Plugins](#supported-jenkins-plugins)
+parameters | [parameters]({{site.baseurl}}/2.0/reusing-config/#using-the-parameters-declaration) | Unsupported
+triggers | [cron]({{site.baseurl}}/2.0/workflows/#scheduling-a-workflow) | Unsupported
+stage | [job]({{site.baseurl}}/2.0/configuration-reference/#jobs) | Supported
+{: class="table table-striped"}
+
+### Limitations
+{: #limitations }
+
+* A limited number of syntaxes and plugins are supported. Jenkinsfiles relying on unsupported syntaxes and plugins cannot be converted. Please manually remove them.
+
+* Only a single Jenkinsfile is accepted per request. Namely, [Shared Libraries](https://www.jenkins.io/doc/book/pipeline/shared-libraries/) will not be resolved, and the resulting `config.yml` may be incomplete. Note that under certain cases the converter does not raise errors even if there are unresolvable Shared Libraries.
+
+* Only `Default` is supported as a tool name for `maven`, `jdk` and `gradle` in the [`tools` block](https://www.jenkins.io/doc/book/pipeline/syntax/#tools), and other names will cause conversion failures. Please configure them as follows or remove them manually.
+
+  For example, the following stanza:
+  ```groovy
+  tools {
+    maven 'Maven 3.6.3'
+    jdk 'Corretto 8.232'
+  }
+  ```
+  should be changed to:
+  ```groovy
+  tools {
+    maven 'Default'
+    jdk 'Default'
+  }
+  ```
+
+### Next steps after conversion
+{: #next-steps-after-conversion }
+
+The following sections describe next steps with various aspects of the CircleCI pipeline.
+
+#### Executors
+{: #executors }
+
+A static Docker executor, [cimg/base](https://github.com/CircleCI-Public/cimg-base), is inserted as the [executor]({{site.baseurl}}/2.0/configuration-reference/#executors-requires-version-21) regardless of the one defined within the Jenkinsfile input.
+
+Given that `cimg/base` is a very lean image, it's highly likely that your project will require a different image. [CircleCI's convenience images](https://circleci.com/developer/images/) are a good place to find other images. Refer to [custom Docker image]({{site.baseurl}}/2.0/custom-images/) for advanced steps to create your own custom image.
+
+Depending on the use case, you might require the [machine executor]({{site.baseurl}}/2.0/configuration-reference/#machine) if your application requires full access to OS resources and the job environment, or the [macOS executor]({{site.baseurl}}/2.0/using-macos).
+
+#### Workflows
+{: #workflows }
+
+[CircleCI Workflows]({{site.baseurl}}/2.0/workflows/) (the equivalent of Jenkins pipelines) are transferred from your Jenkinsfile to the `.circleci/config.yml`, including branch filters. The converter will not transfer any [scheduled builds]({{site.baseurl}}/2.0/configuration-reference/#triggers) to prevent unintentional builds from being triggered.
+
+#### Jobs
+{: #jobs }
+
+Many of the configuration options within CircleCI jobs do not have equivalents to Jenkins' offerings. It is best practice to start with the following features to get a richer experience from CircleCI:
+
+- [Checkout code]({{site.baseurl}}/2.0/configuration-reference/#checkout)
+- [Resource class]({{site.baseurl}}/2.0/configuration-reference/#resource_class)
+- [Parallelism]({{site.baseurl}}/2.0/configuration-reference/#parallelism)
+- Caches, [saving]({{site.baseurl}}/2.0/configuration-reference/#save_cache) and [restoring]({{site.baseurl}}/2.0/configuration-reference/#restore_cache)
+- [Store Artifacts]({{site.baseurl}}/2.0/configuration-reference/#store_artifacts)
+
+#### Steps
+{: #steps }
+
+While the Jenkinsfile Converter attempts to directly translate steps, it does not provide full translation of all steps. To address this, the `JFC_STACK_TRACE` key was added to translate specific steps within the output YAML and to provide some guidance on how to proceed with unsupported step directives.
+
+## Next steps
+{: #next-steps }
+
+* [Introduction to the CircleCI Web App]({{site.baseurl}}/introduction-to-the-circleci-web-app)

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -38,24 +38,24 @@ en:
           link: 2.0/bitbucket-integration/
     - name: Migration
       children:
-        - name: Migration Introduction
-          link: 2.0/migration-intro/
-        - name: Migrating from AWS
-          link: 2.0/migrating-from-aws/
-        - name: Migrating from Azure
-          link: 2.0/migrating-from-azuredevops/
-        - name: Migrating from Buildkite
-          link: 2.0/migrating-from-buildkite/
-        - name: Migrating from GitHub
-          link: 2.0/migrating-from-github/
-        - name: Migrating from GitLab
-          link: 2.0/migrating-from-gitlab/
-        - name: Migrating from Jenkins
-          link: 2.0/migrating-from-jenkins/
-        - name: Migrating from TeamCity
-          link: 2.0/migrating-from-teamcity/
-        - name: Migrating from Travis CI
-          link: 2.0/migrating-from-travis/
+        - name: Introduction to CircleCI migration
+          link: 2.0/introduction-to-circleci-migration/
+        - name: Migrate from AWS
+          link: 2.0/migrate-from-aws/
+        - name: Migrate from Azure DevOps
+          link: 2.0/migrate-from-azure-devops/
+        - name: Migrate from Buildkite
+          link: 2.0/migrate-from-buildkite/
+        - name: Migrate from GitHub Actions
+          link: 2.0/migrate-from-github-actions/
+        - name: Migrate from GitLab
+          link: 2.0/migrate-from-gitlab/
+        - name: Migrate from Jenkins
+          link: 2.0/migrate-from-jenkins/
+        - name: Migrate from TeamCity
+          link: 2.0/migrate-from-teamcity/
+        - name: Migrate from Travis CI
+          link: 2.0/migrate-from-travis-ci/
 
 - name: Pipelines
   icon: icons/sidebar/pipelines.svg


### PR DESCRIPTION
# Description

- First commit is merging the Jenkins migration page with the Jenkins converter tool page.
- Second commit is cleaning up the Titles, Side nav and URLs of all the migration pages (and changing Github to GitHub).

# Reasons
[Jira](https://circleci.atlassian.net/jira/software/c/projects/DOCTEAM/boards/554?modal=detail&selectedIssue=DOCTEAM-625)

We had a page that wasn't on the side nav promoting CCI's Jenkins converter tool. It made more sense to merge the information into the Jenkins migration page.

Cleaned up the titles, etc to be more action oriented.

All the migration pages could probably use an overhaul/be double checked.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
