### PR TITLE
Troubleshooting runner install on M1 macOS

### DIFF
--- a/jekyll/_cci2/container-runner-installation.adoc
+++ b/jekyll/_cci2/container-runner-installation.adoc
@@ -17,6 +17,7 @@ This page describes how to install CircleCI's container runner.
 
 {% include snippets/runner-platform-prerequisites.adoc %}
 
+[#installation-instructions]
 == Installation instructions
 
 1. Add the container runner Helm repo by running `helm repo add container-agent https://packagecloud.io/circleci/container-agent/helm`
@@ -71,6 +72,7 @@ CAUTION: **Do not** use an existing job that uses <<building-docker-images#,setu
 
 Refer to the <<troubleshoot-self-hosted-runner#troubleshoot-container-runner,Troubleshoot Container Runner section>> of the Troubleshoot Self-hosted Runner guide if you encounter issues installing or running container runner.
 
+[#additional-resources]
 == Additional resources
 
 - xref:container-runner.adoc[Container runner reference guide]

--- a/jekyll/_cci2/container-runner-installation.adoc
+++ b/jekyll/_cci2/container-runner-installation.adoc
@@ -66,6 +66,11 @@ workflows:
 
 CAUTION: **Do not** use an existing job that uses <<building-docker-images#,setup_remote_docker>> (see <<container-runner#building-container-images,Building container images>> for more information).
 
+[#troubleshooting]
+== Troubleshooting
+
+Refer to the <<troubleshoot-self-hosted-runner#troubleshoot-container-runner,Troubleshoot Container Runner section>> of the Troubleshoot Self-hosted Runner guide if you encounter issues installing or running container runner.
+
 == Additional resources
 
 - xref:container-runner.adoc[Container runner reference guide]

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -246,3 +246,8 @@ You can also see the logs for the system by running:
 ```shell
 journalctl -u circleci
 ```
+
+[#troubleshooting]
+== Troubleshooting
+
+Refer to the <<troubleshoot-self-hosted-runner#troubleshoot-machine-runner,Troubleshoot Machine Runner section>> of the Troubleshoot Self-hosted Runner guide if you encounter issues installing or running machine runner on Linux.

--- a/jekyll/_cci2/runner-installation-mac.adoc
+++ b/jekyll/_cci2/runner-installation-mac.adoc
@@ -116,7 +116,7 @@ Copy the following to the new `/Library/LaunchDaemons/com.circleci.runner.plist`
         <string>com.circleci.runner</string>
 
         <key>Program</key>
-        <string>/var/opt/circleci/circleci-launch-agent</string>
+        <string>/opt/circleci/circleci-launch-agent</string>
 
         <key>ProgramArguments</key>
         <array>

--- a/jekyll/_cci2/runner-installation-mac.adoc
+++ b/jekyll/_cci2/runner-installation-mac.adoc
@@ -174,3 +174,8 @@ sudo launchctl unload '/Library/LaunchDaemons/com.circleci.runner.plist'
 == Verify the service is running
 
 Open the pre-installed macOS application *Console*. In this application, you can view the logs for the CircleCI agent under *Log Reports*. Look for the logs called `com.circleci.runner.log` in the list. You can also find this file by navigating to *Library > Logs*.
+
+[#troubleshooting]
+== Troubleshooting
+
+Refer to the <<troubleshoot-self-hosted-runner#troubleshoot-machine-runner,Troubleshoot Machine Runner section>> of the Troubleshoot Self-hosted Runner guide if you encounter issues installing or running machine runner on macOS.

--- a/jekyll/_cci2/runner-installation-windows.adoc
+++ b/jekyll/_cci2/runner-installation-windows.adoc
@@ -67,3 +67,8 @@ Uninstalling machine runners will prepare the system for installation again.
 By default, Windows machine runners run in <<runner-config-reference#runner-mode,single task mode>> in order to ensure high reliablity of the underlying technology that the self-hosted runner uses to execute jobs. This is the **recommended mode** for Windows machine runners. 
 
 A Windows machine runner *can* be run in `continuous` mode, however, doing so eliminates the guarantee of a clean job environment.  This may translate into jobs not executing as expected and failing.  
+
+[#troubleshooting]
+== Troubleshooting
+
+Refer to the <<troubleshoot-self-hosted-runner#troubleshoot-machine-runner,Troubleshoot Machine Runner section>> of the Troubleshoot Self-hosted Runner guide if you encounter issues installing or running machine runner on Windows.

--- a/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
+++ b/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
@@ -112,8 +112,8 @@ The following are errors you could encounter using machine runner.
 Try running the following two commands:
 
 ```bash
-sudo chmod +x /var/opt/circleci/circleci-launch-agent
-sudo /var/opt/circleci/circleci-launch-agent --config=/Library/Preferences/com.circleci.runner/launch-agent-config.yaml
+sudo chmod +x /opt/circleci/circleci-launch-agent
+sudo /opt/circleci/circleci-launch-agent --config=/Library/Preferences/com.circleci.runner/launch-agent-config.yaml
 ```
 Cancel the job and rerun it. If your job is still not running, file a https://support.circleci.com/hc/en-us[support ticket].
 

--- a/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
+++ b/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
@@ -109,7 +109,7 @@ The following are errors you could encounter using machine runner.
 [#i-installed-my-first-self-hosted-runner-on-macOS-and-the-job-is-stuck-in-preparing-environment-but-there-are-no-errors-what-should-i-do]
 === I installed my first self-hosted runner on macOS and the job is stuck in "Preparing Environment", but there are no errors, what should I do?
 
-Try running the following two commands:
+In some cases, you may need to update the execution permission for the launch-agent so it is executable by root. Try running the following two commands:
 
 ```bash
 sudo chmod +x /opt/circleci/circleci-launch-agent

--- a/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
+++ b/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
@@ -12,8 +12,8 @@ contentTags:
 
 This page describes errors and troubleshooting mehtods for container and machine runners.
 
-[#troubleshooting-container-runner]
-== Troubleshooting container runner
+[#troubleshoot-container-runner]
+== Troubleshoot container runner
 
 The following are errors you could encounter using container runner.
 


### PR DESCRIPTION
# Description
Update code snippet in t[roubleshooting step](https://circleci.com/docs/troubleshoot-self-hosted-runner/#i-installed-my-first-self-hosted-runner-on-macOS-and-the-job-is-stuck-in-preparing-environment-but-there-are-no-errors-what-should-i-do) with correct filepath.

Also adds links to Troubleshoot self-hosted runner page from platform-specific installation docs.

# Reasons
[Jira ticket](https://circleci.atlassian.net/browse/DOCTEAM-823)
The launch-agent installation script does not make circleci-launch-agent executable by root, which is necessary for the `launchd` service to start the launch-agent. When running a job, it gets stuck at the "Preparing environment" step.

The troubleshooting step is linked on the sidenav, but isn't necessarily easy to find as the reader is going through the actual install instructions.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
