### PR TITLE
Revert "Windows was not available in server 2.x"

### DIFF
--- a/jekyll/_cci2/using-windows.md
+++ b/jekyll/_cci2/using-windows.md
@@ -5,6 +5,7 @@ description: "Learn how to configure a your jobs to run in the Windows execution
 version:
 - Cloud
 - Server v3.x
+- Server v2.x
 ---
 
 The Windows execution environment provides the tools to build Windows projects, such as a Universal Windows Platform (UWP) application, a .NET executable, or Windows-specific (like the .NET framework) projects. The following specifications detail the capacities and included features of the Windows executor:
@@ -56,6 +57,20 @@ jobs:
 {:.tab.windowsblock.Server_v3.x}
 ```yaml
 version: 2.1
+
+jobs:
+  build: # name of your job
+    machine:
+      image: windows-default
+    steps:
+      # Commands are run in a Windows virtual machine environment
+        - checkout
+        - run: Write-Host 'Hello, Windows'
+```
+
+{:.tab.windowsblock.Server_v2.x}
+```yaml
+version: 2
 
 jobs:
   build: # name of your job


### PR DESCRIPTION
Reverts circleci/circleci-docs#7243

Turns out I was wrong: 
https://github.com/circleci/server-manifest/blob/de7dc0ab9eb60e44c65c3135a3dc0aede3d4183c/rcli/templates/replicated_yml_template/components/vm_service.yml#L147-L151

It's not clear to me if anyone was able to actually use this feature though because we didn't provide a Windows image builder at the time.

I also noticed we need a 4.x tab on this page now :(