### PR TITLE
Fix openid-connect-tokens doc typo

### DIFF
--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -337,9 +337,9 @@ commands:
             echo $CIRCLE_OIDC_TOKEN > << parameters.oidc_token_file_path >>
             # Create a credential configuration for the generated OIDC ID Token
             gcloud iam workload-identity-pools create-cred-config \
-                "projects/${<< parameters.project_id >>}/locations/global/workloadIdentityPools/${<< parameters.workload_identity_pool_id >>}/providers/${<< parameters.workload_identity_pool_provider_id >>}"\
+                "projects/<< parameters.project_id >>/locations/global/workloadIdentityPools/<< parameters.workload_identity_pool_id >>/providers/<< parameters.workload_identity_pool_provider_id >>"\
                 --output-file="<< parameters.gcp_cred_config_file_path >>" \
-                --service-account="${<< parameters.service_account_email >>}" \
+                --service-account="<< parameters.service_account_email >>" \
                 --credential-source-file=<< parameters.oidc_token_file_path >>
 
   gcp-oidc-authenticate:


### PR DESCRIPTION
# Description
Fix command parametes in openid-connect-tokens doc.

# Reasons
With the current document, `gcloud` command fails with these parameters.


