### PR TITLE
[SERVER-1954] Remove references to prometheus

### DIFF
--- a/jekyll/_cci2/server/installation/migrate-from-server-3-to-server-4.adoc
+++ b/jekyll/_cci2/server/installation/migrate-from-server-3-to-server-4.adoc
@@ -144,6 +144,7 @@ Below are the changes you should expect to see in `helm-diff` output:
 * Secret and annotation for `distributor-*` deployments are deleted
 * Upstream chart `postgresql` is updated
 * Upsteam charts will be recreated (delete and create):
+** prometheus (circleci-server-kube-state-metrics, node-exporter,prometheus-server)
 ** mongodb
 ** rabbitmq
 ** redis (redis-master, redis-slave)

--- a/jekyll/_cci2/server/installation/migrate-from-server-3-to-server-4.adoc
+++ b/jekyll/_cci2/server/installation/migrate-from-server-3-to-server-4.adoc
@@ -144,7 +144,6 @@ Below are the changes you should expect to see in `helm-diff` output:
 * Secret and annotation for `distributor-*` deployments are deleted
 * Upstream chart `postgresql` is updated
 * Upsteam charts will be recreated (delete and create):
-** prometheus (circleci-server-kube-state-metrics, node-exporter,prometheus-server)
 ** mongodb
 ** rabbitmq
 ** redis (redis-master, redis-slave)

--- a/jekyll/_cci2/server/operator/using-metrics.adoc
+++ b/jekyll/_cci2/server/operator/using-metrics.adoc
@@ -26,14 +26,6 @@ toc::[]
 === Scope
 Your CircleCI server installation collects a number of metrics and logs by default, which can be useful in monitoring the health of your system and debugging issues with your installation.
 
-NOTE: Data is retained for a maximum of 15 days.
-
-NOTE: Prometheus Server is not limited to scraping metrics from your CircleCI server install. By default, it scrapes metrics from your entire cluster. You may disable Prometheus from within the KOTS Admin Console config if needed.
-
-[#prometheus]
-=== Prometheus
-https://prometheus.io/[Prometheus] is a leading monitoring and alerting system for Kubernetes. Server 4.x ships with a basic implementation of monitoring common performance metrics.
-
 [#telegraph]
 === Telegraf
 Most services running on server report StatsD metrics to the https://www.influxdata.com/time-series-platform/telegraf/[Telegraf] pod running in server.


### PR DESCRIPTION
# Description

By default we ship with telegraf which provides aggregated component metrics in prometheus format. The telegraf pod can be scraped if needed but including Prometheus as part of the server stack is out of scope so let's leave it disabled.

# Reasons

https://circleci.atlassian.net/browse/SERVER-1954

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
