### PR TITLE
We do not support config.yaml only config.yml

### DIFF
--- a/jekyll/_cci2/introduction-to-yaml-configurations.adoc
+++ b/jekyll/_cci2/introduction-to-yaml-configurations.adoc
@@ -15,14 +15,14 @@ version:
 :toc: macro
 :toc-title:
 
-The crux of connecting CircleCI to your project is a `config.yaml` file (can also be `config.yml`), which is held in a `.circleci` directory. CircleCI configuration files are written in https://yaml.org/[YAML], a more human-friendly data serialization format for programming languages. YAML is a strict superset of JSON, so anything you can do in JSON, you can also do in YAML. CircleCI YAML configurations will largely consist of key-value pairs, and nested key-value pairs.
+The crux of connecting CircleCI to your project is a `config.yml`, which is held in a `.circleci` directory. CircleCI configuration files are written in https://yaml.org/[YAML], a more human-friendly data serialization format for programming languages. YAML is a strict superset of JSON, so anything you can do in JSON, you can also do in YAML. CircleCI YAML configurations will largely consist of key-value pairs, and nested key-value pairs.
 
 The most basic configuration file will need a CircleCI version, an execution environment, and a job to run.
 
 [#circleci-version]
 == CircleCI version
 
-Your `.circleci/config.yaml` will start off with the version of CircleCI you wish to use. CircleCI cloud and newer server versions should be using CircleCI `2.1`.
+Your `.circleci/config.yml` will start off with the version of CircleCI you wish to use. CircleCI cloud and newer server versions should be using CircleCI `2.1`.
 
 ```yaml
 # CircleCI configuration file
@@ -46,7 +46,7 @@ Next, your configuration needs a job to run, and an execution environment for th
 
 There are some limitations depending on the execution environment in your configuration. Please visit the <<executor-intro#,Introduction to Execution Environments>> page to get started in that section of our documentation, which has extensive information on each execution environment.
 
-In the `.circleci/config.yaml` file, we will add a Docker execution environment to our job `build`.
+In the `.circleci/config.yml` file, we will add a Docker execution environment to our job `build`.
 
 ```yaml
 # CircleCI configuration file
@@ -178,7 +178,7 @@ simulation:
 [#anchors-and-aliases]
 === Anchors and aliases
 
-To https://en.wikipedia.org/wiki/Don%27t_repeat_yourself[DRY] up your `.circleci/config.yaml`, use anchors and aliases. Anchors are identified by an `&` character, and aliases by an `*` character.
+To https://en.wikipedia.org/wiki/Don%27t_repeat_yourself[DRY] up your `.circleci/config.yml`, use anchors and aliases. Anchors are identified by an `&` character, and aliases by an `*` character.
 
 ```yaml
 song:


### PR DESCRIPTION
# Description
config.yaml replaced with config.yml

# Reasons
A customer was using config.yaml and it broke their config

https://circleci.zendesk.com/agent/tickets/113201

# Content Checklist
N/A only text changes
