### PR TITLE
Clarify server use, minor fixes

### DIFF
--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -175,7 +175,7 @@ Find out more about the Windows execution environment in the [Using the Windows 
 
 To access the GPU execution environment, either use the Windows orb and then specify the GPU-enabled executor from the orb, or use the `machine` executor and specify a Linux or Windows GPU-enabled image. For a full list of `machine` images, see the [CircleCI Developer Hub](https://circleci.com/developer/images?imageType=machine).
 
-You are not able to run a GPU build on a server instance.
+It is not possible to run a GPU build on a server instance.
 {: class="alert alert-info"}
 
 {:.tab.gpublock.Linux}

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -84,7 +84,10 @@ Find out more about the Linux VM execution environment in the [Using Linux Virtu
 
 To access the macOS execution environment, use the `macos` executor and specify an image using the `xcode` key. For a full list of macOS images, see the [CircleCI Developer Hub](https://circleci.com/developer/machine/image/macos).
 
-```
+If you want to run a macOS build on a server instance, you will need to use [self-hosted runner]({{site.baseurl}}/runner-overview).
+{: class="alert alert-info"}
+
+```yml
 jobs:
   build: # name of your job
     macos: # executor type
@@ -95,7 +98,7 @@ jobs:
       # with Xcode 12.5.1 installed
 ```
 
-Find out more about the macOS execution environment in the [Using macOS]({{ site.baseurl }}/using-macos) section of the Choosing an Executor Type page.
+Find out more about the macOS execution environment on the [Using macOS]({{site.baseurl}}/using-macos) page.
 
 ## Windows
 {: #windows }
@@ -172,6 +175,9 @@ Find out more about the Windows execution environment in the [Using the Windows 
 
 To access the GPU execution environment, either use the Windows orb and then specify the GPU-enabled executor from the orb, or use the `machine` executor and specify a Linux or Windows GPU-enabled image. For a full list of `machine` images, see the [CircleCI Developer Hub](https://circleci.com/developer/images?imageType=machine).
 
+You are not able to run a GPU build on a server instance.
+{: class="alert alert-info"}
+
 {:.tab.gpublock.Linux}
 ```yaml
 version: 2.1
@@ -212,7 +218,7 @@ jobs:
       - run: 'Write-Host ''Hello, Windows'''
 ```
 
-Find out more about the GPU execution environment in the [Using the GPU Execution Environment]({{ site.baseurl }}/using-gpu) page.
+Find out more about the GPU execution environment on the [Using the GPU Execution Environment]({{site.baseurl}}/using-gpu) page.
 
 ## Arm
 


### PR DESCRIPTION
# Description
Add a banner on macOS and GPU section of page to clarify it's not compatible with server. This is a temporary solution until we have tagging in place.

# Reasons
Not enough clarity on whether or not someone can use certain builds with server because the page tags indicate the content is for both cloud and server.
[Jira ticket](https://circleci.atlassian.net/jira/software/c/projects/DOCTEAM/boards/554?modal=detail&selectedIssue=DOCTEAM-444)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
