### PR TITLE
Correct Alpine Linux environment variables configuration example

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -239,7 +239,7 @@ jobs:
   build:
     shell: /bin/sh -leo pipefail
     environment:
-      - BASH_ENV: /etc/profile
+      BASH_ENV: /etc/profile
 ```
 
 ## Setting an environment variable in a shell command


### PR DESCRIPTION
# Description
Correct "Alpine Linux environment variables with bash" configuration example.

# Reasons

The environment should be a Map, instead of array of map.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.

