### PR TITLE
[RT-838] Pin Buildah image version to `v1.27.0`

### DIFF
--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -398,7 +398,7 @@ Another option is to use a tool called link:https://github.com/containers/builda
 
 ```yaml
 docker:
-  - image: quay.io/buildah/stable
+  - image: quay.io/buildah/stable:v1.27.0
 ```
 
 [#using-the-buildah-image]


### PR DESCRIPTION
# Description
Due to an upstream issue with the latest `Buildah` image and building images, this PR pins the Buildah version to the last working version with container-agent. See: https://circleci.atlassian.net/browse/RT-838?focusedCommentId=233319

# Reasons
https://circleci.atlassian.net/browse/RT-838

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
