### PR TITLE
add links in to server 4 release notes

### DIFF
--- a/jekyll/_cci2/server/overview/release-notes.adoc
+++ b/jekyll/_cci2/server/overview/release-notes.adoc
@@ -22,6 +22,12 @@ Server v4.x offers the following:
 
 For existing customers interested in migrating from v3.x to v4.x, or v2.x to v4.x contact your customer success manager. Server v4.x will receive monthly patch releases and quarterly feature releases.
 
+Find information about migration in the link:/docs/server/installation/migrate-from-server-3-to-server-4[Migrate From Server v3 to v4 Guide].
+
+[#upgrade]
+== Upgrade
+For upgrade steps see the link:/docs/server/installation/upgrade-server-4[Upgrade Server v4 Guide]. 
+
 [#release-4]
 == Release 4.0.1
 


### PR DESCRIPTION
# Description
I couldn't get some links working for the server release yesterday so I removed them. I now see where my error was so this fixes them.

