### PR TITLE
Do not reference Docker Hub anymore

### DIFF
--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -38,7 +38,7 @@ TIP: Once you have created your namespace, we recommend setting your `kubectl` c
 
 Credentials to pull the images from CircleCI's image registry will be provided to you as part of the onboarding process. A `docker-registry` Kubernetes secret will be used to pull images from Azure Container Registry (ACR). You have two options, depending on whether your application has access to the public internet.
 
-[.tab.azure.Public]
+[.tab.pullimage.Public]
 --
 **Option 1:** Your application has access to the public internet.
 

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -54,7 +54,7 @@ kubectl create secret docker-registry regcred \
 ----
 --
 
-[.tab.azure.Private]
+[.tab.pullimage.Private]
 --
 **Option 2:** Your application does NOT have access to the public internet.
 

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -33,8 +33,8 @@ kubectl create ns <namespace>
 
 TIP: Once you have created your namespace, we recommend setting your `kubectl` context too, with the following command: `kubectl config set-context --current --namespace <namespace>`
 
-[#pull-image-from-azure]
-== 2. Pull Images
+[#pull-images]
+== 2. Pull images
 
 Credentials to pull the images from CircleCI's image registry will be provided to you as part of the onboarding process. A `docker-registry` Kubernetes secret will be used to pull images from Azure Container Registry (ACR). You have two options, depending on whether your application has access to the public internet.
 

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -33,12 +33,12 @@ kubectl create ns <namespace>
 
 TIP: Once you have created your namespace, we recommend setting your `kubectl` context too, with the following command: `kubectl config set-context --current --namespace <namespace>`
 
-[#pull-image-from-dockerhub]
-== 2. Pull image from DockerHub
+[#pull-image-from-azure]
+== 2. Pull Images
 
 Credentials to pull the images from CircleCI's image registry will be provided to you as part of the onboarding process. A `docker-registry` Kubernetes secret will be used to pull images from Azure Container Registry (ACR). You have two options, depending on whether your application has access to the public internet.
 
-[.tab.dockerhub.Public]
+[.tab.azure.Public]
 --
 **Option 1:** Your application has access to the public internet.
 
@@ -54,7 +54,7 @@ kubectl create secret docker-registry regcred \
 ----
 --
 
-[.tab.dockerhub.Private]
+[.tab.azure.Private]
 --
 **Option 2:** Your application does NOT have access to the public internet.
 
@@ -561,7 +561,7 @@ Instead of providing AWS accessKey and secretKey credentials in your values file
 ----
 kubectl create secret generic object-storage-secret \
   --from-literal=s3AccessKey=<access-key> \
-  --from-literal=s3SecretKey=<secret-key> 
+  --from-literal=s3SecretKey=<secret-key>
 ----
 --
 


### PR DESCRIPTION
# Description
Replacing Docker Hub with Azure, but not being overly specific because public images are still hosted in Docker Hub.

# Reasons
https://circleci.atlassian.net/browse/SERVER-2007

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
