### PR TITLE
docs: add requirements on EKS service account name

### DIFF
--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -488,9 +488,13 @@ Create a new user with programmatic access:
 aws iam create-user --user-name circleci-vm-service
 ```
 +
+[TIP]
+====
 Optionally, vm-service does support the use of a https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[service account role] in place of AWS keys. If you would prefer to use a role, follow these https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[instructions] using the policy in step 6 below.
 **When creating the service account, please ensure the name is set as `vm-service`.**
+
 Once done, you may skip to step 9 which is enabling vm-service in KOTS.
+====
 +
 . *Create policy*
 +

--- a/jekyll/_cci2/server-3-install-build-services.adoc
+++ b/jekyll/_cci2/server-3-install-build-services.adoc
@@ -489,6 +489,7 @@ aws iam create-user --user-name circleci-vm-service
 ```
 +
 Optionally, vm-service does support the use of a https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[service account role] in place of AWS keys. If you would prefer to use a role, follow these https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[instructions] using the policy in step 6 below.
+**When creating the service account, please ensure the name is set as `vm-service`.**
 Once done, you may skip to step 9 which is enabling vm-service in KOTS.
 +
 . *Create policy*


### PR DESCRIPTION
# Description

Adds a note on the hard requirement for the EKS service account name to be `vm-service`.

Currently, this `vm-service` name is hard-coded on CircleCI's end, so users would need to ensure they create a EKS service account with the same name.

# Reasons

Addresses https://circleci.atlassian.net/browse/DOCTEAM-394

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
