### PR TITLE
[WIP] CLI overhaul

### DIFF
--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -319,6 +319,36 @@ If the context is restricted with a group other than `All members`, you must be 
 
 3. Type Delete and click Confirm. The Context and all associated environment variables will be deleted. **Note:** If the context was being used by a job in a Workflow, the job will start to fail and show an error.
 
+## Context management with the CLI
+{: #context-management-with-the-cli}
+
+While contexts can be managed on the CircleCI web application, the [CircleCI CLI](https://circleci-public.github.io/circleci-cli/) provides an alternative method for managing the usage of contexts in your projects if you prefer this method. With the CLI, you can execute several context-oriented commands:
+
+- `create` - Create a new context
+- `delete` - Delete the named context
+- `list` - List all contexts
+- `remove-secret` - Remove an environment variable from the named context
+- `show` - Show a context
+- `store-secret` - Store a new environment variable in the named context
+
+The above list are "sub-commands" in the CLI, which would be executed like so:
+
+```shell
+circleci context create
+
+# Returns the following:
+List all contexts
+
+Usage:
+  circleci context list <vcs-type> <org-name> [flags]
+```
+
+Many commands will require that you include additional information as indicated by the parameters delimited by `< >`.
+
+As with most of the CLI's commands, you will need to have properly authenticated your version of the CLI with a token to enable performing context related actions.
+
+Some use cases for the CLI are described below in the [Enironment variable usage](#environment-variable-usage) section.
+
 ## Environment variable usage
 {: #environment-variable-usage }
 
@@ -333,7 +363,6 @@ Environment variables are used according to a specific precedence order, as foll
 
 Environment variables declared inside a shell command `run step`, for example `FOO=bar make install`, will override environment variables declared with the `environment` and `contexts` keys. Environment variables added on the Contexts page will take precedence over variables added on the Project Settings page.
 
-
 ### Secure Environment Variable Creation, Deletion, and Rotation
 {: #secure-environment-variable-creation-deletion-and-rotation }
 
@@ -344,7 +373,6 @@ This section will walk through interacting with context environment variables us
 
 ##### Using CircleCI’s CLI
 {: #using-circlecis-cli }
-{:.no_toc}
 
 _If this is your first time using the CLI, follow the instructions on
 [CircleCI CLI Configuration]({{site.baseurl}}/local-cli/?section=configuration)

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -43,15 +43,10 @@ CircleCI does not preserve entrypoints by default.
 See [Adding an Entrypoint](#adding-an-entrypoint)
 for more details.
 
-## CircleCI Dockerfile wizard
-{: #circleci-dockerfile-wizard }
-
-Refer to the [`dockerfile-wizard` GitHub repository of CircleCI Public](https://github.com/circleci-public/dockerfile-wizard) for instructions to clone and use the wizard to create a Dockerfile to generate your custom image without installing Docker.
-
 ## Creating a custom image manually
 {: #creating-a-custom-image-manually }
 
-The following sections provide a walkthrough of how to create a custom image manually. In most cases you'll want to have a custom image for your [primary container]({{ site.baseurl }}/glossary/#primary-container) so that is the focus of this document. But, you can easily apply this knowledge to create images for supporting containers as well.
+The following sections provide a walkthrough of how to create a custom image manually. In most cases you'll want to have a custom image for your [primary container]({{site.baseurl}}/glossary/#primary-container) so that is the focus of this document. But, you can easily apply this knowledge to create images for supporting containers as well.
 
 ### Prerequisite
 {: #prerequisite }

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: Installing the CircleCI Local CLI
+title: Installing the CircleCI local CLI
 description: How to install the CircleCI local CLI
 categories: [troubleshooting]
 redirect_from: local-cli-getting-started
@@ -12,8 +12,6 @@ version:
 suggested:
   - title: CircleCI CLI tutorial
     link: https://circleci.com/blog/local-pipeline-development/
-  - title: Validate your config using local CLI
-    link: https://support.circleci.com/hc/en-us/articles/360006735753?input_string=how+to+validate+config+before+pushing
   - title: Check your CircleCI installation
     link: https://support.circleci.com/hc/en-us/articles/360011235534?input_string=how+to+validate+config
   - title: Troubleshoot CLI errors
@@ -23,7 +21,7 @@ suggested:
 ## Overview
 {: #overview }
 
-The CircleCI command line interface (CLI) brings CircleCI's advanced and powerful tools to your terminal. The CLI is supported on cloud and server v3.x+ installations. If you are using server v2.x, please see the [legacy CLI installation](#using-the-cli-on-circleci-server-v2-x) section.
+The [CircleCI command line interface (CLI)](https://circleci-public.github.io/circleci-cli/) brings CircleCI's advanced and powerful tools to your terminal. The CLI is supported on cloud and server v3.x+ installations. If you are using server v2.x, please see the [legacy CLI installation](#using-the-cli-on-circleci-server-v2-x) section.
 
 Some of the things you can do with the CLI include:
 
@@ -113,16 +111,16 @@ You can visit the [GitHub releases](https://github.com/CircleCI-Public/circleci-
 ## Updating the CLI
 {: #updating-the-cli }
 
-For **Linux and Windows** installs, you can update to the newest version of the CLI using the following command:
-
-  ```shell
-  circleci update
-  ```
-
 If you would just like to check for updates manually (and not install them), use the command:
 
   ```shell
   circleci update check
+  ```
+
+For **Linux and Windows** installs, you can update to the newest version of the CLI using the following command:
+
+  ```shell
+  circleci update
   ```
 
 For **macOS** installations with Homebrew, you will need to run the following command to update:

--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -29,7 +29,7 @@ See the [Persisting Data]({{site.baseurl}}/persist-data/#custom-storage-usage) p
 Choosing the right docker image for your project can have huge impact on build time. For example, choosing a basic language image means dependencies and tools need to be downloaded each time your pipeline is run, whereas, if you choose or build an image that has these dependencies and tools already installed, this time will be saved for each build run. When configuring your projects and specifying images, consider the following options:
 
 * CircleCI provides a range of [convenience images]({{site.baseurl}}/circleci-images/#section=configuration), typically based on official Docker images, but with a range of useful language tools pre-installed.
-* You can [create your own images]({{site.baseurl}}/custom-images/#section=configuration), maximizing specificity for your projects. To help with this we provide both a [Docker image build wizard](https://github.com/circleci-public/dockerfile-wizard), and [guidance for building images manually]({{site.baseurl}}/custom-images/#creating-a-custom-image-manually).
+* You can create [custom images]({{site.baseurl}}/custom-images/#section=configuration), maximizing specificity for your projects. To help with this we provide [guidance for building images manually]({{site.baseurl}}/custom-images/#creating-a-custom-image-manually).
 
 ## Docker layer caching
 {: #docker-layer-caching }

--- a/jekyll/_cci2/orb-author-validate-publish.md
+++ b/jekyll/_cci2/orb-author-validate-publish.md
@@ -6,12 +6,12 @@ version:
 - Cloud
 ---
 
-This guide covers the steps required to create a simple orb, manually, without using the orb development kit. We recommend the orb development kit for most orb projects, to find out more, see the [Orb Authoring Guide]({{site.baseurl}}/orb-author).
+This guide covers the steps required to create a simple [orb]({{site.baseurl}}/orb-intro), manually, without using the orb development kit. We recommend the [orb development kit]({{site.baseurl}}/orb-development-kit) for most orb projects.
 
 ## Create a namespace
 {: #create-a-namespace }
 
-1. If you have not already done so, claim a namespace for your user/organization using the following command, substituting your namespace choice and GitHub organization name:
+If you have not already done so, claim a namespace for your user/organization using the following command, substituting your namespace choice and GitHub organization name:
 ```shell
 circleci namespace create <name> --org-id <your-organization-id>
 ```
@@ -19,7 +19,7 @@ circleci namespace create <name> --org-id <your-organization-id>
 ## Create your orb
 {: #create-your-orb }
 
-1. Create your orb inside your namespace. At this stage no orb content is being generated, but the naming is reserved for when the orb is published. **If you are using CircleCI server, you should ensure the `--private` flag is used here to keep your orbs private within your installation**.
+Create your orb inside your namespace. At this stage no orb content is being generated, but the naming is reserved for when the orb is published. **If you are using CircleCI server, you should ensure the `--private` flag is used here to keep your orbs private within your installation**.
 To create a **[public]({{site.baseurl}}/orb-intro/#public-orbs)** orb:
 ```shell
 circleci orb create <my-namespace>/<my-orb-name>
@@ -29,7 +29,7 @@ To create a **[private]({{site.baseurl}}/orb-intro/#private-orbs)** orb:
 circleci orb create <my-namespace>/<my-orb-name> --private
 ```
 
-1. Create the content of your orb in a YAML file. Here is a simple example to get you started:
+Next, create the content of your orb in a YAML file. Here is a simple example to get you started:
 ```yaml
 version: 2.1
 description: A greeting command orb
@@ -44,28 +44,204 @@ commands:
             - run: echo "Hello, << parameters.to >>"
 ```
 
+## Pack a configuration (optional)
+{: #pack-a-configuration }
+
+The CLI pack command (different than `circleci orb pack`) allows you to create a single YAML file from several separate files (based on directory structure and file contents). The `pack` command implements [FYAML](https://github.com/CircleCI-Public/fyaml), a scheme for breaking YAML documents across files in a directory tree. This is particularly useful for breaking up source code for large orbs and allows custom organization of your orbs' YAML configuration.
+
+```shell
+circleci config pack
+```
+
+How you **name** and **organize** your files when using the `pack` command will determine the final `orb.yml` output. Consider the following folder structure example:
+
+```shell
+$ tree
+.
+└── your-orb-source
+    ├── @orb.yml
+    ├── commands
+    │   └── foo.yml
+    └── jobs
+        └── bar.yml
+
+3 directories, 3 files
+```
+
+The unix `tree` command is great for printing out folder structures. In the example tree structure above, the `pack` command will map the folder names and file names to **YAML keys**, and map the file contents as the **values** to those keys. 
+
+The following command will `pack` up the example folder from above:
+
+```shell
+$ circleci config pack your-orb-source
+```
+
+And the output will be in your `.yml` file:
+
+```yaml
+# Contents of @orb.yml appear here
+commands:
+  foo:
+    # contents of foo.yml appear here
+jobs:
+  bar:
+    # contents of bar.yml appear here
+```
+
+### Other configuration packing capabilities
+{: #other-configuration-packing-capabilities }
+
+A file beginning with `@` will have its contents merged into its parent folder level. This can be useful at the top level of an orb, when one might want generic `orb.yml` to contain metadata, but not to map into an `orb` key-value pair.
+
+Thus:
+
+```shell
+$ cat foo/bar/@baz.yml
+{baz: qux}
+```
+
+Is mapped to:
+
+```yaml
+bar:
+  baz: qux
+```
+
 ## Validate your orb
 {: #validate-your-orb }
 
-1. Validate your orb code using the CLI:
+Validate your orb code using the CLI:
+
 ```
 circleci orb validate /tmp/orb.yml
+```
+
+### Processing a configuration (optional)
+{: #processing-a-configuration }
+
+Running the following command validates your configuration, but will also display expanded source configuration alongside your original configuration (useful if you are using orbs):
+
+```shell
+circleci config process
+```
+
+Consider the following example configuration that uses the link:https://circleci.com/developer/orbs/orb/circleci/node[`node`] orb:
+
+```yml
+version: 2.1
+
+orbs:
+  node: circleci/node@4.7.0
+
+workflows:
+  version: 2
+  example-workflow:
+      jobs:
+        - node/test
+```
+
+Running the following command will output a YAML file like the example below (which is a mix of the expanded source and the original configuration commented out):
+
+```shell
+circleci config process .circleci/config.yml
+```
+```yml
+{% raw %}
+# Orb 'circleci/node@4.7.0' resolved to 'circleci/node@4.7.0'
+version: 2
+jobs:
+  node/test:
+    docker:
+    - image: cimg/node:13.11.0
+      auth:
+        username: mydockerhub-user
+        password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+    steps:
+    - checkout
+    - run:
+        command: |
+          if [ ! -f "package.json" ]; then
+            echo
+            echo "---"
+            echo "Unable to find your package.json file. Did you forget to set the app-dir parameter?"
+            echo "---"
+            echo
+            echo "Current directory: $(pwd)"
+            echo
+            echo
+            echo "List directory: "
+            echo
+            ls
+            exit 1
+          fi
+        name: Checking for package.json
+        working_directory: ~/project
+    - run:
+        command: |
+          if [ -f "package-lock.json" ]; then
+            echo "Found package-lock.json file, assuming lockfile"
+            ln package-lock.json /tmp/node-project-lockfile
+          elif [ -f "npm-shrinkwrap.json" ]; then
+            echo "Found npm-shrinkwrap.json file, assuming lockfile"
+            ln npm-shrinkwrap.json /tmp/node-project-lockfile
+          elif [ -f "yarn.lock" ]; then
+            echo "Found yarn.lock file, assuming lockfile"
+            ln yarn.lock /tmp/node-project-lockfile
+          fi
+          ln package.json /tmp/node-project-package.json
+        name: Determine lockfile
+        working_directory: ~/project
+    - restore_cache:
+        keys:
+        - node-deps-{{ arch }}-v1-{{ .Branch }}-{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
+        - node-deps-{{ arch }}-v1-{{ .Branch }}-{{ checksum "/tmp/node-project-package.json" }}-
+        - node-deps-{{ arch }}-v1-{{ .Branch }}-
+    - run:
+        command: "if [[ ! -z \"\" ]]; then\n  echo \"Running override package installation command:\"\n  \nelse\n  npm ci\nfi\n"
+        name: Installing NPM packages
+        working_directory: ~/project
+    - save_cache:
+        key: node-deps-{{ arch }}-v1-{{ .Branch }}-{{ checksum "/tmp/node-project-package.json" }}-{{ checksum "/tmp/node-project-lockfile" }}
+        paths:
+        - ~/.npm
+    - run:
+        command: npm run test
+        name: Run NPM Tests
+        working_directory: ~/project
+workflows:
+  version: 2
+  example-workflow:
+    jobs:
+    - node/test
+
+# Original config.yml file:
+# version: 2.1
+#
+# orbs:
+#   node: circleci/node@4.7.0
+#
+# workflows:
+#   version: 2
+#   example-workflow:
+#       jobs:
+#         - node/test
+{% endraw %}
 ```
 
 ## Publish your orb
 {: #publish-your-orb }
 
-1. Publish a dev version of your orb:
+Publish a dev version of your orb:
 ```shell
 circleci orb publish /tmp/orb.yml <my-namespace>/<my-orb-name>@dev:first
 ```
 
-1. Once you are ready to push your orb to production, you can publish it manually using `circleci orb publish` or promote it directly from the dev version. Using the following command will increment the dev version to become `0.0.1`:
+Once you are ready to push your orb to production, you can publish it manually using `circleci orb publish` or promote it directly from the dev version. Using the following command will increment the dev version to become `0.0.1`:
 ```shell
 circleci orb publish promote <my-namespace>/<my-orb-name>@dev:first patch
 ```
 
-1. Your orb is now published, in an immutable form, as a production version and can be used safely in CircleCI projects. You can pull the source of your orb using:
+Your orb is now published, in an immutable form, as a production version and can be used safely in CircleCI projects. You can pull the source of your orb using:
 ```shell
 circleci orb source <my-namespace>/<my-orb-name>@0.0.1
 ```
@@ -73,7 +249,7 @@ circleci orb source <my-namespace>/<my-orb-name>@0.0.1
 ## List available orbs
 {: #list-available-orbs }
 
-1. List your available orbs using the CLI:
+List your available orbs using the CLI:
 
 To list **[public]({{site.baseurl}}/orb-intro/#public-orbs)** orbs:
 ```shell

--- a/jekyll/_cci2/orb-development-kit.adoc
+++ b/jekyll/_cci2/orb-development-kit.adoc
@@ -1,0 +1,31 @@
+---
+layout: classic-docs
+title: Orb development kit
+description: How to use CircleCI's orb development kit
+redirect_from: local-jobs
+version:
+- Cloud
+- Server v4.x
+- Server v3.x
+---
+
+[#orb-development-kit]
+== Overview
+
+<<orb-intro#,Orbs>> are reusable snippets of code that help automate repeated processes, accelerate project setup, and make it easy to integrate with third-party tools. CircleCI maintains and link:https://circleci.com/developer/orbs[orb registry] with certified, partner, and third-party orbs.
+
+The orb development kit refers to a suite of tools that work together to simplify the <<orb-author#,orb development process>> when authoring your own orb. The kit provides automatic testing and deployment on CircleCI.
+
+The `orb init` command is the key to using the orb development kit. This command initiates a new orb project based on a template, and that template uses the other tools in the kit to automatically test and deploy your orb.
+
+[#orb-development-kit-components]
+== Orb development kit components
+The orb development kit is made up of the following components:
+
+* link:https://github.com/CircleCI-Public/Orb-Template[Orb template]: Repository with CircleCI's orb project template, which is automatically ingested and modified by the `orb init` command.
+* link:https://circleci-public.github.io/circleci-cli/[CircleCI CLI]: Contains two commands which are designed to work with the kit. The **orb init command** initializes a new orb project, and the **orb pack command** packs the orb source into a single `orb.yml` file.
+  ** link:https://circleci-public.github.io/circleci-cli/circleci_orb_pack.html[Orb pack command]: Initializes a new orb project.
+  ** link:https://circleci-public.github.io/circleci-cli/circleci_orb_init.html[Orb init command]: Packs an orb with local scripts.
+* link:https://circleci.com/developer/orbs/orb/circleci/orb-tools[Orb tools orb]: An orb for creating orbs, which is automatically implemented as a part of the generated configuration when using the **orb init command**.
+
+For more information on orb packing, see the <<orb-concepts#orb-packing,Orbs concepts>> page.

--- a/jekyll/_cci2/testing-orbs.md
+++ b/jekyll/_cci2/testing-orbs.md
@@ -78,7 +78,6 @@ Using CircleCI's Local Execute:
 circleci local execute --job orb-tools/lint
 ```
 
-
 ### Orb Validation
 {: #orb-validation }
 

--- a/jekyll/_cci2/using-docker.md
+++ b/jekyll/_cci2/using-docker.md
@@ -220,6 +220,79 @@ In all cases, cache hits are not guaranteed, but are a bonus convenience when av
 
 In summary, the availability of caching is not something that can be controlled via settings or configuration, but by choosing a popular image, such as [CircleCI convenience images](https://circleci.com/developer/images), you will have more chances of hitting cached layers in the "Spin Up Environment" step.
 
+## Run a job in a container on your machine
+{: run-a-job-in-a-container-on-your-machine }
+
+The [CLI](https://circleci-public.github.io/circleci-cli/) enables you to run jobs in your configuration with Docker. This can be useful to run tests before pushing configuration changes, or debugging your build process without impacting your build queue.
+
+### Prerequisites
+{: #prerequisites }
+
+You will need to have link:https://www.docker.com/products/docker-desktop[Docker] installed on your system, as well as the most recent version of the CLI. You will also need to have a project with a valid `.circleci/config.yml` file in it.
+
+### Running a job
+{: #running-a-job}
+
+The CLI allows you to run a single job from CircleCI on your desktop using Docker with the following command:
+
+```shell
+$ circleci local execute --job JOB_NAME
+```
+
+If your CircleCI configuration is set to version 2.1 or greater, you must first export your configuration to `process.yml`, and specify it when executing with the following commands:
+
+```shell
+circleci config process .circleci/config.yml > process.yml
+circleci local execute -c process.yml --job JOB_NAME
+```
+
+The following commands will run an example build on your local machine on one of CircleCI's demo applications:
+
+```shell
+git clone https://github.com/CircleCI-Public/circleci-demo-go.git
+cd circleci-demo-go
+circleci local execute --job build
+```
+
+The commands above will run the entire `build` job (only jobs, not workflows, can be run locally). The CLI will use Docker to pull down the requirements for the build and then execute your CI steps locally. In this case, Golang and Postgres Docker images are pulled down, allowing the build to install dependencies, run the unit tests, test the service is running, and so on.
+
+### Limitations of running jobs locally
+{: #limitations-of-running-jobs-locally }
+
+Although running jobs locally with `circleci` is very helpful, there are some limitations.
+
+**Machine executor**
+
+You cannot use the machine executor in local jobs. This is because the machine executor requires an extra VM to run its jobs.
+
+**Add SSH keys**
+
+It is currently not possible to add SSH keys using the `add_ssh_keys` CLI command.
+
+**Workflows**
+
+The CLI tool does not provide support for running workflows. By nature, workflows leverage running jobs concurrently on multiple machines allowing you to achieve faster, more complex builds. Because the CLI is only running on your machine, it can only run single jobs (which make up parts of a workflow).
+
+**Caching and online-only Commands**
+
+Caching is not currently supported in local jobs. When you have either a <<configuration-reference#savecache,`save_cache`>> or <</configuration-reference#restorecache,`restore_cache`>> step in your config, `circleci` will skip them and display a warning.
+
+Further, not all commands may work on your local machine as they do online. For example, the Golang build reference above runs a <<configuration-reference#storeartifacts,`store_artifacts`>> step, however, local builds will not upload artifacts. If a step is not available on a local build you will see an error in the console.
+
+**Environment variables**
+
+For security reasons, encrypted environment variables configured in the link:https://app.circleci.com/[web application] will not be imported into local builds. As an alternative, you can specify environment variables to the CLI with the `-e` flag. See the output of the following command for more information.
+
+```shell
+circleci help build
+```
+
+If you have multiple environment variables, you must use the flag for each variable, for example:
+
+```shell
+circleci build -e VAR1=FOO -e VAR2=BAR
+```
+
 ## Next steps
 {: #next-steps }
 

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -246,8 +246,6 @@ en:
           link: sample-config
         - name: Installing the CircleCI CLI
           link: local-cli
-        - name: How to use the CircleCI CLI
-          link: how-to-use-the-circleci-local-cli
     - name: How-To Guides
       children:
         - name: Using matrix jobs


### PR DESCRIPTION
# Description
Removing the content from the how-to CLI page to the other appropriate features/process pages. Content mostly moved to Orbs and Docker pages. Removed the how-to page from the side nav, but the page does still exist until we have a new redirect solution set up.

Also removed mentions of the dockerfile-wizard, as it's no longer supported.

# Reasons
This page was a mishmash of specific CLI commands. Since we have the CLI public page on GitHub, we can just do a better job of linking to this page when we mention the CLI. The commands that were highlighted with examples will be better served in the pages where we specifically talk about the features the commands help with.
[JIRA ticket](https://circleci.atlassian.net/jira/software/c/projects/DOCTEAM/boards/554?modal=detail&selectedIssue=DOCTEAM-746)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
