### PR TITLE
[DD-747] Remove links with `index.html` in it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ src-shared/
 
 # output for docs-platform
 json/
+
+# output from building API doc
+src-api/index.html
+src-api/openapi-final.json
+src-api/openapi-with-examples.json
+src-api/openapi.json

--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -320,8 +320,8 @@ ifndef::env-aws[]
 
 ===== GCP
 . Create a service account for Nomad Autoscaler
-  * Our link:https://github.com/CircleCI-Public/server-terraform/tree/main/nomad-gcp[nomad module] creates a service acount and outputs a file with the keys if you set the variables `nomad_auto_scaler = true` and `enable_workload_identity = false`. You may reference the examples in the link for more details. If you have already created the clients, simply update the variable and run `terraform apply`. The created user's key will be available in a file named `nomad-as-key.json`. If you are using GKE link:https://circleci.com/docs/server-3-install-prerequisites/index.html#enabling-workload-identity-in-gke[Workload Identities], set the variables `nomad_auto_scaler = true` and `enable_workload_identity = true`.
-  * You may also create a nomad gcp service account manually. The service account will need the role `compute.admin`. It will also need the role `iam.workloadIdentityUser` if using link:https://circleci.com/docs/server-3-install-prerequisites/index.html#enabling-workload-identity-in-gke[Workload identities]
+  * Our link:https://github.com/CircleCI-Public/server-terraform/tree/main/nomad-gcp[nomad module] creates a service acount and outputs a file with the keys if you set the variables `nomad_auto_scaler = true` and `enable_workload_identity = false`. You may reference the examples in the link for more details. If you have already created the clients, simply update the variable and run `terraform apply`. The created user's key will be available in a file named `nomad-as-key.json`. If you are using GKE link:https://circleci.com/docs/server-3-install-prerequisites#enabling-workload-identity-in-gke[Workload Identities], set the variables `nomad_auto_scaler = true` and `enable_workload_identity = true`.
+  * You may also create a nomad gcp service account manually. The service account will need the role `compute.admin`. It will also need the role `iam.workloadIdentityUser` if using link:https://circleci.com/docs/server-3-install-prerequisites#enabling-workload-identity-in-gke[Workload identities]
 . Set Nomad Autoscaler to `enabled`
 . Set Maximum Node Count*
 . Set Minimum Node Count*
@@ -331,7 +331,7 @@ ifndef::env-aws[]
 . Instance group type: link:https://cloud.google.com/compute/docs/instance-groups/#types_of_managed_instance_groups[Zonal or Regional].
 . You can choose one of the following:
 .. JSON of GCP service account for Nomad Autoscaler
-.. Or, the Nomad Autoscaler Service Account Email Address if using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identities]. Steps to enable Workload Identities on GCP cluster are link:https://circleci.com/docs/server-3-install-prerequisites/index.html#enabling-workload-identity-in-gke[here].
+.. Or, the Nomad Autoscaler Service Account Email Address if using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identities]. Steps to enable Workload Identities on GCP cluster are link:https://circleci.com/docs/server-3-install-prerequisites#enabling-workload-identity-in-gke[here].
 .. Enable workload identity for `nomad-autoscaler` (kubernetes) service account
 ```shell
 gcloud iam service-accounts add-iam-policy-binding <YOUR_SERVICE_ACCOUNT_EMAIL> \
@@ -720,7 +720,7 @@ gcloud iam service-accounts keys create circleci-server-vm-keyfile --iam-account
 
 . *Enable Workload Identity for Service Account*
 +
-This step is required only if you are using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identities] for GKE. Steps to enable Workload Identities are link:https://circleci.com/docs/server-3-install-prerequisites/index.html#enabling-workload-identity-in-gke[here]
+This step is required only if you are using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identities] for GKE. Steps to enable Workload Identities are link:https://circleci.com/docs/server-3-install-prerequisites#enabling-workload-identity-in-gke[here]
 +
 ```shell
 gcloud iam service-accounts add-iam-policy-binding <YOUR_SERVICE_ACCOUNT_EMAIL> \

--- a/jekyll/_cci2/server-3-install-prerequisites.adoc
+++ b/jekyll/_cci2/server-3-install-prerequisites.adoc
@@ -673,7 +673,7 @@ gcloud iam service-accounts keys create circleci-server-keyfile \
 
 . Enable workload Identity
 +
-This step is required only if you are using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identities] for GKE. Steps to enable Workload Identities are link:https://circleci.com/docs/server-3-install-prerequisites/index.html#enabling-workload-identity-in-gke[here]
+This step is required only if you are using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identities] for GKE. Steps to enable Workload Identities are link:https://circleci.com/docs/server-3-install-prerequisites#enabling-workload-identity-in-gke[here]
 +
 ```shell
 gcloud iam service-accounts add-iam-policy-binding <YOUR_SERVICE_ACCOUNT_EMAIL> \

--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -61,7 +61,7 @@ kubectl kots install circleci-server --http-proxy <YOUR_HTTP_PROXY_URI> --https-
 
 The load balancer endpoints must be added to the no-proxy list for the following services: `output processor` and `vm-service`. This is because the no-proxy list is shared between the application and build-agent. The application and build-agent are assumed to be behind the same firewall and therefore cannot have a proxy between them.
 
-For further information see the https://circleci.com//docs/server-3-operator-proxy/index.html[Configuring a Proxy] guide.
+For further information see the https://circleci.com/docs/server-3-operator-proxy[Configuring a Proxy] guide.
 
 === Frontend Settings
 Frontend settings control the web-application-specific aspects of the CircleCI system.

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -7,7 +7,7 @@ en:
         - name: Welcome
           link: /
         - name: Sign Up and Try
-          link: /first-steps
+          link: first-steps
         - name: About CircleCI
           link: about-circleci
         - name: Concepts


### PR DESCRIPTION
# Description
- Remove internal links that have `index.html` in it
- Cleanup `sidenav.yml` where one link had an extra `/` 

# Reasons
Some internal links have `index.html` in them which triggers an extra set of redirects to route the user to the right place. This PR removes them to optimize users' experience.  

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
