### PR TITLE
Clarification on "without failing"

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -876,7 +876,7 @@ A value of `on_fail` means that the step will run only if one of the preceding s
 ###### Ending a job from within a `step`
 {: #ending-a-job-from-within-a-step }
 
-A job can exit without failing by using `run: circleci-agent step halt`. This can be useful in situations where jobs need to conditionally execute.
+A job can exit without failing by using `run: circleci-agent step halt`. However, if a step within the job is already failing then the job will continue to fail. This can be useful in situations where jobs need to conditionally execute.
 
 Here is an example where `halt` is used to avoid running a job on the `develop` branch:
 


### PR DESCRIPTION
This is to clarify that an already failing job will still fail when calling `circleci-agent step halt`

# Description
Clarification of `step halt`.

# Reasons
The current wording is misleading and implies that `step halt` will cause a job to result in `Success` even if a step is already failing. This is not the case, and the job will still fail.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [*] Break up walls of text by adding paragraph breaks.
- [*] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [*] Keep the title between 20 and 70 characters.
- [*] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [*] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [*] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [*] Include relevant backlinks to other CircleCI docs/pages.
