### PR TITLE
Revert ``` that was accidentally deleted

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -270,6 +270,7 @@ suite. These applications are not developed or supported by CircleCI. Please che
 
   ```shell
   go test -v $(go list ./... | circleci tests split)
+  ```
   
 ## Known Limitations
 {: #known-limitations }


### PR DESCRIPTION
# Description
"```"seems to have been accidentally deleted in the last PR ([#7577](https://github.com/circleci/circleci-docs/pull/7577))

# Reasons
Screenshot:
![Screen Shot 2022-11-20 at 17 38 57](https://user-images.githubusercontent.com/87592312/202893115-033a920b-f734-43f5-92bb-3c1d2d61425f.png)