### PR TITLE
Windows was not available in server 2.x

### DIFF
--- a/jekyll/_cci2/using-windows.md
+++ b/jekyll/_cci2/using-windows.md
@@ -5,7 +5,6 @@ description: "Learn how to configure a your jobs to run in the Windows execution
 version:
 - Cloud
 - Server v3.x
-- Server v2.x
 ---
 
 The Windows execution environment provides the tools to build Windows projects, such as a Universal Windows Platform (UWP) application, a .NET executable, or Windows-specific (like the .NET framework) projects. The following specifications detail the capacities and included features of the Windows executor:
@@ -57,20 +56,6 @@ jobs:
 {:.tab.windowsblock.Server_v3.x}
 ```yaml
 version: 2.1
-
-jobs:
-  build: # name of your job
-    machine:
-      image: windows-default
-    steps:
-      # Commands are run in a Windows virtual machine environment
-        - checkout
-        - run: Write-Host 'Hello, Windows'
-```
-
-{:.tab.windowsblock.Server_v2.x}
-```yaml
-version: 2
 
 jobs:
   build: # name of your job


### PR DESCRIPTION
# Description
There was no Windows support in server 2.x
There was also no config processing (the 2.1 syntax)