### PR TITLE
Gitlab GA update to API doc

### DIFF
--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -138,7 +138,8 @@ The following section details the steps you would need, from start to finish, to
 
 1. On your VCS provider, create a repository. The repo for this example will be called `hello-world`.
 
-2. Next, follow the onboarding guide for a new project on CircleCI. You can either visit the CircleCI web app and click on **Projects** in the sidebar, or go to the link: https://app.circleci.com/projects/project-dashboard/<VCS>/<org-name>/, where `VCS` is either `github` (or `gh`), `bitbucket` (or `bb`), or `circleci` for any other vcs (ie: gitlab), and `org_name` is your organization or personal VCS username. Find your project in the list and click **Set Up Project**. After completing the steps for setting up your project, you should have a valid `config.yml` file in a `.circleci` folder at the root of your repository. In this example, the `.circleci/config.yml` contains the following:
+2. Onboard your new Project on [CircleCI web app](https://app.circleci.com/) by navigating to **Projects > your project > Set Up Project**.
+ After completing the steps for setting up your project, you should have a valid `config.yml` file in a `.circleci` folder at the root of your repository. In this example, the `config.yml` contains the following:
 
     ```yaml
     # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference

--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -138,8 +138,8 @@ The following section details the steps you would need, from start to finish, to
 
 1. On your VCS provider, create a repository. The repo for this example will be called `hello-world`.
 
-2. Onboard your new Project on [CircleCI web app](https://app.circleci.com/) by navigating to **Projects > your project > Set Up Project**.
- After completing the steps for setting up your project, you should have a valid `config.yml` file in a `.circleci` folder at the root of your repository. In this example, the `config.yml` contains the following:
+2. Onboard your new Project on the [CircleCI web app](https://app.circleci.com/) by navigating to **Projects > your project > Set Up Project**.
+ After completing the steps for setting up your project, you should have a valid `config.yml` file in a `.circleci` folder at the root of your repository. In this example, the `.circleci/config.yml` contains the following:
 
     ```yaml
     # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference


### PR DESCRIPTION

# Description
Adjustment to the verbiage of the Onboard project section to match other similar documentation.

# Reasons
[EXT-446](https://circleci.atlassian.net/browse/EXT-446)
The original description failed to encapsulate the change in the org and project name in the url to org id for gitlab updates. Now doc matches style of other documentation and should be easier to maintain if the url structure varies again.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
