### PR TITLE
add section detailing CCI config for Fastlane deployment examples

### DIFF
--- a/jekyll/_cci2/deploy-ios-applications.md
+++ b/jekyll/_cci2/deploy-ios-applications.md
@@ -101,7 +101,7 @@ workflows:
             - build-and-test
 ```
 
-In this example, the `adhoc` job exists to enable producing a development build, or upload to Testflight, on pushes to a dev branch, in this example a branch called `development`.
+In this example, upon pushing to a development branch, the `adhoc` job enables producing a development build, or upload to Testflight.
 
 ## App store connect
 {: #app-store-connect }

--- a/jekyll/_cci2/deploy-ios-applications.md
+++ b/jekyll/_cci2/deploy-ios-applications.md
@@ -21,7 +21,7 @@ Using Fastlane, CircleCI can automatically deploy iOS apps to various services. 
 
 Deployment _lanes_ can be combined with testing _lanes_ so that the app is automatically deployed upon a successful build and test.
 
-Using the deployment examples on this page requires that code signing is already configured for your project. To learn how to set up code signing, see the [Setting Up Code Signing]({{site.baseurl}}/ios-codesigning/) page.
+Using the deployment examples on this page requires that code signing is already configured for your project. To learn how to set up code signing, see the [Setting up code signing]({{site.baseurl}}/ios-codesigning/) page.
 {: class="alert alert-note"}
 
 ## Best practices

--- a/jekyll/_cci2/deploy-ios-applications.md
+++ b/jekyll/_cci2/deploy-ios-applications.md
@@ -50,7 +50,7 @@ increment_build_number(
 
 All the examples on this page use Fastlane to configure deployment. For each example the following example `.circleci/config.yml` configuration can be used to integrate your Fastlane setup with CircleCI. This is an example config which should be edited to fot the needs of your project:
 
-The environment variable `FL_OUTPUT_DIR` is the artifact directory where FastLane logs and a signed `.ipa` file should be stored. Use this to set the path in the `store_artifacts` step to automatically save logs and build artifacts from Fastlane.
+The environment variable `FL_OUTPUT_DIR` is the artifact directory where FastLane logs, and a signed `.ipa` file should be stored. Use this to set the path in the `store_artifacts` step to automatically save logs and build artifacts from Fastlane.
 {: class="alert alert-note"}
 
 ```yaml

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -51,7 +51,6 @@ Simple projects should run with minimal configuration.
 
 ### Adding a Gemfile
 {: #adding-a-gemfile }
-{:.no_toc}
 
 It is recommended to add a `Gemfile` to your repository to make sure that the same version of Fastlane is used both locally and on CircleCI and that all dependencies are installed. Below is a sample of a simple `Gemfile`:
 
@@ -65,7 +64,6 @@ After you have created a `Gemfile` locally, you will need to run `bundle install
 
 ### Setting up Fastlane for use on CircleCI
 {: #setting-up-fastlane-for-use-on-circleci }
-{:.no_toc}
 
 When using Fastlane in your CircleCI project, we recommend adding the following to beginning of your `Fastfile`:
 
@@ -91,7 +89,6 @@ new code signing certificates or provisioning profiles.
 
 ### Example Configuration for Using Fastlane on CircleCI
 {: #example-configuration-for-using-fastlane-on-circleci }
-{:.no_toc}
 
 A basic Fastlane configuration that can be used on CircleCI is as follows:
 


### PR DESCRIPTION
# Description

* Add in config.yml for integrating projects with Fastlane to the start of the iOS deploy page.
* Also removed some `no_toc`s from the testing iOS page

Relevant thread: https://circleci.slack.com/archives/CEX928FM3/p1667218438678789

# Reasons
https://circleci.atlassian.net/browse/DOCTEAM-807?atlOrigin=eyJpIjoiNjA1MDFmYjhkZmU0NDEyMGFiZDlmZDJhMTZmNGU3MjQiLCJwIjoiaiJ9


# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
