### PR TITLE
Add pixel widths to style guide images

### DIFF
--- a/jekyll/_cci2/style/using-images.adoc
+++ b/jekyll/_cci2/style/using-images.adoc
@@ -43,7 +43,7 @@ Sometimes a screenshot will need to be marked up to provide more context for a u
 .Example of marked up screenshot
 image::style-guide_screenshot-markup.png[Change user icon, main]
 
-The screenshot above shows a user where to select a branch and where to find the edit **Edit Config** button. The branch inside the markup has also been changed from "master" to "main".
+The screenshot above shows a user where to select a branch and where to find the **Edit Config** button. The branch inside the markup has also been changed from "master" to "main".
 
 The elements are highlighted with the approved markup color of #E8178A, with shapes that make sense for the content of the screenshot. The stroke/border-width of any shape or line should be no less than 7px, and can be wider if the content requires.
 

--- a/jekyll/_cci2/style/using-images.adoc
+++ b/jekyll/_cci2/style/using-images.adoc
@@ -43,7 +43,11 @@ Sometimes a screenshot will need to be marked up to provide more context for a u
 .Example of marked up screenshot
 image::style-guide_screenshot-markup.png[Change user icon, main]
 
-The screenshot above shows a user where to select a branch and where to find the edit **Edit Config** button. The elements are highlighted with the approved markup color of #E8178A, with shapes that make sense for the content of the screenshot. The branch inside the markup has also been changed from "master" to "main".
+The screenshot above shows a user where to select a branch and where to find the edit **Edit Config** button. The branch inside the markup has also been changed from "master" to "main".
+
+The elements are highlighted with the approved markup color of #E8178A, with shapes that make sense for the content of the screenshot. The stroke/border-width of any shape or line should be no less than 7px, and can be wider if the content requires.
+
+Any text added to a screenshot should be no less than 18px, and can be larger if the content requires. If text needs to be added on top of the #E8178A markup color, the text should be white.
 
 == Add images to a PR
 * If you are adding a screenshot, make it easier to see and help consistency across docs by sticking it in here: https://browserframe.com/. Choose **Generic Light** and drag and drop your screenshot into the window, then download and you will get a PNG.


### PR DESCRIPTION
# Description
Minor update to last week's PR to add more detail regarding pixel widths.

# Reasons
Was waiting on some final details from design to clear up some guidelines.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
