### PR TITLE
Add an FAQ for runner on `circleci` vs. `circleci-agent` [RT-719]

### DIFF
--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -134,6 +134,13 @@ circleci runner token create <resource-class-name> <nickname>
 
 No, runner resource classes cannot be used by jobs that are not associated with the organization that owns the runner resource classes. Only forks of your OSS project that _are_ a part of your organization may use the organization's self-hosted runners.
 
+[#why-did-my-test-splitting-job-step-error-with-circleci-command-not-found]
+== Why did my test splitting job step error with `circleci: command not found`?
+
+On self-hosted runners, `circleci-agent` is used for all commands that you may use either `circleci-agent` or `circleci` on CircleCI cloud, such as test splitting and step halt commands. Please note `circleci` is not to be confused with the <<local-cli#,local CircleCI CLI>>, and is simply an alias of `circleci-agent`.
+
+If you would like to use the local CircleCI CLI in your self-hosted runner jobs, which can proxy test commands to `circleci-agent`, you can install it via a job step, install it as a <<how-do-i-install-dependencies-needed-for-my-jobs,dependency>> on your machine for machine runner, or include it in a Docker image for container runner.
+
 [#container-runner-specific-faqs]
 == Container runner specific FAQs
 
@@ -166,7 +173,7 @@ An organization’s runner concurrency limit is shared with any existing `machin
 [#build-docker-images-with-container-agent]
 === Can I build Docker images with container runner either via Remote Docker or Docker in Docker (DIND)?
 
-See <<building-container-images,building contaier images>> for details.
+See <<building-container-images,building container images>> for details.
 
 [#can-i-use-something-other-than-kubernetes]
 === Can I use something other than Kubernetes with container runner?

--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -137,9 +137,9 @@ No, runner resource classes cannot be used by jobs that are not associated with 
 [#why-did-my-test-splitting-job-step-error-with-circleci-command-not-found]
 == Why did my test splitting job step error with `circleci: command not found`?
 
-On self-hosted runners, `circleci-agent` is used for all commands that you may use either `circleci-agent` or `circleci` on CircleCI cloud, such as test splitting and step halt commands. Please note `circleci` is not to be confused with the <<local-cli#,local CircleCI CLI>>, and is simply an alias of `circleci-agent`.
+On self-hosted runners, `circleci-agent` is used for all commands in which you may use either `circleci-agent` or `circleci` on CircleCI cloud (such as test splitting and step halt commands). Please note, `circleci` is not to be confused with the <<local-cli#,local CircleCI CLI>>, and is simply an alias of `circleci-agent`.
 
-If you would like to use the local CircleCI CLI in your self-hosted runner jobs, which can proxy test commands to `circleci-agent`, you can install it via a job step, install it as a <<how-do-i-install-dependencies-needed-for-my-jobs,dependency>> on your machine for machine runner, or include it in a Docker image for container runner.
+If you would like to use the local CircleCI CLI in your self-hosted runner jobs, which can proxy test commands to `circleci-agent`, you can install the CLI via a job step. Install the CLI as a <<how-do-i-install-dependencies-needed-for-my-jobs,dependency>> on your machine for machine runner, or include it in a Docker image for container runner.
 
 [#container-runner-specific-faqs]
 == Container runner specific FAQs


### PR DESCRIPTION
# Description
There's a difference between cloud and runner where cloud, for backward compatibility reasons, injects symlinks to the `circleci-agent` binary with the aliases `circleci` and `picard`, but these are all the same binary. Runner doesn't support this and only has the `circleci-agent` on the path. This adds an FAQ to help clear up this difference.

# Reasons
Jira: https://circleci.atlassian.net/browse/RT-719

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
