### PR TITLE
Removed incompatible entrypoint arguments

### DIFF
--- a/jekyll/_cci2/using-docker.md
+++ b/jekyll/_cci2/using-docker.md
@@ -173,7 +173,6 @@ jobs:
      - image: cimg/base:current
     # Secondary container image on common network.
      - image: cimg/mariadb:10.6
-       command: [mongod, --smallfiles]
 
     steps:
       # command will execute in an Ubuntu-based container


### PR DESCRIPTION
# Description
The "mongod, --smallfiles" are for a MongoDB Daemon arguments and are incompatible with MariaDB

# Reasons
When users attempt to try out the example code "as is", the incompatible entrypoint args will potentially cause the MariaDB service container to fail on startup.  The fix will resolve the issue.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.
