### PR TITLE
Documenting MinIO Uploads - 5GB Limit

### DIFF
--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -615,6 +615,8 @@ Under `object_storage.s3`, you may provide the `accessKey` and `secretKey`, the 
 --
 **Option 1:** Use IAM keys.
 
+*Note*: This option is not recommended if your pipelines store artifacts greater than 5GB. A limitation with the MinIO backend causes S3 uploads with objects greater than 5GB to fail when using IAM keys. For 5GB+ object support, use IRSA (documented below).
+
 Add the following to the `object_storage.s3` section:
 
 [source,yaml]

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -615,7 +615,7 @@ Under `object_storage.s3`, you may provide the `accessKey` and `secretKey`, the 
 --
 **Option 1:** Use IAM keys.
 
-*Note*: This option is not recommended if your pipelines store artifacts greater than 5GB. A limitation with the MinIO backend causes S3 uploads with objects greater than 5GB to fail when using IAM keys. For 5GB+ object support, use IRSA (documented below).
+NOTE: This option is not recommended if your pipelines store artifacts greater than 5GB. A limitation with the MinIO backend causes S3 uploads with objects greater than 5GB to fail when using IAM keys. For 5GB+ object support, use IRSA (documented below).
 
 Add the following to the `object_storage.s3` section:
 


### PR DESCRIPTION
# Description
Documents a limitation when using AWS IAM keys, a S3 backend, and MinIO that causes uploads of greater than 5GB to fail. Workaround/recommendation is to use IRSA.

# Reasons
[SERVER-2071]

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.


[SERVER-2071]: https://circleci.atlassian.net/browse/SERVER-2071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ