### PR TITLE
Add in AWS command to create SSH rule between VM service instances and nomad clients

### DIFF
--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -526,13 +526,13 @@ aws ec2 describe-subnets --subnet-ids=<NOMAD_SUBNET_ID>
 [source,shell]
 ----
 # add a security group allowing docker access from nomad clients, to VM instances
-aws ec2 authorize-security-group-ingress --group-id "<SECURITY_GROUP_ID>" --protocol tcp --port 2376 --cidr "<SUBNET_IPV4_CIDR>"
+aws ec2 authorize-security-group-ingress --group-id "<VM_SECURITY_GROUP_ID>" --protocol tcp --port 2376 --cidr "<SUBNET_IPV4_CIDR>"
 ----
 +
 [source,shell]
 ----
 # add a security group allowing SSH access from nomad clients, to VM instances
-aws ec2 authorize-security-group-ingress --group-id "<SECURITY_GROUP_ID>" --protocol tcp --port 22 --cidr "<SUBNET_IPV4_CIDR>"
+aws ec2 authorize-security-group-ingress --group-id "<VM_SECURITY_GROUP_ID>" --protocol tcp --port 22 --cidr "<SUBNET_IPV4_CIDR>"
 ----
 
 . *Apply the security group for SSH (If using public IPs for machines)*
@@ -541,7 +541,7 @@ If using public IPs for VM service instances, run the following command to apply
 +
 [source,shell]
 ----
-aws ec2 authorize-security-group-ingress --group-id "<SECURITY_GROUP_ID>" --protocol tcp --port 54782 --cidr "0.0.0.0/0"
+aws ec2 authorize-security-group-ingress --group-id "<VM_SECURITY_GROUP_ID>" --protocol tcp --port 54782 --cidr "0.0.0.0/0"
 ----
 
 [#set-up-authentication]

--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -502,19 +502,19 @@ This outputs a GroupID to be used in the next steps:
 +
 [source, json]
 {
-    "GroupId": "<SECURITY_GROUP_ID>"
+    "GroupId": "<VM_SECURITY_GROUP_ID>"
 }
 
 . *Apply security group Nomad*
 +
-Use the security group you just created and CIDR block values to apply the security group to the following:
+Use the security group you just created and CIDR block values to apply the security group to the following. This will allow the VM service in your cluster to communicate on port 22 with created EC2 instances.
 +
 [source,shell]
 ----
-aws ec2 authorize-security-group-ingress --group-id "<SECURITY_GROUP_ID>" --protocol tcp --port 22 --cidr "<SERVICE_IPV4_CIDR>"
+aws ec2 authorize-security-group-ingress --group-id "<VM_SECURITY_GROUP_ID>" --protocol tcp --port 22 --cidr "<SERVICE_IPV4_CIDR>"
 ----
 +
-For each https://github.com/CircleCI-Public/server-terraform/blob/main/nomad-aws/variables.tf#L1-L11[subnet] used by the nomad clients, find it's subnet cidr block add a rule with the following commands.
+For each https://github.com/CircleCI-Public/server-terraform/blob/main/nomad-aws/variables.tf#L1-L11[subnet] used by the nomad clients, find it's subnet cidr block add two rules with the following commands.
 +
 Find the subnet cidr block with this command
 +
@@ -525,12 +525,19 @@ aws ec2 describe-subnets --subnet-ids=<NOMAD_SUBNET_ID>
 +
 [source,shell]
 ----
+# add a security group allowing docker access from nomad clients, to VM instances
 aws ec2 authorize-security-group-ingress --group-id "<SECURITY_GROUP_ID>" --protocol tcp --port 2376 --cidr "<SUBNET_IPV4_CIDR>"
 ----
-
-. *Apply the security group for SSH*
 +
-Run the following command to apply the security group rules so users can SSH into their jobs:
+[source,shell]
+----
+# add a security group allowing SSH access from nomad clients, to VM instances
+aws ec2 authorize-security-group-ingress --group-id "<SECURITY_GROUP_ID>" --protocol tcp --port 22 --cidr "<SUBNET_IPV4_CIDR>"
+----
+
+. *Apply the security group for SSH (If using public IPs for machines)*
++
+If using public IPs for VM service instances, run the following command to apply the security group rules so users can SSH into their jobs:
 +
 [source,shell]
 ----


### PR DESCRIPTION
# Description
This PR adds in an AWS command that creates an ingress rule between the spun up VMs of VM service in EC2, and the nomad clients' subnet CIDR range.

# Reasons
This is a necessary requirement for VM service to work.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
