### PR TITLE
[SNC-30] Adding caution about open-fail behavior in open preview stage

### DIFF
--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -13,6 +13,8 @@ contentTags:
 
 NOTE: Config policy management is available on the **Scale** plan and is currently in **open preview**. All aspects of the feature are subject to change.
 
+CAUTION: While config policy management is in open preview stage, it should be **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
+
 Use config policy management to create organization-level policies to impose rules and scopes around which configuration elements are required, allowed, not allowed etc.
 
 [#introduction]

--- a/jekyll/_cci2/config-policy-reference.adoc
+++ b/jekyll/_cci2/config-policy-reference.adoc
@@ -13,6 +13,8 @@ contentTags:
 
 NOTE: Config policy management is available on the **Scale** plan and is currently in **open preview**. All aspects of the feature are subject to change.
 
+CAUTION: While config policy management is in open preview stage, it should be **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
+
 This reference page lists a selection of _helpers_, or CircleCI-specific funtions that are likely to be useful for you when you are writing your policies. These helpers will lead to _cleaner_ policies with less boilerplate.
 
 The `circle-policy-agent` package includes built-in functions for common config policy

--- a/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
+++ b/jekyll/_cci2/use-the-cli-and-vcs-for-config-policy-management.adoc
@@ -13,6 +13,8 @@ contentTags:
 
 NOTE: Config policy management is available on the **Scale** plan and is currently in **open preview**. All aspects of the feature are subject to change.
 
+CAUTION: While config policy management is in open preview stage, it should be **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
+
 CAUTION: Ensure you have authenticated your version of the CLI with a token, and updated the CLI, before attempting to use the CLI for config policy management. See the link:/docs/local-cli[Installing the Local CLI] page for more information.
 
 Use the CircleCI CLI to manage your organization's policies programmatically. The sub-commands to perform policy management are grouped under the `policy` command. 

--- a/jekyll/_cci2/use-the-cli-for-config-and-policy-development.adoc
+++ b/jekyll/_cci2/use-the-cli-for-config-and-policy-development.adoc
@@ -13,6 +13,8 @@ contentTags:
 
 NOTE: Config policy management is available on the **Scale** plan and is currently in **open preview**. All aspects of the feature are subject to change.
 
+CAUTION: While config policy management is in open preview stage, it should be **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
+
 CAUTION: Ensure you have authenticated your version of the CLI with a token, and updated the CLI, before attempting to use the CLI for config policy management. See the link:/docs/local-cli[Installing the Local CLI] page for more information.
 
 [#develop-configs]


### PR DESCRIPTION
# Description
This PR adds a caution banner on config policy management doc pages, notifying the readers that it should **not** be used for compliance purposes during the open-preview stage.

# Reasons
https://circleci.atlassian.net/browse/SNC-30

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
