### PR TITLE
Fix incorrect link

### DIFF
--- a/jekyll/_cci2/server-3-install.adoc
+++ b/jekyll/_cci2/server-3-install.adoc
@@ -86,16 +86,20 @@ cat /etc/letsencrypt/live/<CIRCLECI_SERVER_DOMAIN>/privkey.pem
 ```bash
 cat /etc/letsencrypt/live/<CIRCLECI_SERVER_DOMAIN>/fullchain.pem
 ```
+* *Private Load Balancer (optional)* - Load balancer does not generate external IP addresses.
++
+NOTE: If you are selecting the option to use private load balancers, the Let's Encrypt option will no longer work and become unavailable.
 
-****
 For the **Frontend TLS private key and certificate** you have 4 options: 
 
 * You can supply a private key and certificate
 * Check the box that allows https://letsencrypt.org/[Let's Encrypt] to automatically request and manage certificates for you. 
-* Check the box that allows https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html[AWS Certificate Manager (ACM)] to automatically request and manage certificates for you. For more information about using ACM see the [CircleCI Server v3.x Operator Certificates] guide.
+* Check the box that allows https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html[AWS Certificate Manager (ACM)] to automatically request and manage certificates for you. For more information about using ACM see the <<using-acm-tls-certificates>> section below.
 * You can also disable TLS termination at this point, but the system will still need to be accessed over HTTPS.
 
-**Using ACM TLS Certificates**
+
+[#using-acm-tls-certificates]
+==== Using ACM TLS certificates
 
 If you would like to use https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html[AWS Certificate Manager (ACM)] to manage your TLS certificates, follow the https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html[ACM documentation] for instructions on how to generate ACM certificates.
 
@@ -106,12 +110,6 @@ Once you have generated your certificates, enable ACM from the KOTS admin consol
 If you have already deployed CircleCI server, enabling ACM is a destructive change to your frontend service. The service will have to be regenerated to allow the use of your ACM certificates and so the associated loadbalancer will also be regenerated. 
 You will need to reroute your DNS records to the new loadbalancer once you have redeployed CircleCI server.
 ====
-
-****
-
-* *Private Load Balancer (optional)* - Load balancer does not generate external IP addresses.
-+
-NOTE: If you are selecting the option to use private load balancers, the Let's Encrypt option will no longer work and become unavailable.
 
 === Encryption
 


### PR DESCRIPTION
# Description
The start of a link to a page that does not exist yet was left in a server three install doc. This PR points the link to the section on the page instead.

# Reasons

https://circleci.atlassian.net/browse/DOCTEAM-702?atlOrigin=eyJpIjoiMDYwNGViNzYyYWQ5NGQ3ZWI4OWFlZjZkMmE3NDk1ZWIiLCJwIjoiaiJ9

Please follow our style when contributing to CircleCI docs. Our style guide is here: https://circleci.com/docs/style-guide-overview/.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
