### PR TITLE
fix resource_class_by_project example var

### DIFF
--- a/jekyll/_cci2/config-policies.md
+++ b/jekyll/_cci2/config-policies.md
@@ -465,13 +465,13 @@ import data.circleci.config
 
 policy_name["example"]
 
-ban_orbs_versioned = config.resource_class_by_project({
+check_resource_class = config.resource_class_by_project({
   "large": {"$PROJECT_UUID_A","$PROJECT_UUID_B"},
 })
 
-enable_rule["ban_orbs_versioned"]
+enable_rule["check_resource_class"]
 
-hard_fail["ban_orbs_versioned"]
+hard_fail["check_resource_class"]
 ```
 
 ## Leveraging the CLI for Config and Policy Development


### PR DESCRIPTION
# Description
Adjusted the resource_class_by_project example to use `check_resource_class` as the var instead of `ban_orbs_versioned`.

# Reasons
Fixing a type
