### PR TITLE
Fix init and pack links which have incorrect description

### DIFF
--- a/jekyll/_cci2/orb-development-kit.adoc
+++ b/jekyll/_cci2/orb-development-kit.adoc
@@ -25,8 +25,8 @@ The orb development kit is made up of the following components:
 
 * link:https://github.com/CircleCI-Public/Orb-Template[Orb template]: Repository with CircleCI's orb project template, which is automatically ingested and modified by the `orb init` command.
 * link:https://circleci-public.github.io/circleci-cli/[CircleCI CLI]: Contains two commands which are designed to work with the kit. The `orb init` command initializes a new orb project, and the `orb pack` command packs the orb source into a single `orb.yml` file.
-  ** link:https://circleci-public.github.io/circleci-cli/circleci_orb_pack.html[Orb pack command]: Initializes a new orb project.
-  ** link:https://circleci-public.github.io/circleci-cli/circleci_orb_init.html[Orb init command]: Packs an orb with local scripts.
+  ** link:https://circleci-public.github.io/circleci-cli/circleci_orb_init.html[Orb init command]: Initializes a new orb project.
+  ** link:https://circleci-public.github.io/circleci-cli/circleci_orb_pack.html[Orb pack command]: Packs an orb with local scripts.
 * link:https://circleci.com/developer/orbs/orb/circleci/orb-tools[Orb tools orb]: An orb for creating orbs, which is automatically implemented as a part of the generated configuration when using the **orb init command**.
 
 For more information on orb packing, see the <<orb-concepts#orb-packing,Orbs concepts>> page.


### PR DESCRIPTION
# Description

Fix the orb init and orb pack links to match the corresponding descriptions. They were switched.

# Reasons

The links are backwards as seen here: https://circleci.com/docs/orb-development-kit/

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
