### PR TITLE
Update reusing-config.md

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -72,7 +72,7 @@ Key Name | Description | Default value
 ---|---|---
 description | Optional. Used to generate documentation for your orb. | N/A
 type | Required. See **Parameter Types** in the section below for details. | N/A
-default | The default value for the parameter. If not present, the parameter is implied to be required. | N/A
+default | Required. The default value for the parameter. If the parameter is required, use his own name for the default value and check if it exist with an if. | N/A
 {: class="table table-striped"}
 
 ### Parameter types


### PR DESCRIPTION
# Description
Change in documentation according to this discussion. https://discuss.circleci.com/t/using-pipeline-parameters/34980/9

# Reasons
The default is always required for parameters.
![image](https://user-images.githubusercontent.com/7040664/195075349-b7370038-784c-447f-b392-b7ba02ec2b93.png)
