### PR TITLE
No cli pager fix

### DIFF
--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -153,7 +153,7 @@ jobs:
                --output text)
             export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
             # interact with AWS
-            aws sts get-caller-identity
+            aws --no-cli-pager sts get-caller-identity
 ```
 
 [#advanced-usage]

--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -123,7 +123,7 @@ In your job, use the OpenID Connect token to do AWS STS's https://docs.aws.amazo
 * AWS region that you want to operate in
 * ARN of the IAM role that you created earlier
 
-Here is an example config that uses the AWS CLI's https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html[assume-role-with-web-identity subcommand] to authenticate with AWS. It then performs a trivial interaction (`aws sts get-caller-identity`) with AWS, demonstrating that authentication works. Replace that demonstration with whatever you want, such as uploading to an S3 bucket, pushing to ECR, or interacting with EKS.
+Here is an example config that uses the AWS CLI's https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html[assume-role-with-web-identity subcommand] to authenticate with AWS. It then performs a trivial interaction (`aws --no-cli-pager sts get-caller-identity`) with AWS, demonstrating that authentication works. Replace that demonstration with whatever you want, such as uploading to an S3 bucket, pushing to ECR, or interacting with EKS.
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2_ja/openid-connect-tokens.adoc
+++ b/jekyll/_cci2_ja/openid-connect-tokens.adoc
@@ -122,7 +122,7 @@ trusted entity には、**Web Identity** を選択し、先程作成した ID �
 * 運用する AWS リージョン
 * 先程作成した IAM ロールの ARN
 
-下記は、AWS と認証するために AWS CLI の https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html[assume-role-with-web-identity サブコマンド] を使ったサンプル設定です。 その後、AWS との簡単なやり取りにより (`aws sts get-caller-identity`)、認証に成功したことを示します。 これを、S3 バケットへのアップロード、ECR へのプッシュ、EKS とのやり取りなど、任意のものに置き換えてください。
+下記は、AWS と認証するために AWS CLI の https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html[assume-role-with-web-identity サブコマンド] を使ったサンプル設定です。 その後、AWS との簡単なやり取りにより (`aws --no-cli-pager sts get-caller-identity`)、認証に成功したことを示します。 これを、S3 バケットへのアップロード、ECR へのプッシュ、EKS とのやり取りなど、任意のものに置き換えてください。
 
 ```yaml
 version: 2.1
@@ -152,7 +152,7 @@ jobs:
                --output text)
             export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
             # interact with AWS
-            aws sts get-caller-identity
+            aws --no-cli-pager sts get-caller-identity
 ```
 
 [#advanced-usage]

--- a/jekyll/_cci2_ja/openid-connect-tokens.adoc
+++ b/jekyll/_cci2_ja/openid-connect-tokens.adoc
@@ -122,7 +122,7 @@ trusted entity には、**Web Identity** を選択し、先程作成した ID �
 * 運用する AWS リージョン
 * 先程作成した IAM ロールの ARN
 
-下記は、AWS と認証するために AWS CLI の https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html[assume-role-with-web-identity サブコマンド] を使ったサンプル設定です。 その後、AWS との簡単なやり取りにより (`aws --no-cli-pager sts get-caller-identity`)、認証に成功したことを示します。 これを、S3 バケットへのアップロード、ECR へのプッシュ、EKS とのやり取りなど、任意のものに置き換えてください。
+下記は、AWS と認証するために AWS CLI の https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role-with-web-identity.html[assume-role-with-web-identity サブコマンド] を使ったサンプル設定です。 その後、AWS との簡単なやり取りにより (`aws sts get-caller-identity`)、認証に成功したことを示します。 これを、S3 バケットへのアップロード、ECR へのプッシュ、EKS とのやり取りなど、任意のものに置き換えてください。
 
 ```yaml
 version: 2.1
@@ -152,7 +152,7 @@ jobs:
                --output text)
             export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
             # interact with AWS
-            aws --no-cli-pager sts get-caller-identity
+            aws sts get-caller-identity
 ```
 
 [#advanced-usage]


### PR DESCRIPTION
# Description
Added the `--no-cli-pager` flag to the `aws sts get-caller-identitiy` command example so that the job won't hang indefinitely.

# Reasons
This will create a better customer experience to avoid having the aws command causing the job to hang indefinitely.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
