### PR TITLE
Remove experiment and add GitLab signup steps

### DIFF
--- a/jekyll/_cci2/first-steps.md
+++ b/jekyll/_cci2/first-steps.md
@@ -9,69 +9,48 @@ version:
 - Cloud
 ---
 
-To run your very first build on CircleCI, go to the [Sign Up](https://circleci.com/signup/){:target="_blank"} page. Sign up with your GitHub or Bitbucket account, or your email address for the option to connect to your code later in the process.
+To run your very first build on CircleCI, go to the [Sign Up](https://circleci.com/signup/){:target="_blank"} page. Sign up with your GitHub or Bitbucket account, or your email address for the option to connect to your code (including your GitLab projects) later in the process.
 
 ## Sign up with GitHub or Bitbucket
 {: #vcs-signup }
 
-1. Click on either **Sign Up with GitHub** or **Sign Up with Bitbucket** to start the authentication process and allow CircleCI to access your code. **Note:** if you are using GitHub, you have the option to limit CircleCI, preventing access to your private repositories. To do this, use the drop down menu at the side of the Sign Up button, and select Public Repos Only from the list.
-    <!-- start: experiment code - #docs-discovery -->
-    <div class="signup-and-try-block">
-      <div class="signup-buttons">
-        <div class="signup-button-wrapper gh-signup-button-wrapper">
-          <a class="track-signup-link gh-signup-button no-external-icon" target="_blank" href="https://circleci.com/auth/vcs-connect?connection=Github">
-            <img class="gh-icon" src="{{site.baseurl}}/assets/img/icons/companies/github.svg"/>
-            <div class="button-text">Sign up with GitHub</div>
-          </a>
-          <button class="gh-dropdown-button">
-            <div class="gh-dropdown-caret"></div>
-          </button>
-          <ul class="gh-signup-dropdown">
-            <li><a class="gh-link track-signup-link" target="_blank" href="https://circleci.com/login/">All Repos</a></li>
-            <li><a class="gh-link track-signup-link" target="_blank" href="https://circleci.com/login-public/">Public Repos Only</a></li>
-          </ul>
-        </div>
-        <div class="signup-button-wrapper">
-          <a href="https://circleci.com/auth/vcs-connect?connection=Bitbucket" target="_blank" class="track-signup-link bb-signup-button no-external-icon">
-            <img class="gh-icon" src="{{site.baseurl}}/assets/img/icons/companies/bitbucket.svg"/>
-            <div class="button-text">Sign up with Bitbucket</div>
-          </a>
-        </div>
-      </div>
-    </div>
-    <!-- end: experiment code -->
-2. Type your GitHub or Bitbucket username, password, and two-factor authorization if applicable, then click Sign In/Login.
+1. Click on either [**Sign Up with GitHub**](https://circleci.com/auth/vcs-connect?connection=Github) or [**Sign Up with Bitbucket**](https://circleci.com/auth/vcs-connect?connection=Bitbucket) to start the authentication process and allow CircleCI to access your code.   
 
-3. Click the Authorize Application or equivalent button. The CircleCI Pipelines Dashboard appears.
+    If you are using GitHub, you have the option to limit CircleCI, preventing access to your private repositories. To do this, use the drop down menu at the side of the Sign Up button, and select **Public Repos Only** from the list.
+    {: class="alert alert-info"}  
 
-4. Use the Projects page of the CircleCI app to start building your project code.
+2. Type your GitHub or Bitbucket username, password, and two-factor authorization if applicable, then click **Sign In/Login**.
+
+3. Click the **Authorize Application** or equivalent button. You will be redirected to the CircleCI pipelines dashboard.
+
+4. Use the **Projects** page of the CircleCI app to start building your project code.
+
+## Sign up with GitLab
+{: #gitlab-signup }
+
+1. Click [**Sign Up with GitLab**](https://circleci.com/auth/signup/).
+
+2. Enter your email address, and then set a secure password for your CircleCI account. A verification email is sent to the email address provided.
+
+3. You will be taken to a screen with the option to create a new project from your GitLab repository. Follow the prompts to connect to your GitLab account. Once you have selected a repository and created a new project, you will be redirected to the CircleCI web app dashboard.
+
+The full set of documentation for integrating GitLab with CircleCI can be found on the [GitLab SaaS integration page]({{site.baseurl}}/gitlab-integration).
+{: class="alert alert-info"}
 
 ## Sign up with email
 {: #email-signup }
 
-1. Click **Sign Up with Email**.
-
-    <!-- start: experiment code - #docs-discovery -->
-    <div class="signup-and-try-block">
-      <div class="signup-button-wrapper">
-        <div class="signup-buttons">
-        <a href="https://circleci.com/auth/signup/" class="track-signup-link email-signup-button no-external-icon">
-            <img class="gh-icon" src="{{site.baseurl}}/assets/img/icons/companies/circleci.svg"/>
-            <div class="button-text">Sign Up with Email</div>
-        </a>
-        </div>
-      </div>
-    </div>
-    <!-- end: experiment code -->
+1. Click [**Sign Up with Email**](https://circleci.com/auth/signup/).
 
 2. Enter your email address, and then set a secure password for your CircleCI account. A verification email is sent to the email address provided.
 
-3. Select the options that best describe you and your engineering organization.
+3. If you do not want to connect to your code and only wish to continue with the email signup, click **Cancel**. You will be taken to a screen where you can respond to prompts that best describe your role and your engineering organization.
 
-4. Connect to your code, or explore some example projects within the CircleCI app if you don't want to connect to your code at this time.
+4. Explore some example projects within the CircleCI app if you do not want to connect to your code at this time. You can take a look at a popular open source project building on CircleCI ([React by Facebook](https://app.circleci.com/pipelines/github/facebook/react)), or one of our own sample projects: a [sample JavaScript app](https://app.circleci.com/pipelines/github/CircleCI-Public/sample-javascript-cfd/), and a [sample Python app](https://app.circleci.com/pipelines/github/CircleCI-Public/sample-python-cfd/).   
 
-    - Connect to your GitHub or Bitbucket account to build and deploy your projects on CircleCI. Type your GitHub or Bitbucket username, password, and two-factor authorization if applicable, then click Sign In/Login.
-    - Explore the app using a popular open source project building on CircleCI ([React by Facebook](https://app.circleci.com/pipelines/github/facebook/react)), or one of our own sample projects: a [sample JavaScript app](https://app.circleci.com/pipelines/github/CircleCI-Public/sample-javascript-cfd/), and a [sample Python app](https://app.circleci.com/pipelines/github/CircleCI-Public/sample-python-cfd/). You'll be able to start exploring features such as [pipelines]({{ site.baseurl }}/pipelines/) and [workflows]({{ site.baseurl }}/workflows). The Dashboard, Projects, Organization Settings, and Plan pages are not available until you connect your GitHub or Bitbucket accounts.
+    You'll be able to start exploring features such as [pipelines]({{site.baseurl}}/pipelines/) and [workflows]({{site.baseurl}}/workflows). The Dashboard, Projects, Organization Settings, and Plan pages are not available until you connect your code.  
+
+    Otherwise, when you are ready, you can connect to your GitHub, BitBucket, or GitLab accounts from the CircleCI web app.  
 
 ## Terms
 {: #terms}

--- a/jekyll/_cci2/first-steps.md
+++ b/jekyll/_cci2/first-steps.md
@@ -9,7 +9,7 @@ version:
 - Cloud
 ---
 
-To run your very first build on CircleCI, go to the [Sign Up](https://circleci.com/signup/){:target="_blank"} page. Sign up with your GitHub or Bitbucket account, or your email address for the option to connect to your code (including your GitLab projects) later in the process.
+To run your very first build on CircleCI, go to the [Sign Up](https://circleci.com/signup/) page. Sign up with your GitHub or Bitbucket account, or your email address for the option to connect to your code (including your GitLab projects) later in the process.
 
 ## Sign up with GitHub or Bitbucket
 {: #vcs-signup }
@@ -48,9 +48,9 @@ The full set of documentation for integrating GitLab with CircleCI can be found 
 
 4. Explore some example projects within the CircleCI app if you do not want to connect to your code at this time. You can take a look at a popular open source project building on CircleCI ([React by Facebook](https://app.circleci.com/pipelines/github/facebook/react)), or one of our own sample projects: a [sample JavaScript app](https://app.circleci.com/pipelines/github/CircleCI-Public/sample-javascript-cfd/), and a [sample Python app](https://app.circleci.com/pipelines/github/CircleCI-Public/sample-python-cfd/).   
 
-    You'll be able to start exploring features such as [pipelines]({{site.baseurl}}/pipelines/) and [workflows]({{site.baseurl}}/workflows). The Dashboard, Projects, Organization Settings, and Plan pages are not available until you connect your code.  
+You will be able to start exploring features such as [pipelines]({{site.baseurl}}/pipelines/) and [workflows]({{site.baseurl}}/workflows). The Dashboard, Projects, Organization Settings, and Plan pages are not available until you connect your code.  
 
-    Otherwise, when you are ready, you can connect to your GitHub, BitBucket, or GitLab accounts from the CircleCI web app.  
+Otherwise, when you are ready, you can connect to your GitHub, BitBucket, or GitLab accounts from the CircleCI web app.  
 
 ## Terms
 {: #terms}


### PR DESCRIPTION
# Description
- Remove signup buttons that were part of a Docs Disco experiment.
- Add a section for signing up with GitLab.
- Modify Sign up with email instructions as there is actually some overlap with the email signup process and GitLab signup.

# Reasons
GitLab integration is GA and this page needed to be refreshed.
Docs Disco will also be creating components that can be reused as CTAs on pages such as these so the code from the experiment is no longer needed.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
