### PR TITLE
Change rsa to ed25519

### DIFF
--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -41,72 +41,57 @@ would run: `ssh -p <remote_ip> -- powershell.exe`. Consider reading the [Hello W
 
 The build VM will remain available for an SSH connection for **10 minutes after the build finishes running** and then automatically shut down (or you can cancel it). After you SSH into the build, the connection will remain open for **one hour** for customers on a free plan or **two hours** for all other customers.
 
-**Note**: If your job has parallel steps, CircleCI launches more than one VM to perform them. Thus, you'll see more than one 'Enable SSH' and 'Wait for SSH' section in the build output.
+**Note**: If your job has parallel steps, CircleCI launches more than one VM to perform them. Thus, you will see more than one 'Enable SSH' and 'Wait for SSH' section in the build output.
 
 ## Debugging: "permission denied (publickey)"
 {: #debugging-permission-denied-publickey }
 
-If you run into permission troubles trying to SSH to your job, try
-these things:
+If you run into permission troubles trying to SSH to your job, try these things:
 
 ### Ensure authentication with GitHub/Bitbucket
 {: #ensure-authentication-with-githubbitbucket }
-{:.no_toc}
 
-A single command can be used to test that your keys are set up as expected. For
-GitHub run:
+A single command can be used to test that your keys are set up as expected. 
 
+For GitHub run
 ```bash
 ssh git@github.com
 ```
 
 or for Bitbucket run:
-
 ```bash
 ssh -Tv git@bitbucket.org
 ```
 
 and you should see:
-
 ```bash
 $ Hi :username! You've successfully authenticated...
 ```
 
-for GitHub or for Bitbucket:
-
+as well as:
 ```bash
 $ logged in as :username.
 ```
 
-If you _don't_ see output like that, you need to start by
+If you _do not_ see output as described above, you need to start by:
 [troubleshooting your SSH keys with GitHub](https://help.github.com/articles/error-permission-denied-publickey)/
 [troubleshooting your SSH keys with Bitbucket](https://confluence.atlassian.com/bitbucket/troubleshoot-ssh-issues-271943403.html).
 
 ### Ensure authenticating as the correct user
 {: #ensure-authenticating-as-the-correct-user }
-{:.no_toc}
 
-If you have multiple accounts, double-check that you are
-authenticated as the right one!
+If you have multiple accounts, double-check that you are authenticated as the right one!
 
-In order to SSH into a CircleCI build, the username must be one which has
-access to the project being built!
+In order to SSH into a CircleCI build, the username must be one which has access to the project being built!
 
-If you're authenticating as the wrong user, you can probably resolve this
-by offering a different SSH key with `ssh -i`. See the next section if
-you need a hand figuring out which key is being offered.
+If you are authenticating as the wrong user, you can probably resolve this by offering a different SSH key with `ssh -i`. See the next section if you need a hand figuring out which key is being offered.
 
 ### Ensure the correct key is offered to CircleCI
 {: #ensure-the-correct-key-is-offered-to-circleci }
-{:.no_toc}
 
-If you've verified that you can authenticate as the correct
-user, but you're still getting "Permission denied" from CircleCI, you
-may be offering the wrong credentials to us. (This can happen for
-several reasons, depending on your SSH configuration.)
+If you have verified that you can authenticate as the correct user, but you are still getting "Permission denied" from CircleCI, you may be offering the wrong credentials to us. This can happen for several reasons, depending on your SSH configuration.
 
-Figure out which key is being offered to GitHub that authenticates you, by
-running:
+Figure out which key is being offered to GitHub that authenticates you, by running:
 
 ```bash
 $ ssh -v git@github.com
@@ -119,33 +104,29 @@ $ ssh -v git@bitbucket.com
 In the output, look for a sequence like this:
 
 ```bash
-debug1: Offering RSA public key: /Users/me/.ssh/id_rsa_github
+debug1: Offering RSA public key: /Users/me/.ssh/id_ed25519_github
 <...>
 debug1: Authentication succeeded (publickey).
 ```
 
-This sequence indicates that the key /Users/me/.ssh/id_rsa_github is the one which
-GitHub accepted.
+This sequence indicates that the key /Users/me/.ssh/id_ed25519_github is the one which GitHub accepted.
 
-Next, run the SSH command for your CircleCI build, but add the -v flag.
-In the output, look for one or more lines like this:
+Next, run the SSH command for your CircleCI build, but add the -v flag. In the output, look for one or more lines like this:
 
 ```bash
 debug1: Offering RSA public key: ...
 ```
 
-Make sure that the key which GitHub accepted (in our
-example, /Users/me/.ssh/id_rsa_github) was also offered to CircleCI.
+Make sure that the key which GitHub accepted (in our example, /Users/me/.ssh/id_ed25519_github) was also offered to CircleCI.
 
-If it was not offered, you can specify it via the `-i` command-line
-argument to SSH. For example:
+If it was not offered, you can specify it via the `-i` command-line argument to SSH. For example:
 
 ```bash
-$ ssh -i /Users/me/.ssh/id_rsa_github -p 64784 54.224.97.243
+$ ssh -i /Users/me/.ssh/id_ed25519_github -p 64784 54.224.97.243
 ```
 
 ## See also
 {: #see-also }
 {:.no_toc}
 
-[GitHub and Bitbucket Integration](  {{ site.baseurl }}/gh-bb-integration/)
+- [GitHub and Bitbucket Integration]({{site.baseurl}}/gh-bb-integration/)

--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -80,7 +80,7 @@ If you _do not_ see output as described above, you need to start by:
 ### Ensure authenticating as the correct user
 {: #ensure-authenticating-as-the-correct-user }
 
-If you have multiple accounts, double-check that you are authenticated as the right one!
+If you have multiple accounts, double-check that you are authenticated as the right one.
 
 In order to SSH into a CircleCI build, the username must be one which has access to the project being built!
 


### PR DESCRIPTION
# Description
- Change RSA to ed25519 in examples on page.
- Changed the format of the page a little and fixed some other minor errors.

# Reasons
This is GH's directive on what they think is best/most secure.
These changes were made in another PR that got stuck in a build.
[Jira ticket](https://circleci.atlassian.net/jira/software/c/projects/DOCTEAM/boards/554?modal=detail&selectedIssue=DOCTEAM-755)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
