### PR TITLE
Clarify that only public orbs are open source and licensed to CircleCI under MIT

### DIFF
--- a/jekyll/_cci2/orbs-faq.md
+++ b/jekyll/_cci2/orbs-faq.md
@@ -36,12 +36,12 @@ This document describes various questions and technical issues that you may find
  
   Orbs are not available on installations of server v2.19.x, however, if you process your config prior to committing, orbs can be translated and used. Follow this guide on using git pre-commit hooks to [use orbs on server](https://discuss.circleci.com/t/orbs-on-server-solution/36264).
 
-## Report an issue with an orb
-{: #report-an-issue-with-an-orb }
+## Report an issue with a public orb
+{: #report-an-issue-with-a-public-orb }
 
-* **Question:** How can I report a bug or issue with an orb?
+* **Question:** How can I report a bug or issue with a public orb?
 
-* **Answer:** All orbs are open source projects. Issues, bug reports, or even pull requests can be made against the orb's git repository. Orb authors may opt to include a link to the git repo on the Orb Registry.
+* **Answer:** All public orbs are open source projects. Issues, bug reports, or even pull requests can be made against the orb's git repository. Public orb authors may opt to include a link to the git repo on the Orb Registry.
 
   If the git repo link is unavailable, contact support and we will attempt to contact the author. Alternatively, consider forking the orb and publishing your own version.
 


### PR DESCRIPTION
# Description
Update language in [Orbs FAQ doc](https://circleci.com/docs/orbs-faq/#report-an-issue-with-an-orb) so that only public orbs are indicated to be open source.

This PR does not make changes to any applicable text within the Dev Hub.

# Reasons
[Jira ticket](https://circleci.atlassian.net/browse/DOCTEAM-850)
Existing language is misleading and implies that private orbs are also open source and CircleCI owns private orb code under the MIT license.

Docs Disco (in collaboration with CPE) will address the changes needed for the Dev Hub.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
