### PR TITLE
[DD-763] Prism wrapping / scrolling: change capital C to little c

### DIFF
--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -149,7 +149,7 @@ This section describes how to get [core dumps](http://man7.org/linux/man-pages/m
 
 2. Create a `main.c` file with the following lines.
 
-     ```C
+     ```c
      #include <stdlib.h>
 
      int main(int argc, char **argv) {

--- a/src/styles/prism/_theme.scss
+++ b/src/styles/prism/_theme.scss
@@ -19,6 +19,7 @@
   color: #ffffff;
   background-color: #2B2B2B;
   white-space: pre-wrap !important;
+	word-wrap: break-word;
 }
 
 pre[class*="language-"],


### PR DESCRIPTION
# Description
[DD-763](https://circleci.atlassian.net/browse/DD-763) 

This was discovered during our QA mob session. Please refer to the [mob session spreadsheet](https://docs.google.com/spreadsheets/d/1woo91rYq34wdePSnxfJYMpGzeTfX1KUu3Pu809bc2ZY/edit#gid=1786852033) for examples of pages that are impacted by that issue.

We want to fix some prism display issues. 

## Before
<img width="742" alt="Screen Shot 2022-07-20 at 12 18 37 PM" src="https://user-images.githubusercontent.com/86666932/180032725-8086c962-ff9d-4d15-a3da-fa90a05ddcd7.png">


## After
<img width="754" alt="Screen Shot 2022-07-20 at 12 23 41 PM" src="https://user-images.githubusercontent.com/86666932/180033683-bf0d54f8-0dd2-48d4-b3b6-d4482b6b1415.png">

