### PR TITLE
Add launch-agent version for server 4.0

### DIFF
--- a/jekyll/_cci2/runner-installation-cli.adoc
+++ b/jekyll/_cci2/runner-installation-cli.adoc
@@ -163,6 +163,9 @@ For *server v3.1.0 and up*, use the table below to find the compatible machine r
 
 | 3.4
 | 1.0.33818-051c2fc
+
+| 4.0
+| 1.0.33818-051c2fc
 |===
 +
 Substitute `<launch-agent-version>` with your launch-agent version for server and run the following:


### PR DESCRIPTION
# Description
Adds a launch-agent version that is compatible with server 4.0

# Reasons
There have been a couple of question from support recently where the customers were using the incorrect version of launch-agent. Versions later than `1.0.33818-051c2fc` are currently not compatible with server.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
