### PR TITLE
Add Android machine images to config reference

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -849,7 +849,7 @@ jobs:
 
 The Android image can also be accessed using the [Android orb](https://circleci.com/developer/orbs/orb/circleci/android).
 
-For examples, refer to the [Using Android Images with the Machine Executor](/android-machine-image) page.
+For examples, refer to the [Using Android Images with the Machine Executor](/docs/android-machine-image) page.
 
 ---
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -831,6 +831,28 @@ When using the Linux [GPU executor]({{ site.baseurl }}/using-gpu), the available
 
 ---
 
+##### Available Android `machine` images
+{: #available-android-machine-images }
+
+CircleCI supports running jobs on Android for testing and deploying Android applications. 
+
+To use the [Android image](https://circleci.com/developer/machine/image/android) directly with the machine executor, add the following to your job:
+
+```yaml
+version: 2.1
+
+jobs:
+  build:
+    machine:
+      image: android:2022.09.1
+```
+
+The Android image can also be accessed using the [Android orb](https://circleci.com/developer/orbs/orb/circleci/android).
+
+For examples, refer to the [Using Android Images with the Machine Executor](/android-machine-image) page.
+
+---
+
 ##### Available Windows `machine` images
 {: #available-windows-machine-images-cloud }
 


### PR DESCRIPTION
# Description
Add section for Android machine image in config reference. The section links out to the image page on Dev Hub.

It also mentions that there are two methods for using the Android image (the other using the Android orb).

# Reasons
[Jira ticket](https://circleci.atlassian.net/browse/DOCTEAM-480)
The Android image was missing from the config reference.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
