### PR TITLE
Fix Bad URL reference in Trigger Overview page

### DIFF
--- a/jekyll/_cci2/triggers-overview.adoc
+++ b/jekyll/_cci2/triggers-overview.adoc
@@ -42,7 +42,7 @@ image::trigger-pipeline-popup.png[screenshot showing the popup you will see when
 [#run-a-pipeline-using-the-api]
 == Trigger a pipeline using the API
 
-You can trigger a pipeline for a project using the https://circleci.com/api/v2/#operation/triggerPipeline[Trigger a New Pipeline] endpoint. 
+You can trigger a pipeline for a project using the https://circleci.com/docs/api/v2/index.html#operation/triggerPipeline[Trigger a New Pipeline] endpoint. 
 
 . If you have not already, get set up to use API v2 by following the steps in the  <<api-developers-guide#authentication-and-authorization,API Developers Guide>>.
 


### PR DESCRIPTION
# Description
This commit fixes the URL for triggering a pipeline with the API which points to a 404 Page not found.

# Reasons
Self explanatory

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.
