### PR TITLE
fix: typo in the runner overview page

### DIFF
--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -77,7 +77,7 @@ To get started with CircleCI's self-hosted runners:
 
 * Provide your own platform to deploy your CircleCI's self-hosted runners (see the <<#available-self-hosted-runner-platforms,Available self-hosted runner platforms>> section for supported platforms)
 * For container runner installation, visit the <<container-runner#, Container runner>> page.
-* For machine runner, installation vistit the xref:runner-installation.adoc[Web app installation] page.
+* For machine runner, installation visit the xref:runner-installation.adoc[Web app installation] page.
 
 [#circleci-self-hosted-runner-operation]
 == CircleCI's self-hosted runner operation


### PR DESCRIPTION
# Description

Fix small typo in the `Getting started` section of [this](https://circleci.com/docs/runner-overview#machine-runner-use-case) page:

![image](https://user-images.githubusercontent.com/21243061/192636467-60ef6126-dee5-43c9-a02c-021f16af3e81.png)


# Reasons

Typo.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
