### PR TITLE
Minimum k8s version is 1.22 for server 4.0

### DIFF
--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -122,7 +122,7 @@ CircleCI server installs into an existing Kubernetes cluster. The application us
 | Kubernetes Version
 
 | 4.0.0
-| 1.16 - 1.23
+| 1.22 - 1.23
 |===
 
 Creating a Kubernetes cluster is your responsibility. Please note:


### PR DESCRIPTION
Earlier versions will throw an error like this (seen on v1.21):

```
Error: INSTALLATION FAILED: Kubernetes cluster unreachable: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
```