### PR TITLE
Include missing required attribute mapping

### DIFF
--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -13,8 +13,6 @@ contentTags:
 
 In jobs using a <<contexts#,context>>, CircleCI provides an OpenID Connect ID (OIDC) token in an environment variable. A job can use this to access compatible cloud services without a long-lived credential stored in CircleCI.
 
-toc::[]
-
 [#openid-connect-id-token-availability]
 == OpenID Connect ID token availability
 

--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -213,6 +213,9 @@ Configuring the provider attributes provides an opportunity to map claims in Cir
 | google.subject
 | attribute.project_id
 
+| attribute.org_id
+| assertion.aud
+
 | assertion.sub
 | assertion['oidc.circleci.com/project-id']
 |===


### PR DESCRIPTION
# Description
Added the missing mapping `attribute.org_id` -> `assertion.aud` to the GCP OIDC setup docs.

# Reasons
Encountered errors due to the missing field