### PR TITLE
[SERVER-1942] Clarify docs around manually creating the nomad-gossip-encryption-key secret 

### DIFF
--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -231,16 +231,7 @@ kubectl create secret generic nomad-gossip-encryption-key \
 --from-literal=gossip-key=<secret-key-32-chars>
 ----
 +
-You must then provide the following to the values.yaml file:
-+
-[source,yaml]
-----
-nomad:
-  server:
-    gossip:
-      encryption:
-        key: "" # "" indicates the secret nomad-gossip-encryption-key already exists
-----
+Once the secret exists no changes to values.yaml is required. The secret will be referenced by default.
 
 * *Option 2 - CircleCI creates the secret*
 +


### PR DESCRIPTION
# Description

In a situation when a customer chooses to manually create the `nomad-gossip-encryption-key` secret, no changes to the default values is needed. This PR simply clarifies the documentation.

# Reasons

See https://circleci.atlassian.net/browse/SERVER-1942.

Also related to https://github.com/circleci/server/pull/6710.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
