### PR TITLE
Fix: remove unnecessary p-tag

### DIFF
--- a/jekyll/_cci2_ja/concepts.md
+++ b/jekyll/_cci2_ja/concepts.md
@@ -47,7 +47,7 @@ CircleCI の設定はお客様のプロジェクトの様々なニーズに合�
 
 下記では、
 
-Java アプリケーション例を用いてさまざまな設定要素を紹介します。</p> 
+Java アプリケーション例を用いてさまざまな設定要素を紹介します。
 
 ![設定要素]({{ site.baseurl }}/assets/img/docs/config-elements.png)
 


### PR DESCRIPTION
# Description
Fix for removing unnecessary p-tag. 

# Reasons

This was determined to be unnecessary because only the end of the P tag remained.
I have confirmed that the `</p>` does not show up in the markdown preview on GitHub, but `</p>` does show up on https://circleci.com/docs/ja/concepts.

<img src="https://user-images.githubusercontent.com/37968814/181917419-b5eb5cc4-f591-4fff-a222-3bd42de26353.png" width=500>

https://circleci.com/docs/ja/concepts#configuration

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
