### PR TITLE
Remove reference to tokens for deleting Runner resource class

### DIFF
--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -82,12 +82,6 @@ Yes, self-hosted runner resource classes can be deleted through the <<local-cli#
 circleci runner resource-class delete <resource-class> --force
 ```
 
-If you have lost your token, you can use the CLI to retrieve the token in order to delete it:
-
-```bash
-circleci runner token list <resource_class>
-```
-
 [#who-can-create-delete-and-view-self-hosted-runner-resource-classes]
 == Who can create, delete, and view self-hosted runner resource classes?
 


### PR DESCRIPTION
# Description
Just realized I missed this bit in [my last PR](https://github.com/circleci/circleci-docs/pull/7097) about getting runner tokens for deletion which doesn't make much sense in context of the simplified resource class deletion method...

# Reasons
Jira: https://circleci.atlassian.net/browse/RT-295

# Content Checklist

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
