### PR TITLE
New orbs sections in sidebar

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -274,34 +274,32 @@ en:
 - name: Orbs
   icon: icons/sidebar/orbs.svg
   children:
-    - name: Using orbs
+    - name: Use orbs
       children:
         - name: Orb introduction
           link: orb-intro
-        - name: Orbs concepts
-          link: orb-concepts
-        - name: Orbs FAQ
-          link: orbs-faq
-    - name: Authoring orbs
+    - name: Author orbs
       children:
         - name: Intro to authoring an orb
           link: orb-author-intro
         - name: Author an orb
           link: orb-author
-        - name: Orb author FAQ
-          link: orb-author-faq
         - name: Orb authoring best practices
           link: orbs-best-practices
-        - name: Orb testing methodologies
-          link: testing-orbs
-        - name: Orb publishing process
-          link: creating-orbs
         - name: Orb development kit
           link: orb-development-kit
-        - name: Manual orb authoring
-          link: orb-author-validate-publish
+    - name: Test orbs
+      children: 
+        - name: Orb testing methodologies
+          link: testing-orbs
+    - name: Publish orbs
+      children:
+        - name: Orb publishing process
+          link: creating-orbs
     - name: Tutorials
       children:
+        - name: Manually author an orb
+          link: orb-author-validate-publish
         - name: Using the Slack orb
           link: slack-orb-tutorial
     - name: How-to guides
@@ -310,6 +308,18 @@ en:
           link: deploy-service-update-to-aws-ec2
         - name: Notify a Slack channel of a paused workflow
           link: notify-a-slack-channel-of-a-paused-workflow
+    - name: Reference
+      children:
+        - name: Orbs concepts
+          link: orb-concepts
+        - name: Orbs FAQ
+          link: orbs-faq
+        - name: Orb author FAQ
+          link: orb-author-faq
+        - name: Configuration reference
+          link: configuration-reference
+        - name: Reusing configuration
+          link: reusing-config
 
 - name: Insights
   icon: icons/sidebar/insights.svg
@@ -451,7 +461,6 @@ en:
     - name: Publish packages to Packagecloud
       link: publish-packages-to-packagecloud
 
-
 - name: Reference
   icon: icons/sidebar/reference.svg
   children:
@@ -550,7 +559,6 @@ en:
           link: server-pdfs/CircleCI-Server-4.0.0-GCP-Installation-Guide.pdf
         - name: v4.0.0 Operations Guide
           link: server-pdfs/CircleCI-Server-4.0.0-Operations-Guide.pdf
-
 
 - name: Server administration v3.x
   icon: icons/sidebar/admin.svg

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -271,7 +271,7 @@ en:
         - name: Migrate from deploy to run
           link: migrate-from-deploy-to-run
 
-- name: Orbs
+- name: Package and re-use config with orbs
   icon: icons/sidebar/orbs.svg
   children:
     - name: Use orbs


### PR DESCRIPTION
# Description
Split out orbs pages into new sections

# Reasons
There are a log of pages in the orbs docs set, some of which have got overly long. We plan to split some of the pages up further so they are easier to consume. The first stage of this process is to get the categorisation right. The sections come from the sidebar reorg plan.3

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
