### PR TITLE
Change jest example to remove ./reports/junit/

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -137,9 +137,9 @@ steps:
       name: Run tests with JUnit as reporter
       command: jest --ci --runInBand --reporters=default --reporters=jest-junit
       environment:
-        JEST_JUNIT_OUTPUT_DIR: ./reports/junit/
+        JEST_JUNIT_OUTPUT_DIR: ./reports/
   - store_test_results:
-      path: ./reports/junit/
+      path: ./reports/
 ```
 
 For a full walkthrough, refer to this article by Viget: [Using JUnit on CircleCI 2.0 with Jest and ESLint](https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint). Note that usage of the jest cli argument `--testResultsProcessor` in the article has been superseded by the `--reporters` syntax, and JEST_JUNIT_OUTPUT has been replaced with `JEST_JUNIT_OUTPUT_DIR` and `JEST_JUNIT_OUTPUT_NAME`, as demonstrated above.


### PR DESCRIPTION
# Description
Jest example is being changed to remove the folder as it causes issues

# Reasons
A customer has explained with examples that setting the folder in that way causes issues.

https://circleci.zendesk.com/agent/tickets/112947

They have also explained that this is outlined in the following support article

https://support.circleci.com/hc/en-us/articles/360021624194?input_string=store_test_results+with+jest+shows+no+results+in+the+%22tests%22+tab+despite+valid+junit.xml

# Content Checklist
N/A formatting is not changed
