### PR TITLE
Adding instructions for AWS Certificate Manager

### DIFF
--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -369,6 +369,21 @@ gcloud projects add-iam-policy-binding <PROJECT_ID> \
 certbot certonly --dns-google --dns-google-credentials <KEY_FILE> -d "<CIRCLECI_SERVER_DOMAIN>" -d "app.<CIRCLECI_SERVER_DOMAIN>"
 ----
 
+[#aws-certmanager]
+=== AWS Certificate Manager
+Instead of provisioning your own TLS certificates, if you're setting up circleci-server in an AWS environment, you can have AWS provision TLS certificates using Certificate Manager.
+
+[source,shell]
+----
+aws acm request-certificate \
+  --domain-name <CIRCLECI_SERVER_DOMAIN> \
+  --subject-alternative-names app.<CIRCLECI_SERVER_DOMAIN> \
+  --validation-method DNS \
+  --idempotency-token circle
+----
+
+After running this command, navigate to the Certificate Manager AWS console and follow the wizard to provision the required DNS validation records with Route53. Take note of the ARN of the certificate once it is issued.
+
 endif::env-aws[]
 
 [#encryption-signing-keys]


### PR DESCRIPTION
# Description
Adds in instructions for provisioning certificates using AWS Certificate manager.

# Reasons
We support certificate manager later in the docs, but there is no reference made to it while discussing TLS options earlier in the prerequisites section - this change adds it in.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
