### PR TITLE
Move Workflow `when` section to current nav section

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1839,7 +1839,7 @@ workflows:
                 command: echo "upload artifact to s3"
 ```
 
-##### **Using `when` in Workflows**
+#### **Using `when` in Workflows**
 {: #using-when-in-workflows }
 
 With version 2.1 configuration, you may use a `when` clause (the inverse clause `unless` is also supported) under a workflow declaration with a [logic statement]({{site.baseurl}}/configuration-reference/#logic-statements) to determine whether or not to run that workflow.

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1532,6 +1532,43 @@ only | Y | String, or List of Strings | Either a single branch specifier, or a l
 ignore | N | String, or List of Strings | Either a single branch specifier, or a list of branch specifiers
 {: class="table table-striped"}
 
+#### **Using `when` in Workflows**
+{: #using-when-in-workflows }
+
+With version 2.1 configuration, you may use a `when` clause (the inverse clause `unless` is also supported) under a workflow declaration with a [logic statement]({{site.baseurl}}/configuration-reference/#logic-statements) to determine whether or not to run that workflow.
+
+The example configuration below uses a pipeline parameter, `run_integration_tests` to drive the `integration_tests` workflow.
+
+```yaml
+version: 2.1
+
+parameters:
+  run_integration_tests:
+    type: boolean
+    default: false
+
+workflows:
+  integration_tests:
+    when: << pipeline.parameters.run_integration_tests >>
+    jobs:
+      - mytestjob
+
+jobs:
+...
+```
+
+This example prevents the workflow `integration_tests` from running unless the tests are invoked explicitly when the pipeline is triggered with the following in the `POST` body:
+
+```json
+{
+    "parameters": {
+        "run_integration_tests": true
+    }
+}
+```
+
+Refer to the [Orchestrating Workflows]({{ site.baseurl }}/workflows) document for more examples and conceptual information.
+
 #### **`jobs`**
 {: #jobs-in-workflow }
 A job can have the keys `requires`, `name`, `context`, `type`, and `filters`.
@@ -1838,43 +1875,6 @@ workflows:
             - run:
                 command: echo "upload artifact to s3"
 ```
-
-#### **Using `when` in Workflows**
-{: #using-when-in-workflows }
-
-With version 2.1 configuration, you may use a `when` clause (the inverse clause `unless` is also supported) under a workflow declaration with a [logic statement]({{site.baseurl}}/configuration-reference/#logic-statements) to determine whether or not to run that workflow.
-
-The example configuration below uses a pipeline parameter, `run_integration_tests` to drive the `integration_tests` workflow.
-
-```yaml
-version: 2.1
-
-parameters:
-  run_integration_tests:
-    type: boolean
-    default: false
-
-workflows:
-  integration_tests:
-    when: << pipeline.parameters.run_integration_tests >>
-    jobs:
-      - mytestjob
-
-jobs:
-...
-```
-
-This example prevents the workflow `integration_tests` from running unless the tests are invoked explicitly when the pipeline is triggered with the following in the `POST` body:
-
-```json
-{
-    "parameters": {
-        "run_integration_tests": true
-    }
-}
-```
-
-Refer to the [Orchestrating Workflows]({{ site.baseurl }}/workflows) document for more examples and conceptual information.
 
 ## Logic statements
 {: #logic-statements }

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -232,7 +232,7 @@ See [Parameter Syntax]({{ site.baseurl }}/reusing-config/#parameter-syntax) <!--
 
 CircleCI offers several execution environments in which to run your jobs. To specify an execution environment choose an _executor_, then specify and image and a resource class. An executor defines the underlying technology, environment and operating system in which to run a job.
 
-Set up your jobs to run using the `docker` (Linux), `machine` (LinuxVM, Windows, GPU, Arm), or `macos` executor, then specify an image with the tools and packages you need, and a resource class. 
+Set up your jobs to run using the `docker` (Linux), `machine` (LinuxVM, Windows, GPU, Arm), or `macos` executor, then specify an image with the tools and packages you need, and a resource class.
 
 Learn more about execution environments and executors in the [Introduction to Execution Environments]({{ site.baseurl }}/executor-intro/).
 


### PR DESCRIPTION
# Description
Move "Using `when` in Workflows" to under "<`workflow_name`>" section.

# Reasons
The `when` clause is used to determine whether or not to run that workflow. So it should under "<`workflow_name`>" section.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
