### PR TITLE
[SERVER-1940] remove gcp vm service networking rules

### DIFF
--- a/jekyll/_cci2/server/installation/hardening-your-cluster.adoc
+++ b/jekyll/_cci2/server/installation/hardening-your-cluster.adoc
@@ -19,8 +19,6 @@ toc::[]
 == Network topology
 A server installation basically runs three different type of compute instances: The Kubernetes nodes, Nomad clients, and external VMs.
 
-It is highly recommended that you deploy these into separate subnets with distinct CIDR blocks. This will make it easier for you to control traffic between the different components of the system and isolate them from each other.
-
 Best practice is to make as many of the resources as private as possible. If your users will access your CircleCI server installation via VPN, there is no need to assign any public IP addresses at all, as long as you have a working NAT gateway setup. Otherwise, you will need at least one public subnet for the `circleci-proxy` load balancer.
 
 However, in this case, it is also recommended to place Nomad clients and VMs in a public subnet to enable your users to SSH into jobs and scope access via networking rules.

--- a/jekyll/_cci2/server/installation/hardening-your-cluster.adoc
+++ b/jekyll/_cci2/server/installation/hardening-your-cluster.adoc
@@ -25,8 +25,6 @@ Best practice is to make as many of the resources as private as possible. If you
 
 However, in this case, it is also recommended to place Nomad clients and VMs in a public subnet to enable your users to SSH into jobs and scope access via networking rules.
 
-Currently, custom subnetting is not supported for GCP. Custom subnetting support will be available in a future update/release.
-
 NOTE: An NGINX reverse proxy is placed infront of https://github.com/Kong/charts[Kong] and exposed as a Kubernetes service named `circleci-proxy`. NGINX is responsible routing the traffic to the following services: `kong`, `vm-service`, `output-processor` and `nomad`.
 
 CAUTION: When using Amazon Certificate Manager (ACM), the name of nginx's service will be `circleci-proxy-acm` instead of `circleci-proxy`. If you have switched from some other method of handling your TLS certificates to using ACM, this change will recreate the loadbalancer and you will have to reroute your associated DNS records for your <domain> and app.<domain>.

--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -57,7 +57,7 @@ This returns something similar to the following:
 vpc-02fdfff4ca
 
 # Subnet Ids
-subnet-08922063f12541f93 subnet-03b94b6fb1e5c2a1d subnet-0540dd7b2b2ddb57e subnet-01833e1fa70aa4488 
+subnet-08922063f12541f93 subnet-03b94b6fb1e5c2a1d subnet-0540dd7b2b2ddb57e subnet-01833e1fa70aa4488
 ----
 +
 Then, using the VPCID you just found, run the following command to get the CIDR Block for your cluster. For AWS, the DNS Server is the third IP in your CIDR block (`CidrBlock`), for example your CIDR block might be `10.100.0.0/16`, so the third IP would be `10.100.0.2`.
@@ -172,7 +172,7 @@ nomad:
 --
 **Option 2:** Create the Kubernetes Secret yourself
 
-Instead of storing the access key and secret in your `values.yaml` file, you may create the Kubernetes Secret yourself. 
+Instead of storing the access key and secret in your `values.yaml` file, you may create the Kubernetes Secret yourself.
 
 NOTE: When using this method, an additional field is required for this secret, as outlined below.
 
@@ -423,7 +423,7 @@ kubectl -n <namespace> exec -it $(kubectl -n <namespace> get pods -l app=nomad-s
 ----
 
 You should be able to see output like this:
- 
+
 [source,shell]
 ----
 ID        DC       Name              Class        Drain  Eligibility  Status
@@ -1093,7 +1093,7 @@ When using service account keys for configuring access for the VM service, there
 --
 **Option 1:** CircleCI creates the Kubernetes Secret.
 
-Add the VM Service configuration to values.yaml. 
+Add the VM Service configuration to values.yaml.
 
 [source,yaml]
 ----

--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -1005,7 +1005,7 @@ databaseEncryption:
 . *Create firewall rules*
 +
 
-External VMs need the networking rules described in [Hardening your Cluster](https://circleci.com/docs/server/installation/hardening-your-cluster/#external-vms)
+External VMs need the networking rules described in link:/docs/server/installation/hardening-your-cluster/#external-vms[Hardening your Cluster]
 
 . *Create user*
 +

--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -1004,24 +1004,8 @@ databaseEncryption:
 
 . *Create firewall rules*
 +
-Run the following commands to create a firewall rule for VM service in GKE:
-+
-NOTE: If you have used auto-mode, you can find the Nomad clients CIDR based on the region by referring to the https://cloud.google.com/vpc/docs/vpc#ip-ranges[table here].
-+
-[source,shell]
-----
-gcloud compute firewall-rules create "circleci-vm-service-internal-nomad-fw" --network "<network>" --action allow --source-ranges "0.0.0.0/0" --rules "TCP:22,TCP:2376"
-----
-+
-[source,shell]
-----
-gcloud compute firewall-rules create "circleci-vm-service-internal-k8s-fw" --network "<network>" --action allow --source-ranges "<clusterIpv4Cidr>" --rules "TCP:22,TCP:2376"
-----
-+
-[source,shell]
-----
-gcloud compute firewall-rules create "circleci-vm-service-external-fw" --network "<network>" --action allow --rules "TCP:54782"
-----
+
+External VMs need the networking rules described in [Hardening your Cluster](https://circleci.com/docs/server/installation/hardening-your-cluster/#external-vms)
 
 . *Create user*
 +


### PR DESCRIPTION
# Description

Cleans up whitespace

One can use custom subnetting in GCP ,this removes the recommendation that it is not possible

We have been recommending customers put k8s nodes, Nomad Clients and VMs for machine jobs in separate subnets.  
We we also suggesting three firewall rules to accompany the separate network.  The `source` for the firewall rules was overlapping and no guidance was provided on how to deal with that.  This removes those recommendations

There is still the recommendation that customers keep everything behind a private VPC and use a VPN to connect, which is a good first step in securing the networking.

The information needed to build out the firewall rules between subnets is still provided in the "hardening your cluster" section, which is now linked from here.

The bottom line is customer environments are all unique in terms of structure and security requirements, it is difficult to even reference a similar starting point in GCP because of the project inheritance and hierarchy.  Lets remove anything that is ambiguous and empower the customer to make the decisions that are right for them (by linking to the Hardening your Cluster docs)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
