### PR TITLE
chore(docs): Fix typo

### DIFF
--- a/jekyll/_cci2/testing-orbs.md
+++ b/jekyll/_cci2/testing-orbs.md
@@ -135,13 +135,13 @@ circleci local execute --job shellcheck/check
 
 The orb-tools orb includes a job `orb-tools/review` which will run a suite of tests against your orb designed to find opportunities to implement best practices and improve the quality of the orb. The "review" job was modeled closely after _ShellCheck_, and operates based on a list of rules called "RC" Review Checks. Each "RC" code corresponds to a specific rule, which can optionally be ignored.
 
-Review Checks output to JUNIT XML formatted and are automatically uploaded to CircleCI to be displayed natively in the UI.
+Review Checks output to JUnit XML format and are automatically uploaded to CircleCI to be displayed natively in the UI.
 
 ![orb-tools review check RC008]({{site.baseurl}}/assets/img/docs/orbtools-rc008.png)
 
 When you click into the error you will receive more information such as what file and at what line in the code the error was found, along with suggestions for resolution.
 
-**Note:** The "orb-tools/review" job currently can not be ran locally due to the fact that the results are output as JUNIT XML and uploaded to CircleCI, which is not supported by the local execute command at this time.
+**Note:** The `orb-tools/review` job currently can not be run locally due to the fact that the results are output as JUnit XML and uploaded to CircleCI, which is not supported by the local execute command at this time.
 {: class="alert alert-warning"}
 
 ## Unit testing


### PR DESCRIPTION
# Description

This PR fixes a minor typo (ran vs. run), and while there changes `JUNIT` to `JUnit`, which is how the JUnit project refers to itself.

# Reasons

Improve quality!

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
