### PR TITLE
Update Runner docs with simplified steps to delete a resource class

### DIFF
--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -76,18 +76,10 @@ Yes, by running multiple replicas of the `launch-agent` with unique names, it is
 [#can-i-delete-self-hosted-runner-resource-classes]
 == Can I delete self-hosted runner resource classes?
 
-Yes, self-hosted runner resource classes can be deleted through the <<local-cli#,CLI>>. Please be sure you want to permanently delete the resource class, as this action cannot be undone.
-
-Before you can delete the resource class, any tokens associated with the resource class will need to be deleted first.
+Yes, self-hosted runner resource classes can be deleted through the <<local-cli#,CLI>>. Please be sure you want to permanently delete the resource class and its associated tokens, as this action cannot be undone.
 
 ```bash
-circleci runner token delete <token-id>
-```
-
-Once the tokens have been deleted, you can delete the resource class.
-
-```bash
-circleci runner resource-class delete <resource-class>
+circleci runner resource-class delete <resource-class> --force
 ```
 
 If you have lost your token, you can use the CLI to retrieve the token in order to delete it:


### PR DESCRIPTION
# Description
Update Runner docs with simplified steps to delete a resource class.

After this [PR to the CLI](https://github.com/CircleCI-Public/circleci-cli/pull/748), a new `--force` flag was added to the `circleci runner resource-class delete` command that will delete the resource class and any associated tokens in one step.

# Reasons
Jira: https://circleci.atlassian.net/browse/RT-295

# Content Checklist
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
