### PR TITLE
Add auth to docker examples

### DIFF
--- a/jekyll/_cci2/browser-testing.md
+++ b/jekyll/_cci2/browser-testing.md
@@ -115,6 +115,9 @@ jobs:
   test-cypress:
     docker:
       - image: cimg/node:lts
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - setup_remote_docker:

--- a/jekyll/_cci2/building-docker-images.md
+++ b/jekyll/_cci2/building-docker-images.md
@@ -26,6 +26,9 @@ jobs:
   build:
     docker:
       - image: cimg/base:2022.06
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       # ... steps for building/testing app ...
       - setup_remote_docker:

--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -67,6 +67,9 @@ Using the `base` image in your config looks like the example shown below:
   myjob:
     docker:
       - image: cimg/base:2021.04
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 ```
 
 This is a brand new Ubuntu-based image designed to install the bare minimum. The
@@ -87,6 +90,9 @@ The example below demonstrates how to use the next-gen Go image, which is based 
   myjob:
     docker:
       - image:  cimg/go:1.16
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 ```
 
 This is a direct replacement for the legacy CircleCI Go image (`circleci/golang`). Note, the Docker Hub namespace is `cimg`. You can view other next generation images for other languages [below](#next-gen-language-images).

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -581,6 +581,9 @@ jobs:
   build:
     docker:
       - image: circleci/clojure:tools-deps-1.9.0.394
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - run: bin/kaocha

--- a/jekyll/_cci2/concepts.md
+++ b/jekyll/_cci2/concepts.md
@@ -596,6 +596,9 @@ jobs:
   build:
     docker:
       - image: cimg/node:current
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     resource_class: large
 ```
 

--- a/jekyll/_cci2/config-intro.adoc
+++ b/jekyll/_cci2/config-intro.adoc
@@ -49,6 +49,9 @@ jobs:
   build:
     docker:
       - image: alpine:3.15
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: The First Step
@@ -114,6 +117,9 @@ jobs:
   build:
     docker:
       - image: cimg/base:2021.04
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - run:
@@ -162,6 +168,9 @@ jobs:
   Hello-World:
     docker:
       - image: cimg/base:2021.04
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: Saying Hello
@@ -172,6 +181,9 @@ jobs:
   Fetch-Code:
     docker:
       - image: cimg/base:2021.04
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - run:
@@ -183,6 +195,9 @@ jobs:
   Using-Node:
     docker:
       - image: cimg/node:17.2
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: Running the Node Container
@@ -255,6 +270,9 @@ jobs:
   Hello-World:
     docker:
       - image: alpine:3.15
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: Saying Hello
@@ -265,6 +283,9 @@ jobs:
   Fetch-Code:
     docker:
       - image: cimg/base:2021.04
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - run:
@@ -276,6 +297,9 @@ jobs:
   Using-Node:
     docker:
       - image: cimg/node:17.2
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: Running the Node Container
@@ -284,6 +308,9 @@ jobs:
   Now-Complete:
     docker:
       - image: alpine:3.15
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run:
           name: Approval Complete

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1104,6 +1104,9 @@ jobs:
   deploy-step-job:
     docker:
       - image: cimg/base:stable
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     parallelism: 3
     steps:
       - checkout
@@ -1138,6 +1141,9 @@ jobs:
   doing-things-job:
     docker:
       - image: cimg/base:stable
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     parallelism: 3
     steps:
       - checkout
@@ -1157,6 +1163,9 @@ jobs:
   deploy-job:
     docker:
       - image: cimg/base:stable
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run: # change "deploy" to "run"
           command: |
@@ -1181,6 +1190,9 @@ jobs:
   doing-things-job:
     docker:
       - image: cimg/base:stable
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     parallelism: 3
     steps:
       - checkout
@@ -1205,6 +1217,9 @@ jobs:
   deploy-job:
     docker:
       - image: cimg/base:stable
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       # attach the files you persisted in the doing-things-job
       - attach_workspace:
@@ -1431,6 +1446,9 @@ jobs:
     circleci_ip_ranges: true # opts the job into the IP ranges feature
     docker:
       - image: curlimages/curl
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run: echo “Hello World”
 workflows:

--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -487,6 +487,9 @@ jobs:
   build:
     docker:
       - image: cimg/base:2021.11
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     resource_class: <namespace>/<resource-class>
     steps:
       - checkout

--- a/jekyll/_cci2/deploy-android-applications.adoc
+++ b/jekyll/_cci2/deploy-android-applications.adoc
@@ -259,6 +259,9 @@ jobs:
   test-fastlane: 
       docker:
         - image: cimg/android:2022.07
+          auth:
+            username: mydockerhub-user
+            password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
       resource_class: large
       steps: 
         - checkout  

--- a/jekyll/_cci2/deploy-to-aws.adoc
+++ b/jekyll/_cci2/deploy-to-aws.adoc
@@ -54,14 +54,14 @@ jobs: # Define the build and deploy jobs
     build:
     docker: # Use the Docker executor for the build job
         - image: <image-name-and-tag> # Specify the Docker image to use for the build job
-        auth:
+          auth:
             username: mydockerhub-user
             password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     ... # build job steps omitted for brevity
     deploy:
     docker: # Use the Docker executor for the deploy job
         - image: <image-name-and-tag>  # Specify the Docker image to use for the deploy job
-        auth:
+          auth:
             username: mydockerhub-user
             password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
@@ -103,14 +103,14 @@ jobs:
     build:
     docker: # Specify executor for running build job - this example uses a Docker container
         - image: <docker-image-name-tag> # Specify docker image to use
-        auth:
+          auth:
             username: mydockerhub-user
             password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     ... # build job steps omitted for brevity
     deploy:
     docker: # Specify executor for running deploy job
         - image: <docker-image-name-tag> # Specify docker image to use
-        auth:
+          auth:
             username: mydockerhub-user
             password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:

--- a/jekyll/_cci2/deploy-to-heroku.adoc
+++ b/jekyll/_cci2/deploy-to-heroku.adoc
@@ -57,9 +57,9 @@ jobs:
     deploy:
     docker:
         - image: <docker-image-name-tag>
-        auth:
-            username: mydockerhub-user
-            password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+            auth:
+                username: mydockerhub-user
+                password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
         - checkout
         - run:

--- a/jekyll/_cci2/deploy-to-npm-registry.adoc
+++ b/jekyll/_cci2/deploy-to-npm-registry.adoc
@@ -32,9 +32,9 @@ jobs:
     publish:
     docker:
         - image: <docker-image-name-tag>
-        auth:
-            username: mydockerhub-user
-            password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+            auth:
+                username: mydockerhub-user
+                password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
         - checkout
         - run:

--- a/jekyll/_cci2/docker-hub-pull-through-mirror.adoc
+++ b/jekyll/_cci2/docker-hub-pull-through-mirror.adoc
@@ -201,6 +201,9 @@ jobs:
   remote-docker:
     docker:
       - image: yourmachineaccount/private-image-with-docker-client # A copy of library/docker
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - setup_remote_docker
       - run: docker pull yourmachineaccount/private-image-with-docker-client

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -35,6 +35,9 @@ jobs:
   build: # name of your job
     docker: # executor type
       - image: cimg/base:stable # primary container will run the latest, production-ready base image
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 
       steps:
         # Commands run in the primary container

--- a/jekyll/_cci2/gitlab-integration.adoc
+++ b/jekyll/_cci2/gitlab-integration.adoc
@@ -518,6 +518,9 @@ If you must use these as environment variables in your pipelines, you can do so 
 build: 
   docker:
     - image: cimg/node:17.0
+      auth:
+        username: mydockerhub-user
+        password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
   environment:
     CIRCLE_PROJECT_REPONAME: << pipeline.trigger_parameters.gitlab.repo_name >>
   steps:

--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -140,6 +140,9 @@ jobs:
   node/test:
     docker:
     - image: cimg/node:13.11.0
+      auth:
+        username: mydockerhub-user
+        password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
     - checkout
     - run:

--- a/jekyll/_cci2/introduction-to-yaml-configurations.adoc
+++ b/jekyll/_cci2/introduction-to-yaml-configurations.adoc
@@ -59,6 +59,9 @@ jobs:
     docker:
     # Primary container image where all steps run
      - image: cimg/base:2022.05
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 ```
 
 `jobs` is a collection of steps which are executed as a unit, either within a fresh container, or a virtual machine. In this example, `jobs` is being built within a Docker container, which is set up in the configuration using nested key-pairs. `docker` is calling a pre-built CircleCI Docker image, `cimg/base`, an Ubuntu Docker image. The image in this example contains the minimum tools required to operate a build on CircleCI, as well as Docker.
@@ -92,6 +95,9 @@ jobs:
   build:
     docker:
      - image: cimg/base:2022.05
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
         - run: echo "Say hello to YAML!"
 ```
@@ -109,12 +115,18 @@ jobs:
   say_hello:
     docker:
      - image: cimg/base:2022.05
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run: echo "Say hello to YAML!"
   # Job two with a unique name
   say_goodbye:
     docker:
      - image: cimg/base:2022.05
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run: echo "Say goodbye to YAML!"
 

--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -46,6 +46,9 @@ jobs:
     circleci_ip_ranges: true # opts the job into the IP ranges feature
     docker:
       - image: curlimages/curl
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - run: echo “Hello World”
 workflows:

--- a/jekyll/_cci2/jobs-steps.md
+++ b/jekyll/_cci2/jobs-steps.md
@@ -51,6 +51,9 @@ jobs:
   print-a-message:
     docker:
       - image: cimg/base:2022.03
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     parameters:
       message:
         type: string

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -106,6 +106,9 @@ jobs:
   job1:
     docker:
       - image: node:10
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 ----
 
 2+| Define a multi-stage build pipeline. Job1 and Job2 run concurrently. Once they are done, Job3 runs. Once Job3 is done, Job4 runs.

--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -132,6 +132,9 @@ jobs:
   deploy:
     docker:
       - image: amazon/aws-cli
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     environment:
       AWS_DEFAULT_REGION: YOUR_AWS_REGION
       AWS_ROLE_ARN: YOUR_ROLE_ARN

--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -303,6 +303,9 @@ description: >
 
 docker:
   - image: cimg/base:current
+    auth:
+      username: mydockerhub-user
+      password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 parameters:
   greeting:
     type: string

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -180,6 +180,9 @@ description: >
   https://circleci.com/developer/images/image/cimg/node
 docker:
   - image: 'cimg/node:<<parameters.tag>>'
+    auth:
+      username: mydockerhub-user
+      password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 parameters:
   tag:
     default: '13.11'

--- a/jekyll/_cci2/server-3-operator-proxy.adoc
+++ b/jekyll/_cci2/server-3-operator-proxy.adoc
@@ -51,6 +51,9 @@ Users can get around this restriction by setting environment variables on their 
 jobname:
   docker:
   - image: ubuntu:latest
+      auth:
+        username: mydockerhub-user
+        password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     environment:
       HTTP_PROXY: http://proxy.example.com:3128
       HTTPS_PROXY: http://proxy.example.com:3128

--- a/jekyll/_cci2/server/installation/installing-server-behind-a-proxy.adoc
+++ b/jekyll/_cci2/server/installation/installing-server-behind-a-proxy.adoc
@@ -39,6 +39,9 @@ jobs:
   my-job:
     docker:
       - image: cimg/node:17.2.0
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
         environment:
           HTTP_PROXY: http://proxy.example.com:3128
           HTTPS_PROXY: http://proxy.example.com:3128

--- a/jekyll/_cci2/slack-orb-tutorial.adoc
+++ b/jekyll/_cci2/slack-orb-tutorial.adoc
@@ -54,6 +54,9 @@ jobs:
   notify:
     docker:
       - image: 'cimg/base:stable'
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - slack/notify:
           custom: |
@@ -259,6 +262,9 @@ jobs:
   notify:
     docker:
       - image: 'cimg/base:stable'
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
 - slack/notify:
 	  event: fail

--- a/jekyll/_cci2/test-splitting-tutorial.adoc
+++ b/jekyll/_cci2/test-splitting-tutorial.adoc
@@ -60,6 +60,9 @@ jobs:
   build-and-test:
     docker:
       - image: cimg/node:16.10
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - node/install-packages:
@@ -204,6 +207,9 @@ jobs:
     build-and-test:
         docker:
             - image: cimg/node:16.10
+                auth:
+                    username: mydockerhub-user
+                    password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
         parallelism: 5
         steps:
             - checkout

--- a/jekyll/_cci2/test.md
+++ b/jekyll/_cci2/test.md
@@ -28,6 +28,9 @@ jobs:
   build-and-test:
     docker:
       - image: cimg/node:16.10
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - node/install-packages:

--- a/jekyll/_cci2/testing-orbs.md
+++ b/jekyll/_cci2/testing-orbs.md
@@ -207,6 +207,9 @@ jobs:
     command-tests:
       docker:
         - image: cimg/base:current
+          auth:
+            username: mydockerhub-user
+            password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
       steps:
         # Run your orb's commands to validate them.
         - <orb-name>/greet
@@ -219,6 +222,9 @@ jobs:
     command-tests:
       docker:
         - image: cimg/base:current
+          auth:
+            username: mydockerhub-user
+            password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
       steps:
         - github-cli/install
         - run:

--- a/jekyll/_cci2/troubleshoot-test-splitting.adoc
+++ b/jekyll/_cci2/troubleshoot-test-splitting.adoc
@@ -90,6 +90,9 @@ jobs:
     parallelism: 2
     docker:
       - image: cimg/python:3.8
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
       - python/install-packages:

--- a/jekyll/_cci2/using-docker.md
+++ b/jekyll/_cci2/using-docker.md
@@ -24,6 +24,9 @@ jobs:
   my-job:
     docker:
       - image: cimg/node:lts
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
 ```
 
 A container is an instance of a specified Docker image. The first image listed in your configuration for a job is referred to as the _primary_ container image and this is where all steps in the job will run. _Secondary_ containers can also be specified to run alongside for running services, such as, databases. If you are new to Docker, see the [Docker Overview documentation](https://docs.docker.com/engine/docker-overview/) for concepts.


### PR DESCRIPTION
# Description
Add missing `auth:` to Docker executor examples

# Reasons
Some Docker executor examples were missing the `auth:`
[Jira ticket](https://circleci.atlassian.net/jira/software/c/projects/DOCTEAM/boards/554?modal=detail&selectedIssue=DOCTEAM-622)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
