### PR TITLE
Specify the registry for server 4.x installs

### DIFF
--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -22,6 +22,9 @@ The below is an example manifest of the necessary parameters for an installation
 global:
   domainName: "<full-domain-name-of-your-install>"
   license: '<license>'
+  container:
+    registry: cciserver.azurecr.io
+    org:
 
 apiToken: "<circleci-api-token>"
 sessionCookieKey: "<session-cookie-key>"
@@ -92,6 +95,9 @@ The below is an example manifest of the necessary parameters for an installation
 global:
   domainName: "<full-domain-name-of-your-install>"
   license: '<license-for-circleci-server>'
+  container:
+    registry: cciserver.azurecr.io
+    org:
 
 apiToken: "<circleci-api-token>"
 sessionCookieKey: "<session-cookie-key>"
@@ -152,9 +158,9 @@ nomad:
 [.table.table-striped]
 [cols=4*, options="header"]
 |===
-| Key 
-| Type 
-| Default 
+| Key
+| Type
+| Default
 | Description
 
 | apiToken
@@ -229,7 +235,7 @@ nomad:
 
 | github
 | object
-a| 
+a|
 [source,yaml]
 ----
 {


### PR DESCRIPTION
The tricky part is specifying the org as null
and we don't want customers to be confused.

(Also some whitespace)

Question: do we want to just specify `<registry>` and it will be provided to them? I'm unclear how much information is provided them with the license.