### PR TITLE
add information about ECR auth precidence for container runner

### DIFF
--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -262,10 +262,10 @@ The container runner application promises backwards compatibility for releases w
 
 Just like a machine runner, a container runner allows users to run arbitrary code in the infrastructure where container runner is hosted, meaning a bad actor could potentially use it as a method to gain knowledge of internal systems. Ensure you are following all best practices for security to mitigate this risk.
 
-[#IAM-ECR-authorization]
+[#iam-ecr-authorization]
 === How can an IAM role be used to authorize pulling images from ECR?
 
-An IAM role can be associated with the service account used for the container runner by following the link:https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[AWS documentation]. If an image in a job config specifies AWS credentials those credentials will be used instead of the IAM role attached to the container runner service account. See the <<container-runner#, container runner documentation>> for more details about the container runner service account.
+An IAM role can be associated with the service account used for the container runner by following the link:https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[AWS documentation]. If an image in a job configuration specifies AWS credentials, those credentials will be used instead of the IAM role attached to the container runner service account. See the <<container-runner#, container runner>> documentation for more details about the container runner service account.
 
 [#sample-configuration-container-agent]
 === What does a full sample configuration look like that uses container runner?

--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -262,6 +262,11 @@ The container runner application promises backwards compatibility for releases w
 
 Just like a machine runner, a container runner allows users to run arbitrary code in the infrastructure where container runner is hosted, meaning a bad actor could potentially use it as a method to gain knowledge of internal systems. Ensure you are following all best practices for security to mitigate this risk.
 
+[#IAM-ECR-authorization]
+=== How can an IAM role be used to authorize pulling images from ECR?
+
+An IAM role can be associated with the service account used for the container runner by following the link:https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[AWS documentation]. If an image in a job config specifies AWS credentials those credentials will be used instead of the IAM role attached to the container runner service account. See the <<container-runner#, container runner documentation>> for more details about the container runner service account.
+
 [#sample-configuration-container-agent]
 === What does a full sample configuration look like that uses container runner?
 


### PR DESCRIPTION
# Description
Adding information to the runner FAQ about authorization precedence and IAM role configuration for container runner

# Reasons
A customer ran into an issue where how the precedence for authorization was not clear https://circleci.slack.com/archives/C0306RYMR8D/p1666881989011949?thread_ts=1666632048.029859&cid=C0306RYMR8D

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
