### PR TITLE
Update IP Ranges for MacOS Cloud [MAC-1372]

### DIFF
--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -175,6 +175,9 @@ In addition to AWS and GCP (see above), CircleCI's macOS Cloud hosts jobs execut
 - 38.23.38.0/24
 - 38.23.39.0/24
 - 38.23.40.0/24
+- 38.23.41.0/24
+- 38.23.42.0/24
+- 38.23.43.0/24
 - 198.206.135.0/24
 
 **IP ranges** is the recommended method for configuring an IP-based firewall to allow traffic from CircleCI’s platform.


### PR DESCRIPTION
# Description
The MacOS Team is adding three additional subnets for MacOS executors:

- 38.23.41.0/24
- 38.23.42.0/24
- 38.23.43.0/24

# Reasons
[Jira Ticket](https://circleci.atlassian.net/browse/MAC-1372)

# Content Checklist

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
