### PR TITLE
[SERVER-2000] Update info for upstream TLS termination (core instructions)

### DIFF
--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -418,7 +418,13 @@ You will need to update your DNS records to the new loadbalancer once you have r
 --
 *Disable TLS within CircleCI*
 
-You can choose to disable TLS termination within CircleCI. The system will still need to be accessed over HTTPS, so TLS termination will be required somewhere upstream of CircleCI. Implement this by following the first option (do nothing) and forward to CircleCI on port 80 after terminating TLS.
+You can choose to disable TLS termination within CircleCI. The system will still need to be accessed over HTTPS, so TLS termination will be required somewhere upstream of CircleCI. Implement this by following the first option (do nothing) and forward the following ports to your CircleCI load balancer:
+
+* Frontend / API Gateway [TCP 80, 443]
+* VM service [TCP 3000]
+* Nomad server [TCP 4647]
+* Output processor [gRPC 8585]
+
 --
 
 [#github-integration]


### PR DESCRIPTION
# Description

An update to the upstream TLS termination section was missed the first time around. Adding the small changes to this PR to stay consistent with what we have in the pre-reqs section. See https://github.com/circleci/circleci-docs/commit/37129734ed021c9ec53677546d651e1f4f030139.

# Reasons
- [SERVER-2000](https://circleci.atlassian.net/browse/SERVER-2000)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
