### PR TITLE
Improve instructions for RUNNER_NAME

### DIFF
--- a/jekyll/_cci2/runner-installation-mac.adoc
+++ b/jekyll/_cci2/runner-installation-mac.adoc
@@ -38,6 +38,8 @@ After successful installation, the launch-agent.sh file can be deleted.
 
 You will need to choose a user to run the CircleCI agent. These instructions refer to the selected user as `USERNAME`. The `USERNAME` refers to the user on the machine that the agent will be installed on, _not_ the CircleCI account username.
 
+The `RUNNER_NAME` refers to the `resource-class` and should not include the `namespace`.
+
 Complete the template shown below, with the various capitalized parameters filled in. When complete, save the template as `launch-agent-config.yaml`.
 
 ```yaml


### PR DESCRIPTION
# Description
Improves instructions for variable `RUNNER_NAME`.

# Reasons
The instructions for the variable `RUNNER_NAME` are confusing, since previous docs refer to `resource-class`. In addition, it's not clear if `namespace` is required. This clarifies that as well.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
