### PR TITLE
Update browser-testing.md code example to use version:2.1

### DIFF
--- a/jekyll/_cci2/browser-testing.md
+++ b/jekyll/_cci2/browser-testing.md
@@ -38,7 +38,7 @@ WebDriver can operate in two modes: local or remote. When run locally, your test
 If Selenium is not included in your primary docker image, install and run Selenium as shown below::
 
 ```yaml
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -106,6 +106,7 @@ If you are using JavaScript to test your web application, you can still take adv
 {% raw %}
 ```yaml
 version: 2.1
+
 orbs:
   saucectl: saucelabs/saucectl-run@2.0.0
 
@@ -120,7 +121,6 @@ jobs:
       - saucectl/saucectl-run
 
 workflows:
-  version: 2
   default_workflow:
     jobs:
       - test-cypress


### PR DESCRIPTION
Change config version to 2.1 for Selenium code example.

# Description
Change the config version to 2.1 for Selenium code example as well as adding newlines.

# Reasons
The other code examples on the page reference version: 2.1 and it would be good to unify all of the examples.
