### PR TITLE
Update curl command/resolve issue 7133

### DIFF
--- a/jekyll/_cci2/selecting-a-workflow-to-run-using-pipeline-parameters.adoc
+++ b/jekyll/_cci2/selecting-a-workflow-to-run-using-pipeline-parameters.adoc
@@ -67,9 +67,9 @@ In this example, the workflow named `report` would run. Remember to substitute <
 [source,shell]
 ----
 curl -X POST https://circleci.com/api/v2/project/{project-slug}/pipeline \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json' \
-  -H 'Circle-Token: API_KEY' \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "Circle-Token: API_KEY" \
   -d '{ "parameters": { "action": report } }'
 ----
 


### PR DESCRIPTION
# Description
Update curl command to use double quotes as single quotes are not compatible with Windows. (the -d should fix the one line that still uses single quotes).

# Reasons
[Issue 7133](https://github.com/circleci/circleci-docs/issues/7133)
