### PR TITLE
Update the runner Linux installation docs

### DIFF
--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -22,7 +22,7 @@ toc::[]
 Save the link:https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh[launch-agent.sh] script file to an easily accessible location. From that location, install the launch agent binary for your target platform, either x86_64, or ARM64:
 
 ```shell
-curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh --output ./download-launch-agent.sh
+curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent --output ./download-launch-agent.sh
 ```
 
 ```shell
@@ -75,7 +75,7 @@ sudo chmod 0750 /var/opt/circleci
 sudo chown -R circleci /var/opt/circleci /opt/circleci/circleci-launch-agent
 ```
 
-Consider running the following additional command if you would like to use certified orbs that work on Cloud on your self-hosted runner, without errors. Note that this enables code to execute root commands on your machine, and changes to the system may persist after the job is run.
+Consider running the following additional command if you would like to use certified orbs, without errors, that work on Cloud on your self-hosted runner. Note that this enables code to execute root commands on your machine, and changes to the system may persist after the job is run.
 
 ```shell
 echo "circleci ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers
@@ -112,7 +112,7 @@ runner:
   cleanup_working_directory: true
 ```
 
-- Replace `AUTH_TOKEN` with the resource class token created in the xref:runner-installation.adoc#authentication[Authentication] step.
+- Replace `AUTH_TOKEN` with the resource class token created in the xref:runner-installation#circleci-web-app-installation.adoc[set up process].
 - Replace `RUNNER_NAME` with the name you would like for your self-hosted runner. `RUNNER_NAME` is unique to the the machine that is installing the runner. `RUNNER_NAME` can be any value you would like, and it does not need to include any part of your namespace or resource class name.
 
 [#configure-selinux-policy]
@@ -179,7 +179,7 @@ sudo chown root: /usr/lib/systemd/system/circleci.service
 sudo chmod 755 /usr/lib/systemd/system/circleci.service
 ```
 
-You must ensure that `TimeoutStopSec` is greater than the total amount of time a task will run for - which defaults to 5 hours.
+You must ensure that `TimeoutStopSec` is greater than the total amount of time a task will run for, which defaults to 5 hours.
 
 If you want to configure the CircleCI self-hosted runner installation to start on boot, it is important to note that the launch agent will attempt to consume and start jobs as soon as it starts, so it should be configured appropriately before starting. The launch agent may be configured as a service and be managed by `systemd` with the following scripts:
 
@@ -197,7 +197,7 @@ TimeoutStopSec=18300
 WantedBy = multi-user.target
 ```
 
-Unlike the task agent, which uses the environment of the `circleci` user, the launch agent will need to have any required environment variables (e.g., proxy settings) explicitly defined in the unit configuration file. These can be set by `Environment=` or `EnvironmentFile=`. https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment[Please visit the `systemd` documentation for more information].
+Unlike the task agent, which uses the environment of the `circleci` user, the launch agent will need to have any required environment variables (e.g., proxy settings) explicitly defined in the unit configuration file. These can be set by `Environment=` or `EnvironmentFile=`. Please visit the `systemd` https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment[documentation] for more information.
 
 You can now enable the service:
 

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -22,7 +22,7 @@ toc::[]
 Save the link:https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh[launch-agent.sh] script file to an easily accessible location. From that location, install the launch agent binary for your target platform, either x86_64, or ARM64:
 
 ```shell
-curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent --output ./download-launch-agent.sh
+curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh --output ./download-launch-agent.sh
 ```
 
 ```shell

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -140,7 +140,7 @@ You can now start launch agent as follows:
 sudo /var/opt/circleci/circleci-launch-agent --config /var/opt/circleci/launch-agent-config.yaml
 ```
 
-You can also optionally run launch agent link:#enable-the-systemd-unit[as a systemd service].
+You can also optionally run launch agent <<#enable-the-systemd-unit,as a systemd service>>.
 
 {% include snippets/runner-config-reference.adoc %}
 

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -131,37 +131,18 @@ sudo curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-
 sudo /var/opt/circleci/policy/circleci_launch_agent.sh
 ```
 
+[#start-launch-agent]
+== Start launch agent
+
+You can now start launch agent as follows:
+
+```shell
+sudo /var/opt/circleci/circleci-launch-agent --config /var/opt/circleci/launch-agent-config.yaml
+```
+
+You can also optionally run launch agent link:#enable-the-systemd-unit[as a systemd service].
+
 {% include snippets/runner-config-reference.adoc %}
-
-[#verify-the service-is-running]
-=== Verify the service is running
-
-The system reports a very basic health status through the `status` field in `systemctl`. This will report **Healthy** or **Unhealthy** based on connectivity to the CircleCI APIs.
-
-You can see the status of the agent by running:
-
-```shell
-systemctl status circleci.service --no-pager
-```
-
-Which should produce output similar to:
-
-```
-circleci.service - CircleCI Runner
-   Loaded: loaded (/var/opt/circleci/circleci.service; enabled; vendor preset: enabled)
-   Active: active (running) since Fri 2020-05-29 14:33:31 UTC; 18min ago
- Main PID: 5592 (circleci-launch)
-   Status: "Healthy"
-    Tasks: 8 (limit: 2287)
-   CGroup: /system.slice/circleci.service
-           └─5592 /var/opt/circleci/circleci-launch-agent --config /var/opt/circleci/launch-agent-config.yaml
-```
-
-You can also see the logs for the system by running:
-
-```shell
-journalctl -u circleci
-```
 
 [#enable-the-systemd-unit]
 == Enable the `systemd` unit
@@ -203,14 +184,44 @@ Unlike the task agent, which uses the environment of the `circleci` user, the la
 You can now enable the service:
 
 ```shell
-systemctl enable /var/opt/circleci/circleci.service
+sudo systemctl enable /var/opt/circleci/circleci.service
 ```
 
 [#start-the-service]
-== Start the service
+=== Start the service
 
 When the CircleCI self-hosted runner service starts, it will immediately attempt to start running jobs, so it should be fully configured before the first start of the service.
 
 ```shell
-systemctl start circleci.service
+sudo systemctl start circleci.service
+```
+
+[#verify-the service-is-running]
+=== Verify the service is running
+
+The system reports a very basic health status through the `status` field in `systemctl`. This will report **Healthy** or **Unhealthy** based on connectivity to the CircleCI APIs.
+
+You can see the status of the agent by running:
+
+```shell
+systemctl status circleci.service --no-pager
+```
+
+Which should produce output similar to:
+
+```
+circleci.service - CircleCI Runner
+   Loaded: loaded (/var/opt/circleci/circleci.service; enabled; vendor preset: enabled)
+   Active: active (running) since Fri 2020-05-29 14:33:31 UTC; 18min ago
+ Main PID: 5592 (circleci-launch)
+   Status: "Healthy"
+    Tasks: 8 (limit: 2287)
+   CGroup: /system.slice/circleci.service
+           └─5592 /var/opt/circleci/circleci-launch-agent --config /var/opt/circleci/launch-agent-config.yaml
+```
+
+You can also see the logs for the system by running:
+
+```shell
+journalctl -u circleci
 ```

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -22,33 +22,83 @@ toc::[]
 Save the link:https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh[launch-agent.sh] script file to an easily accessible location. From that location, install the launch agent binary for your target platform, either x86_64, or ARM64:
 
 ```shell
+curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh --output ./download-launch-agent.sh
+```
+
+```shell
+chmod +x ./download-launch-agent.sh
+```
+
+```shell
 # For Linux x86_64:
 export platform=linux/amd64 && sh ./download-launch-agent.sh
+```
 
+```shell
 # For Linux ARM64:
 export platform=linux/arm64 && sh ./download-launch-agent.sh
 ```
 
-After successful installation, the launch-agent.sh file can be deleted.
+After successful installation, the download-launch-agent.sh file can be deleted.
+
+[#create-the-circleci-user-and-working-directory]
+== Create the `circleci` user and working directory
+
+These will be used when executing the task agent. These commands must be run as a user with permissions to create other users (e.g. `root`). For information about GECOS, see the https://en.wikipedia.org/wiki/Gecos_field[wiki page].
+
+[#ubuntu-debian]
+=== Ubuntu/Debian
+
+```shell
+id -u circleci &>/dev/null || sudo adduser --disabled-password --gecos GECOS circleci
+```
+
+[#centos-rhel]
+=== CentOS/RHEL
+
+```shell
+id -u circleci &>/dev/null || sudo adduser -c GECOS circleci
+```
+
+[#create-the-working-directory]
+=== Create the working directory and set permissions
+
+```shell
+sudo mkdir -p /var/opt/circleci
+```
+
+```shell
+sudo chmod 0750 /var/opt/circleci
+```
+
+```shell
+sudo chown -R circleci /var/opt/circleci /opt/circleci/circleci-launch-agent
+```
+
+Consider running the following additional command if you would like to use certified orbs that work on Cloud on your self-hosted runner, without errors. Note that this enables code to execute root commands on your machine, and changes to the system may persist after the job is run.
+
+```shell
+echo "circleci ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers
+```
 
 [#create-the-circleci-self-hosted-runner-configuration]
 == Create the CircleCI self-hosted runner configuration
 
-Create a `launch-agent-config.yaml` file with a path of `/var/opt/circleci/launch-agent-config.yaml`, owned by `root`, with permissions `600`. Use the following commands:
+Create a `launch-agent-config.yaml` file with a path of `/etc/opt/circleci/launch-agent-config.yaml`, owned by `circleci`, with permissions `600`. Use the following commands:
 
 ```shell
-sudo touch /var/opt/circleci/launch-agent-config.yaml
+sudo mkdir -p /etc/opt/circleci && sudo touch /etc/opt/circleci/launch-agent-config.yaml
 ```
 
 ```shell
-sudo chown root: /var/opt/circleci/launch-agent-config.yaml
+sudo chown circleci: /etc/opt/circleci/launch-agent-config.yaml
 ```
 
 ```shell
-sudo chmod 600 /var/opt/circleci/launch-agent-config.yaml
+sudo chmod 600 /etc/opt/circleci/launch-agent-config.yaml
 ```
 
-Copy the following to the new `/var/opt/circleci/launch-agent-config.yaml` file:
+Copy the following to the new `/etc/opt/circleci/launch-agent-config.yaml` file:
 
 ```yaml
 api:
@@ -58,77 +108,41 @@ api:
 
 runner:
   name: RUNNER_NAME
-  command_prefix: ["sudo", "-niHu", "USERNAME", "--"]
   working_directory: /var/opt/circleci/workdir
   cleanup_working_directory: true
 ```
 
 - Replace `AUTH_TOKEN` with the resource class token created in the xref:runner-installation.adoc#authentication[Authentication] step.
 - Replace `RUNNER_NAME` with the name you would like for your self-hosted runner. `RUNNER_NAME` is unique to the the machine that is installing the runner. `RUNNER_NAME` can be any value you would like, and it does not need to include any part of your namespace or resource class name.
-- `USERNAME` is the user on your machine that you want to run the runner launch agent. This is _not_ your CircleCI account username, but the user on the machine that the agent will be installed on.
-
-[#create-the-username-user-and-working-directory]
-== Create the USERNAME user and working directory
-
-These will be used when executing the task agent. These commands must be run as a user with permissions to create other users (e.g. `root`). For information about GECOS, see the https://en.wikipedia.org/wiki/Gecos_field[wiki page].
-
-[#ubuntu-debian]
-=== Ubuntu/Debian
-
-```shell
-id -u USERNAME &>/dev/null || sudo adduser --disabled-password --gecos GECOS USERNAME
-
-sudo mkdir -p /var/opt/circleci/workdir
-sudo chown -R USERNAME /var/opt/circleci/workdir
-sudo chmod 0750 /var/opt/circleci/workdir
-```
-
-Consider running the following additional command if you would like to use certified orbs that work on Cloud on your self-hosted runner, without errors. Note that this enables code to execute root commands on your machine, and changes to the system may persist after the job is run.
-
-```shell
-echo "USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-```
-
-[#centos-rhel]
-=== CentOS/RHEL
-
-```shell
-id -u USERNAME &>/dev/null || sudo adduser -c GECOS USERNAME
-
-sudo mkdir -p /var/opt/circleci/workdir
-sudo chown -R USERNAME /var/opt/circleci/workdir
-sudo chmod 0750 /var/opt/circleci/workdir
-```
-
-Consider running the following additional command if you would like to use certified orbs that work on Cloud on your self-hosted runner, without errors. Note that this enables code to execute root commands on your machine, and changes to the system may persist after the job is run.
-
-```shell
-echo "circleci ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-```
 
 [#configure-selinux-policy]
 == Configure SELinux policy (RHEL 8)
 
 An SELinux policy is required for self-hosted runner to accept and launch jobs on RHEL 8 systems (earlier versions of RHEL are unsupported). Note that this policy does not add any permissions to the ones that may be required by individual jobs on this self-hosted runner install.
 
-Create directory `/var/opt/circleci/policy` and generate the initial policy module:
+Create directory `/etc/opt/circleci/policy` and generate the initial policy module:
 
 ```shell
-sudo mkdir -p /var/opt/circleci/policy
+sudo mkdir -p /etc/opt/circleci/policy
+```
 
+```shell
 # Install sepolicy and rpmbuild if you haven't already
-sudo yum install -y policycoreutils-devel
-sudo yum install -y rpm-build
+sudo yum install -y policycoreutils-devel rpm-build
+```
 
-sudo sepolicy generate --path /var/opt/circleci/policy --init /var/opt/circleci/circleci-launch-agent
+```shell
+sudo sepolicy generate --path /etc/opt/circleci/policy --init /opt/circleci/circleci-launch-agent
 ```
 
 Download the following type enforcing file https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te[`circleci_launch_agent.te`] and install the policy:
 
 ```shell
-sudo curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te --output /var/opt/circleci/policy/circleci_launch_agent.te
+sudo curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te --output /etc/opt/circleci/policy/circleci_launch_agent.te
+```
 
-sudo /var/opt/circleci/policy/circleci_launch_agent.sh
+```shell
+sudo /etc/opt/circleci/policy/circleci_launch_agent.sh
 ```
 
 [#start-launch-agent]
@@ -137,7 +151,7 @@ sudo /var/opt/circleci/policy/circleci_launch_agent.sh
 You can now start launch agent as follows:
 
 ```shell
-sudo /var/opt/circleci/circleci-launch-agent --config /var/opt/circleci/launch-agent-config.yaml
+sudo /opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
 ```
 
 You can also optionally run launch agent <<#enable-the-systemd-unit,as a systemd service>>.
@@ -151,14 +165,18 @@ NOTE: This step is optional.
 
 You will need to have https://systemd.io/[systemd] version 235+ installed for this optional step.
 
-Create `/var/opt/circleci/circleci.service` owned by `root` with permissions `755`.
+Create `/usr/lib/systemd/system/circleci.service` owned by `root` with permissions `755`.
 
 ```shell
-sudo chown root: /var/opt/circleci/circleci.service
+sudo touch /usr/lib/systemd/system/circleci.service
 ```
 
 ```shell
-sudo chmod 755 /var/opt/circleci/circleci.service
+sudo chown root: /usr/lib/systemd/system/circleci.service
+```
+
+```shell
+sudo chmod 755 /usr/lib/systemd/system/circleci.service
 ```
 
 You must ensure that `TimeoutStopSec` is greater than the total amount of time a task will run for - which defaults to 5 hours.
@@ -170,9 +188,9 @@ If you want to configure the CircleCI self-hosted runner installation to start o
 Description=CircleCI Runner
 After=network.target
 [Service]
-ExecStart=/var/opt/circleci/circleci-launch-agent --config /var/opt/circleci/launch-agent-config.yaml
+ExecStart=/opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
 Restart=always
-User=root
+User=circleci
 NotifyAccess=exec
 TimeoutStopSec=18300
 [Install]
@@ -184,7 +202,7 @@ Unlike the task agent, which uses the environment of the `circleci` user, the la
 You can now enable the service:
 
 ```shell
-sudo systemctl enable /var/opt/circleci/circleci.service
+sudo systemctl enable circleci.service
 ```
 
 [#start-the-service]
@@ -196,7 +214,7 @@ When the CircleCI self-hosted runner service starts, it will immediately attempt
 sudo systemctl start circleci.service
 ```
 
-[#verify-the service-is-running]
+[#verify-the-service-is-running]
 === Verify the service is running
 
 The system reports a very basic health status through the `status` field in `systemctl`. This will report **Healthy** or **Unhealthy** based on connectivity to the CircleCI APIs.
@@ -217,7 +235,7 @@ circleci.service - CircleCI Runner
    Status: "Healthy"
     Tasks: 8 (limit: 2287)
    CGroup: /system.slice/circleci.service
-           └─5592 /var/opt/circleci/circleci-launch-agent --config /var/opt/circleci/launch-agent-config.yaml
+           └─5592 /opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
 ```
 
 You can also see the logs for the system by running:


### PR DESCRIPTION
# Description
- Update the Linux runner to use more conventional file locations:
  - `circleci.service`: `/usr/lib/systemd/system/circleci.service`
  - `launch-agent-config.yaml`: `/etc/opt/circleci/launch-agent-config.yaml`
  - SELinux policy (for RHEL): `/etc/opt/circleci/policy/` 
  - Task agent working directory: `/var/opt/circleci/workdir`
  - Launch agent binary: `/opt/circleci/circleci-launch-agent`
- Run launch agent as the `circleci` user so that it doesn't require root privileges
- Move the step to verify the launch agent service to the end of the section for creating and running the systemd service as it's dependent on it
- Update the relevant systemctl commands that need sudo
- Add a step for starting launch agent while pointing to the optional instructions of running it as a systemd service daemon

This PR is dependent on: https://github.com/CircleCI-Public/runner-installation-files/pull/11

# Reasons
Jira: N/A

See description above

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
