### PR TITLE
Update launch agent install instructions on macos

### DIFF
--- a/jekyll/_cci2/runner-installation-cli.adoc
+++ b/jekyll/_cci2/runner-installation-cli.adoc
@@ -96,7 +96,7 @@ fi
 
 # Set up runner directory
 echo "Setting up CircleCI Runner directory"
-prefix=/opt/circleci
+prefix=/var/opt/circleci
 sudo mkdir -p "${prefix}/workdir"
 
 # Downloading launch agent

--- a/jekyll/_cci2/runner-installation-mac.adoc
+++ b/jekyll/_cci2/runner-installation-mac.adoc
@@ -39,6 +39,15 @@ logging:
   file: /Library/Logs/com.circleci.runner.log
 ```
 
+[#update-workdir-ownership]
+== Update the Working Directory Permission
+
+The CircleCI agent requires write permission to the directory containing the working directory. Change the ownership of that directory to `USERNAME`:
+
+```shell
+sudo chown USERNAME /var/opt/circleci
+```
+
 [#install-the-circleci-self-hosted-runner-configuration]
 == Install the CircleCI self-hosted runner configuration
 
@@ -82,7 +91,7 @@ Copy the following to the new `/Library/LaunchDaemons/com.circleci.runner.plist`
         <string>com.circleci.runner</string>
 
         <key>Program</key>
-        <string>/opt/circleci/circleci-launch-agent</string>
+        <string>/var/opt/circleci/circleci-launch-agent</string>
 
         <key>ProgramArguments</key>
         <array>


### PR DESCRIPTION
# Description

Update the working directory created by the install script to match to the default used elsewhere in the install instructions. Also add a section detailing how to give this directory the correct permissions on MacOS

# Reasons

An internal user was attempting to follow the MacOS install instructions and ran into a permission error

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
