### PR TITLE
[RT-700] Update container agent helm chart to point at new package cloud repo

### DIFF
--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -49,13 +49,13 @@ WARNING: Use with caution as the product is still in a preview phase.
 [#installing-the-helm-chart]
 === Install the Helm chart
 
-NOTE: These instructions may change during the open preview.
+NOTE: The location for the helm chart has changed as of October 6, 2022. The previous helm chart repository location will continue to be kept up-to-date until a date to be announced later
 
 Install the Helm chart with the release name `container-agent`:
 
-* Run `helm repo add circleci https://circleci-binary-releases.s3.amazonaws.com/charts/`
+* Run `helm repo add container-agent https://packagecloud.io/circleci/container-agent/helm`
 * Run `helm repo update`
-* Run `helm install container-agent circleci/container-agent -n circleci` to install the chart.
+* Run `helm install container-agent container-agent/container-agent -n circleci` to install the chart.
  
 This will deploy the container runner to the Kubernetes cluster as a release called `container-agent`. You can view the default values by running `helm show values circleci/container-agent` and override these using the `--values` or `--set name=value` flags on the install command below.
 

--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -49,7 +49,7 @@ WARNING: Use with caution as the product is still in a preview phase.
 [#installing-the-helm-chart]
 === Install the Helm chart
 
-NOTE: The location for the helm chart has changed as of October 6, 2022. The previous helm chart repository location will continue to be kept up-to-date until a date to be announced later
+NOTE: The location for the Helm chart has changed as of October 6, 2022. The previous Helm chart repository location will continue to be kept up to date until a date to be announced later.
 
 Install the Helm chart with the release name `container-agent`:
 


### PR DESCRIPTION
# Description

The runner team has migrated the container agent helm chart to a new repository. This updates the install instructions to use the new repository

# Reasons

https://circleci.atlassian.net/browse/RT-700

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
