### PR TITLE
fix: correct link to ubuntu image definition

### DIFF
--- a/jekyll/_cci2/using-linuxvm.md
+++ b/jekyll/_cci2/using-linuxvm.md
@@ -45,7 +45,7 @@ You can view the list of available images [in the docs Configuration Reference](
 ## Pre-installed software
 {: #pre-installed-software }
 
-The most up to date list of pre-installed software can be found on the [image builder](https://github.com/CircleCI-Public/circleci-server-linux-image-builder) page. You can also visit the [Discuss](https://discuss.circleci.com/tag/machine-images) page for more information.
+The most up to date list of pre-installed software can be found on the [Discuss](https://discuss.circleci.com/tag/machine-images) page.
 
 Additional packages can be installed with `sudo apt-get install <package>`. If the package in question is not found, `sudo apt-get update` may be required before installing it.
 

--- a/jekyll/_cci2/using-linuxvm.md
+++ b/jekyll/_cci2/using-linuxvm.md
@@ -45,7 +45,7 @@ You can view the list of available images [in the docs Configuration Reference](
 ## Pre-installed software
 {: #pre-installed-software }
 
-The most up to date list of pre-installed software can be found on the [image builder](https://raw.githubusercontent.com/circleci/image-builder/picard-vm-image/provision.sh) page. You can also visit the [Discuss](https://discuss.circleci.com/tag/machine-images) page for more information.
+The most up to date list of pre-installed software can be found on the [image builder](https://github.com/CircleCI-Public/circleci-server-linux-image-builder) page. You can also visit the [Discuss](https://discuss.circleci.com/tag/machine-images) page for more information.
 
 Additional packages can be installed with `sudo apt-get install <package>`. If the package in question is not found, `sudo apt-get update` may be required before installing it.
 

--- a/jekyll/_cci2/using-linuxvm.md
+++ b/jekyll/_cci2/using-linuxvm.md
@@ -14,7 +14,7 @@ You can run your jobs in the linux VM (virtual machine) execution environment by
 
 Using the machine executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack; for example, to listen on a network interface, or to modify the system with `sysctl` commands.
 
-To use the machine executor, use the [`machine` key]({{ site.baseurl }}/configuration-reference/#machine) in your job configuration and specify an image:
+To use the machine executor, use the [`machine` key]({{site.baseurl}}/configuration-reference/#machine) in your job configuration and specify an image:
 
 {:.tab.machineblock.Cloud}
 ```yaml
@@ -35,7 +35,7 @@ jobs:
     resource_class: large
 ```
 
-You can view the list of available images [in the docs Configuration Reference]({{ site.baseurl }}/configuration-reference/#available-linux-machine-images), or on the [Developer Hub](https://circleci.com/developer/images?imageType=machine). If you are working on an installation of CircleCI server, you will notice in the example above the syntax is slightly different, and the available Linux images are managed by your system administrator.
+You can view the list of available images [in the docs Configuration Reference]({{site.baseurl}}/configuration-reference/#available-linux-machine-images), or on the [Developer Hub](https://circleci.com/developer/images?imageType=machine). If you are working on an installation of CircleCI server, you will notice in the example above the syntax is slightly different, and the available Linux images are managed by your system administrator.
 
 ## Available LinuxVM resource classes
 {: #available-linuxvm-resource-classes } 
@@ -46,6 +46,20 @@ You can view the list of available images [in the docs Configuration Reference](
 {: #pre-installed-software }
 
 The most up to date list of pre-installed software can be found on the [Discuss](https://discuss.circleci.com/tag/machine-images) page.
+
+If you are already using an image and would like to verify the all the packages that come pre-installed, you can run the `apt list --installed` command as a step, like in the example below:
+
+```yaml
+version: 2.1
+...
+jobs:
+  whats-installed:
+    machine: # executor type
+      image: ubuntu-2004:2022.07.1
+    steps:
+      - run: apt list --installed
+...
+```
 
 Additional packages can be installed with `sudo apt-get install <package>`. If the package in question is not found, `sudo apt-get update` may be required before installing it.
 


### PR DESCRIPTION
# Description

The previous link went to an archived repo (https://discuss.circleci.com/tag/machine-images).

# Reasons

This links to the replacement.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
