### PR TITLE
[RT-703] Add documentation for container agent custom token secret

### DIFF
--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -145,6 +145,33 @@ agent:
           - name: "other"
 ```
 
+[#custom-secret]
+=== Custom Token Secret
+
+Using the above configuration will provision a Kubernetes secret containing your Resource Class tokens. In some circumstances you may wish to provision your own secret, or you simply might not want to specify the tokens via helm. Instead you can provision your own Kubernetes secret containing your tokens and specify its name in the `agent.customSecret` field.
+
+The secret should contain a field for each Resource Class, using the Resource Class name as the key and the token as the value. Consider the following `resourceClasses` configuration:
+
+```yaml
+agent:
+  resourceClasses:  
+    circleci-runner/resourceClass:
+      metadata:
+        annotations:
+          custom.io: my-annotation
+    
+    circleci-runner/resourceClass2:
+```
+The corresponding custom secret would have 2 fields:
+
+```yaml
+circleci-runner.resourceClass: TOKEN1
+circleci-runner.resourceClass2: TOKEN2
+```
+
+Due to Kubernetes secret key character constraints, the `/` separating the Namespace and Resouce Class name is replaced with a `.` character. Other than this the name must exactly match the `resourceClasses` config to match the token with the correct configuration.
+
+Even if there is no further pod configuration, the resource class must be present in `resourceClasses` as an emtpy map, as shown by `circleci-runner/resourceClass2` in the above config
 
 [#parameters]
 === Helm Chart Parameters
@@ -167,8 +194,12 @@ The following are **CircleCI specific settings**:
 | `container-agent` (the name of the deployment)
 
 | agent.resourceClasses *Default must be updated in order to run a job successfully*
-| Resource class task configuration. See "Resource Class Configuration” section below
-| " "
+| Resource class task configuration. See "<<resource-class-configuration-custom-pod,Resource Class Configuration>>" section above
+| {}
+
+| agent.customSecret
+| A user provided Kubernetes containing resource class tokens. See "<<custom-secret,Custom Token Secret>>" section above
+| ""
 
 | agent.terminationGracePeriodSeconds
 | Termination grace period during container runner shutdown
@@ -217,11 +248,11 @@ The following is for **Kubernetes object settings**. All settings prefixed with 
 
 | nameOverride
 | Override the chart name
-| " "
+| ""
 
 | fullnameOverride
 | Override the full generated name
-| " "
+| ""
 
 | agent.replicaCount
 | Number of container-agents to deploy. The recommendation is to leave this value at 1
@@ -229,7 +260,7 @@ The following is for **Kubernetes object settings**. All settings prefixed with 
 
 | agent.image.registry
 | Agent image registry
-| " "
+| ""
 
 | agent.image.repository
 | Agent image repository
@@ -237,7 +268,7 @@ The following is for **Kubernetes object settings**. All settings prefixed with 
 
 | agent.pullPolicy
 | Agent image pull policy
-| ifNotPresent
+| Always
 
 | agent.tag
 | Agent image tag
@@ -289,7 +320,7 @@ The following is for **Kubernetes object settings**. All settings prefixed with 
 
 | rbac.create
 | Create a Role and RoleBinding for the service account
-| 
+| true
 |===
 
 Container runner needs the following Kubernetes permissions:

--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -146,11 +146,11 @@ agent:
 ```
 
 [#custom-secret]
-=== Custom Token Secret
+=== Custom token secret
 
-Using the above configuration will provision a Kubernetes secret containing your Resource Class tokens. In some circumstances you may wish to provision your own secret, or you simply might not want to specify the tokens via helm. Instead you can provision your own Kubernetes secret containing your tokens and specify its name in the `agent.customSecret` field.
+Using the configuration described above provisions a Kubernetes secret containing your resource class tokens. In some circumstances, you may wish to provision your own secret, or you simply might not want to specify the tokens via helm. Instead, you can provision your own Kubernetes secret containing your tokens and specify its name in the `agent.customSecret` field.
 
-The secret should contain a field for each Resource Class, using the Resource Class name as the key and the token as the value. Consider the following `resourceClasses` configuration:
+The secret should contain a field for each resource class, using the resource class name as the key and the token as the value. Consider the following `resourceClasses` configuration:
 
 ```yaml
 agent:
@@ -158,20 +158,21 @@ agent:
     circleci-runner/resourceClass:
       metadata:
         annotations:
-          custom.io: my-annotation
+          custom.io: <my-annotation>
     
     circleci-runner/resourceClass2:
 ```
+
 The corresponding custom secret would have 2 fields:
 
 ```yaml
-circleci-runner.resourceClass: TOKEN1
-circleci-runner.resourceClass2: TOKEN2
+circleci-runner.resourceClass: <my-token>
+circleci-runner.resourceClass2: <my-token-2>
 ```
 
-Due to Kubernetes secret key character constraints, the `/` separating the Namespace and Resouce Class name is replaced with a `.` character. Other than this the name must exactly match the `resourceClasses` config to match the token with the correct configuration.
+Due to Kubernetes secret key character constraints, the `/` separating the namespace and resouce class name is replaced with a `.` character. Other than this, the name must exactly match the `resourceClasses` config to match the token with the correct configuration.
 
-Even if there is no further pod configuration, the resource class must be present in `resourceClasses` as an emtpy map, as shown by `circleci-runner/resourceClass2` in the above config
+Even if there is no further pod configuration, the resource class must be present in `resourceClasses` as an emtpy map, as shown by `circleci-runner/resourceClass2` in the above config example.
 
 [#parameters]
 === Helm Chart Parameters
@@ -194,11 +195,11 @@ The following are **CircleCI specific settings**:
 | `container-agent` (the name of the deployment)
 
 | agent.resourceClasses *Default must be updated in order to run a job successfully*
-| Resource class task configuration. See "<<resource-class-configuration-custom-pod,Resource Class Configuration>>" section above
+| Resource class task configuration. See the "<<resource-class-configuration-custom-pod,Resource Class Configuration>>" section above.
 | {}
 
 | agent.customSecret
-| A user provided Kubernetes containing resource class tokens. See "<<custom-secret,Custom Token Secret>>" section above
+| A user provided Kubernetes containing resource class tokens. See the "<<custom-secret,Custom Token Secret>>" section above.
 | ""
 
 | agent.terminationGracePeriodSeconds


### PR DESCRIPTION
# Description

Add documentation for the custom token secret feature in the container agent helm chart

# Reasons

Documentation supporting this feature: https://circleci.atlassian.net/browse/RT-703

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
