### PR TITLE
Describe how to use BATS

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -606,6 +606,33 @@ A working `.circleci/config.yml` section for testing might look like the followi
           path: build/out.xml
 ```
 
+### BATS for Bash
+{: #bats-for-bash }
+
+While CircleCI can't ingest the TAP data created by [BATS](https://bats-core.readthedocs.io/) directly, you can post-process the data into a format that can be ingested.
+To use this feature, you will need both BATS to run the tests (e.g. install it using the [circleci/bats](https://circleci.com/developer/orbs/orb/circleci/bats) orb's [install](https://circleci.com/developer/orbs/orb/circleci/bats#commands-install) command) and a converter that turns TAP into something that CircleCI understands (e.g. [`tap2junit`](https://manpages.ubuntu.com/manpages/trusty/man1/tap2junit.1p.html)) and then ensure that, regardless of the return result from `bats`, the converter always runs.
+
+A working `.circleci/config.yml` section for testing might look like the following example:
+
+```yml
+    steps:
+      - checkout
+      - bats/install
+      - run:
+          command: |
+            sudo apt install libtap-formatter-junit-perl
+            mkdir -p /tmp/bats-tap-data
+            if bats --tap src/tests | tee /tmp/bats-tap-data/bats.tap; then
+              tap2junit --verbose /tmp/bats-tap-data/bats.tap
+            else
+              return_code=$?
+              tap2junit --verbose /tmp/bats-tap-data/bats.tap
+              exit ${return_code}
+            fi
+      - store_test_results:
+          path: /tmp/bats-tap-data/bats.tap.xml
+```
+
 ## API
 {: #api }
 

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -606,11 +606,11 @@ A working `.circleci/config.yml` section for testing might look like the followi
           path: build/out.xml
 ```
 
-### BATS for Bash
+### Bats for Bash
 {: #bats-for-bash }
 
 While CircleCI can't ingest the TAP data created by [BATS](https://bats-core.readthedocs.io/) directly, you can post-process the data into a format that can be ingested.
-To use this feature, you will need both BATS to run the tests (e.g. install it using the [circleci/bats](https://circleci.com/developer/orbs/orb/circleci/bats) orb's [install](https://circleci.com/developer/orbs/orb/circleci/bats#commands-install) command) and a converter that turns TAP into something that CircleCI understands (e.g. [`tap2junit`](https://manpages.ubuntu.com/manpages/trusty/man1/tap2junit.1p.html)) and then ensure that, regardless of the return result from `bats`, the converter always runs.
+To use this feature, you will need both BATS to run the tests (e.g. install it using the [circleci/bats](https://circleci.com/developer/orbs/orb/circleci/bats) orb's [install](https://circleci.com/developer/orbs/orb/circleci/bats#commands-install) command) and a converter that turns TAP into something that CircleCI understands (e.g. [`tap2junit`](https://manpages.ubuntu.com/manpages/trusty/man1/tap2junit.1p.html)), and then you'll need to ensure that, regardless of the return result from `bats`, the converter always runs.
 
 A working `.circleci/config.yml` section for testing might look like the following example:
 

--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -609,9 +609,9 @@ A working `.circleci/config.yml` section for testing might look like the followi
 ### Bats for Bash
 {: #bats-for-bash }
 
-[BATS](https://bats-core.readthedocs.io/) provides a `--report-formatter junit` option to create a JUnit-format report
-(in a location specified by the `--output` option; a subsequent `store_test_results` step should be passed that same location).
-The [circleci/bats](https://circleci.com/developer/orbs/orb/circleci/bats) orb's [run](https://circleci.com/developer/orbs/orb/circleci/bats?version=1.1.0#jobs-run) job encapsulates this functionality.
+[Bats](https://bats-core.readthedocs.io/) provides a `--report-formatter junit` option to create a JUnit-format report in a location specified by the `--output` option. A subsequent `store_test_results` step can be passed to that same location.
+
+The [circleci/bats](https://circleci.com/developer/orbs/orb/circleci/bats) orb's [run job](https://circleci.com/developer/orbs/orb/circleci/bats?version=1.1.0#jobs-run) takes care of this functionality for you.
 
 For example, a `.circleci/config.yml` section for running all `*.bats` tests within the `src/tests` folder might look like the following:
 


### PR DESCRIPTION
# Description
Adds a section that describes how to use BATS (the unit-test framework recommended by CircleCI for testing scripts in orbs).

# Reasons
This is non-trivial because CircleCI can't ingest the format output by BATS natively and the CircleCI "bats" orb doesn't do it either (see bats orb [issue 4](https://github.com/CircleCI-Public/BATS-orb/issues/4)), leaving users without a good example/easy path to follow without this documentation.
...and this is important because BATS is highlighted as "the" way of testing scripts in orbs, and orb development is core to CircleCI.

# Content Checklist

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
