### PR TITLE
fix: correct Helm repo name

### DIFF
--- a/jekyll/_cci2/container-runner-installation.adoc
+++ b/jekyll/_cci2/container-runner-installation.adoc
@@ -32,7 +32,7 @@ agent:
       token: MY_TOKEN
 ```
 +
-4. Run `helm install container-agent circleci/container-agent -n circleci`
+4. Run `helm install container-agent container-agent/container-agent -n circleci`
 
 [#container-runner-configuration-example]
 == Container runner configuration example


### PR DESCRIPTION
# Description

A tiny PR to fix the instructions for installing the Helm chart for container Runners.

The Helm repo for our container Runners was added as per:

```shell
helm repo add container-agent https://packagecloud.io/circleci/container-agent/helm
```

As such, the Helm repo's name would be `container-agent` , not `circleci`. The Helm chart would thus also be found under `container-agent/container-agent` , not `circleci/container-agent`.

```console
$ helm repo list
NAME           	URL
container-agent	https://packagecloud.io/circleci/container-agent/helm

$ helm show chart container-agent/container-agent
apiVersion: v2
appVersion: "3"
description: For deploying a CircleCI Container Agent
icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
name: container-agent
type: application
version: 100.0.0
```

# Reasons

I understand @Stuart133 made the original PR here that shows the correct instructions:
https://github.com/circleci/circleci-docs/pull/7431/files#diff-469f6368bfd041f81c7e14162107c1d33c75fa26d4c50293a48e8d2c615a9338R58

However, I am guessing the subsequent PRs around this doc perhaps reverted this particular line.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
