### PR TITLE
[SERVER-2000] Add information about upstream TLS termination

### DIFF
--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -391,8 +391,8 @@ You may have a requirement to terminate TLS for CircleCI Server outside the appl
 CircleCI Server listens on a number of ports which need to be configured depending how your are routing the traffic. See the list of port numbers below:
 
 * Frontend / API Gateway [TCP 80, 443]
-* Nomad Server [TCP 4647]
 * VM Service [TCP 3000]
+* Nomad Server [TCP 4647]
 * Output Processor [gRPC 8585]
 
 Depending on your requirements you may choose to terminate TLS for only the frontend/api-gateway or provide TLS for services listening on all the ports. 

--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -385,7 +385,7 @@ aws acm request-certificate \
 After running this command, navigate to the Certificate Manager AWS console and follow the wizard to provision the required DNS validation records with Route53. Take note of the ARN of the certificate once it is issued.
 
 [#upstream-tls]
-=== Upstream TLS Termination
+=== Upstream TLS termination
 You may have a requirement to terminate TLS for CircleCI Server outside the application. This is an alternate method to using ACM or supplying the certificate chain during Helm deployment. An example would be a proxy running in front of the CircleCI installation providing TLS termination for your domain name. In this case the CircleCI application acts as the backend for your load balancer or proxy.
 
 CircleCI Server listens on a number of ports which need to be configured depending how your are routing the traffic. See the list of port numbers below:

--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -386,14 +386,14 @@ After running this command, navigate to the Certificate Manager AWS console and 
 
 [#upstream-tls]
 === Upstream TLS termination
-You may have a requirement to terminate TLS for CircleCI Server outside the application. This is an alternate method to using ACM or supplying the certificate chain during Helm deployment. An example would be a proxy running in front of the CircleCI installation providing TLS termination for your domain name. In this case the CircleCI application acts as the backend for your load balancer or proxy.
+You may have a requirement to terminate TLS for CircleCI server outside the application. This is an alternate method to using ACM or supplying the certificate chain during Helm deployment. An example would be a proxy running in front of the CircleCI installation providing TLS termination for your domain name. In this case the CircleCI application acts as the backend for your load balancer or proxy.
 
-CircleCI Server listens on a number of ports which need to be configured depending how your are routing the traffic. See the list of port numbers below:
+CircleCI server listens on a number of ports which need to be configured depending how your are routing the traffic. See the list of port numbers below:
 
 * Frontend / API Gateway [TCP 80, 443]
-* VM Service [TCP 3000]
-* Nomad Server [TCP 4647]
-* Output Processor [gRPC 8585]
+* VM service [TCP 3000]
+* Nomad server [TCP 4647]
+* Output processor [gRPC 8585]
 
 Depending on your requirements you may choose to terminate TLS for only the frontend/api-gateway or provide TLS for services listening on all the ports. 
 

--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -384,6 +384,21 @@ aws acm request-certificate \
 
 After running this command, navigate to the Certificate Manager AWS console and follow the wizard to provision the required DNS validation records with Route53. Take note of the ARN of the certificate once it is issued.
 
+[#upstream-tls]
+=== Upstream TLS Termination
+You may have a requirement to terminate TLS for CircleCI Server outside the application. This is an alternate method to using ACM or supplying the certificate chain during Helm deployment. An example would be a proxy running in front of the CircleCI installation providing TLS termination for your domain name. In this case the CircleCI application acts as the backend for your load balancer or proxy.
+
+CircleCI Server listens on a number of ports which need to be configured depending how your are routing the traffic. See the list of port numbers below:
+
+* Frontend / API Gateway [TCP 80, 443]
+* Nomad Server [TCP 4647]
+* VM Service [TCP 3000]
+* Output Processor [gRPC 8585]
+
+Depending on your requirements you may choose to terminate TLS for only the frontend/api-gateway or provide TLS for services listening on all the ports. 
+
+NOTE: The Output Processor service communicates using gRPC and requires the proxy or loadbalancer to support HTTP/2.
+
 endif::env-aws[]
 
 [#encryption-signing-keys]


### PR DESCRIPTION
# Description

We have (and may have more) customers that need to terminate TLS outside the CircleCI application. Adding brief instructions on which CircleCI service binds to which ports to hopefully make this type of TLS configuration a bit less cryptic.  

# Reasons

- [SERVER-2000](https://circleci.atlassian.net/browse/SERVER-2000)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
