### PR TITLE
clear up that docker compose is pre-installed and a few formatting fixes

### DIFF
--- a/jekyll/_cci2/circleci-images.md
+++ b/jekyll/_cci2/circleci-images.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: "Convenience Images"
+title: "Convenience images"
 description: "Listing of available Docker images maintained by CircleCI"
 version:
 - Cloud
@@ -20,7 +20,6 @@ This document provides information about convenience images (pre-built Docker im
 
 ## Overview
 {: #overview }
-{:.no_toc}
 
 For convenience, CircleCI maintains several Docker images. These images are
 typically extensions of official Docker images, and include tools especially
@@ -41,7 +40,6 @@ Discuss](https://discuss.circleci.com/tags/convenience-images) to be notified in
 
 ### Examples
 {: #examples }
-{:.no_toc}
 
 Refer to the [Examples and Guides Overview]({{ site.baseurl }}/examples-and-guides-overview/) for examples of using pre-built CircleCI Docker Images in a demo application.
 
@@ -154,7 +152,6 @@ jobs:
 
 #### Finding an image id
 {: #finding-an-image-id }
-{:.no_toc}
 
 Follow these steps to find your docker image id:
 
@@ -170,28 +167,21 @@ cimg/python@sha256:bdabda041f88d40d194c65f6a9e2a2e69ac5632db8ece657b15269700b018
 ## Image types
 {: #image-types }
 
-CircleCI's convenience images fall into two categories: **language** images and
-**service** images. All images add a `circleci` user as a system user. The sections below will walk through the available next-generation and legacy images.
+CircleCI's convenience images fall into two categories: 
+* **language** images
+* **service** images 
+
+All images add a `circleci` user as a system user. The sections below walk through the available next-generation and legacy images.
 
 ### Next-gen language images
 {: #next-gen-language-images }
-{:.no_toc}
 
-Like the legacy images, the next-gen language images are convenience images for common programming languages.
-These images include both the same relevant language and [commonly-used tools](#pre-installed-tools).
-A language image should be listed first under the `docker` key in your configuration,
+Next-gen language images are convenience images for common programming languages.
+These images include relevant language tools and [commonly-used tools](#pre-installed-tools).
+To use a language image, list it first under the `docker` key in your configuration,
 making it the [primary container]({{ site.baseurl }}/glossary/#primary-container){:target="_blank"} during execution.
 
-CircleCI is developing next-gen images for the languages below.
-
-- [Elixir](https://circleci.com/developer/images/image/cimg/elixir)
-- [Go (Golang)](https://circleci.com/developer/images/image/cimg/go)
-- [Node.js](https://circleci.com/developer/images/image/cimg/node)
-- [OpenJDK (Java)](https://circleci.com/developer/images/image/cimg/openjdk)
-- [PHP](https://circleci.com/developer/images/image/cimg/php)
-- [Python](https://circleci.com/developer/images/image/cimg/python)
-- [Ruby](https://circleci.com/developer/images/image/cimg/ruby)
-- [Rust](https://circleci.com/developer/images/image/cimg/rust)
+See the [Developer Hub](https://circleci.com/developer/images?imageType=docker) for a full list of next-gen images.
 
 If your language is not listed, feel free to request an image on our [Ideas
 Board](https://ideas.circleci.com/). First, check to see if that "idea" is
@@ -199,11 +189,10 @@ already on CircleCI Ideas. If it is, up-vote it. If not, create it and set the
 category as "images". Finally, go and market your "idea" to friends, co-workers,
 forums, and other communities in order to help it build traction.
 
-If we see an idea on the board take off, we'll consider building it officially.
+If we see an idea on the board take off, we will consider building it officially.
 
 #### Next-gen language image variants
 {: #next-gen-language-image-variants }
-{:.no_toc}
 
 CircleCI maintains several variants for the next-gen language image. For
 next-gen images be sure to check each image listing for information on each
@@ -213,7 +202,6 @@ for details on which variants it supports.
 
 ### Legacy language images
 {: #legacy-language-images }
-{:.no_toc}
 
 The legacy language images are convenience images for common programming languages.
 These images include both the relevant language and [commonly-used tools](#pre-installed-tools).
@@ -236,7 +224,6 @@ CircleCI maintains legacy images for the languages below.
 
 #### Language image variants
 {: #language-image-variants }
-{:.no_toc}
 
 CircleCI maintains several variants for language images. To use these variants,
 add one of the following suffixes to the end of an image tag.
@@ -250,7 +237,6 @@ the `circleci/golang:1.9-browsers` image.
 
 ### Next-Gen Service images
 {: #next-gen-service-images }
-{:.no_toc}
 
 Service images are convenience images for services like databases. These images should be listed **after** language images so they become secondary service containers.
 
@@ -261,7 +247,6 @@ Service images are convenience images for services like databases. These images 
 
 ### Legacy Service images
 {: #legacy-service-images }
-{:.no_toc}
 
 CircleCI maintains legacy images for the services below.
 
@@ -275,20 +260,12 @@ CircleCI maintains legacy images for the services below.
 
 #### Service image variant
 {: #service-image-variant }
-{:.no_toc}
 
 CircleCI maintains only one variant for service images. To speed up builds using
 RAM volume, add the `-ram` suffix to the end of a service image tag.
 
 For example, if you want the `circleci/postgres:9.5-postgis` image to use RAM
 volume, use the `circleci/postgres:9.5-postgis-ram` image.
-
-### Next-gen service images
-{: #next-gen-service-images }
-{:.no_toc}
-
-CircleCI is working on adding next-gen service convenience images.
-Checkout CircleCI's [Developer Hub](https://circleci.com/developer/images/) for the latest available service images.
 
 ## Pre-installed tools
 {: #pre-installed-tools }
@@ -322,7 +299,7 @@ or [Stretch](https://packages.debian.org/stretch/)-based images,
 however the next-gen images, `cimg`, extend the official [Ubuntu](https://packages.ubuntu.com) image.
 For details on the next-gen images, see the [Developer Hub](https://circleci.com/developer/images/). Each image is tracked in its own repository.
 
-The following packages are installed via `curl` or other means.
+The following packages are pre-installed in convenience images using `curl` or other means.
 
 - [Docker client](https://docs.docker.com/install/)
 - [Docker Compose](https://docs.docker.com/compose/overview/)
@@ -333,7 +310,7 @@ The following packages are installed via `curl` or other means.
 ## Out of scope
 {: #out-of-scope }
 
-1. If an image is not listed above, it is not available. As the Convenience Image
+1. If an image is not listed above, it is not available. As the convenience image
    program is revamped, proposals for new images are not currently being
    accepted.
 1. Old versions of software will not be rebuilt. Once an upstream image stops
@@ -342,7 +319,7 @@ The following packages are installed via `curl` or other means.
    example, will no longer be updated either.
 1. We do not support building preview, beta, or release candidate images tags. On
    occasion they will be available but these tags tend to cause our build system
-   for Convenience Images to fail. If you need a non-stable release of a
+   for convenience images to fail. If you need a non-stable release of a
    language, we suggest installing it via [an orb](https://circleci.com/orbs/)
    or a custom Docker image instead.
 
@@ -369,7 +346,6 @@ images!
 
 ### {{ image[1].name }}
 {: # {{image1name}} }
-{:.no_toc}
 
 **Resources:**
 
@@ -387,9 +363,8 @@ See [the tag list for circleci/{{ image[0] }} on Docker Hub](https://hub.docker.
 
 {% endfor %}
 
-## See also
-{: #see-also }
-{:.no_toc}
+## Next steps
+{: #next-steps }
 
 - See [Using Docker Authenticated Pulls]({{ site.baseurl }}/private-images/) for information about how to authorize your build to use an image in a private repository or in Amazon ECR.
 - For information about macOS images for iOS, see ({{ site.baseurl }}/testing-ios/).


### PR DESCRIPTION
# Description
A reader reported that the language around pre-installed packages in convenience images was ambiguous. This PR fixes that and a few other formatting and style bits.

* Removed list of images and replaces with a link to the dev hub
* Removed `no_toc` so all sections are visible in the right hand TOC
 

# Reasons
https://circleci.atlassian.net/browse/DOCTEAM-512?atlOrigin=eyJpIjoiODE0YjNlMzFiOGFjNGFjNThiZmJlNWFkNWIzZGYxMDYiLCJwIjoiaiJ9

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
