### PR TITLE
Fix min img step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,21 +102,11 @@ workflows:
           requires:
             - build_server_pdfs
             - build_api_docs
-      - minimize-images:
-          requires:
-            - build              
-          filters: 
-            branches:
-              only: 
-                - master 
-                - /.*-preview/
       - reindex-search:
           filters:
             branches:
               only: master
       - deploy:
-          requires:
-            - minimize-images
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,25 +295,3 @@ jobs:
     steps:
       - trigger-docs-platform-build
       
-  minimize-images:
-    executor:
-      name: node/default
-      tag: '14.17.3'
-    description: Compressing images with imagemin for prod
-    working_directory: *workspace_root
-    steps:
-      - *attach_workspace
-      - set-jekyll-basename
-      - run: 
-          name: move to correct workspace 
-          command: cd /tmp/workspace 
-      - node/install-packages:
-          pkg-manager: yarn
-          cache-version: &npm-cache-version v1 # Gets cache version from project environment variable (E.g v1)
-      - run:
-          name: Minimize Images
-          command: yarn minimize-img
-      - persist_to_workspace:
-          root: *workspace_root
-          paths: 
-            - _site/*/assets/*


### PR DESCRIPTION
# Description
Remove unused minimize-img deploy step

# Reasons
 This step is not useful anymore because images are imported as submodule into nextjs. NextJS does an optimization itself too anyway - via Romain

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
