### PR TITLE
Specify postgres in the right place

### DIFF
--- a/jekyll/_cci2/server/operator/configuring-external-services.adoc
+++ b/jekyll/_cci2/server/operator/configuring-external-services.adoc
@@ -30,7 +30,7 @@ postgresql:
   postgresqlPort: <port> # The port of your PostgreSQL instance
 ----
 
-[tab.mongo.Create_secret_yourself]
+[tab.postgres.Create_secret_yourself]
 --
 Create the secret and then add the following values to `values.yaml`:
 


### PR DESCRIPTION
We had mongo specified twice by accident, causing some tab issues
![image](https://user-images.githubusercontent.com/5102611/181773010-26e8dc71-e811-44ee-bfc9-c99d93d21a48.png)
