### PR TITLE
The latest tag no longer exists its now current

### DIFF
--- a/jekyll/_cci2/pipeline-variables.md
+++ b/jekyll/_cci2/pipeline-variables.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: "Pipeline values and parameters"
+title: Pipeline values and parameters
 description: "Detailed information about pipeline parameters and values"
 categories: [getting-started]
 order: 1

--- a/jekyll/_cci2/pipeline-variables.md
+++ b/jekyll/_cci2/pipeline-variables.md
@@ -70,7 +70,7 @@ version: 2.1
 parameters:
   image-tag:
     type: string
-    default: "latest"
+    default: "current"
   workingdir:
     type: string
     default: "~/main"


### PR DESCRIPTION
# Description
This fixes the example as I ran into the issue when trying this just now

# Reasons
I ran into this issue just now and we have updated the latest tag to now be current so the build fails when using the example.
