### PR TITLE
[SERVER-1948] Add random string command

### DIFF
--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -109,6 +109,8 @@ apiToken: "<your-super-secret-random-value>"
 ----
 --
 
+NOTE: You may use the following command to generate a random alphanumeric value: `cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c <num-of-chars>`. This command should work on any *nix based system.
+
 [#session-cookie]
 === b. Session cookie
 

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -77,9 +77,9 @@ For sensitive data there are two options:
 * add into the `values.yaml` file
 * add them as Kubernetes Secrets directly
 
-This flexibility allows you to manage Kubernetes Secrets using whichever process you prefer.
+This flexibility allows you to manage Kubernetes Secrets using whichever process you prefer. Whichever option you choose, this sensitive information is stored as a Kubernetes Secret within CircleCI.
 
-NOTE: Whichever option you choose, this sensitive information is stored as a Kubernetes Secret within CircleCI.
+NOTE: During the installation process, you may use the following command to generate a random alphanumeric value as required: `cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c <num-of-chars>`. This command should work on any *nix based system.
 
 [#api-token]
 === a. API token
@@ -108,8 +108,6 @@ Add the value to `values.yaml`. CircleCI will create the Kubernetes Secret autom
 apiToken: "<your-super-secret-random-value>"
 ----
 --
-
-NOTE: You may use the following command to generate a random alphanumeric value: `cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c <num-of-chars>`. This command should work on any *nix based system.
 
 [#session-cookie]
 === b. Session cookie


### PR DESCRIPTION
# Description


Adding a helper command for generating random alphanumeric strings which can be used for the various secrets. Placing this in the "core services" section right below the api-key.

# Reasons

- [SERVER-1948](https://circleci.atlassian.net/browse/SERVER-1948)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
