### PR TITLE
Remove duplicate writing YAML

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -240,8 +240,6 @@ en:
           link: dynamic-config
         - name: Using the CircleCI configuration editor
           link: config-editor
-        - name: Writing YAML
-          link: writing-yaml
     - name: Reference
       children:
         - name: Configuration reference


### PR DESCRIPTION
# Description
Removes duplicate YAML page

# Reasons
This is a duplicate page that redirects to the Intro page in Getting Started - I think it can be removed.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
