### PR TITLE
docs: add notes on GHE defaultToken

### DIFF
--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -245,6 +245,7 @@ a|
 {
   "clientId": "",
   "clientSecret": "",
+  "defaultToken": "",
   "enterprise": false,
   "fingerprint": null,
   "hostname": "ghe.example.com",
@@ -273,6 +274,15 @@ a| Client Secret for OAuth Login via Github:
 **Option 1:** Set the value here and CircleCI will create the Kubernetes Secret automatically. 
 
 **Option 2:** Leave this blank, and create the secret yourself. CircleCI will assume it exists. Retrieved from the same location as specified in `github.clientID`.
+
+|`github.defaultToken`
+|string
+|`""`
+a| link:/docs/server/installation/phase-1-prerequisites/#github-enterprise[Personal access token for your GitHub Enterprise instance]:
+
+**Option 1:** Set the value here and CircleCI will create the Kubernetes Secret automatically.
+
+**Option 2:** Leave this blank, and create the secret yourself. CircleCI will assume it exists.
 
 |`github.enterprise`
 |bool

--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -278,7 +278,7 @@ a| Client Secret for OAuth Login via Github:
 |`github.defaultToken`
 |string
 |`""`
-a| link:/docs/server/installation/phase-1-prerequisites/#github-enterprise[Personal access token for your GitHub Enterprise instance]:
+a| link:/docs/server/installation/phase-2-core-services/#github-enterprise-integration[Personal access token for your GitHub Enterprise instance]:
 
 **Option 1:** Set the value here and CircleCI will create the Kubernetes Secret automatically.
 


### PR DESCRIPTION
# Description
[edited]

~This is to document how to add the GitHub Enterprise (GHE) defaultToken.~

I noted the defaultToken for GHE is missing from the installation reference's table:
https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options

Our document **already** informs the admin to create & add this personal access token on their GHE instance:
- https://circleci.com/docs/server/installation/phase-1-prerequisites/#github-enterprise
- https://circleci.com/docs/server/installation/phase-2-core-services/#github-enterprise-integration

# Reasons

I noted the defaultToken is missing from the installation reference's table:
https://circleci.com/docs/server/installation/installation-reference/#all-values-yaml-options

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
