### PR TITLE
[SECENG-853] Adding documentation for `settings` sub-command

### DIFF
--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -27,7 +27,7 @@ Config policy decisions are stored, and can be audited. This provides useful dat
 [#quickstart]
 == Quickstart
 
-If you already have a link:/docs/first-steps[CircleCI account] connected to your VCS, and you would like to get started with config policy management right away, check out the steps in the link:/docs/use-the-cli-and-vcs-for-config-policy-management/#config-policy-management-enablement[Use the CLI and VCS for config policy management] how-to guide.
+If you already have a link:/docs/first-steps[CircleCI account] connected to your VCS, and you would like to get started with config policy management right away, check out the steps in the link:/docs/use-the-cli-and-vcs-for-config-policy-management/#create-and-upload-a-policy[Use the CLI and VCS for config policy management] how-to guide.
 
 [#how-config-policy-management-works]
 == How config policy management works

--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -27,7 +27,7 @@ Config policy decisions are stored, and can be audited. This provides useful dat
 [#quickstart]
 == Quickstart
 
-If you already have a link:/docs/first-steps[CircleCI account] connected to your VCS, and you would like to get started with config policy management right away, check out the steps in the link:/docs/use-the-cli-and-vcs-for-config-policy-management/#create-and-upload-a-policy[Use the CLI and VCS for config policy management] how-to guide.
+If you already have a link:/docs/first-steps[CircleCI account] connected to your VCS, and you would like to get started with config policy management right away, check out the steps in the link:/docs/use-the-cli-and-vcs-for-config-policy-management/#config-policy-management-enablement[Use the CLI and VCS for config policy management] how-to guide.
 
 [#how-config-policy-management-works]
 == How config policy management works

--- a/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
+++ b/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
@@ -20,33 +20,26 @@ Use the CircleCI CLI to manage your organization's policies programmatically. Th
 The following sub-commands are currently supported within the CLI for configuration policy management:
 
 * `diff` - shows the difference between local and remote policy bundles
-* `push` - pushes the policy bundle (activate policy bundle)
 * `fetch` - fetches the policy bundle (or one policy, based on name) from remote
-
+* `push` - pushes the policy bundle (activate policy bundle)
++
 For example, running the following command activates a policy bundle stored at `./policy_bundle_dir_path`:
-
++
 [source,shell]
 ----
 circleci policy push ./policy_bundle_dir_path --owner-id <your-organization-ID>
 ----
-
-[NOTE]
-====
-The organization ID is required, and is provided with `--owner-id` flag. To find your organization/user ID, select **Organization Settings** in the CircleCI web app side bar.
-
-image:org-id.png[screenshot showing where to find your organization ID]
-====
-
-[#config-policy-management-settings]
-== Config Policy Management Settings
-
-The CLI provides `settings` sub-command to modify config policy management settings as required.
-When `settings` sub-command is called without any flags, current settings are fetched and printed on console.
+*  `settings` - used to modify config policy management settings as required.
++
+When the `settings` sub-command is called without any flags, current settings are fetched and printed on console.
++
 [source,shell]
 ----
 circleci-cli policy settings --owner-id <your-organization-ID>
 ----
++
 Example output:
++
 [source,shell]
 ----
 {
@@ -54,30 +47,33 @@ Example output:
 }
 ----
 
-[#config-policy-management-enablement]
-=== Enable/Disable Policy Evaluation in CI
+[NOTE]
+====
+The organization ID is required, and is provided with the `--owner-id` flag. To find your organization/user ID, select **Organization Settings** in the CircleCI web app side bar.
 
-This option controls policy evaluation in CI build pipeline. The setting can be modified using `--enabled` flag.
+image:org-id.png[screenshot showing where to find your organization ID]
+====
 
-If --enabled is set to `true`: project configuration will be evaluated against your organization's policies in CI
-If --enabled is set to `false`: project configuration will *not* be evaluated against your organization's policies in CI
+[#create-and-upload-a-policy]
+== Create and upload a policy 
 
+Follow these steps to create a policy that checks the `version` of CircleCI config files to ensure it is greater than or equal to `2.1`.
+
+. Enable config policy management for your organization
++
 [source,shell]
 ----
 circleci-cli policy settings --enabled=true --owner-id <your-organization-ID>
 ----
++
 Example output:
++
 [source,shell]
 ----
 {
   "enabled": true
 }
 ----
-
-[#create-and-upload-a-policy]
-== Create and upload a policy 
-
-Follow these steps to create a policy that checks the `version` of CircleCI config files to ensure it is greater than or equal to `2.1`.
 
 . Create a policy file in an empty directory. For example:
 +
@@ -146,6 +142,26 @@ To illustrate making a change to an existing policy, suppose you made an error w
 [source,shell]
 ----
 circleci-cli policy push ./config-policies --owner-id <your-organization-ID>
+----
+
+[#config-policy-management-enablement]
+== Enable/Disable Policy Evaluation in CI
+
+This option controls policy evaluation in CI build pipeline. The setting can be modified using `--enabled` flag.
+
+If --enabled is set to `true`: project configuration will be evaluated against your organization's policies in CI
+If --enabled is set to `false`: project configuration will *not* be evaluated against your organization's policies in CI
+
+[source,shell]
+----
+circleci-cli policy settings --enabled=true --owner-id <your-organization-ID>
+----
+Example output:
+[source,shell]
+----
+{
+  "enabled": true
+}
 ----
 
 [#manage-policies-with-your-vcs]

--- a/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
+++ b/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
@@ -37,6 +37,43 @@ The organization ID is required, and is provided with `--owner-id` flag. To find
 image:org-id.png[screenshot showing where to find your organization ID]
 ====
 
+[#config-policy-management-settings]
+== Config Policy Management Settings
+
+The CLI provides `settings` sub-command to modify config policy management settings as required.
+When `settings` sub-command is called without any flags, current settings are fetched and printed on console.
+[source,shell]
+----
+circleci-cli policy settings --owner-id <your-organization-ID>
+----
+Example output:
+[source,shell]
+----
+{
+  "enabled": false
+}
+----
+
+[#config-policy-management-enablement]
+=== Enable/Disable Policy Evaluation in CI
+
+This option controls policy evaluation in CI build pipeline. The setting can be modified using `--enabled` flag.
+
+If --enabled is set to `true`: project configuration will be evaluated against your organization's policies in CI
+If --enabled is set to `false`: project configuration will *not* be evaluated against your organization's policies in CI
+
+[source,shell]
+----
+circleci-cli policy settings --enabled=true --owner-id <your-organization-ID>
+----
+Example output:
+[source,shell]
+----
+{
+  "enabled": true
+}
+----
+
 [#create-and-upload-a-policy]
 == Create and upload a policy 
 

--- a/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
+++ b/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
@@ -123,7 +123,7 @@ circleci-cli policy push ./config-policies --owner-id <your-organization-ID>
 Now, when a pipeline is triggered within your organization, the project's `.circleci/config.yml` will be validated against this policy.
 
 [#update-a-policy]
-== Update a policy
+=== Update a policy
 
 To illustrate making a change to an existing policy, suppose you made an error when creating the policy above. You realise that configs in your organization are using CircleCI config version `2.0` and you want your policy to reflect this.
 
@@ -145,18 +145,20 @@ circleci-cli policy push ./config-policies --owner-id <your-organization-ID>
 ----
 
 [#config-policy-management-enablement]
-== Enable/Disable Policy Evaluation in CI
+== Enable or disable policy evaluation for an organization
 
-This option controls whether policy evaluation is applied to pipeline configurations within your organization. The setting can be modified using `--enabled` flag.
+Control whether policy evaluation is applied to pipeline configurations within your organization using the `--enabled` flag.
 
-* If `--enabled` is set to `true`, project configuration **will** be evaluated against your organization's policies when pipelines are triggered.
-* If `--enabled` is set to `false`, project configuration will **not** be evaluated against your organization's policies when pipelines are triggered.
+* If `--enabled` is set to `true`, project configurations **will** be evaluated against your organization's policies when pipelines are triggered.
+* If `--enabled` is set to `false`, project configurations will **not** be evaluated against your organization's policies when pipelines are triggered.
 
 [source,shell]
 ----
 circleci-cli policy settings --enabled=true --owner-id <your-organization-ID>
 ----
+
 Example output:
+
 [source,shell]
 ----
 {

--- a/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
+++ b/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
@@ -149,8 +149,8 @@ circleci-cli policy push ./config-policies --owner-id <your-organization-ID>
 
 This option controls whether policy evaluation is applied to pipeline configurations within your organization. The setting can be modified using `--enabled` flag.
 
-If --enabled is set to `true`: project configuration will be evaluated against your organization's policies in CI
-If --enabled is set to `false`: project configuration will *not* be evaluated against your organization's policies in CI
+* If `--enabled` is set to `true`, project configuration **will** be evaluated against your organization's policies when pipelines are triggered.
+* If `--enabled` is set to `false`, project configuration will **not** be evaluated against your organization's policies when pipelines are triggered.
 
 [source,shell]
 ----

--- a/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
+++ b/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
@@ -147,7 +147,7 @@ circleci-cli policy push ./config-policies --owner-id <your-organization-ID>
 [#config-policy-management-enablement]
 == Enable/Disable Policy Evaluation in CI
 
-This option controls policy evaluation in CI build pipeline. The setting can be modified using `--enabled` flag.
+This option controls whether policy evaluation is applied to pipeline configurations within your organization. The setting can be modified using `--enabled` flag.
 
 If --enabled is set to `true`: project configuration will be evaluated against your organization's policies in CI
 If --enabled is set to `false`: project configuration will *not* be evaluated against your organization's policies in CI


### PR DESCRIPTION
# Description
Adding documentation for `settings` sub-command under `policy` command.

# Reasons
https://circleci.atlassian.net/browse/SECENG-853

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
