### PR TITLE
Update Ruby info in iOS testing doc

### DIFF
--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -295,6 +295,7 @@ The Xcode images are supplied with at least one version of NodeJS ready to use.
 
 ### Images using Xcode 13 and later
 {: #images-using-xcode-13-and-later }
+{:.no_toc}
 
 These images have NodeJS installations managed by `nvm` and will always be supplied with the latest `current` and `lts` release as of the time the image was built. Additionally, `lts` is set as the default NodeJS version.
 
@@ -328,6 +329,7 @@ These images are also compatible with the official [CircleCI Node orb](https://c
 
 ### Images using Xcode 12.5 and earlier
 {: #images-using-xcode-125-and-earlier }
+{:.no_toc}
 
 These images come with at least one version of NodeJS installed directly using `brew`.
 

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -169,7 +169,7 @@ workflows:
 
 The environment variable `FL_OUTPUT_DIR` is the artifact directory where FastLane logs and signed `.ipa` file should be stored. Use this to set the path in the `store_artifacts` step to automatically save logs and build artifacts from Fastlane.
 
-### Code Signing with Fastlane Match
+### Code signing with Fastlane Match
 {: #code-signing-with-fastlane-match }
 
 We recommend the use of Fastlane Match for signing your iOS applications as it simplifies and automates the process of code signing both locally and in the CircleCI environment.
@@ -183,12 +183,13 @@ Our macOS images contain multiple versions of Ruby. The default version in use o
 
 If you want to run steps with a version of Ruby that is listed as "available to chruby" in the manifest, then you can use [`chruby`](https://github.com/postmodern/chruby) to do so.
 
-**Note:** Installing Gems with the system Ruby is not advised due to the restrictive permissions enforced on the system directories. As a general rule, we advise using one of the alternative Rubies provided by Chruby, as configured by default in all images, for jobs.
+Installing gems with the system Ruby is not advised due to the restrictive permissions enforced on the system directories. As a general rule, CircleCI advises using one of the alternative Rubies provided by Chruby (as configured by default in all images) for jobs.
+{: class="alert alert-info" }
 
-### Switching Rubies with the macOS Orb
+### Switching Rubies with the macOS orb
 {: #switching-rubies-with-the-macos-orb }
 
-Using the official macOS Orb (version `2.0.0` and above) is the easiest way to switch Rubies in your jobs. It automatically uses the correct switching command, regardless of which Xcode image is in use.
+Using the official macOS orb (version `2.0.0` and above) is the easiest way to switch Rubies in your jobs. It automatically uses the correct switching command, regardless of which Xcode image is in use.
 
 To get started, include the orb at the top of your config:
 
@@ -251,7 +252,7 @@ steps:
 
 To run a job with a version of Ruby that is not pre-installed, you must install the required version of Ruby. We use the [ruby-install](https://github.com/postmodern/ruby-install) tool to install the required version. After the install is complete, you can select it using the appropriate technique above.
 
-### Using Custom Versions of CocoaPods and Other Ruby Gems
+### Using custom versions of CocoaPods and other Ruby gems
 {: #using-custom-versions-of-cocoapods-and-other-ruby-gems }
 
 

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -125,7 +125,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.0.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -142,7 +142,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 12.5.1
+      xcode: 14.0.1
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -183,10 +183,10 @@ Our macOS images contain multiple versions of Ruby. The default version in use o
 
 If you want to run steps with a version of Ruby that is listed as "available to chruby" in the manifest, then you can use [`chruby`](https://github.com/postmodern/chruby) to do so.
 
-**Note:** Installing Gems with the system Ruby is not advised due to the restrictive permissions enforced on the system directories. As a general rule, we advise using one of the alternative Rubies provided by Chruby for all jobs.
+**Note:** Installing Gems with the system Ruby is not advised due to the restrictive permissions enforced on the system directories. As a general rule, we advise using one of the alternative Rubies provided by Chruby, as configured by default in all images, for jobs.
 
-### Switching Rubies with the macOS Orb (Recommended)
-{: #switching-rubies-with-the-macos-orb-recommended }
+### Switching Rubies with the macOS Orb
+{: #switching-rubies-with-the-macos-orb }
 
 Using the official macOS Orb (version `2.0.0` and above) is the easiest way to switch Rubies in your jobs. It automatically uses the correct switching command, regardless of which Xcode image is in use.
 
@@ -204,10 +204,10 @@ Then, call the `switch-ruby` command with the version number required. For examp
 steps:
   # ...
   - macos/switch-ruby:
-      version: "2.6"
+      version: "3.0"
 ```
 
-Replace `2.6` with the version you require from the Software Manifest file. You do not need to specify the full Ruby version, `3.0.2` for example, just the major version. This will ensure your config does not break when switching to newer images that might have newer patch versions of Ruby.
+Replace `3.0` with the version you require from the Software Manifest file. You do not need to specify the full Ruby version, `3.0.2` for example, just the major version. This will ensure your config does not break when switching to newer images that might have newer patch versions of Ruby.
 
 To switch back to the system default Ruby (the Ruby shipped by Apple with macOS), define the `version` as `system`:
 
@@ -218,10 +218,8 @@ steps:
       version: "system"
 ```
 
-**Note:** Xcode 11.7 images and later images default to Ruby 2.7 via `chruby` out of the box. Xcode 11.6 images and earlier default to the System Ruby.
-
-### Images using Xcode 11.7 and later
-{: #images-using-xcode-117-and-later }
+### Switching Rubies manually
+{: #switching-rubies-manually }
 {:.no_toc}
 
 To switch to another Ruby version, add the following to the beginning of your job.
@@ -245,38 +243,6 @@ steps:
       name: Set Ruby Version
       command: sed -i '' 's/^chruby.*/chruby system/g' ~/.bash_profile
 ```
-
-### Images using Xcode 11.2 and later
-{: #images-using-xcode-112-and-later }
-
-
-To select a version of Ruby to use, add the `chruby` function to `~/.bash_profile`:
-
-```yaml
-steps:
-  # ...
-  - run:
-      name: Set Ruby Version
-      command: echo 'chruby ruby-2.6' >> ~/.bash_profile
-```
-
-Replace `2.6` with the version of Ruby required - you do not need to specify the full Ruby version, `2.6.5` for example, just the major version. This will ensure your config does not break when switching to newer images that might have slightly newer Ruby versions.
-
-### Images using Xcode 11.1 and earlier
-{: #images-using-xcode-111-and-earlier }
-
-
-To specify a version of Ruby to use, you can [create a file named `.ruby-version`, as documented by `chruby`](https://github.com/postmodern/chruby#auto-switching). This can be done from a job step, for example:
-
-```yaml
-steps:
-  # ...
-  - run:
-      name: Set Ruby Version
-      command:  echo "ruby-2.4" > ~/.ruby-version
-```
-
-Replace `2.4` with the version of Ruby required - you do not need to specify the full Ruby version, `2.4.9` for example, just the major version. This will ensure your config does not break when switching to newer images that might have slightly newer Ruby versions.
 
 ### Installing additional Ruby versions
 {: #installing-additional-ruby-versions }


### PR DESCRIPTION
# Description
Update Ruby info in iOS testing doc to reflect current image support. Also bumped version numbers and tidied the NodeJS TOC section to make it cleaner.

# Reasons
The oldest image we now support is Xcode 11.7, therefore a lot of the old documentation is no longer relevant. We will be switching to rbenv shortly, so needed to tidy the chruby based information in advance.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
