### PR TITLE
Fix typo in canceled state of workflow

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -48,7 +48,7 @@ Workflows may appear with one of the following states:
 |-------|-------------|
 | RUNNING | Workflow is in progress |
 | NOT RUN | Workflow was never started |
-| CANCELLED | Workflow was cancelled before it finished |
+| CANCELED | Workflow was canceled before it finished |
 | FAILING | A job in the workflow has failed |
 | FAILED | One or more jobs in the workflow failed |
 | SUCCESS | All jobs in the workflow completed successfully |


### PR DESCRIPTION
# Description
This PR fixes a typo in the `canceled` state of a workflow.
The correct value is `canceled` and not `cancelled`.

# Reasons
We spotted this error while checking the status of a workflow. We had followed the docs with `cancelled` (with 2 `l`s) but it turned out that the real value was `canceled` (with 1 `l` only).
