### PR TITLE
Clarify basic auth for API v2

### DIFF
--- a/jekyll/_cci2/api-developers-guide.md
+++ b/jekyll/_cci2/api-developers-guide.md
@@ -30,7 +30,7 @@ Currently, [Personal API tokens]({{site.baseurl}}/managing-api-tokens/#creating-
 
 The CircleCI API utilizes token-based authentication to manage access to the API server and validate that a user has permission to make API requests. Before you can make an API request, you must first add an API token and then verify that you are authenticated by the API server to make requests. The process to add an API token and have the API server authenticate you is described in the sections below.
 
-**Note** You may use the API token as the username for HTTP Basic Authentication, by passing the `-u` flag to the `curl` command.
+For **public repositories only**, you may use the API token as the username for HTTP Basic Authentication, by passing the `-u` flag to the `curl` command. For private repositories, you must include the token value in the request header as shown in the examples below.
 
 ### Add an API token
 {: #add-an-api-token }

--- a/jekyll/_cci2/api-intro.md
+++ b/jekyll/_cci2/api-intro.md
@@ -48,13 +48,15 @@ The `project_slug` is included in the payload when pulling information about a p
 ## Authentication
 {: #authentication }
 
-The CircleCI API v2 enables users to be authenticated by simply sending your [Personal API token]({{site.baseurl}}/managing-api-tokens/#creating-a-personal-api-token) as the username of the HTTP request. For example, if you have set `CIRCLE_TOKEN` in your shell's environment, you could then use `curl` with that token like the example shown below:
+For **public repositories only**, the CircleCI API v2 enables users to be authenticated by sending your [Personal API token]({{site.baseurl}}/managing-api-tokens/#creating-a-personal-api-token) as the username of the HTTP request. For example, if you have set `CIRCLE_TOKEN` in your shell's environment, you could then use `curl` with that token like the example shown below:
 
 ```shell
 curl -u ${CIRCLE_TOKEN}: https://circleci.com/api/v2/me
 ```
 
-**Note:** the `:` is included to indicate there is no password.
+The `:` is included to indicate there is no password.
+
+For **private repositories**, you must send the API token as a HTTP header in the request, with the name `Circle-Token` and the token as the value. You can find examples in the [API Developer's Guide]({{site.baseurl}}/api-developers-guide).
 
 #### Triggering a pipeline with parameters example
 {: #triggering-a-pipeline-with-parameters-example }

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -448,7 +448,7 @@ en:
         link: https://circleci.com/docs/api/v2
       - name: API v2 introduction
         link: api-intro
-      - name: API v2 developer's Guide
+      - name: API v2 developer's guide
         link: api-developers-guide
       - name: API v1.1 reference
         link: https://circleci.com/docs/api/v1


### PR DESCRIPTION
# Description
Our docs currently mention basic auth (by passing in the API token as the username, no password) but do not specify that this can be used only with public repositories. 

# Reasons
If the basic auth method is used with private repositories, it will return a 404 error "Project not found".
[Jira ticket](https://circleci.atlassian.net/browse/DOCTEAM-761)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
