### PR TITLE
Fix a broken link to the orb template repository

### DIFF
--- a/jekyll/_cci2_ja/orb-development-kit.adoc
+++ b/jekyll/_cci2_ja/orb-development-kit.adoc
@@ -25,7 +25,7 @@ Orb 開発キットは、`orb init` コマンドにより使用できます。 �
 
 Orb 開発キットは、次の要素で構成されています。
 
-* link:https://github.com/CircleCI-Public/Orb-TemplateOrb[Orb  テンプレート]: `orb init`コマンドにより自動的に取り込まれ、変更される CircleCI の Orb プロジェクトテンプレートを含むリポジトリ
+* link:https://github.com/CircleCI-Public/Orb-Template[Orb  テンプレート]: `orb init`コマンドにより自動的に取り込まれ、変更される CircleCI の Orb プロジェクトテンプレートを含むリポジトリ
 * link:https://circleci-public.github.io/circleci-cli/[CircleCI CLI]: キットと連動するように設計された 2 つのコマンドが含まれています。 `orb init` コマンドにより、新しい Orb プロジェクトが開始され、`orb pack` コマンドにより、Orb ソースが 1 つの `orb.yml` ファイルにパッケージ化されます。
 ** link:https://circleci-public.github.io/circleci-cli/circleci_orb_pack.html[Orb パッケージ化コマンド]: 新しい Orb プロジェクトを開始します。
 ** link:https://circleci-public.github.io/circleci-cli/circleci_orb_init.html[Orb 開始コマンド]: 新しい Orb プロジェクトを開始します。


### PR DESCRIPTION
# Description
Fixes broken link here:

[Orb  テンプレート](https://github.com/CircleCI-Public/Orb-Template)

# Reasons

Link was broken, gave a HTTP 404 error.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
