### PR TITLE
Update ssh-access-jobs.md

### DIFF
--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -123,29 +123,29 @@ $ ssh -v git@bitbucket.com
 In the output, look for a sequence like this:
 
 ```bash
-debug1: Offering RSA public key: /Users/me/.ssh/id_rsa_github
+debug1: Offering public key: /Users/me/.ssh/id_ed25519_github
 <...>
 debug1: Authentication succeeded (publickey).
 ```
 
-This sequence indicates that the key /Users/me/.ssh/id_rsa_github is the one which
+This sequence indicates that the key /Users/me/.ssh/id_ed25519_github is the one which
 GitHub accepted.
 
 Next, run the SSH command for your CircleCI build, but add the -v flag.
 In the output, look for one or more lines like this:
 
 ```bash
-debug1: Offering RSA public key: ...
+debug1: Offering public key: ...
 ```
 
 Make sure that the key which GitHub accepted (in our
-example, /Users/me/.ssh/id_rsa_github) was also offered to CircleCI.
+example, /Users/me/.ssh/id_ed25519_github) was also offered to CircleCI.
 
 If it was not offered, you can specify it via the `-i` command-line
 argument to SSH. For example:
 
 ```bash
-$ ssh -i /Users/me/.ssh/id_rsa_github -p 64784 54.224.97.243
+$ ssh -i /Users/me/.ssh/id_ed25519_github -p 64784 54.224.97.243
 ```
 
 ## See also


### PR DESCRIPTION
# Description
Changed RSA to ed25519

# Reasons
OpenSSH >8.8 has deprecated RSA+SSH by default. https://www.openssh.com/txt/release-8.8
We also recommend right above to create an ed25519 key.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [✓] Break up walls of text by adding paragraph breaks.
- [✓] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [✓] Keep the title between 20 and 70 characters.
- [✓] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [✓] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [✓] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [✓] Include relevant backlinks to other CircleCI docs/pages.
