### PR TITLE
Replaced privacy policy link from the global footer

### DIFF
--- a/jekyll/_includes/global-footer.html
+++ b/jekyll/_includes/global-footer.html
@@ -15,7 +15,7 @@
 
           <li><a class="nav-link" href="https://circleci.com/terms-of-service/"
               data-analytics-child='{ "menu": "terms-of-service" }'>Terms of Service</a></li>
-          <li><a class="nav-link" href="https://circleci.com/privacy/"
+          <li><a class="nav-link" href="https://circleci.com/legal/privacy/"
               data-analytics-child='{ "menu": "privacy-policy" }'>Privacy Policy</a></li>
           <li><a class="nav-link" href="https://circleci.com/legal/cookie-policy/"
               data-analytics-child='{ "menu": "cookie-policy" }'>Cookie Policy</a></li>

--- a/jekyll/_includes/ja/global-footer.html
+++ b/jekyll/_includes/ja/global-footer.html
@@ -14,7 +14,7 @@
         <ul class="docs-footer--nav-list">
 
           <li><a class="nav-link" href="https://circleci.com/ja/terms-of-service/" data-analytics-child='{ "menu": "terms-of-service" }'>利用規約</a></li>
-          <li><a class="nav-link" href="https://circleci.com/ja/privacy/" data-analytics-child='{ "menu": "privacy-policy" }'>プライバシー ポリシー</a></li>
+          <li><a class="nav-link" href="https://circleci.com/ja/legal/privacy/" data-analytics-child='{ "menu": "privacy-policy" }'>プライバシー ポリシー</a></li>
           <li><a class="nav-link" href="https://circleci.com/ja/legal/cookie-policy/" data-analytics-child='{ "menu": "cookie-policy" }'>Cookie ポリシー</a></li>
           <li><a class="nav-link" href="https://circleci.com/ja/security/" data-analytics-child='{ "menu": "security" }'>セキュリティ</a></li>
         </ul>


### PR DESCRIPTION
# Description
I replaced the link for the privacy policy from the old to the new (https://circleci.com/legal/privacy/)

# Reasons
We replaced these links across the Outer and Marketo because the previous URL was redirecting to our legal portal which is privacy.circleci.com. 

We made this decision a while ago that, we'd only want folks who want to take an action against their personal data to be landed on privacy.circleci.com - everyone else should land https://circleci.com/legal/privacy/

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
