### PR TITLE
Remove 'in the following sections' from intro

### DIFF
--- a/jekyll/_cci2/browser-testing.md
+++ b/jekyll/_cci2/browser-testing.md
@@ -10,20 +10,15 @@ version:
 - Server v2.x
 ---
 
-This document describes common methods for running and debugging browser testing in your CircleCI config in the following sections:
-
-* TOC
-{:toc}
+This document describes common methods for running and debugging browser testing in your CircleCI config.
 
 ## Prerequisites
 {: #prerequisites }
-{:.no_toc}
 
 Refer to the [Pre-Built CircleCI Docker Images]({{ site.baseurl }}/circleci-images/) and add `-browsers:` to the image name for a variant that includes Java 8, Geckodriver, Firefox, and Chrome. Add  `-browsers-legacy` to the image name for a variant which includes PhantomJS.
 
 ## Overview
 {: #overview }
-{:.no_toc}
 
 Every time you commit and push code, CircleCI automatically runs all of your tests against the browsers you choose. You can configure your browser-based tests to run whenever a change is made, before every deployment, or on a certain branch.
 

--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -11,16 +11,12 @@ version:
 - Server v2.x
 ---
 
-Contexts provide a mechanism for securing and sharing environment variables across projects. The environment variables are defined as name/value pairs and are injected at runtime. This document describes creating and using contexts in CircleCI in the following sections:
-
-* TOC
-{:toc}
+Contexts provide a mechanism for securing and sharing environment variables across projects. The environment variables are defined as name/value pairs and are injected at runtime. This document describes creating and using contexts in CircleCI.
 
 ## Overview
 {: #overview }
-{:.no_toc}
 
-Create and manage contexts on the Organization Settings page of the CircleCI application. You must be an organization member to view, create, or edit contexts. After a context has been created, you can use the `context` key in the workflows section of a project [`config.yml`]({{ site.baseurl }}/configuration-reference/#context) file to give any job(s) access to the environment variables associated with the context, as shown in the image below.
+You can create and manage contexts on the **Organization Settings** page of the [CircleCI web app](https://app.circleci.com). You must be an organization member to view, create, or edit contexts. After a context has been created, you can use the `context` key in the workflows section of a project [`config.yml`]({{ site.baseurl }}/configuration-reference/#context) file to give any job(s) access to the environment variables associated with the context, as shown in the image below.
 
 {:.tab.contextsimage.Cloud}
 ![Contexts Overview]({{ site.baseurl }}/assets/img/docs/contexts_cloud.png)

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -12,10 +12,7 @@ version:
 - Server v2.x
 ---
 
-This document describes how to create and use custom Docker images with CircleCI in the following sections:
-
-* TOC
-{:toc}
+This document describes how to create and use custom Docker images with CircleCI.
 
 ## Overview
 {: #overview }

--- a/jekyll/_cci2/docker-layer-caching.md
+++ b/jekyll/_cci2/docker-layer-caching.md
@@ -13,10 +13,7 @@ version:
 ---
 
 Docker layer caching (DLC) can reduce Docker image build times on CircleCI. DLC is available on
-the [Free and above](https://circleci.com/pricing/) usage plans (credits are charged per run job) and on installations of [CircleCI server](https://circleci.com/enterprise/). This document provides an overview of DLC in the following sections:
-
-* TOC
-{:toc}
+the [Free and above](https://circleci.com/pricing/) usage plans (credits are charged per run job) and on installations of [CircleCI server](https://circleci.com/enterprise/).
 
 ## Overview
 {: #overview }

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -17,14 +17,8 @@ suggested:
     link: https://support.circleci.com/hc/en-us/articles/360003540393?input_string=how+to+i+inject+an+environment+variable+using+the+api%3F
 ---
 
-This document describes using environment variables in CircleCI in the following sections:
-
-* TOC
-{:toc}
-
 ## Overview
 {: #overview }
-{:.no_toc}
 
 There are several ways to use environment variables in CircleCI to provide variety in scope and authorization level. Environment variables are governed by an [order of precedence](#order-of-precedence), depending on how they are set, allowing control at each level in your configuration.
 

--- a/jekyll/_cci2/ios-tutorial.md
+++ b/jekyll/_cci2/ios-tutorial.md
@@ -9,16 +9,12 @@ version:
 - Cloud
 ---
 
-This document describes how to automate builds, testing, and deployment of an iOS application project with CircleCI in the following sections:
-
-* TOC
-{:toc}
+This document describes how to automate builds, testing, and deployment of an iOS application project with CircleCI.
 
 **Note:** There is also documentation for [testing iOS]({{site.baseurl}}/testing-ios/) and [getting started on MacOS]({{site.baseurl}}/hello-world-macos/).
 
 ## Overview
 {: #overview }
-{:.no_toc}
 
 The following sections walk through how to write Jobs and Steps that use `xcodebuild` for this application, how to set up code signing and a provisioning profile in the CircleCI environment, and how to deploy with Fastlane.
 

--- a/jekyll/_cci2/oss.md
+++ b/jekyll/_cci2/oss.md
@@ -8,14 +8,10 @@ order: 1
 ---
 
 This document provides tips and best practices
-for building your open source project on CircleCI in the following sections:
-
-* TOC
-{:toc}
+for building your open source project on CircleCI.
 
 ## Overview
 {: #overview }
-{:.no_toc}
 
 To support the open source community, organizations on Github or Bitbucket will be given free credits every week that can be spent on open source projects. These credits can be spent on Linux resources.
 

--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -11,10 +11,7 @@ version:
 - Server v2.x
 ---
 
-This document provides example database [config.yml]({{ site.baseurl }}/databases/) files using PostgreSQL/Rails and MySQL/Ruby in the following sections:
-
-* TOC
-{:toc}
+This document provides example database [config.yml]({{ site.baseurl }}/databases/) files using PostgreSQL/Rails and MySQL/Ruby.
 
 ## Example CircleCI configuration for a rails app with structure.sql
 {: #example-circleci-configuration-for-a-rails-app-with-structuresql }

--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -12,13 +12,9 @@ version:
 - Server v2.x
 ---
 
-This document describes how to access a build container using SSH on CircleCI in the following sections:
-
-* TOC
-{:toc}
-
 ## Overview
 {: #overview }
+
 Often the best way to troubleshoot problems is to SSH into a job and inspect things like log files, running processes, and directory paths. CircleCI gives you the option to access all jobs via SSH. Read our [blog post](https://circleci.com/blog/debugging-ci-cd-pipelines-with-ssh-access/) on debugging CI/CD pipelines with SSH.
 
 When you log in with SSH, you are running an interactive login shell. You may be running the command on top of the directory where the command failed the first time, **or** you may be running the command from the directory one level up from where the command failed (e.g. `~/project/` or `~/`). Either way, you will not be initiating a clean run (you may wish to execute `pwd` or `ls` to ensure that you are in the correct directory).

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -9,14 +9,10 @@ version:
 - Cloud
 ---
 
-This document describes how to set up and customize testing for an iOS application with CircleCI in the following sections:
-
-* TOC
-{:toc}
+This document describes how to set up and customize testing for an iOS application with CircleCI.
 
 ## Overview
 {: #overview }
-{:.no_toc}
 
 CircleCI offers support for building, testing and deploying iOS projects in macOS virtual machines. Each image provided has a set of common tools installed, such as Ruby and OpenJDK, alongside a version of Xcode. For more information about supplied images, refer to the [software manifest](#supported-xcode-versions) for each Xcode image.
 

--- a/jekyll/_cci2/using-shell-scripts.md
+++ b/jekyll/_cci2/using-shell-scripts.md
@@ -12,14 +12,8 @@ version:
 - Server v2.x
 ---
 
-This document describes best practices for using shell scripts in your [CircleCI configuration]({{ site.baseurl }}/configuration-reference/) in the following sections:
-
-* TOC
-{:toc}
-
 ## Overview
 {: #overview }
-{:.no_toc}
 
 Configuring CircleCI often requires writing shell scripts. While shell scripting can grant finer control over your build, it is a subtle art that can produce equally subtle errors. You can avoid many of these errors by reviewing the best practices explained below.
 

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -22,7 +22,6 @@ suggested:
 ---
 
 Workflows help you increase the speed of your software development through faster feedback, shorter reruns, and more efficient use of resources. This document describes the workflows feature and provides example configurations.
-{:toc}
 
 ## Overview
 {: #overview }

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -21,9 +21,7 @@ suggested:
     link: https://support.circleci.com/hc/en-us/articles/360043638052-Conditional-steps-in-jobs-and-conditional-workflows
 ---
 
-Workflows help you increase the speed of your software development through faster feedback, shorter reruns, and more efficient use of resources. This document describes the Workflows feature and provides example configurations in the following sections:
-
-* TOC
+Workflows help you increase the speed of your software development through faster feedback, shorter reruns, and more efficient use of resources. This document describes the workflows feature and provides example configurations.
 {:toc}
 
 ## Overview


### PR DESCRIPTION
# Description

- Removes "...in the following sections:" from page introductions.
- Also removes the no_toc tag from the Overview heading so that it is also included in the right hand side nav / toc.
- A few minot text edits.

# Reasons
Previously, we had this phrase in some doc intros as a lead in to a table of contents. We have since moved the TOC to the right hand nav, and no longer need this phrase.
[Jira ticket](https://circleci.atlassian.net/browse/DOCTEAM-484)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
