### PR TITLE
Update BASH_ENV code examples

### DIFF
--- a/jekyll/_cci2/databases.md
+++ b/jekyll/_cci2/databases.md
@@ -112,7 +112,7 @@ To use `pg_dump`, `pg_restore` and similar utilities requires some extra configu
 ```yml
     steps:
     # Add the Postgres 12.0 binaries to the path.
-       - run: echo 'export PATH=/usr/lib/postgresql/1bin/:"$PATH"' >> "$"
+       - run: echo 'export PATH=/usr/lib/postgresql/1bin/:"$PATH"' >> "$BASH_ENV"
 ```
 
 ### Using Dockerize to wait for dependencies

--- a/jekyll/_cci2/databases.md
+++ b/jekyll/_cci2/databases.md
@@ -112,7 +112,7 @@ To use `pg_dump`, `pg_restore` and similar utilities requires some extra configu
 ```yml
     steps:
     # Add the Postgres 12.0 binaries to the path.
-       - run: echo 'export PATH=/usr/lib/postgresql/1bin/:$PATH' >> $BASH_ENV
+       - run: echo 'export PATH=/usr/lib/postgresql/1bin/:"$PATH"' >> "$"
 ```
 
 ### Using Dockerize to wait for dependencies

--- a/jekyll/_cci2/deploy-service-update-to-aws-ec2.adoc
+++ b/jekyll/_cci2/deploy-service-update-to-aws-ec2.adoc
@@ -119,7 +119,7 @@ jobs:
                 --output text \
                 --query 'taskDefinition.taskDefinitionArn')
             echo "export TASK_DEFINITION_ARN='${TASK_DEFINITION_ARN}'" >>
-            $BASH_ENV
+            "$BASH_ENV"
       - aws-ecs/verify-revision-is-deployed:
           family: '${MY_APP_PREFIX}-service'
           cluster: '${MY_APP_PREFIX}-cluster'
@@ -181,7 +181,7 @@ jobs:
                 --output text \
                 --query 'taskDefinition.taskDefinitionArn')
             echo "export TASK_DEFINITION_ARN='${TASK_DEFINITION_ARN}'" >>
-            $BASH_ENV
+            "$BASH_ENV"
       - aws-ecs/verify-revision-is-deployed:
           family: '${MY_APP_PREFIX}-service'
           cluster: '${MY_APP_PREFIX}-cluster'

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -115,7 +115,7 @@ jobs: # basic units of work in a run
       # Redirect MY_ENV_VAR into $BASH_ENV
       - run:
           name: "Setup custom environment variables"
-          command: echo 'export MY_ENV_VAR="FOO"' >> $BASH_ENV
+          command: echo 'export MY_ENV_VAR="FOO"' >> "$BASH_ENV"
       - run: # print the name of the branch we're on
           name: "What branch am I on?"
           command: echo ${CIRCLE_BRANCH}
@@ -214,8 +214,8 @@ steps:
   - run:
       name: Setup Environment Variables
       command: |
-        echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
-        echo 'export GIT_SHA1=$CIRCLE_SHA1' >> $BASH_ENV
+        echo 'export PATH="$GOPATH"/bin:"$PATH"' >> "$BASH_ENV"
+        echo 'export GIT_SHA1="$CIRCLE_SHA1"' >> "$BASH_ENV"
 ```
 
 In every step, CircleCI uses `bash` to source `BASH_ENV`. This means that `BASH_ENV` is automatically loaded and run,
@@ -260,10 +260,12 @@ jobs:
     steps:
       - run:
           name: Update PATH and Define Environment Variable at Runtime
+          # Add source command to execute code and make variables 
+          # available in current step.
           command: |
-            echo 'export PATH=/path/to/foo/bin:$PATH' >> $BASH_ENV
-            echo 'export VERY_IMPORTANT=$(cat important_value)' >> $BASH_ENV
-            source $BASH_ENV
+            echo 'export PATH=/path/to/foo/bin:"$PATH"' >> "$BASH_ENV"
+            echo 'export VERY_IMPORTANT=$(cat important_value)' >> "$BASH_ENV"
+            source "$BASH_ENV"
 ```
 
 **Note**:

--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -354,7 +354,7 @@ commands:
             # Configure gcloud to leverage the generated credential configuration
             gcloud auth login --brief --cred-file "<< parameters.gcp_cred_config_file_path >>"
             # Configure ADC
-            echo "export GOOGLE_APPLICATION_CREDENTIALS='<< parameters.gcp_cred_config_file_path >>'" | tee -a $BASH_ENV
+            echo "export GOOGLE_APPLICATION_CREDENTIALS='<< parameters.gcp_cred_config_file_path >>'" | tee -a "$BASH_ENV"
 
 jobs:
   gcp-oidc-defaults:

--- a/jekyll/_cci2/orb-author-faq.md
+++ b/jekyll/_cci2/orb-author-faq.md
@@ -114,7 +114,7 @@ steps:
     command: >
       curl -fsSL
       "https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh" | bash
-      /home/linuxbrew/.linuxbrew/bin/brew shellenv >> $BASH_ENV
+      /home/linuxbrew/.linuxbrew/bin/brew shellenv >> "$BASH_ENV"
     name: Install Homebrew (for Linux)
 ```
 

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -736,7 +736,7 @@ jobs:
             - run:
                   name: Setup __BUILD_VERSION envvar
                   command: |
-                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> "$BASH_ENV"
+                      echo 'export __BUILD_VERSION="$(cat version.txt)"' >> "$BASH_ENV"
             - docker/check:
                   registry: $DOCKER_REGISTRY
             - docker/build:
@@ -776,7 +776,7 @@ jobs:
             - run:
                   name: Setup __BUILD_VERSION envvar
                   command: |
-                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> "$BASH_ENV"
+                      echo 'export __BUILD_VERSION="$(cat version.txt)"' >> "$BASH_ENV"
             - docker/check:
                   registry: $DOCKER_REGISTRY
             - docker/pull:
@@ -883,7 +883,7 @@ jobs:
             - run:
                   name: Setup __BUILD_VERSION envvar
                   command: |
-                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> "$BASH_ENV"
+                      echo 'export __BUILD_VERSION="$(cat version.txt)"' >> "$BASH_ENV"
             - docker/check:
                   registry: $DOCKER_REGISTRY
             - docker/build:
@@ -923,7 +923,7 @@ jobs:
             - run:
                   name: Setup __BUILD_VERSION envvar
                   command: |
-                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> "$BASH_ENV"
+                      echo 'export __BUILD_VERSION="$(cat version.txt)"' >> "$BASH_ENV"
             - docker/check:
                   registry: $DOCKER_REGISTRY
             - docker/pull:
@@ -1340,7 +1340,7 @@ jobs:
       - run:
           name: Compute version number
           command: |
-            echo "export IPERF3_BUILD_VERSION=\"<< pipeline.parameters.branch-name>>-${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:7}\"" | tee -a "$BASH_ENV"
+            echo 'export IPERF3_BUILD_VERSION="<< pipeline.parameters.branch-name>>-${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:7}"' | tee -a "$BASH_ENV"
       - github-release/release:
           tag: v$IPERF3_BUILD_VERSION
           title: $IPERF3_BUILD_VERSION

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -736,7 +736,7 @@ jobs:
             - run:
                   name: Setup __BUILD_VERSION envvar
                   command: |
-                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> $BASH_ENV
+                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> "$BASH_ENV"
             - docker/check:
                   registry: $DOCKER_REGISTRY
             - docker/build:
@@ -776,7 +776,7 @@ jobs:
             - run:
                   name: Setup __BUILD_VERSION envvar
                   command: |
-                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> $BASH_ENV
+                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> "$BASH_ENV"
             - docker/check:
                   registry: $DOCKER_REGISTRY
             - docker/pull:
@@ -883,7 +883,7 @@ jobs:
             - run:
                   name: Setup __BUILD_VERSION envvar
                   command: |
-                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> $BASH_ENV
+                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> "$BASH_ENV"
             - docker/check:
                   registry: $DOCKER_REGISTRY
             - docker/build:
@@ -923,7 +923,7 @@ jobs:
             - run:
                   name: Setup __BUILD_VERSION envvar
                   command: |
-                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> $BASH_ENV
+                      echo "export __BUILD_VERSION=\"$(cat version.txt)\"" >> "$BASH_ENV"
             - docker/check:
                   registry: $DOCKER_REGISTRY
             - docker/pull:
@@ -1340,7 +1340,7 @@ jobs:
       - run:
           name: Compute version number
           command: |
-            echo "export IPERF3_BUILD_VERSION=\"<< pipeline.parameters.branch-name>>-${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:7}\"" | tee -a $BASH_ENV
+            echo "export IPERF3_BUILD_VERSION=\"<< pipeline.parameters.branch-name>>-${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:7}\"" | tee -a "$BASH_ENV"
       - github-release/release:
           tag: v$IPERF3_BUILD_VERSION
           title: $IPERF3_BUILD_VERSION


### PR DESCRIPTION
# Description
Place double quotes around env var names in BASH_ENV examples
Also add comment explaining why `source`  might included in code example

# Reasons
If any of the variables contain spaces or special characters in them, adding double-quotes in the right places will ensure that any spaces or special characters are properly escaped.
[Jira ticket](https://circleci.atlassian.net/browse/DOCTEAM-559)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
