### PR TITLE
[SERVER-2167] add namespaced admin permission recomendation

### DIFF
--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -122,15 +122,12 @@ CircleCI server installs into an existing Kubernetes cluster. The application us
 | 1.22 - 1.23
 |===
 
-Creating a Kubernetes cluster is your responsibility. Please note:
-
-* You must have appropriate permissions to list, create, edit, and delete pods in your cluster. Run this command to verify your permissions:
-+
-[source,shell]
-----
-kubectl auth can-i <list|create|edit|delete> pods
-----
 * There are no requirements regarding VPC setup or disk size for your cluster. It is recommended that you set up a new VPC rather than use an existing one.
+
+**Minimum Permission Requirments:**
+
+A user with at least Admin permissions for the namespace CircleCI will be installed into is required.
+
 
 ifndef::env-gcp[]
 
@@ -435,7 +432,7 @@ CircleCI server listens on a number of ports which need to be configured dependi
 * Nomad server [TCP 4647]
 * Output processor [gRPC 8585]
 
-Depending on your requirements you may choose to terminate TLS for only the frontend/api-gateway or provide TLS for services listening on all the ports. 
+Depending on your requirements you may choose to terminate TLS for only the frontend/api-gateway or provide TLS for services listening on all the ports.
 
 NOTE: The Output Processor service communicates using gRPC and requires the proxy or loadbalancer to support HTTP/2.
 

--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -126,7 +126,7 @@ CircleCI server installs into an existing Kubernetes cluster. The application us
 
 **Minimum Permission Requirments:**
 
-A user with at least Admin permissions for the namespace CircleCI will be installed into is required.
+A user with at least admin permissions for the namespace CircleCI will be installed into is required.
 
 
 ifndef::env-gcp[]

--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -110,7 +110,10 @@ CircleCI server installs into an existing Kubernetes cluster. The application us
 | 10 Gbps
 |===
 
-**Supported Kubernetes versions:**
+There are no requirements regarding VPC setup or disk size for your cluster. It is recommended that you set up a new VPC rather than use an existing one.
+
+[#supported-kubernetes-versions]
+=== Supported Kubernetes versions
 
 [.table.table-striped]
 [cols=2*, options="header", stripes=even]
@@ -122,12 +125,10 @@ CircleCI server installs into an existing Kubernetes cluster. The application us
 | 1.22 - 1.23
 |===
 
-* There are no requirements regarding VPC setup or disk size for your cluster. It is recommended that you set up a new VPC rather than use an existing one.
+[#minimum-permissions-requirments]
+=== Minimum permissions requirments
 
-**Minimum Permission Requirments:**
-
-A user with at least admin permissions for the namespace CircleCI will be installed into is required.
-
+The installing user must have **at least** admin permissions for the namespace into which CircleCI is to be installed.
 
 ifndef::env-gcp[]
 


### PR DESCRIPTION
# Description
We can now recommend a tighter scoped k8s user for customers to install and administer server

Also I removed the section about permissions around pods as that is not completly accurate, the users needs more than just full control of the pods.

Auto fixed some extra whitespace

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
