### PR TITLE
revert change to page level tags in testing doc

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -4,10 +4,10 @@ title: "Collecting test data"
 description: "A guide to collecting test data in your CircleCI projects."
 contentTags:
   platform:
-    - cloud
-    - server-v4
-    - server-v3
-    - server-v2
+    - Cloud
+    - Server v4.x
+    - Server v3.x
+    - Server v2.x
 sectionTags:
   javascript:
     - "#jest"


### PR DESCRIPTION
# Description
Revert change to page level tags format.

# Reasons
https://circleci.atlassian.net/browse/DOCTEAM-792?atlOrigin=eyJpIjoiZTkxYzdkNDU3ODQxNDY1Mzg0MWI5OWQzNjE5ZmExNGIiLCJwIjoiaiJ9

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
