### PR TITLE
Add clarification of scheduled pipelines for gitlab

### DIFF
--- a/jekyll/_cci2/gitlab-integration.adoc
+++ b/jekyll/_cci2/gitlab-integration.adoc
@@ -87,7 +87,9 @@ image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-configu
 [#triggers]
 === Triggers
 
-Add a trigger that specifies which configuration source starts a pipeline. If you followed the steps above to connect GitLab, a trigger set with GitLab as the configuration source has been automatically added for you.
+**The scheduled pipelines feature is not currently available for use with GitLab.** GitLab triggers are described below, including how to use filters to trigger pipelines based on certain conditions.
+
+Add a trigger that specifies which configuration source starts a pipeline. If you followed the steps above to connect GitLab, a trigger set with GitLab as the configuration source has been automatically added for you. 
 
 image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-triggers.png[Trigger setup page]
 
@@ -99,11 +101,11 @@ In addition to a configuration source, each trigger includes the webhook URL, an
 
 image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-edit-trigger.png[Trigger details]
 
-**Trigger filters** allow you to determine when a trigger should initiate a build based on the parameters provided by Gitlab’s webhook. CircleCI provides some common options, for example, only build on merge requests, but you can also build your own rules using the customer filter option. For example, a custom filter would allow you to only build on a specific branch or user.
+**Trigger filters** allow you to determine when a trigger should initiate a build based on the parameters provided by Gitlab’s webhook. CircleCI provides some common options, for example, only build on merge requests, but you can also build your own rules using the customer filter option. For example, a custom filter would allow you to only build on a specific branch or user. 
 
 image::{{site.baseurl}}/assets/img/docs/gl-preview/gitlab-preview-project-settings-customize-triggers.png[Trigger details]
 
-NOTE: Please also note the differences in functionality with the project settings below for GitLab support.
+NOTE: Also note the differences in functionality with the project settings below for GitLab support.
 
 [#project-settings-advanced]
 === **Advanced**
@@ -578,7 +580,7 @@ The ability to connect to multiple account integrations on CircleCI allows you t
 [#pipeline-values]
 == Pipeline values
 
-GitLab-based triggers provide access to additional pipeline values. For more information on using pipeline values and parameters in CircleCI, refer to the <<pipeline-variables#,Pipeline Values and Parameters>> document.
+GitLab-based triggers provide access to additional pipeline values. For more information on using pipeline values and parameters in CircleCI, refer to the <<pipeline-variables#,Pipeline Values and Parameters>> document. **Scheduled pipelines are not currently available to GitLab users.**
 
 [.table.table-striped]
 [cols=2*, options="header"]

--- a/jekyll/_cci2/scheduled-pipelines.md
+++ b/jekyll/_cci2/scheduled-pipelines.md
@@ -138,4 +138,4 @@ Not currently. Scheduled pipelines require highly deterministic inputs such as a
 
 - [Migrate scheduled workflows to scheduled pipelines](/docs/migrate-scheduled-workflows-to-scheduled-pipelines)
 - [Schedule pipelines with multiple workflows](/docs/schedule-pipelines-with-multiple-workflows)
-gitlab
+- [Set a nightly scheduled pipeline](/docs/set-a-nightly-scheduled-pipeline)

--- a/jekyll/_cci2/scheduled-pipelines.md
+++ b/jekyll/_cci2/scheduled-pipelines.md
@@ -11,7 +11,7 @@ contentTags:
 ## Introduction
 {: #introduction }
 
-Scheduled pipelines allow you to trigger pipelines periodically based on a schedule. Scheduled pipelines retain all the features of pipelines:
+**Scheduled pipelines are currently available for GitHub and Bitbucket VCS users.** Scheduled pipelines allow you to trigger pipelines periodically based on a schedule. Scheduled pipelines retain all the features of pipelines:
 
 - Control the actor associated with the pipeline, which can enable the use of [restricted contexts](/docs/contexts/#project-restrictions)
 - Use [dynamic config](/docs/dynamic-config) via setup workflows
@@ -107,8 +107,6 @@ curl --location --request GET "https://circleci.com/api/v2/project/<project-slug
 
 For GitHub and Bitbucket users: `project-slug` takes the form of `vcs-type/org-name/repo-name`, e.g. `gh/CircleCI-Public/api-preview-docs`.
 
-For GitLab SaaS Support users: `project-slug` takes the form of `circleci/:slug-remainder`. Refer to the [Getting started section](/docs/api-developers-guide/#getting-started-with-the-api) of the API Developer's Guide for more information on the project slug format.
-
 ---
 
 **Q:** Why is my scheduled pipeline not running?
@@ -140,4 +138,4 @@ Not currently. Scheduled pipelines require highly deterministic inputs such as a
 
 - [Migrate scheduled workflows to scheduled pipelines](/docs/migrate-scheduled-workflows-to-scheduled-pipelines)
 - [Schedule pipelines with multiple workflows](/docs/schedule-pipelines-with-multiple-workflows)
-- [Set a nightly scheduled pipeline](/docs/set-a-nightly-scheduled-pipeline)
+gitlab


### PR DESCRIPTION
# Description
- Add a bit about the scheduled pipelines feature not being available for GitLab users to the Scheduled pipelines and GitLab pages.
- Remove bit about slug URLs for GitLab on Scheduled pipelines page

# Reasons
We are missing clarification that the scheduled pipelines feature is not available for GitLab.
[Jira ticket](https://circleci.atlassian.net/jira/software/c/projects/DOCTEAM/boards/554?modal=detail&selectedIssue=DOCTEAM-878)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
