### PR TITLE
Update test splitting documentation

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -63,7 +63,8 @@ jobs:
       - run: go test -v $(go list ./... | circleci tests split --split-by=timings)
 ```
 
-**Note:** The first time the tests are run there will be no timing data for the command to use, but on subsequent runs the test time will be optimized.
+**Note:** 
+The first time the tests are run there will be no timing data for the command to use, but on subsequent runs the test time will be optimized.
 
 ### Is it worth it?
 {: #is-it-worth-it }
@@ -165,7 +166,7 @@ To split by test timings, use the `--split-by` flag with the `timings` split typ
 circleci tests glob "**/*.go" | circleci tests split --split-by=timings
 ```
 
-The CLI expects both filenames and classnames to be present in the timing data produced by the testing suite. By default, splitting defaults to filename, but you can specify classnames by using the `--timings-type` flag.
+The CLI expects both filenames and classnames to be present in the timing data produced by the testing suite. By default, splitting defaults `--timings-type` to `filename`. You may need to choose a different timings type depending on how your test coverage output is formatted. Valid timing types are `filename`, `classname`, `testname`, and `autodetect`.
 
 ```shell
 cat my_java_test_classnames | circleci tests split --split-by=timings --timings-type=classname


### PR DESCRIPTION
# Description
Adds additional information regarding the `--timings-type` flag and its corresponding values.

# Reasons
The current documentation briefly mentions the `--timings-type` flag but stops short of including valid flag values. This PR expands on the existing documentation and includes known flag values.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
