### PR TITLE
Improvements to server 4 VM service docs

### DIFF
--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -493,6 +493,8 @@ image::realitycheck-pipeline.png[Screenshot showing the realitycheck project bui
 
 VM service configures virtual machine and remote docker jobs. You can configure a number of options for VM service, such as scaling rules. VM service is unique to AWS and GCP installations because it relies on specific features of these cloud providers.
 
+NOTE: Once you have completed the server installation process you can further configure VM service, including building a specifying a Windows image to give developers access to the Windows execution environment, specifying an alternative Linux machine image, and specifying a number of preallocated instances to remain spun up at all times. For more information, see the link:/docs/server/operator/manage-virtual-machines-with-vm-service[Managing Virtual Machines with VM Service] page.
+
 ifndef::env-gcp[]
 
 [#aws-vm-service]
@@ -936,7 +938,22 @@ aws iam create-access-key --user-name circleci-vm-service
 . *Configure server (there are two options)*
 +
 * *Option 1 - Add the keys to `values.yaml`*
-Add the VM Service configuration to `values.yaml`. Details of the available configuration options can be found in the link:/docs/server/operator/manage-virtual-machines-with-vm-service[Managing Virtual Machines with VM Service] guide.
+Add the VM Service configuration to `values.yaml`.
++
+[source,shell]
+----
+vm_service:
+  providers:
+    ec2:
+      enabled: true
+      region: "<REGION>"
+      assignPublicIP: true
+      accessKey: "<ACCESS-KEY>"
+      secretKey: "<SECRET-KEY>"
+      subnets:
+      - "<SUBNET_ID>"
+      securityGroupId: "<SECURITY_GROUP_ID>"
+----
 +
 * *Option 2 - Create the Kubernetes Secret yourself*
 Instead of providing the access key and secret in your `values.yaml` file, you may create the Kubernetes Secret yourself.
@@ -987,12 +1004,12 @@ databaseEncryption:
 +
 Run the following commands to create a firewall rule for VM service in GKE:
 +
+NOTE: If you have used auto-mode, you can find the Nomad clients CIDR based on the region by referring to the https://cloud.google.com/vpc/docs/vpc#ip-ranges[table here].
++
 [source,shell]
 ----
 gcloud compute firewall-rules create "circleci-vm-service-internal-nomad-fw" --network "<network>" --action allow --source-ranges "0.0.0.0/0" --rules "TCP:22,TCP:2376"
 ----
-+
-NOTE: If you have used auto-mode, you can find the Nomad clients CIDR based on the region by referring to the https://cloud.google.com/vpc/docs/vpc#ip-ranges[table here].
 +
 [source,shell]
 ----
@@ -1038,27 +1055,33 @@ And
 gcloud projects add-iam-policy-binding <YOUR_PROJECT_ID> --member serviceAccount:<YOUR_SERVICE_ACCOUNT_EMAIL> --role roles/iam.serviceAccountUser --condition=None
 ----
 
-. *Enable Workload Identity for Service Account*
+. *Enable Workload Identity for Service Account or get JSON key file*
 +
+Choose one of the following options, depending on whether your are using Workload Identity.
++
+[.tab.workloadorjson.Enable_Workload_Identity_for_Service_Account]
+--
 This step is required only if you are using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identities] for GKE. Steps to enable Workload Identities are provided in link:https://circleci.com/docs/2.0/server-3-install-prerequisites/index.html#enabling-workload-identity-in-gke[Phase 1 - Prerequisites].
-+
+
 [source,shell]
 ----
 gcloud iam service-accounts add-iam-policy-binding <YOUR_SERVICE_ACCOUNT_EMAIL> \
     --role roles/iam.workloadIdentityUser \
     --member "serviceAccount:<GCP_PROJECT_ID>.svc.id.goog[circleci-server/vm-service]"
 ----
-
-. *Optionally, get JSON Key File*
+--
 +
+[.tab.workloadorjson.Get_Service_Account_JSON_key_file]
+--
 If you are using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identities] for GKE, this step is not required.
-+
+
 After running the following command, you should have a file named `circleci-server-vm-keyfile` in your local working directory. You will need this when you configure your server installation.
-+
+
 [source,shell]
 ----
 gcloud iam service-accounts keys create circleci-server-vm-keyfile --iam-account <YOUR_SERVICE_ACCOUNT_EMAIL>
 ----
+--
 
 . *Configure Server*
 +
@@ -1068,7 +1091,29 @@ When using service account keys for configuring access for the VM service, there
 --
 **Option 1:** CircleCI creates the Kubernetes Secret.
 
-Add the VM Service configuration to values.yaml. Details of the available configuration options can be found in the link:/docs/server/operator/manage-virtual-machines-with-vm-service[Managing Virtual Machines with VM Service] guide.
+Add the VM Service configuration to values.yaml. 
+
+[source,yaml]
+----
+vm_service:
+  enabled: true
+  replicas: 1
+  providers:
+    gcp:
+      enabled: false
+      project_id: <project-id>
+      network_tags:
+      - circleci-vm
+      - <your-network>
+      zone: <zone>
+      network: <network>
+      subnetwork: <subnetwork>
+
+      service_account: <service-account-json>
+      # OR
+      workloadIdentity: ""  # Leave blank if using JSON keys of service account else service account email address
+----
+
 --
 
 [.tab.configureserver.You_create_Secret]

--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -491,7 +491,7 @@ image::realitycheck-pipeline.png[Screenshot showing the realitycheck project bui
 [#vm-service]
 == 3. VM service
 
-VM service is used to configure instances for jobs that run in Linux VM, Windows amd Arm execution environments, and those that are configured to use link:/docs/configuration-reference/#setupremotedocker[remote Docker]. You can configure a number of options for VM service, such as scaling rules. VM service is unique to AWS and GCP installations because it relies on specific features of these cloud providers.
+VM service is used to configure virtual machines for jobs that run in Linux VM, Windows amd Arm execution environments, and those that are configured to use link:/docs/configuration-reference/#setupremotedocker[remote Docker]. You can configure a number of options for VM service, such as scaling rules. VM service is unique to AWS and GCP installations because it relies on specific features of these cloud providers.
 
 NOTE: Once you have completed the server installation process you can further configure VM service, including building and specifying a Windows image to give developers access to the Windows execution environment, specifying an alternative Linux machine image, and specifying a number of preallocated instances to remain spun up at all times. For more information, see the link:/docs/server/operator/manage-virtual-machines-with-vm-service[Managing Virtual Machines with VM Service] page.
 

--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -491,9 +491,9 @@ image::realitycheck-pipeline.png[Screenshot showing the realitycheck project bui
 [#vm-service]
 == 3. VM service
 
-VM service configures virtual machine and remote docker jobs. You can configure a number of options for VM service, such as scaling rules. VM service is unique to AWS and GCP installations because it relies on specific features of these cloud providers.
+VM service is used to configure instances for jobs that run in Linux VM, Windows amd Arm execution environments, and those that are configured to use link:/docs/configuration-reference/#setupremotedocker[remote Docker]. You can configure a number of options for VM service, such as scaling rules. VM service is unique to AWS and GCP installations because it relies on specific features of these cloud providers.
 
-NOTE: Once you have completed the server installation process you can further configure VM service, including building a specifying a Windows image to give developers access to the Windows execution environment, specifying an alternative Linux machine image, and specifying a number of preallocated instances to remain spun up at all times. For more information, see the link:/docs/server/operator/manage-virtual-machines-with-vm-service[Managing Virtual Machines with VM Service] page.
+NOTE: Once you have completed the server installation process you can further configure VM service, including building and specifying a Windows image to give developers access to the Windows execution environment, specifying an alternative Linux machine image, and specifying a number of preallocated instances to remain spun up at all times. For more information, see the link:/docs/server/operator/manage-virtual-machines-with-vm-service[Managing Virtual Machines with VM Service] page.
 
 ifndef::env-gcp[]
 

--- a/jekyll/_cci2/server/operator/manage-virtual-machines-with-vm-service.adoc
+++ b/jekyll/_cci2/server/operator/manage-virtual-machines-with-vm-service.adoc
@@ -29,46 +29,22 @@ The following configuration options are for the VM provider: either AWS or GCP.
 
 [#aws]
 === AWS
-You will need to add a section to your `values.yaml` file to configure VM Service to work with AWS EC2. 
+There is a section in your `values.yaml` file that configures VM Service to work with AWS EC2. During installation you will have set up a security group and authentication. See the link:/docs/server/installation/phase-3-execution-environments/#aws-vm-service[Installation Phase 3 - Execution Environments] page for more information.
 
-[#aws-authentication]
-==== Authentication
-One of the following options is required:
+The informaiton in this section describes post-installation configuration options for VM service.
 
-* Either, select "IAM Keys" and provide:
-** *Access Key ID* (required): https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Access Key ID] for EC2 access.
-** *Secret Key* (required): https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Secret Key] for EC2 access.
-+
-NOTE: The Access Key and Secret Key used by VM Service differs from the policy used by object storage in the previous section.
+==== Windows image
 
-* Or, select "IAM role" and provide:
-** *Role ARN* (required): 
-+
-https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[Role ARN for Service Accounts] (Amazon Resource Name) for EC2 access.
+==== Alternative Linux VM image
 
-[source,yaml]
-----
-vm_service:
-  providers:
-    ec2:
-      enabled: true
-      region: <region>
-      # Subnets must be in the same availability zone
-      subnets:
-      - <subnet-id>
-      securityGroupId: <security-group-id>
+==== Instance preallocation
 
-      # Authenticate with IAM access keys
-      accessKey: <access-key>
-      secretKey: <secret-key>
-      # or IRSA (IAM roles for service accounts)
-      irsaRole: <role-arn>
-----
-
-[#default-aws-ami-list]
-==== Default AWS AMI list
+[#default-aws-ami-lists]
+==== Default AWS AMI lists
 
 The default AMIs for server v4.x are based on Ubuntu 22.04.
+
+===== x86 AMI list
 
 [.table.table-striped]
 [cols=2*, options="header", stripes=even]
@@ -128,39 +104,72 @@ The default AMIs for server v4.x are based on Ubuntu 22.04.
 | `ami-02abf947586cae56b`
 |===
 
+[#arm-ami-list]
+===== Arm AMI list
+
+[.table.table-striped]
+[cols=2*, options="header", stripes=even]
+|===
+| Region
+| AMI
+
+|`us-east-1`
+|`ami-0b11ce74f44e45578`
+
+|`ca-central-1`
+|`ami-07400e987dd82901d`
+
+|`ap-south-1`
+|`ami-072fe819d7b94b095`
+
+|`ap-southeast-2`
+|`ami-0510826f7f3a83b3e`
+
+|`ap-southeast-1`
+|`ami-0e5b703665f3e4517`
+
+|`eu-central-1`
+|`ami-045ea67b0f35ef1ef`
+
+|`eu-west-1`
+|`ami-044ac39c87438d89d`
+
+|`eu-west-2`
+|`ami-0a399817fbbb240e4`
+
+|`sa-east-1`
+|`ami-0ebc0e64fb943e191`
+
+|`us-east-2`
+|`ami-01f7dc2f8590b1611`
+
+|`us-west-1`
+|`ami-085fb1dd323aa02c7`
+
+|`us-west-2`
+|`ami-0e5ea38c131f05c8f`
+
+|`ap-northeast-1`
+|`ami-02c8fac0dbbbad74f`
+
+|`ap-northeast-2`
+|`ami-022e2eacee7328cca`
+
+|`us-gov-east-1`
+|`ami-0bb797dcfa52ce04d`
+
+|`us-gov-west-1`
+|`ami-0ab175883ff460b17`
+|===
+
 [#gcp]
 === GCP
-You will need to add a section to your `values.yaml` file to configure VM Service to work with Google Cloud Platform (GCP). 
+There is a section in your `values.yaml` file that configures VM Service to work with GCP. During installation you will have set up a security group and authentication. See the link:/docs/server/installation/phase-3-execution-environments/#aws-vm-service[Installation Phase 3 - Execution Environments] page for more information. 
 
-[#gcp-authentication]
-==== Authentication
+The informaiton in this section describes post-installation configuration options for VM service.
 
-TIP: We recommend you create a unique service account used exclusively by VM Service. The Compute Instance Admin (Beta) role is broad enough to allow VM Service to operate. If you wish to make permissions more granular, you can use the
-https://cloud.google.com/compute/docs/access/iam#compute.instanceAdmin[Compute Instance Admin (beta) role] documentation as reference.
+==== Windows image
 
-Choose one of the following options:
+==== Alternative Linux VM image
 
-* If you choose to use *GCP IAM Workload Identity*, use the VM service account email address (`service-account-name`@`project-id`.iam.gserviceaccount.com ) which you created link:/docs/server/installation/phase-3-execution-environments[here] in point 2 and 3 for the `workloadIdentity` field below.
-
-* If you choose to use a *GCP Service Account JSON file*, use the contents of your https://cloud.google.com/iam/docs/service-accounts[service account JSON file] for `service-account` below.
-
-[source,yaml]
-----
-vm_service:
-  enabled: true
-  replicas: 1
-  providers:
-    gcp:
-      enabled: false
-      project_id: <project-id>
-      network_tags:
-      - circleci-vm
-      - <your-network>
-      zone: <zone>
-      network: <network>
-      subnetwork: <subnetwork>
-
-      service_account: <service-account-json>
-      # OR
-      workloadIdentity: ""  # Leave blank if using JSON keys of service account else service account email address
-----
+==== Instance preallocation

--- a/jekyll/_cci2/server/operator/manage-virtual-machines-with-vm-service.adoc
+++ b/jekyll/_cci2/server/operator/manage-virtual-machines-with-vm-service.adoc
@@ -17,11 +17,7 @@ This section describes the available configuration options for VM service. Refer
 
 toc::[]
 
-CAUTION: We recommend that you leave these options at their defaults until you have successfully configured and verified the core and build services of your server installation. Steps to set up VM service are provided in the installation guide for https://circleci.com/docs/2.0/server/installation/phase-3-execution-environments/#aws[AWS] and https://circleci.com/docs/2.0/server/installation/phase-3-execution-environments/#gcp[GCP].
-
-WARNING: If https://circleci.com/docs/2.0/docker-layer-caching/[Docker Layer Caching (DLC)] is used, VM Service instances need to be spun up on demand. For this to happen, **either** ensure any preallocated instances are in use, **or** set both remote Docker and `machine` preallocated instance fields to `0`.
-
-CAUTION: When using preallocated instances be aware that a cron job is scheduled to cycle through these instances once per day to ensure they do not end up in an unworkable state.
+CAUTION: We recommend that you leave these options at their defaults until you have successfully configured and verified the core and build services of your server installation. Steps to set up VM service are provided in the installation guide for link:/docs/server/installation/phase-3-execution-environments/#aws-vm-service[AWS] and link:/docs/server/installation/phase-3-execution-environments/#gcp-authentication[GCP].
 
 [#vm-provider]
 == VM provider
@@ -33,17 +29,40 @@ There is a section in your `values.yaml` file that configures VM Service to work
 
 The informaiton in this section describes post-installation configuration options for VM service.
 
+[#windows-image-aws]
 ==== Windows image
 
+If you require Windows executors, you can supply an AMI ID in your `values.yaml` file. To create a Windows image, use the link:https://github.com/CircleCI-Public/circleci-server-windows-image-builder[CircleCI Server Windows Image Builder].
+
+[source,yaml]
+----
+vm_service:
+  providers:
+    ec2:
+      ...
+      windowsAMI: "<my-windows-ami>"
+----
+
+[#linux-image-aws]
 ==== Alternative Linux VM image
 
-==== Instance preallocation
+If you wish to provide a custom AMI for Linux machine executors, you can supply an AMI ID in your `values.yaml` file. To create a Linux image, use the link:https://github.com/CircleCI-Public/circleci-server-linux-image-builder[CircleCI Server Linux Image Builder].
+
+[source,yaml]
+----
+vm_service:
+  providers:
+    ec2:
+      ...
+      linuxAMI: "<my-linux-ami>"
+----
 
 [#default-aws-ami-lists]
 ==== Default AWS AMI lists
 
 The default AMIs for server v4.x are based on Ubuntu 22.04.
 
+[#x86-ami-list]
 ===== x86 AMI list
 
 [.table.table-striped]
@@ -168,8 +187,80 @@ There is a section in your `values.yaml` file that configures VM Service to work
 
 The informaiton in this section describes post-installation configuration options for VM service.
 
+[#windows-image-gcp]
 ==== Windows image
 
+If you require Windows executors, you can supply an AMI ID in your `values.yaml` file. To create a Windows image, use the link:https://github.com/CircleCI-Public/circleci-server-windows-image-builder[CircleCI Server Windows Image Builder].
+
+[source,yaml]
+----
+vm_service:
+  providers:
+    gcp:
+      ...
+      windowsImage: "<my-windows-image>"
+----
+
+[#linux-image-gcp]
 ==== Alternative Linux VM image
 
-==== Instance preallocation
+If you wish to provide a custom AMI for Linux machine executors, you can supply an AMI ID in your `values.yaml` file. To create a Linux image, use the link:https://github.com/CircleCI-Public/circleci-server-linux-image-builder[CircleCI Server Linux Image Builder].
+
+[source,yaml]
+----
+vm_service:
+  providers:
+    gcp:
+      ...
+      linuxImage: "<my-linux-image>"
+----
+
+[#instance-preallocation]
+== Instance preallocation
+
+WARNING: If https://circleci.com/docs/2.0/docker-layer-caching/[Docker Layer Caching (DLC)] is used, VM Service instances need to be spun up on demand. For this to happen, **either** ensure any preallocated instances are in use, **or** set both remote Docker and `machine` preallocated instance fields to `0`.
+
+CAUTION: When using preallocated instances be aware that a cron job is scheduled to cycle through these instances once per day to ensure they do not end up in an unworkable state.
+
+To configure server to keep instances preallocated, use the keys shown in the following `values.yaml` examples:
+
+NOTE: For a full list of options, see the link:/docs/server/installation/installation-reference/#all-values-yaml-options[Installation Reference] page.
+
+[source,yaml]
+----
+vm_scaler:
+  # -- Number of replicas to deploy for the vm-scaler deployment.
+  replicas: 1
+  # -- Configuration options for, and numbers of, prescaled instances for remote Docker jobs.
+  prescaled:
+    - type: l1.medium
+      image: docker-default
+      docker-engine: true # remote Docker environment
+      cron: ""
+      count: 2
+----
+
+[source,yaml]
+----
+vm_scaler:
+  # -- Number of replicas to deploy for the vm-scaler deployment.
+  replicas: 1
+  # -- Configuration options for, and numbers of, prescaled instances for remote Docker jobs.
+  prescaled:
+    - type: l1.medium
+      image: default
+      docker-engine: false # machine execution environment
+      cron: ""
+      count: 2
+----
+
+[#apply-changes]
+== Apply changes
+
+Apply the changes made to your `values.yaml` file:
+
+[source,shell,subs=attributes+]
+----
+namespace=<your-namespace>
+helm upgrade circleci-server oci://cciserver.azurecr.io/circleci-server -n $namespace --version {serverversion4} -f <path-to-values.yaml>
+----


### PR DESCRIPTION
# Description
Docs for VM service in server 4 need improvements, and there are some missing sections:

- [x] Add in Arm AMI list
- [x] Add in info for WIndows images for AWS and GCP
- [x] Add in info about preallocated instances
- [x] Add in infor about alternative linux images
- [x] Move all installation info into the installation guide. The VM service page in the operators guide should just be for config options that can be applied post installation.

# Reasons
https://circleci.atlassian.net/browse/DOCTEAM-779?atlOrigin=eyJpIjoiMjI4YjU2YzZjMTdiNDY5MmI3ZWExYmY3ZDlmYjM5ZjQiLCJwIjoiaiJ9

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
