### PR TITLE
Fix env var configuration in Runner config ref

### DIFF
--- a/jekyll/_cci2/runner-config-reference.adoc
+++ b/jekyll/_cci2/runner-config-reference.adoc
@@ -126,6 +126,7 @@ runner:
 
 [#runner-cleanup-working-directory]
 === runner.cleanup_working_directory
+`$LAUNCH_AGENT_RUNNER_CLEANUP_WORK_DIR`
 
 CircleCI recommends using a knowable directory, however it is possbile to specify `%s` in the path. This value will be replaced with a different value for each job. This is a substitution that is only knowable at job runtime, under the environment variable `$CIRCLE_WORKING_DIRECTORY`. 
 
@@ -226,7 +227,7 @@ runner:
 
 [#runner-disable-auto-update]
 === runner.disable_auto_update
-`$DISABLE_AUTO_UPDATE`
+`$LAUNCH_AGENT_RUNNER_DISABLE_AUTO_UPDATE`
 
 This parameter will disable launch-agent from attempting to automatically update itself, and stop making requests to CircleCI to check for new versions. This parameter is recommended to be set to `true` on server installations where version pinning is used.
 


### PR DESCRIPTION
# Description
While investigating some runner issues, I discovered that the env var for disabling auto update is incorrect, and the env var for specifying whether the working directory should be cleaned is missing.

This can be verified from running help on the latest version of launch-agent:
```
Usage: circleci-launch-agent

This is the launch agent for CircleCI runner. It is responsible for bootstrapping the task agent.

For more information on configuring CircleCI runner, visit https://circleci.com/docs/2.0/runner-config-reference/.

Flags:
  -h, --help                                     Show context-sensitive help.
  -c, --config="launch-agent-config.yaml"        Path to configuration YAML file.
  -v, --version                                  Print version information and quit.
      --api.url="https://runner.circleci.com"    ($LAUNCH_AGENT_API_URL)
      --api.auth_token=STRING                    ($LAUNCH_AGENT_API_AUTH_TOKEN)
      --runner.name=STRING                       ($LAUNCH_AGENT_RUNNER_NAME)
      --runner.idle_timeout=DURATION             ($LAUNCH_AGENT_RUNNER_IDLE_TIMEOUT)
      --runner.command_prefix=LIST               ($LAUNCH_AGENT_RUNNER_COMMAND_PREFIX)
      --runner.cleanup_working_directory         ($LAUNCH_AGENT_RUNNER_CLEANUP_WORK_DIR)
      --runner.working_directory=STRING          ($LAUNCH_AGENT_RUNNER_WORK_DIR)
      --runner.disable_auto_update               ($LAUNCH_AGENT_RUNNER_DISABLE_AUTO_UPDATE)
      --runner.max_run_time=5h                   ($LAUNCH_AGENT_RUNNER_MAX_RUN_TIME)
      --runner.mode=STRING                       ($LAUNCH_AGENT_RUNNER_MODE)
      --runner.ssh.advertise_addr=STRING         ($LAUNCH_AGENT_RUNNER_SSH_ADVERTISE_ADDR)
      --logging.file=STRING                      ($LAUNCH_AGENT_LOGGING_FILE)
```

# Reasons
One of the config options is missing its env var config and another is incorrect. This fixes it to prevent users from having issues configuring their launch-agent.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
