### PR TITLE
[server-2019] remove external vault docs

### DIFF
--- a/jekyll/_cci2/server/operator/configuring-external-services.adoc
+++ b/jekyll/_cci2/server/operator/configuring-external-services.adoc
@@ -190,17 +190,3 @@ mongodb:
     password: <password>
 ----
 --
-
-[#vault]
-== Vault
-
-If you choose to use an external Vault instance, add the following to your `values.yaml` file.
-
-[source,yaml]
-----
-vault:
-  internal: false
-  url: <protocol://host:port> # The URL to your Vault service.
-  transitPath: <transit-path> # Your Vault secrets transit path.
-  token: <token> # The access token for Vault.
-----


### PR DESCRIPTION
# Description
new customers are not presented the option to use external vault

for existing customers we have internal docs on how to support them [here](https://support.circleci.com/hc/en-us/articles/7705503434011?page=1#comment_7706384164507)