### PR TITLE
[SERVER-2190] Adding CIRCLE_CLOUD_PROVIDER environment variable

### DIFF
--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -465,6 +465,9 @@ Once you have successfully cloned the repository, you can follow it from within 
 
 |CIRCLE_TOKEN
 |<YOUR_CIRCLECI_API_TOKEN>
+
+|CIRCLE_CLOUD_PROVIDER
+|< `aws`, `gcp`, or `other` >
 |===
 
 .Contexts


### PR DESCRIPTION
# Description
Adds the CIRCLE_CLOUD_PROVIDER environment variable to the required env vars for the running of reality check. This is referenced in the reality check readme, but not yet in this installation document.

# Reasons
[SERVER-2190]

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
