### PR TITLE
typo: `testss` -> `tests`

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -13,7 +13,7 @@ contentTags:
 Use parallelism and test splitting to:
 
 * Reduce the time taken for the testing portion of your CI/CD pipeline. 
-* Specify a number of [executors]({{site.baseurl}}/executor-intro/) across which to split your testss. 
+* Specify a number of [executors]({{site.baseurl}}/executor-intro/) across which to split your tests. 
 * Split your test suite using one of the options provided by the CircleCI CLI: by name, size or by using timing data.
 
 ## Introduction


### PR DESCRIPTION
# Description
Fixing a typo on the CircleCI parallelism docs

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
