### PR TITLE
[DD-841] write a script that transforms all the current doc files frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ src-shared/
 # output for docs-platform
 json/
 
+# output of scripts
+scripts/frontmatter_tagging/tmp/*
+
 # output from building API doc
 src-api/index.html
 src-api/openapi-final.json

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -154,6 +154,8 @@ defaults:
       suggested: false # Disable helpful resources section by default
       sitemap: true # Enable sitemap by default
       readtime: true # Enable Read Time by default
+      tags: null
+      sectionTags: null
 
 t:
     translation_in_progress:

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -154,7 +154,7 @@ defaults:
       suggested: false # Disable helpful resources section by default
       sitemap: true # Enable sitemap by default
       readtime: true # Enable Read Time by default
-      tags: null
+      contentTags: null
 
 t:
     translation_in_progress:

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -155,7 +155,6 @@ defaults:
       sitemap: true # Enable sitemap by default
       readtime: true # Enable Read Time by default
       tags: null
-      sectionTags: null
 
 t:
     translation_in_progress:

--- a/scripts/frontmatter_tagging/frontmatter_tagging.py
+++ b/scripts/frontmatter_tagging/frontmatter_tagging.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-# This script iterates over our docs and converts the front matter to 
-# tags and section tags format
+# This script iterates over our docs and converts version front matter to tags format
+# sectionTags are not dealt with in this script
 
 import os
 import glob
@@ -51,17 +51,13 @@ def iterate_docs():
         proc.run({'addedVariable': version})
         with open(tmpPath, 'w') as f:
           print(proc.dumpFileData(), file=f)
-      else: ### Test case file has no front matter and file does not have version frontmatter
-        post.__setitem__('tags', None)
-        post.__setitem__('sectionTags', None)
+        ### Test case file has no front matter and file does not have version frontmatter
+        ### Covered inside of _config default value null
+
+        # This is a work around of EditFrontMatter not encoding japanese characters properly
+        # We rewrite the file with frontmatter that does encode japanese correctly
+        post = frontmatter.load(tmpPath)
         with open(tmpPath, 'w') as f:
           print(frontmatter.dumps(post), file=f)
-
-      # This is a work around of EditFrontMatter not encoding japanese characters properly
-      # We rewrite the file with frontmatter that does encode japanese correctly
-      post = frontmatter.load(tmpPath)
-      with open(tmpPath, 'w') as f:
-        print(frontmatter.dumps(post), file=f)
-
 
 iterate_docs()

--- a/scripts/frontmatter_tagging/frontmatter_tagging.py
+++ b/scripts/frontmatter_tagging/frontmatter_tagging.py
@@ -42,8 +42,10 @@ def iterate_docs():
 
       if matchFrontmatter:
         if matchFrontmatter[0].find("version:") != -1:
-          temp = open(tmpPath, "w")
           matchVersion = re.search( r'version:[\s\S]+?---', content)[0]
+          if matchFrontmatter[0].find("suggested:") != -1:
+            matchVersion = re.search( r'version:[\s\S]+?suggested:', content)[0]
+          temp = open(tmpPath, "w")
           removeFirstnLast = matchVersion.replace('\n', '\n' + "  ")
           indentedChildren = removeFirstnLast[removeFirstnLast.find('\n')+1:removeFirstnLast.rfind('\n')]
           newContent = content.replace(matchVersion[matchVersion.find('\n')+1:matchVersion.rfind('\n')], indentedChildren)

--- a/scripts/frontmatter_tagging/frontmatter_tagging.py
+++ b/scripts/frontmatter_tagging/frontmatter_tagging.py
@@ -12,8 +12,7 @@ import re
 docs_paths = (
   '../../jekyll/_cci2/*.md',
   '../../jekyll/_cci2/*.adoc',
-  '../../jekyll/_cci2_ja/*.md',
-  '../../jekyll/_cci2_ja/*.adoc',
+  # Request has been made for no script to effect ja content
 )
 
 def iterate_docs():
@@ -48,12 +47,15 @@ def iterate_docs():
           if removeFirstnLast.find(":") != -1: # check if any other meta data after version
             for line in removeFirstnLast.splitlines(): # grab only the children after version
               if line[0] == '-' or line[0] == ' ':     # (---) been removed do not have to worry about it as edge case
-                lines += line + '\n'
+                if line[0] == ' ':
+                  lines += line + '\n'
+                else:
+                  lines += line + '\n'
               else:
                 break
           temp = open(tmpPath, "w") # open new file to write to instead of overriding existing, design choice 
           children = lines[: lines.rfind('\n')]  if lines[: lines.rfind('\n')] else matchVersion[matchVersion.find('\n')+1:matchVersion.rfind('\n')] # remove extra new lines
-          paddChild = '  ' + children.replace('\n', '\n' + "  ") # indents the children
+          paddChild = '    ' + children.replace('\n', '\n' + "    ") # indents the children
           replacedoriginal = content.replace(children, paddChild) # replace not indented children with indented
           matchFrontmatter = re.search(r'^---[\s\S]+?---', replacedoriginal) # grab new frontmatter
           contentTagsFrontmatter = matchFrontmatter[0].replace('version:','contentTags: \n  platform:') # turn version into platform

--- a/scripts/frontmatter_tagging/frontmatter_tagging.py
+++ b/scripts/frontmatter_tagging/frontmatter_tagging.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# This script iterates over our docs and converts the front matter to 
+# tags and section tags format
+
+import os
+import glob
+import sys
+import frontmatter
+from pathlib import Path
+from editfrontmatter import EditFrontMatter
+
+## Select desired markdown and adoc files
+docs_paths = (
+  '../../jekyll/_cci2/*.md',
+  '../../jekyll/_cci2/*.adoc',
+  '../../jekyll/_cci2_ja/*.md',
+  '../../jekyll/_cci2_ja/*.adoc',
+)
+
+def iterate_docs():
+    # make temp directory to pull new data from
+    if not os.path.exists('tmp'):
+      os.mkdir('tmp')
+
+    files = []
+    # iterate over selected folders
+    for path in docs_paths:
+        files.extend(glob.glob(path))
+
+    for file in files:
+      path = Path(file)
+      post = frontmatter.load(path)
+      keys = post.keys()
+      
+      version = None ### Test case version needs to be reset to not be version from previous run
+      if post.get('version') is not None: ### Test case version will be deleted need to store it
+        version = post['version']
+
+      if not os.path.exists('tmp/' + str(path.parent.name)): ## Test case file directory could expand e.g _cci2_ko
+        os.mkdir('tmp/' + str(path.parent.name))
+
+      # location to store new versions of each file
+      tmpPath = 'tmp/' + str(path.parent.name) + '/'+ str(Path(path).stem) + str(Path(path).suffix)
+
+      if version is not None: ### Test case file has version frontmatter
+        template_str = ''.join(open(os.path.abspath("frontmatter_template_tags.j2"), "r").readlines())
+        proc = EditFrontMatter(file_path=path, template_str=template_str)
+        proc.keys_toDelete = ['version']
+        proc.run()
+        proc.run({'addedVariable': version})
+        with open(tmpPath, 'w') as f:
+          print(proc.dumpFileData(), file=f)
+      else: ### Test case file has no front matter and file does not have version frontmatter
+        post.__setitem__('tags', None)
+        post.__setitem__('sectionTags', None)
+        with open(tmpPath, 'w') as f:
+          print(frontmatter.dumps(post), file=f)
+
+      # This is a work around of EditFrontMatter not encoding japanese characters properly
+      # We rewrite the file with frontmatter that does encode japanese correctly
+      post = frontmatter.load(tmpPath)
+      with open(tmpPath, 'w') as f:
+        print(frontmatter.dumps(post), file=f)
+
+
+iterate_docs()

--- a/scripts/frontmatter_tagging/frontmatter_tagging.py
+++ b/scripts/frontmatter_tagging/frontmatter_tagging.py
@@ -40,18 +40,18 @@ def iterate_docs():
 
       matchFrontmatter = re.search(r'^---[\s\S]+?---', content)
 
-      if matchFrontmatter:
-        if matchFrontmatter[0].find("version:") != -1:
+      if matchFrontmatter: # check if front matter exists, if no front matter do nothing
+        if matchFrontmatter[0].find("version:") != -1: # check if version tags exist, if no version tags do nothing
           matchVersion = re.search( r'version:[\s\S]+?---', content)[0]
-          if matchFrontmatter[0].find("suggested:") != -1:
+          if matchFrontmatter[0].find("suggested:") != -1: # check if sugested exists, suggested is below version which changes when version tags end
             matchVersion = re.search( r'version:[\s\S]+?suggested:', content)[0]
-          temp = open(tmpPath, "w")
-          removeFirstnLast = matchVersion.replace('\n', '\n' + "  ")
-          indentedChildren = removeFirstnLast[removeFirstnLast.find('\n')+1:removeFirstnLast.rfind('\n')]
-          newContent = content.replace(matchVersion[matchVersion.find('\n')+1:matchVersion.rfind('\n')], indentedChildren)
-          newFrontmatter = re.search( r'^---[\s\S]+?---', newContent)[0]
-          contentTagsFrontmatter = newFrontmatter.replace('version:','contentTags: \n  platform:')
-          replacedoriginal = newContent.replace(newFrontmatter, contentTagsFrontmatter)
-          temp.write(replacedoriginal)
+          temp = open(tmpPath, "w") # open new file to write to instead of overriding existing, design choice
+          removeFirstnLast = matchVersion.replace('\n', '\n' + "  ") # extract only children of version
+          indentedChildren = removeFirstnLast[removeFirstnLast.find('\n')+1:removeFirstnLast.rfind('\n')] # indent the children of version
+          newContent = content.replace(matchVersion[matchVersion.find('\n')+1:matchVersion.rfind('\n')], indentedChildren) # replace version children with indented children
+          newFrontmatter = re.search( r'^---[\s\S]+?---', newContent)[0] # replace new version inside of content with indented children
+          contentTagsFrontmatter = newFrontmatter.replace('version:','contentTags: \n  platform:') # replace word version with contentTags and append platform under contentTags
+          replacedoriginal = newContent.replace(newFrontmatter, contentTagsFrontmatter) # override old front matter with finished new frontmatter
+          temp.write(replacedoriginal) # write to new file
 
 iterate_docs()

--- a/scripts/frontmatter_tagging/frontmatter_tagging.py
+++ b/scripts/frontmatter_tagging/frontmatter_tagging.py
@@ -55,8 +55,10 @@ def iterate_docs():
           children = lines[: lines.rfind('\n')]  if lines[: lines.rfind('\n')] else matchVersion[matchVersion.find('\n')+1:matchVersion.rfind('\n')] # remove extra new lines
           paddChild = '  ' + children.replace('\n', '\n' + "  ") # indents the children
           replacedoriginal = content.replace(children, paddChild) # replace not indented children with indented
-          contentTagsFrontmatter = replacedoriginal.replace('version:','contentTags: \n  platform:') # turn version into platform
-          temp.write(contentTagsFrontmatter) # write to new file
+          matchFrontmatter = re.search(r'^---[\s\S]+?---', replacedoriginal) # grab new frontmatter
+          contentTagsFrontmatter = matchFrontmatter[0].replace('version:','contentTags: \n  platform:') # turn version into platform
+          finalresult = replacedoriginal.replace(matchFrontmatter[0], contentTagsFrontmatter)
+          temp.write(finalresult) # write to new file
 
 # Create tmp folders
 # iterate and read over desired files

--- a/scripts/frontmatter_tagging/frontmatter_tagging.py
+++ b/scripts/frontmatter_tagging/frontmatter_tagging.py
@@ -43,15 +43,28 @@ def iterate_docs():
       if matchFrontmatter: # check if front matter exists, if no front matter do nothing
         if matchFrontmatter[0].find("version:") != -1: # check if version tags exist, if no version tags do nothing
           matchVersion = re.search( r'version:[\s\S]+?---', content)[0]
-          if matchFrontmatter[0].find("suggested:") != -1: # check if sugested exists, suggested is below version which changes when version tags end
-            matchVersion = re.search( r'version:[\s\S]+?suggested:', content)[0]
-          temp = open(tmpPath, "w") # open new file to write to instead of overriding existing, design choice
-          removeFirstnLast = matchVersion.replace('\n', '\n' + "  ") # extract only children of version
-          indentedChildren = removeFirstnLast[removeFirstnLast.find('\n')+1:removeFirstnLast.rfind('\n')] # indent the children of version
-          newContent = content.replace(matchVersion[matchVersion.find('\n')+1:matchVersion.rfind('\n')], indentedChildren) # replace version children with indented children
-          newFrontmatter = re.search( r'^---[\s\S]+?---', newContent)[0] # replace new version inside of content with indented children
-          contentTagsFrontmatter = newFrontmatter.replace('version:','contentTags: \n  platform:') # replace word version with contentTags and append platform under contentTags
-          replacedoriginal = newContent.replace(newFrontmatter, contentTagsFrontmatter) # override old front matter with finished new frontmatter
-          temp.write(replacedoriginal) # write to new file
+          removeFirstnLast = matchVersion[matchVersion.find('\n')+1:matchVersion.rfind('\n')] # remove version: and --- from group
+          lines = '' # stores group of children
+          if removeFirstnLast.find(":") != -1: # check if any other meta data after version
+            for line in removeFirstnLast.splitlines(): # grab only the children after version
+              if line[0] == '-' or line[0] == ' ':     # (---) been removed do not have to worry about it as edge case
+                lines += line + '\n'
+              else:
+                break
+          temp = open(tmpPath, "w") # open new file to write to instead of overriding existing, design choice 
+          children = lines[: lines.rfind('\n')]  if lines[: lines.rfind('\n')] else matchVersion[matchVersion.find('\n')+1:matchVersion.rfind('\n')] # remove extra new lines
+          paddChild = '  ' + children.replace('\n', '\n' + "  ") # indents the children
+          replacedoriginal = content.replace(children, paddChild) # replace not indented children with indented
+          contentTagsFrontmatter = replacedoriginal.replace('version:','contentTags: \n  platform:') # turn version into platform
+          temp.write(contentTagsFrontmatter) # write to new file
 
+# Create tmp folders
+# iterate and read over desired files
+# extract frontmatter
+# no front matter do nothing
+# check frontmatter for version tags
+# extra children
+# indent children
+# insert indented children
+# write to new file
 iterate_docs()

--- a/scripts/frontmatter_tagging/frontmatter_tagging.py
+++ b/scripts/frontmatter_tagging/frontmatter_tagging.py
@@ -2,13 +2,11 @@
 
 # This script iterates over our docs and converts version front matter to tags format
 # sectionTags are not dealt with in this script
-
 import os
 import glob
 import sys
-import frontmatter
 from pathlib import Path
-from editfrontmatter import EditFrontMatter
+import re
 
 ## Select desired markdown and adoc files
 docs_paths = (
@@ -30,34 +28,28 @@ def iterate_docs():
 
     for file in files:
       path = Path(file)
-      post = frontmatter.load(path)
-      keys = post.keys()
-      
-      version = None ### Test case version needs to be reset to not be version from previous run
-      if post.get('version') is not None: ### Test case version will be deleted need to store it
-        version = post['version']
-
       if not os.path.exists('tmp/' + str(path.parent.name)): ## Test case file directory could expand e.g _cci2_ko
         os.mkdir('tmp/' + str(path.parent.name))
 
       # location to store new versions of each file
       tmpPath = 'tmp/' + str(path.parent.name) + '/'+ str(Path(path).stem) + str(Path(path).suffix)
+    
+      f = open(file, "r")
 
-      if version is not None: ### Test case file has version frontmatter
-        template_str = ''.join(open(os.path.abspath("frontmatter_template_tags.j2"), "r").readlines())
-        proc = EditFrontMatter(file_path=path, template_str=template_str)
-        proc.keys_toDelete = ['version']
-        proc.run()
-        proc.run({'addedVariable': version})
-        with open(tmpPath, 'w') as f:
-          print(proc.dumpFileData(), file=f)
-        ### Test case file has no front matter and file does not have version frontmatter
-        ### Covered inside of _config default value null
+      content = f.read()
 
-        # This is a work around of EditFrontMatter not encoding japanese characters properly
-        # We rewrite the file with frontmatter that does encode japanese correctly
-        post = frontmatter.load(tmpPath)
-        with open(tmpPath, 'w') as f:
-          print(frontmatter.dumps(post), file=f)
+      matchFrontmatter = re.search(r'^---[\s\S]+?---', content)
+
+      if matchFrontmatter:
+        if matchFrontmatter[0].find("version:") != -1:
+          temp = open(tmpPath, "w")
+          matchVersion = re.search( r'version:[\s\S]+?---', content)[0]
+          removeFirstnLast = matchVersion.replace('\n', '\n' + "  ")
+          indentedChildren = removeFirstnLast[removeFirstnLast.find('\n')+1:removeFirstnLast.rfind('\n')]
+          newContent = content.replace(matchVersion[matchVersion.find('\n')+1:matchVersion.rfind('\n')], indentedChildren)
+          newFrontmatter = re.search( r'^---[\s\S]+?---', newContent)[0]
+          contentTagsFrontmatter = newFrontmatter.replace('version:','contentTags: \n  platform:')
+          replacedoriginal = newContent.replace(newFrontmatter, contentTagsFrontmatter)
+          temp.write(replacedoriginal)
 
 iterate_docs()

--- a/scripts/frontmatter_tagging/frontmatter_template_tags.j2
+++ b/scripts/frontmatter_tagging/frontmatter_template_tags.j2
@@ -1,4 +1,3 @@
 tags: 
-  platform: 
-    {{ addedVariable }}
-sectionTags: null
+  - platform: 
+      {{ addedVariable }}

--- a/scripts/frontmatter_tagging/frontmatter_template_tags.j2
+++ b/scripts/frontmatter_tagging/frontmatter_template_tags.j2
@@ -1,0 +1,4 @@
+tags: 
+  platform: 
+    {{ addedVariable }}
+sectionTags: null

--- a/scripts/frontmatter_tagging/frontmatter_template_tags.j2
+++ b/scripts/frontmatter_tagging/frontmatter_template_tags.j2
@@ -1,3 +1,0 @@
-tags: 
-  - platform: 
-      {{ addedVariable }}


### PR DESCRIPTION
[DD-841](https://circleci.atlassian.net/browse/DD-841)

# Description
Wrote a script that:
1. Traverses adoc and md files inside of _cci2 and _cci2_ja
2. Checks if version metadata exists
3. Rewrites file in temporary folder with new format

# Reasons
In preparation of allowing content tagging to exist in all files

# How to test
1. Navigate to scripts/frontmatter_tagging in terminal
2. run `python3 ./frontmatter_tagging.py`

Test files:
`_aws-install.adoc` ---> has no existing front matter
` about-circleci` ---> has version in front matter and other keys
` storage-lifecycle.adoc` ---> only has version in front matter
`v.2.18-overview.md` ---> does not have version in front matter

Also do various 'spot' checks

# Considerations
1. This is a Draft PR until testing can be done in `docs-platform` 
2. Files are rewritten as EditFrontMatter will not use proper encoding for Japanese so files have to be rewritten. EditFrontMatter allows for the requested template format.
I left the above inefficiency because:
    a. the script runs relatively fast still 
    b. the script will only be run locally and not very often
3. I will make another PR to update all the .md and .adoc files. There will be over 500 files updated and wanted to focus the script visibility
4. sectionTags was added inside of _config.yml for preperation of adding it in later

# Note
Tags and Section tags are set to null to be picked up easily in `docs-platform` later. In addition, is a default response for adding a None key.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
