### PR TITLE
MONEY-2924 Remove mention of the plan field in api-key example.

### DIFF
--- a/jekyll/_api/v1-reference.md
+++ b/jekyll/_api/v1-reference.md
@@ -59,7 +59,6 @@ $ curl -H "Circle-Token: <circle-token>" https://circleci.com/api/v1.1/me
 {
   "user_key_fingerprint" : null,
   "days_left_in_trial" : -238,
-  "plan" : "p16",
   "trial_end" : "2011-12-28T22:02:15Z",
   "basic_email_prefs" : "smart",
   "admin" : true,

--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -56,7 +56,6 @@ $ curl -H "Circle-Token: <circle-token>" https://circleci.com/api/v1.1/me
 {
   "user_key_fingerprint" : null,
   "days_left_in_trial" : -238,
-  "plan" : "p16",
   "trial_end" : "2011-12-28T22:02:15Z",
   "basic_email_prefs" : "smart",
   "admin" : true,


### PR DESCRIPTION
# Description
The plan field given in this example is not meaningful since container plans have been deprecated and as such we shouldn't be including it in examples, even though the example here doesn't have anything to do with the plan; it could be misinterpreted as committing to support this field.

# Reasons
The `plan` field here is based on data which we are intending to shut off in the future: https://circleci.atlassian.net/browse/MONEY-2924

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.
