### PR TITLE
Update container-runner.adoc

### DIFF
--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -217,9 +217,10 @@ It is assumed that container agent is running in a Kubernetes namespace without 
 To run a job with no custom configuration, simply add the following configuration to the Helm chart `values.yaml`.  `MY_TOKEN` is your Runner resource class token.
 
 ```yaml
-resourceClasses:
-  namespace/my-rc:
-    token: MY_TOKEN
+agent:
+  resourceClasses:
+    namespace/my-rc:
+      token: MY_TOKEN
 ```
 
 Skip to <<#running-a-job,Running a job>> to run your first job, or keep reading to learn how to provide custom configuration to your pods. 

--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -247,33 +247,34 @@ The following fields will be overwritten by container agent to ensure correct ta
 Below is a full configuration example, containing two resource classes:
 
 ```yaml
-resourceClasses:  
-  circleci-runner/resourceClass:
-    token: TOKEN1
-    metadata:
-      annotations:
-        custom.io: my-annotation
-    spec:
-      containers:
-        - resources:
-            limits:
-              cpu: 500m
-          volumeMounts:
-            - name: xyz
-              mountPath: /path/to/mount
-      securityContext:
-        runAsNonRoot: true
-      imagePullSecrets:
-        - name: my_cred
-      volumes:
-        - name: xyz
-          emptyDir: {}
-  
-  circleci-runner/resourceClass2:
-    token: TOKEN2
-    spec: 
-      imagePullSecrets:
-        - name: "other"
+agent:
+  resourceClasses:  
+    circleci-runner/resourceClass:
+      token: TOKEN1
+      metadata:
+        annotations:
+          custom.io: my-annotation
+      spec:
+        containers:
+          - resources:
+              limits:
+                cpu: 500m
+            volumeMounts:
+              - name: xyz
+                mountPath: /path/to/mount
+        securityContext:
+          runAsNonRoot: true
+        imagePullSecrets:
+          - name: my_cred
+        volumes:
+          - name: xyz
+            emptyDir: {}
+    
+    circleci-runner/resourceClass2:
+      token: TOKEN2
+      spec: 
+        imagePullSecrets:
+          - name: "other"
 ```
 
 [#running-a-job]


### PR DESCRIPTION
# Description
Update `values.yaml` as described in community issue [Container agent (container runner) setup](https://discuss.circleci.com/t/container-agent-container-runner-setup/45160).

# Reasons
Though described under parameters, it is not clear that `resourceClasses` is a child of `agent` in the provided `values.yaml` examples.