### PR TITLE
Updated about-circleci.md - Moved GKE to a dedicated bullet point.

### DIFF
--- a/jekyll/_cci2/about-circleci.md
+++ b/jekyll/_cci2/about-circleci.md
@@ -37,7 +37,8 @@ CircleCI then sends an email notification of success or failure after the tests 
 CircleCI may be configured to deploy code to various environments, including:
 - AWS CodeDeploy
 - AWS EC2 Container Service (ECS)
-- AWS S3, Google Kubernetes Engine (GKE)
+- AWS S3
+- Google Kubernetes Engine (GKE)
 - Microsoft Azure
 - Heroku
 


### PR DESCRIPTION
# Description
Moved GKE to a dedicated bullet point. 

# Reasons
There is no reason to group GKE with AWS S3 in one bullet point.