### PR TITLE
[DD-734] Add `HTMLEntities` to force decoding html character

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "kramdown-parser-gfm"
 gem "liquid-c"
 gem 'nokogiri', '~> 1.13'
 gem 'htmlcompressor'
+gem 'htmlentities', '~> 4.3', '>= 4.3.4'
 
 group :jekyll_plugins do
   gem 'jekyll-algolia', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     htmlcompressor (0.4.0)
+    htmlentities (4.3.4)
     http_parser.rb (0.6.0)
     httparty (0.18.1)
       mime-types (~> 3.0)
@@ -184,6 +185,7 @@ DEPENDENCIES
   dotenv
   html-proofer
   htmlcompressor
+  htmlentities (~> 4.3, >= 4.3.4)
   jekyll (~> 4.2.0)!
   jekyll-algolia (~> 1.0)
   jekyll-asciidoc!

--- a/jekyll/_plugins/json_pages.rb
+++ b/jekyll/_plugins/json_pages.rb
@@ -1,4 +1,5 @@
 require 'htmlcompressor'
+require 'htmlentities'
 
 def doc_to_json(document, site)
   puts 'processing json for: ' + document.relative_path
@@ -8,6 +9,10 @@ def doc_to_json(document, site)
   output = document.data.dup
   output['content'] = compressor.compress(document.content)
   output['file_name'] = document.relative_path
+
+  # cleanup title from all HTML encoding introduced by asciidoc
+  # see here for more info: https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/
+  output['title'] = HTMLEntities.new.decode document.data['title']
 
   # get output path
   jsonPath = site.source + '/../json/pages/'


### PR DESCRIPTION
Ticket: [DD-734](https://circleci.atlassian.net/browse/DD-734)

# Description
- Use `HTMLEntities.new.decode` on the document title before it goes to the JSON file

# Reasons
In Asciidoc, titles are automatically escaped with HTML encoding which is then reflected on the site. This PR forces to decode the title before writing it to the HTML. More info here: https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/

# Before
<img width="500" alt="Screen Shot 2022-07-19 at 6 46 20 PM" src="https://user-images.githubusercontent.com/1449325/179878249-22ca10e0-e064-415d-aced-908e92700d3a.png">

# After
<img width="450" alt="Screen Shot 2022-07-19 at 6 45 40 PM" src="https://user-images.githubusercontent.com/1449325/179878310-e977c8a9-35d8-4744-aafd-4b6d129fad08.png">