### PR TITLE
Update quote style

### DIFF
--- a/jekyll/_cci2/orb-author-faq.md
+++ b/jekyll/_cci2/orb-author-faq.md
@@ -96,7 +96,7 @@ steps:
   - run:
     name: Check Ruby shell
     shell: ruby
-    command: puts "hi"
+    command: puts 'hi'
 ```
  
 **Node**
@@ -106,7 +106,7 @@ steps:
   - run:
     name: Check Node shell
     shell: node
-    command: console.log("node")
+    command: console.log('node')
 ```
 
 **Python**
@@ -116,7 +116,7 @@ steps:
   - run:
     name: Check Python shell
     shell: python3
-    command: print("python")
+    command: print('python')
 ```
 
 **Binary**


### PR DESCRIPTION
# Description
Forgot to change the quote style back to single quotes after I was troubleshooting the syntax of the code blocks.

# Reasons
Single quotes are best used for Ruby, Node and Python if referencing a literal string, which we are in these examples.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
