### PR TITLE
Split out webhooks reference and refresh overview page

### DIFF
--- a/jekyll/_cci2/webhooks-reference.adoc
+++ b/jekyll/_cci2/webhooks-reference.adoc
@@ -43,14 +43,14 @@ NOTE: The event payloads are open maps, meaning new fields may be added to maps 
 [#common-sub-entities]
 == Common sub-entities of webhooks
 
-The next sections describe the payloads of different events offered with CircleCI webhooks. The schema of these webhook events will often share data with other webhooks - we refer to these as common maps of data as "sub-entities". For example, when you receive an event payload for the `job-completed` webhook, it will contain maps of data for your *project, organization, job, workflow and pipeline*.
+The following sections describe the payloads of different events offered with CircleCI webhooks. The schema of these webhook events will often share data with other webhooks. We refer to these common maps of data as "sub-entities". For example, when you receive an event payload for the `job-completed` webhook, it will contain maps of data for your *project, organization, job, workflow and pipeline*.
 
-Let us look at some of the common sub-entities that will appear across various webhooks:
+Some common sub-entities that will appear across various webhooks are described in the following sections:
 
 [#project]
 === Project
 
-Data about the project associated with the webhook event.
+The following data about the project associated with the webhook event is provided:
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]
@@ -75,7 +75,7 @@ Data about the project associated with the webhook event.
 [#organization]
 === Organization
 
-Data about the organization associated with the webhook event.
+The following data about the organization associated with the webhook event is provided:
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]
@@ -96,9 +96,9 @@ Data about the organization associated with the webhook event.
 [#job]
 === Job
 
-A job typically represents one phase in a CircleCI workload (e.g. "build", "test", or "deploy") and contains a series of steps.
+A link:/docs/jobs-steps/[job] typically represents one phase in a CircleCI workload (for example, "build", "test", or "deploy") and contains a series of steps.
 
-Data about the job associated with the webhook event.
+THe following data about the job associated with the webhook event is provided:
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]
@@ -123,11 +123,11 @@ Data about the job associated with the webhook event.
 | yes
 | Current status of the job
 
-| started\_at
+| started_at
 | yes
 | When the job started running
 
-| stopped\_at
+| stopped_at
 | no
 | When the job reached a terminal state (if applicable)                                                        |
 |===
@@ -135,9 +135,7 @@ Data about the job associated with the webhook event.
 [#workflow]
 === Workflow
 
-Workflows contain many jobs, which can run in parallel and/or have dependencies between them. A single git-push can trigger zero or more workflows, depending on the CircleCI configuration (but typically one will be triggered).
-
-Data about the workflow associated with the webhook event.
+link:/docs/workflows[Workflows] orchestrate jobs. The following data about the workflow associated with the webhook event is provided:
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]
@@ -176,7 +174,7 @@ Data about the workflow associated with the webhook event.
 
 Pipelines are the most high-level unit of work, and contain zero or more workflows. A single git-push always triggers up to one pipeline. Pipelines can also be triggered manually through the API.
 
-Data about the pipeline associated with the webhook event.
+The following Data about the pipeline associated with the webhook event is provided:
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]
@@ -213,7 +211,7 @@ Data about the pipeline associated with the webhook event.
 [#trigger]
 === Trigger
 
-Data about the trigger associated with the webhook event.
+The following data about the trigger associated with the webhook event is provided:
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]
@@ -224,7 +222,7 @@ Data about the trigger associated with the webhook event.
 
 | type
 | yes
-| How this pipeline was triggered (e.g. "webhook", "api", "schedule")
+| How this pipeline was triggered (for example, "webhook", "api", "schedule")
 |===
 
 [#trigger-parameters]
@@ -627,3 +625,8 @@ NOTE: The VCS map or its contents may not always be provided. Present for pipeli
   }
 }
 ```
+
+[#next-steps]
+== Next steps
+
+* Follow the link:/docs/webhooks-airtable/[Using webhooks with third party tools] tutorial.

--- a/jekyll/_cci2/webhooks-reference.adoc
+++ b/jekyll/_cci2/webhooks-reference.adoc
@@ -230,18 +230,18 @@ Data about the trigger associated with the webhook event.
 [#trigger-parameters]
 === Trigger parameters
 
-Data associated to the pipeline. Present for pipelines associated with providers other than GitHub or Bitbucket. See [VCS](#vcs) below for GitHub and Bitbucket.
+Data associated to the pipeline. Present for pipelines associated with providers other than GitHub or Bitbucket. See <<#vcs>> below for GitHub and Bitbucket.
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]
 |===
 | Field
 | Always present?
-| Description                                                          |
+| Description
 
 | circleci
 | yes
-| A map containing trigger information -- see below
+| A map containing trigger information -- see <<#circleci>>
 
 | git
 | no

--- a/jekyll/_cci2/webhooks-reference.adoc
+++ b/jekyll/_cci2/webhooks-reference.adoc
@@ -98,7 +98,7 @@ The following data about the organization associated with the webhook event is p
 
 A link:/docs/jobs-steps/[job] typically represents one phase in a CircleCI workload (for example, "build", "test", or "deploy") and contains a series of steps.
 
-THe following data about the job associated with the webhook event is provided:
+The following data about the job associated with the webhook event is provided:
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]

--- a/jekyll/_cci2/webhooks-reference.adoc
+++ b/jekyll/_cci2/webhooks-reference.adoc
@@ -1,0 +1,629 @@
+---
+description: Reference page for webhooks payloads
+contentTags:
+  platform:
+  - Cloud
+  - Server v4.x
+  - Server v3.x
+---
+= Webhooks reference
+:page-layout: classic-docs
+:page-liquid:
+:icons: font
+:toc: macro
+:toc-title:
+
+[#common-top-level-keys]
+== Common top level keys of webhooks
+
+Each webhook will have some common data as part of the event:
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Description
+| Type
+
+| id
+| ID used to uniquely identify each event from the system (the client can use this to dedupe events)
+| String
+
+| happened_at
+| ISO 8601 timestamp representing when the event happened
+| String
+
+| webhook
+| A map of metadata representing the webhook that was triggered
+| Map
+|===
+
+NOTE: The event payloads are open maps, meaning new fields may be added to maps in the webhook payload without considering it a breaking change.
+
+[#common-sub-entities]
+== Common sub-entities of webhooks
+
+The next sections describe the payloads of different events offered with CircleCI webhooks. The schema of these webhook events will often share data with other webhooks - we refer to these as common maps of data as "sub-entities". For example, when you receive an event payload for the `job-completed` webhook, it will contain maps of data for your *project, organization, job, workflow and pipeline*.
+
+Let us look at some of the common sub-entities that will appear across various webhooks:
+
+[#project]
+=== Project
+
+Data about the project associated with the webhook event.
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Always present?
+| Description
+
+| id
+| yes
+| Unique ID of the project
+
+| slug
+| yes
+| String that can be used to refer to a specific project in many of CircleCI's APIs (for example, `gh/circleci/web-ui`)
+
+| name
+| yes
+| Name of the project (for example, `web-ui`)
+|===
+
+[#organization]
+=== Organization
+
+Data about the organization associated with the webhook event.
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Always present?
+| Description
+
+| id
+| yes
+| Unique ID of the organization
+
+| name
+| yes
+| Name of the organization (e.g. "circleci")
+|===
+
+[#job]
+=== Job
+
+A job typically represents one phase in a CircleCI workload (e.g. "build", "test", or "deploy") and contains a series of steps.
+
+Data about the job associated with the webhook event.
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Always present?
+| Description
+
+| id
+| yes
+| Unique ID of the job
+
+| number
+| yes
+| An auto-incrementing number for the job, sometimes used in CircleCI's APIs to identify jobs within a project
+
+| name
+| yes
+| Name of the job as defined in .circleci/config.yml
+
+| status
+| yes
+| Current status of the job
+
+| started\_at
+| yes
+| When the job started running
+
+| stopped\_at
+| no
+| When the job reached a terminal state (if applicable)                                                        |
+|===
+
+[#workflow]
+=== Workflow
+
+Workflows contain many jobs, which can run in parallel and/or have dependencies between them. A single git-push can trigger zero or more workflows, depending on the CircleCI configuration (but typically one will be triggered).
+
+Data about the workflow associated with the webhook event.
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Always present?
+| Description
+
+| id
+| Yes
+| Unique ID of the workflow
+
+| name
+| Yes
+| Name of the workflow as defined in .circleci/config.yml
+
+| status
+| No
+| Current status of the workflow. Not included in job-level webhooks
+
+| created\_at
+| Yes
+| When the workflow was created
+
+| stopped_at
+| No
+| When the workflow reached a terminal state (if applicable)
+
+| url
+| Yes
+| URL to the workflow in CircleCI's UI
+|===
+
+[#pipeline]
+=== Pipeline
+
+Pipelines are the most high-level unit of work, and contain zero or more workflows. A single git-push always triggers up to one pipeline. Pipelines can also be triggered manually through the API.
+
+Data about the pipeline associated with the webhook event.
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Always present?
+| Description
+
+| id
+| Yes
+| Globally unique ID of the pipeline
+
+| number
+| Yes
+| Number of the pipeline, which is auto-incrementing / unique per project
+
+| created\_at
+| Yes
+| When the pipeline was created
+
+| trigger
+| Yes
+| A map of metadata about what caused this pipeline to be created -- see below
+
+| trigger_parameters
+| No
+| A map of metadata about the pipeline -- see below
+
+| vcs
+| No
+| A map of metadata about the git commit associated with this pipeline -- see below
+|===
+
+[#trigger]
+=== Trigger
+
+Data about the trigger associated with the webhook event.
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Always present?
+| Description
+
+| type
+| yes
+| How this pipeline was triggered (e.g. "webhook", "api", "schedule")
+|===
+
+[#trigger-parameters]
+=== Trigger parameters
+
+Data associated to the pipeline. Present for pipelines associated with providers other than GitHub or Bitbucket. See [VCS](#vcs) below for GitHub and Bitbucket.
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Always present?
+| Description                                                          |
+
+| circleci
+| yes
+| A map containing trigger information -- see below
+
+| git
+| no
+| A map present when the pipeline is associated with a VCS provider
+
+| gitlab
+| no
+| A map present when the pipeline is associated with a Gitlab trigger
+|===
+
+[#circleci]
+==== circleci
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Always present?
+| Description
+
+| event_time
+| yes
+| ISO 8601 timestamp representing when the pipeline was created
+
+| event_type
+| yes
+| Provider event type that triggered the pipeline (for example, `push`)
+
+| trigger_type
+| yes
+| Trigger provider (for example, `gitlab`)
+
+| actor_id
+| no
+| CircleCI user id that the pipeline was attributed to
+|===
+
+[#vcs]
+=== VCS
+
+NOTE: The VCS map or its contents may not always be provided. Present for pipelines associated with GitHub and Bitbucket. See <<#trigger-parameters,trigger parameters>> above for other providers.
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Field
+| Always present?
+| Description
+
+| target_repository_url
+| no
+| URL to the repository building the commit
+
+| origin_repository_url
+| no
+| URL to the repository where the commit was made (this will only be different in the case of a forked pull request)
+
+| revision
+| no
+| Git commit being built
+
+| commit.subject
+| no
+| Commit subject (first line of the commit message). Note that long commit subjects may be truncated.
+
+| commit.body
+| no
+| Commit body (subsequent lines of the commit message). Note that long commit bodies may be truncated.
+
+| commit.author.name
+| no
+| Name of the author of this commit
+
+| commit.author.email
+| no
+| Email address of the author of this commit
+
+| commit.authored\_at
+| no
+| Timestamp of when the commit was authored
+
+| commit.committer.name
+| no
+| Name of the committer of this commit
+
+| commit.committer.email
+| no
+| Email address of the committer of this commit
+
+| commit.committed_at
+| no
+| Timestamp of when the commit was committed
+
+| branch
+| no
+| Branch being built
+
+| tag
+| no
+| Tag being built (mutually exclusive with "branch")
+|===
+
+[#sample-webhook-payloads]
+== Sample webhook payloads
+
+[#workflow-completed-for-github-and-bitbucket]
+=== workflow-completed for GitHub and Bitbucket
+
+```json
+{
+  "id": "3888f21b-eaa7-38e3-8f3d-75a63bba8895",
+  "type": "workflow-completed",
+  "happened_at": "2021-09-01T22:49:34.317Z",
+  "webhook": {
+    "id": "cf8c4fdd-0587-4da1-b4ca-4846e9640af9",
+    "name": "Sample Webhook"
+  },
+  "project": {
+    "id": "84996744-a854-4f5e-aea3-04e2851dc1d2",
+    "name": "webhook-service",
+    "slug": "github/circleci/webhook-service"
+  },
+  "organization": {
+    "id": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
+    "name": "circleci"
+  },
+  "workflow": {
+    "id": "fda08377-fe7e-46b1-8992-3a7aaecac9c3",
+    "name": "build-test-deploy",
+    "created_at": "2021-09-01T22:49:03.616Z",
+    "stopped_at": "2021-09-01T22:49:34.170Z",
+    "url": "https://app.circleci.com/pipelines/github/circleci/webhook-service/130/workflows/fda08377-fe7e-46b1-8992-3a7aaecac9c3",
+    "status": "success"
+  },
+  "pipeline": {
+    "id": "1285fe1d-d3a6-44fc-8886-8979558254c4",
+    "number": 130,
+    "created_at": "2021-09-01T22:49:03.544Z",
+    "trigger": {
+      "type": "webhook"
+    },
+    "vcs": {
+      "provider_name": "github",
+      "origin_repository_url": "https://github.com/circleci/webhook-service",
+      "target_repository_url": "https://github.com/circleci/webhook-service",
+      "revision": "1dc6aa69429bff4806ad6afe58d3d8f57e25973e",
+      "commit": {
+        "subject": "Description of change",
+        "body": "More details about the change",
+        "author": {
+          "name": "Author Name",
+          "email": "author.email@example.com"
+        },
+        "authored_at": "2021-09-01T22:48:53Z",
+        "committer": {
+          "name": "Committer Name",
+          "email": "committer.email@example.com"
+        },
+        "committed_at": "2021-09-01T22:48:53Z"
+      },
+      "branch": "main"
+    }
+  }
+}
+```
+
+[#job-completed-for-github-and-bitbucket]
+=== job-completed for GitHub and Bitbucket
+
+```json
+{
+  "id": "8bd71c28-4969-3677-8940-3e3a61c46660",
+  "type": "job-completed",
+  "happened_at": "2021-09-01T22:49:34.279Z",
+  "webhook": {
+    "id": "cf8c4fdd-0587-4da1-b4ca-4846e9640af9",
+    "name": "Sample Webhook"
+  },
+  "project": {
+    "id": "84996744-a854-4f5e-aea3-04e2851dc1d2",
+    "name": "webhook-service",
+    "slug": "github/circleci/webhook-service"
+  },
+  "organization": {
+    "id": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
+    "name": "circleci"
+  },
+  "pipeline": {
+    "id": "1285fe1d-d3a6-44fc-8886-8979558254c4",
+    "number": 130,
+    "created_at": "2021-09-01T22:49:03.544Z",
+    "trigger": {
+      "type": "webhook"
+    },
+    "vcs": {
+      "provider_name": "github",
+      "origin_repository_url": "https://github.com/circleci/webhook-service",
+      "target_repository_url": "https://github.com/circleci/webhook-service",
+      "revision": "1dc6aa69429bff4806ad6afe58d3d8f57e25973e",
+      "commit": {
+        "subject": "Description of change",
+        "body": "More details about the change",
+        "author": {
+          "name": "Author Name",
+          "email": "author.email@example.com"
+        },
+        "authored_at": "2021-09-01T22:48:53Z",
+        "committer": {
+          "name": "Committer Name",
+          "email": "committer.email@example.com"
+        },
+        "committed_at": "2021-09-01T22:48:53Z"
+      },
+      "branch": "main"
+    }
+  },
+  "workflow": {
+    "id": "fda08377-fe7e-46b1-8992-3a7aaecac9c3",
+    "name": "welcome",
+    "created_at": "2021-09-01T22:49:03.616Z",
+    "stopped_at": "2021-09-01T22:49:34.170Z",
+    "url": "https://app.circleci.com/pipelines/github/circleci/webhook-service/130/workflows/fda08377-fe7e-46b1-8992-3a7aaecac9c3"
+  },
+  "job": {
+    "id": "8b91f9a8-7975-4e60-916c-f0152ccbc937",
+    "name": "test",
+    "started_at": "2021-09-01T22:49:28.841Z",
+    "stopped_at": "2021-09-01T22:49:34.170Z",
+    "status": "success",
+    "number": 136
+  }
+}
+```
+
+[#workflow-completed-gitlab]
+=== workflow-completed for Gitlab
+
+```json
+{
+  "type": "workflow-completed",
+  "id": "cbabbb40-6084-4f91-8311-a326c0f4963a",
+  "happened_at": "2022-05-27T16:20:13.954328Z",
+  "webhook": {
+    "id": "e4da0d23-31cf-4047-8a7e-8ffb14cd0100",
+    "name": "test"
+  },
+  "workflow": {
+    "id": "c2006ece-778d-49fc-9e6e-b9965f72bee9",
+    "name": "build",
+    "created_at": "2022-05-27T16:20:07.631Z",
+    "stopped_at": "2022-05-27T16:20:13.812Z",
+    "url": "https://app.circleci.com/pipelines/circleci/DdaVtNusHqi24D4YT3X4eu/6EkDPZoN4ZdMKKZtBkRodt/1/workflows/c2006ece-778d-49fc-9e6e-b9965f72bee9",
+    "status": "failed"
+  },
+  "pipeline": {
+    "id": "37c74cb7-d64d-4032-8731-1cb95bfef921",
+    "number": 1,
+    "created_at": "2022-04-13T11:10:18.804Z",
+    "trigger": {
+      "type": "gitlab"
+    },
+    "trigger_parameters": {
+      "gitlab": {
+        "web_url": "https://gitlab.com/circleci/hello-world",
+        "commit_author_name": "Commit Author",
+        "user_id": "9534789",
+        "user_name": "User name",
+        "user_username": "username",
+        "branch": "main",
+        "commit_title": "Update README.md",
+        "commit_message": "Update README.md",
+        "total_commits_count": "1",
+        "repo_url": "git@gitlab.com:circleci/hello-world.git",
+        "user_avatar": "https://secure.gravatar.com/avatar",
+        "type": "push",
+        "project_id": "33852820",
+        "ref": "refs/heads/main",
+        "repo_name": "hello-world",
+        "commit_author_email": "committer.email@example.com",
+        "checkout_sha": "850a1519f25d14e968649cc420d1bd381715c05c",
+        "commit_timestamp": "2022-04-13T11:10:16+00:00",
+        "commit_sha": "850a1519f25d14e968649cc420d1bd381715c05c"
+      },
+      "git": {
+        "tag": "",
+        "checkout_sha": "850a1519f25d14e968649cc420d1bd381715c05c",
+        "ref": "refs/heads/main",
+        "branch": "main",
+        "checkout_url": "git@gitlab.com:circleci/hello-world.git"
+      },
+      "circleci": {
+        "event_time": "2022-04-13T11:10:18.349Z",
+        "actor_id": "6a19122c-40e0-4d56-a875-aac6ccc27700",
+        "event_type": "push",
+        "trigger_type": "gitlab"
+      }
+    }
+  },
+  "project": {
+    "id": "2a68fe5f-2fe5-4d4f-91e1-15f111116743",
+    "name": "hello-world",
+    "slug": "circleci/DdaVtNusHqi24D4YT3X4eu/6EkDPZoN4ZdMKKZtBkRodt"
+  },
+  "organization": {
+    "id": "66491562-90a9-4065-9249-4b0ce3b77452",
+    "name": "circleci"
+  }
+}
+```
+
+[#job-completed-gitlab]
+=== job-completed for Gitlab
+
+```json
+{
+  "type": "workflow-completed",
+  "id": "47a497be-4498-4da0-a4e8-2dabd889af0f",
+  "happened_at": "2022-05-27T16:20:13.954328Z",
+  "webhook": {
+    "id": "e4da0d23-31cf-4047-8a7e-8ffb14cd0100",
+    "name": "test"
+  },
+  "job": {
+    "id": "2fc6977d-7e45-4271-b355-0ea894d82017",
+    "name": "say-hello",
+    "started_at": "2022-07-11T12:16:37.435Z",
+    "stopped_at": "2022-07-11T12:16:59.982Z",
+    "status": "success",
+    "number": 1
+  }
+  "pipeline": {
+    "id": "37c74cb7-d64d-4032-8731-1cb95bfef921",
+    "number": 1,
+    "created_at": "2022-04-13T11:10:18.804Z",
+    "trigger": {
+      "type": "gitlab"
+    },
+    "trigger_parameters": {
+      "gitlab": {
+        "web_url": "https://gitlab.com/circleci/hello-world",
+        "commit_author_name": "Commit Author",
+        "user_id": "9534789",
+        "user_name": "User name",
+        "user_username": "username",
+        "branch": "main",
+        "commit_title": "Update README.md",
+        "commit_message": "Update README.md",
+        "total_commits_count": "1",
+        "repo_url": "git@gitlab.com:circleci/hello-world.git",
+        "user_avatar": "https://secure.gravatar.com/avatar",
+        "type": "push",
+        "project_id": "33852820",
+        "ref": "refs/heads/main",
+        "repo_name": "hello-world",
+        "commit_author_email": "committer.email@example.com",
+        "checkout_sha": "850a1519f25d14e968649cc420d1bd381715c05c",
+        "commit_timestamp": "2022-04-13T11:10:16+00:00",
+        "commit_sha": "850a1519f25d14e968649cc420d1bd381715c05c"
+      },
+      "git": {
+        "tag": "",
+        "checkout_sha": "850a1519f25d14e968649cc420d1bd381715c05c",
+        "ref": "refs/heads/main",
+        "branch": "main",
+        "checkout_url": "git@gitlab.com:circleci/hello-world.git"
+      },
+      "circleci": {
+        "event_time": "2022-04-13T11:10:18.349Z",
+        "actor_id": "6a19122c-40e0-4d56-a875-aac6ccc27700",
+        "event_type": "push",
+        "trigger_type": "gitlab"
+      }
+    }
+  },
+  "project": {
+    "id": "2a68fe5f-2fe5-4d4f-91e1-15f111116743",
+    "name": "hello-world",
+    "slug": "circleci/DdaVtNusHqi24D4YT3X4eu/6EkDPZoN4ZdMKKZtBkRodt"
+  },
+  "organization": {
+    "id": "66491562-90a9-4065-9249-4b0ce3b77452",
+    "name": "circleci"
+  }
+}
+```

--- a/jekyll/_cci2/webhooks-reference.adoc
+++ b/jekyll/_cci2/webhooks-reference.adoc
@@ -43,7 +43,7 @@ NOTE: The event payloads are open maps, meaning new fields may be added to maps 
 [#common-sub-entities]
 == Common sub-entities of webhooks
 
-The following sections describe the payloads of different events offered with CircleCI webhooks. The schema of these webhook events will often share data with other webhooks. We refer to these common maps of data as "sub-entities". For example, when you receive an event payload for the `job-completed` webhook, it will contain maps of data for your *project, organization, job, workflow and pipeline*.
+The following sections describe the payloads of different events offered with CircleCI webhooks. The schema of these webhook events will often share data with other webhooks. These common maps of data are referred to as "sub-entities". For example, when you receive an event payload for the `job-completed` webhook, it will contain maps of data for your *project, organization, job, workflow and pipeline*.
 
 Some common sub-entities that will appear across various webhooks are described in the following sections:
 

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -3,7 +3,7 @@ layout: classic-docs
 title: "Webhooks overview"
 short-title: "Using Webhooks to subscribe to CircleCI events"
 description: "Using Webhooks to subscribe to CircleCI events"
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -66,7 +66,7 @@ A webhook is sent using an HTTP POST to the URL that was registered when the web
 
 CircleCI expects the server that responds to a webhook will return a 2xx response code. If a non-2xx response is received, CircleCI will retry at a later time. If CircleCI does not receive a response to the webhook within a short period of time, CircleCI will assume that delivery has failed, and will retry at a later time. The timeout period is currently 5 seconds.
 
-Webhook requests may be duplicated. To deduplicate (prevent requests from being duplicated for a specific event), there is an [`id` property](#common-top-level-keys) in the webhook payload that can be used to identify the event for this purpose.
+Webhook requests may be duplicated. To deduplicate (prevent requests from being duplicated for a specific event), use the [`id` property](/docs/webhooks-reference/#common-top-level-keys) in the webhook payload for identification.
 
 If you have feedback about timeouts and retries, please get [get in touch](https://circleci.canny.io/webhooks) with our team.
 
@@ -159,5 +159,6 @@ CircleCI currently offers webhooks for the following events:
 ## Next steps
 {: #next-steps}
 
-See the [Webhooks reference](/docs/webhooks-reference/) page for key definitions and sample payloads.
+* See the [Webhooks reference](/docs/webhooks-reference/) page for key definitions and sample payloads.
+* Follow the [Using webhooks with third party tools](/docs/webhooks-airtable/) tutorial.
 

--- a/jekyll/_cci2/webhooks.md
+++ b/jekyll/_cci2/webhooks.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: "Webhooks"
+title: "Webhooks overview"
 short-title: "Using Webhooks to subscribe to CircleCI events"
 description: "Using Webhooks to subscribe to CircleCI events"
 contentTags: 
@@ -10,55 +10,24 @@ contentTags:
   - Server v3.x
 ---
 
-## Webhooks overview
-{: #overview}
+Use webhooks to:
+
+- Build a custom dashboard to visualize or analyze workflow/job events.
+- Send data to incident management tools (such as [PagerDuty](https://www.pagerduty.com)).
+- Use tools like [Airtable]({{site.baseurl}}/webhooks-airtable) to capture data and visualize it.
+- Alert when a workflow is cancelled, then use the API to rerun the workflow.
+- Trigger notification systems to alert people when workflows/jobs complete.
+- Build your own automation plugins and tools.
+
+## Introduction
+{: #introduction}
 
 A webhook allows you to connect a platform you manage (either an API you create yourself, or a third party service) to a stream of future _events_.
 
 Setting up a webhook on CircleCI enables you to receive information (referred to as _events_) from CircleCI, as they happen. This can help you avoid polling the API or manually checking the CircleCI web application for desired information.
 
-The document details how to set up a webhook, as well as the shape of events that will be sent to your webhook destination.
-
-## Use cases for webhooks
-{: #use-cases}
-
-Webhooks can be leveraged for various purposes. Some possible use cases for webhooks might include:
-
-- Building a custom dashboard to visualize or analyze workflow/job events
-- Sending data to incident management tools (such as [PagerDuty](https://www.pagerduty.com))
-- Using tools like [Airtable]({{site.baseurl}}/webhooks-airtable) to capture data and visualize it
-- Alerting when a workflow is cancelled, then using the API to rerun the workflow
-- Triggering internal notification systems to alert people when workflows/jobs complete
-- Building your own automation plugins and tools
-
-## Communication protocol with webhooks
-{: #communication-protocol }
-
-A webhook is sent whenever an event occurs on the CircleCI platform.
-
-A webhook is sent using an HTTP POST to the URL that was registered when the webhook was created, with a body encoded using JSON.
-
-CircleCI expects that the server that responds to a webhook will return a 2xx response code. If a non-2xx response is received, CircleCI will retry at a later time. If CircleCI does not receive a response to the webhook within a short period of time, CircleCI will assume that delivery has failed, and will retry at a later time. The timeout period is currently 5 seconds, but is subject to change during the preview period. The exact details of the retry policy are not currently documented, and are subject to change during the preview period. 
-
-Webhook requests may be duplicated. To deduplicate (prevent requests from being duplicated for a specific event), there is an [`id` property](#common-top-level-keys) in the webhook payload that can be used to identify the event for this purpose.
-
-If you have feedback about timeouts and retries, please get [get in touch](https://circleci.canny.io/webhooks) with our team.
-
-### Webhook headers
-{: #headers }
-
-A number of HTTP headers are set on webhooks, as detailed in the table below.
-
-Header Name | Value
---- | ---
-Content-Type | `application/json`
-User-Agent | A string indicating that the sender was CircleCI (`CircleCI-Webhook/1.0`). The value is subject to change during the preview period.
-Circleci-Event-Type | The type of event, (`workflow-completed`, `job-completed`, etc)
-Circleci-Signature | When present, this signature can be used to verify that the sender of the webhook has access to the secret token.
-{: class="table table-striped"}
-
-## Setting up a webhook
-{: #setting-up-a-hook}
+## Quickstart
+{: #quickstart}
 
 Webhooks are set up on a per-project basis, either within the CircleCI app or via API.
 
@@ -79,7 +48,7 @@ To configure webhooks within the CircleCI app:
 | Webhook name           | Y         | The name of your webhook                                                                    |
 | URL                    | Y         | The URL the webhook will make POST requests to                                              |
 | Certificate Validation | Y         | Ensure the receiving host has a valid SSL certificate before sending an event <sup>1</sup>  |
-| Secret token           | Y         | Used by your API/platform to validate incoming data is from CircleCI                        |
+| Secret token           | N         | Used by your API/platform to validate incoming data is from CircleCI                        |
 | Select an event        | Y         | You must select at least one event that will trigger a webhook                              |
 {: class="table table-striped"}
 
@@ -88,12 +57,38 @@ To configure webhooks within the CircleCI app:
 There is a limit of 5 webhooks per project.
 {: class="alert alert-info"}
 
-## Webhook payload signature
-{: #payload-signature}
+## Communication protocol with webhooks
+{: #communication-protocol }
+
+A webhook is sent whenever an event occurs on the CircleCI platform.
+
+A webhook is sent using an HTTP POST to the URL that was registered when the webhook was created, with a body encoded using JSON.
+
+CircleCI expects the server that responds to a webhook will return a 2xx response code. If a non-2xx response is received, CircleCI will retry at a later time. If CircleCI does not receive a response to the webhook within a short period of time, CircleCI will assume that delivery has failed, and will retry at a later time. The timeout period is currently 5 seconds.
+
+Webhook requests may be duplicated. To deduplicate (prevent requests from being duplicated for a specific event), there is an [`id` property](#common-top-level-keys) in the webhook payload that can be used to identify the event for this purpose.
+
+If you have feedback about timeouts and retries, please get [get in touch](https://circleci.canny.io/webhooks) with our team.
+
+### Webhook headers
+{: #headers }
+
+A number of HTTP headers are set on webhooks, as detailed in the table below.
+
+Header Name | Value
+--- | ---
+`content-type` | `application/json`
+`user-agent` | A string indicating that the sender was CircleCI (`CircleCI-Webhook/1.0`).
+`circleci-event-type` | The type of event, (`workflow-completed`, `job-completed`, etc)
+`circleci-signature` | When present, this signature can be used to verify that the sender of the webhook has access to the secret token.
+{: class="table table-striped"}
+
+## Validate webhooks
+{: #validate-webhooks}
 
 You should validate incoming webhooks to verify that they are coming from CircleCI. To support this, when creating a webhook, you can optionally provide a secret token. Each outgoing HTTP request to your service will contain a `circleci-signature` header. This header will consist of a comma-separated list of versioned signatures.
 
-```
+```shell
 POST /uri HTTP/1.1
 Host: your-webhook-host
 circleci-signature: v1=4fcc06915b43d8a49aff193441e9e18654e6a27c2c428b02e8fcc41ccc2299f9,v2=...,v3=...
@@ -161,444 +156,8 @@ CircleCI currently offers webhooks for the following events:
 | job-completed      | A job has reached a terminal state                       | "success", "failed", "canceled", "unauthorized"          | project, organization, workflow, pipeline, job |
 {: class="table table-striped"}
 
-## Common top level keys of webhooks
-{: #common-top-level-keys}
+## Next steps
+{: #next-steps}
 
-Each webhook will have some common data as part of the event:
+See the [Webhooks reference](/docs/webhooks-reference/) page for key definitions and sample payloads.
 
-| Field       | Description                                                                                        | Type   |
-|-------------|----------------------------------------------------------------------------------------------------|--------|
-| id          | ID used to uniquely identify each event from the system (the client can use this to dedupe events) | String |
-| happened_at | ISO 8601 timestamp representing when the event happened                                            | String |
-| webhook     | A map of metadata representing the webhook that was triggered                                      | Map    |
-{: class="table table-striped"}
-
-**Note:** The event payloads are open maps, meaning new fields may be added to maps in the webhook payload without considering it a breaking change.
-
-
-## Common sub-entities of webhooks
-{: #common-sub-entities}
-
-The next sections describe the payloads of different events offered with CircleCI webhooks. The schema of these webhook events will often share data with other webhooks - we refer to these as common maps of data as "sub-entities". For example, when you receive an event payload for the `job-completed` webhook, it will contain maps of data for your *project, organization, job, workflow and pipeline*.
-
-Let us look at some of the common sub-entities that will appear across various webhooks:
-
-### Project
-{: #project}
-
-Data about the project associated with the webhook event.
-
-| Field | Always present? | Description                                                                                                   |
-|-------|-----------------|---------------------------------------------------------------------------------------------------------------|
-| id    | yes             | Unique ID of the project                                                                                      |
-| slug  | yes             | String that can be used to refer to a specific project in many of CircleCI's APIs (e.g. "gh/circleci/web-ui") |
-| name  | yes             | Name of the project (e.g. "web-ui")                                                                           |
-{: class="table table-striped"}
-
-### Organization
-{: #organization}
-
-Data about the organization associated with the webhook event.
-
-| Field | Always present? | Description                                |
-|-------|-----------------|--------------------------------------------|
-| id    | yes             | Unique ID of the organization              |
-| name  | yes             | Name of the organization (e.g. "circleci") |
-{: class="table table-striped"}
-
-### Job
-{: #job}
-
-A job typically represents one phase in a CircleCI workload (e.g. "build", "test", or "deploy") and contains a series of steps.
-
-Data about the job associated with the webhook event.
-
-
-| Field       | Always present? | Description                                                                                                  |
-|-------------|-----------------|--------------------------------------------------------------------------------------------------------------|
-| id          | yes             | Unique ID of the job                                                                                         |
-| number      | yes             | An auto-incrementing number for the job, sometimes used in CircleCI's APIs to identify jobs within a project |
-| name        | yes             | Name of the job as defined in .circleci/config.yml                                                           |
-| status      | yes             | Current status of the job                                                                                    |
-| started\_at | yes             | When the job started running                                                                                 |
-| stopped\_at | no              | When the job reached a terminal state (if applicable)                                                        |
-{: class="table table-striped"}
-
-
-### Workflow
-{: #workflow}
-
-Workflows contain many jobs, which can run in parallel and/or have dependencies between them. A single git-push can trigger zero or more workflows, depending on the CircleCI configuration (but typically one will be triggered).
-
-Data about the workflow associated with the webhook event.
-
-
-| Field       | Always present? | Description                                                        |
-|-------------|-----------------|--------------------------------------------------------------------|
-| id          | Yes             | Unique ID of the workflow                                          |
-| name        | Yes             | Name of the workflow as defined in .circleci/config.yml            |
-| status      | No              | Current status of the workflow. Not included in job-level webhooks |
-| created\_at | Yes             | When the workflow was created                                      |
-| stopped_at  | No              | When the workflow reached a terminal state (if applicable)         |
-| url         | Yes             | URL to the workflow in CircleCI's UI                               |
-{: class="table table-striped"}
-
-### Pipeline
-{: #pipeline}
-
-Pipelines are the most high-level unit of work, and contain zero or more workflows. A single git-push always triggers up to one pipeline. Pipelines can also be triggered manually through the API.
-
-Data about the pipeline associated with the webhook event.
-
-| Field                 | Always present? | Description                                                                       |
-|-----------------------|-----------------|-----------------------------------------------------------------------------------|
-| id                    | Yes             | Globally unique ID of the pipeline                                                |
-| number                | Yes             | Number of the pipeline, which is auto-incrementing / unique per project           |
-| created\_at           | Yes             | When the pipeline was created                                                     |
-| trigger               | Yes             | A map of metadata about what caused this pipeline to be created -- see below      |
-| trigger_parameters    | No              | A map of metadata about the pipeline -- see below                                 |
-| vcs                   | No              | A map of metadata about the git commit associated with this pipeline -- see below |
-{: class="table table-striped"}
-
-### Trigger
-{: #trigger}
-
-Data about the trigger associated with the webhook event.
-
-| Field    | Always present? | Description                                                         |
-|----------|-----------------|---------------------------------------------------------------------|
-| type     | yes             | How this pipeline was triggered (e.g. "webhook", "api", "schedule") |
-{: class="table table-striped"}
-
-### Trigger parameters
-{: #trigger-parameters}
-
-Data associated to the pipeline. Present for pipelines associated with providers other than GitHub or Bitbucket. See [VCS](#vcs) below for GitHub and Bitbucket.
-
-| Field      | Always present? | Description                                                          |
-|------------|-----------------|----------------------------------------------------------------------|
-| circleci   | yes             | A map containing trigger information -- see below                    |
-| git        | no              | A map present when the pipeline is associated with a VCS provider    |
-| gitlab     | no              | A map present when the pipeline is associated with a Gitlab trigger  |
-{: class="table table-striped"}
-
-#### circleci
-{: #circleci }
-
-| Field           | Always present? | Description                                                                   |
-|-----------------|-----------------|-------------------------------------------------------------------------------|
-| event_time      | yes             | ISO 8601 timestamp representing when the pipeline was created                 |
-| event_type      | yes             | Provider event type that triggered the pipeline (e.g. "push")                 |
-| trigger_type    | yes             | Trigger provider (e.g. "gitlab")                                              |
-| actor_id        | no              | CircleCI user id that the pipeline was attributed to                          |
-{: class="table table-striped"}
-
-
-### VCS
-{: #vcs}
-
-The VCS map or its contents may not always be provided. Present for pipelines associated with GitHub and Bitbucket. See [trigger parameters](#trigger-parameters) above for other providers.
-{: class="alert alert-info"}
-
-
-| Field                  | Always present? | Description                                                                                                        |
-|------------------------|-----------------|--------------------------------------------------------------------------------------------------------------------|
-| target_repository_url  | no              | URL to the repository building the commit                                                                          |
-| origin_repository_url  | no              | URL to the repository where the commit was made (this will only be different in the case of a forked pull request) |
-| revision               | no              | Git commit being built                                                                                             |
-| commit.subject         | no              | Commit subject (first line of the commit message). Note that long commit subjects may be truncated.                |
-| commit.body            | no              | Commit body (subsequent lines of the commit message). Note that long commit bodies may be truncated.               |
-| commit.author.name     | no              | Name of the author of this commit                                                                                  |
-| commit.author.email    | no              | Email address of the author of this commit                                                                         |
-| commit.authored\_at    | no              | Timestamp of when the commit was authored                                                                          |
-| commit.committer.name  | no              | Name of the committer of this commit                                                                               |
-| commit.committer.email | no              | Email address of the committer of this commit                                                                      |
-| commit.committed_at    | no              | Timestamp of when the commit was committed                                                                         |
-| branch                 | no              | Branch being built                                                                                                 |
-| tag                    | no              | Tag being built (mutually exclusive with "branch")                                                                 |
-{: class="table table-striped"}
-
-
-## Sample webhook payloads
-{: #sample-webhook-payloads }
-
-### workflow-completed for GitHub and Bitbucket
-{: #workflow-completed-for-github-and-bitbucket }
-
-```json
-{
-  "id": "3888f21b-eaa7-38e3-8f3d-75a63bba8895",
-  "type": "workflow-completed",
-  "happened_at": "2021-09-01T22:49:34.317Z",
-  "webhook": {
-    "id": "cf8c4fdd-0587-4da1-b4ca-4846e9640af9",
-    "name": "Sample Webhook"
-  },
-  "project": {
-    "id": "84996744-a854-4f5e-aea3-04e2851dc1d2",
-    "name": "webhook-service",
-    "slug": "github/circleci/webhook-service"
-  },
-  "organization": {
-    "id": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
-    "name": "circleci"
-  },
-  "workflow": {
-    "id": "fda08377-fe7e-46b1-8992-3a7aaecac9c3",
-    "name": "build-test-deploy",
-    "created_at": "2021-09-01T22:49:03.616Z",
-    "stopped_at": "2021-09-01T22:49:34.170Z",
-    "url": "https://app.circleci.com/pipelines/github/circleci/webhook-service/130/workflows/fda08377-fe7e-46b1-8992-3a7aaecac9c3",
-    "status": "success"
-  },
-  "pipeline": {
-    "id": "1285fe1d-d3a6-44fc-8886-8979558254c4",
-    "number": 130,
-    "created_at": "2021-09-01T22:49:03.544Z",
-    "trigger": {
-      "type": "webhook"
-    },
-    "vcs": {
-      "provider_name": "github",
-      "origin_repository_url": "https://github.com/circleci/webhook-service",
-      "target_repository_url": "https://github.com/circleci/webhook-service",
-      "revision": "1dc6aa69429bff4806ad6afe58d3d8f57e25973e",
-      "commit": {
-        "subject": "Description of change",
-        "body": "More details about the change",
-        "author": {
-          "name": "Author Name",
-          "email": "author.email@example.com"
-        },
-        "authored_at": "2021-09-01T22:48:53Z",
-        "committer": {
-          "name": "Committer Name",
-          "email": "committer.email@example.com"
-        },
-        "committed_at": "2021-09-01T22:48:53Z"
-      },
-      "branch": "main"
-    }
-  }
-}
-```
-
-### job-completed for GitHub and Bitbucket
-{: #job-completed-for-github-and-bitbucket }
-
-```json
-{
-  "id": "8bd71c28-4969-3677-8940-3e3a61c46660",
-  "type": "job-completed",
-  "happened_at": "2021-09-01T22:49:34.279Z",
-  "webhook": {
-    "id": "cf8c4fdd-0587-4da1-b4ca-4846e9640af9",
-    "name": "Sample Webhook"
-  },
-  "project": {
-    "id": "84996744-a854-4f5e-aea3-04e2851dc1d2",
-    "name": "webhook-service",
-    "slug": "github/circleci/webhook-service"
-  },
-  "organization": {
-    "id": "f22b6566-597d-46d5-ba74-99ef5bb3d85c",
-    "name": "circleci"
-  },
-  "pipeline": {
-    "id": "1285fe1d-d3a6-44fc-8886-8979558254c4",
-    "number": 130,
-    "created_at": "2021-09-01T22:49:03.544Z",
-    "trigger": {
-      "type": "webhook"
-    },
-    "vcs": {
-      "provider_name": "github",
-      "origin_repository_url": "https://github.com/circleci/webhook-service",
-      "target_repository_url": "https://github.com/circleci/webhook-service",
-      "revision": "1dc6aa69429bff4806ad6afe58d3d8f57e25973e",
-      "commit": {
-        "subject": "Description of change",
-        "body": "More details about the change",
-        "author": {
-          "name": "Author Name",
-          "email": "author.email@example.com"
-        },
-        "authored_at": "2021-09-01T22:48:53Z",
-        "committer": {
-          "name": "Committer Name",
-          "email": "committer.email@example.com"
-        },
-        "committed_at": "2021-09-01T22:48:53Z"
-      },
-      "branch": "main"
-    }
-  },
-  "workflow": {
-    "id": "fda08377-fe7e-46b1-8992-3a7aaecac9c3",
-    "name": "welcome",
-    "created_at": "2021-09-01T22:49:03.616Z",
-    "stopped_at": "2021-09-01T22:49:34.170Z",
-    "url": "https://app.circleci.com/pipelines/github/circleci/webhook-service/130/workflows/fda08377-fe7e-46b1-8992-3a7aaecac9c3"
-  },
-  "job": {
-    "id": "8b91f9a8-7975-4e60-916c-f0152ccbc937",
-    "name": "test",
-    "started_at": "2021-09-01T22:49:28.841Z",
-    "stopped_at": "2021-09-01T22:49:34.170Z",
-    "status": "success",
-    "number": 136
-  }
-}
-```
-
-### workflow-completed for Gitlab
-{: #workflow-completed-gitlab }
-
-```json
-{
-  "type": "workflow-completed",
-  "id": "cbabbb40-6084-4f91-8311-a326c0f4963a",
-  "happened_at": "2022-05-27T16:20:13.954328Z",
-  "webhook": {
-    "id": "e4da0d23-31cf-4047-8a7e-8ffb14cd0100",
-    "name": "test"
-  },
-  "workflow": {
-    "id": "c2006ece-778d-49fc-9e6e-b9965f72bee9",
-    "name": "build",
-    "created_at": "2022-05-27T16:20:07.631Z",
-    "stopped_at": "2022-05-27T16:20:13.812Z",
-    "url": "https://app.circleci.com/pipelines/circleci/DdaVtNusHqi24D4YT3X4eu/6EkDPZoN4ZdMKKZtBkRodt/1/workflows/c2006ece-778d-49fc-9e6e-b9965f72bee9",
-    "status": "failed"
-  },
-  "pipeline": {
-    "id": "37c74cb7-d64d-4032-8731-1cb95bfef921",
-    "number": 1,
-    "created_at": "2022-04-13T11:10:18.804Z",
-    "trigger": {
-      "type": "gitlab"
-    },
-    "trigger_parameters": {
-      "gitlab": {
-        "web_url": "https://gitlab.com/circleci/hello-world",
-        "commit_author_name": "Commit Author",
-        "user_id": "9534789",
-        "user_name": "User name",
-        "user_username": "username",
-        "branch": "main",
-        "commit_title": "Update README.md",
-        "commit_message": "Update README.md",
-        "total_commits_count": "1",
-        "repo_url": "git@gitlab.com:circleci/hello-world.git",
-        "user_avatar": "https://secure.gravatar.com/avatar",
-        "type": "push",
-        "project_id": "33852820",
-        "ref": "refs/heads/main",
-        "repo_name": "hello-world",
-        "commit_author_email": "committer.email@example.com",
-        "checkout_sha": "850a1519f25d14e968649cc420d1bd381715c05c",
-        "commit_timestamp": "2022-04-13T11:10:16+00:00",
-        "commit_sha": "850a1519f25d14e968649cc420d1bd381715c05c"
-      },
-      "git": {
-        "tag": "",
-        "checkout_sha": "850a1519f25d14e968649cc420d1bd381715c05c",
-        "ref": "refs/heads/main",
-        "branch": "main",
-        "checkout_url": "git@gitlab.com:circleci/hello-world.git"
-      },
-      "circleci": {
-        "event_time": "2022-04-13T11:10:18.349Z",
-        "actor_id": "6a19122c-40e0-4d56-a875-aac6ccc27700",
-        "event_type": "push",
-        "trigger_type": "gitlab"
-      }
-    }
-  },
-  "project": {
-    "id": "2a68fe5f-2fe5-4d4f-91e1-15f111116743",
-    "name": "hello-world",
-    "slug": "circleci/DdaVtNusHqi24D4YT3X4eu/6EkDPZoN4ZdMKKZtBkRodt"
-  },
-  "organization": {
-    "id": "66491562-90a9-4065-9249-4b0ce3b77452",
-    "name": "circleci"
-  }
-}
-```
-
-### job-completed for Gitlab
-{: #job-completed-gitlab }
-
-```json
-{
-  "type": "workflow-completed",
-  "id": "47a497be-4498-4da0-a4e8-2dabd889af0f",
-  "happened_at": "2022-05-27T16:20:13.954328Z",
-  "webhook": {
-    "id": "e4da0d23-31cf-4047-8a7e-8ffb14cd0100",
-    "name": "test"
-  },
-  "job": {
-    "id": "2fc6977d-7e45-4271-b355-0ea894d82017",
-    "name": "say-hello",
-    "started_at": "2022-07-11T12:16:37.435Z",
-    "stopped_at": "2022-07-11T12:16:59.982Z",
-    "status": "success",
-    "number": 1
-  }
-  "pipeline": {
-    "id": "37c74cb7-d64d-4032-8731-1cb95bfef921",
-    "number": 1,
-    "created_at": "2022-04-13T11:10:18.804Z",
-    "trigger": {
-      "type": "gitlab"
-    },
-    "trigger_parameters": {
-      "gitlab": {
-        "web_url": "https://gitlab.com/circleci/hello-world",
-        "commit_author_name": "Commit Author",
-        "user_id": "9534789",
-        "user_name": "User name",
-        "user_username": "username",
-        "branch": "main",
-        "commit_title": "Update README.md",
-        "commit_message": "Update README.md",
-        "total_commits_count": "1",
-        "repo_url": "git@gitlab.com:circleci/hello-world.git",
-        "user_avatar": "https://secure.gravatar.com/avatar",
-        "type": "push",
-        "project_id": "33852820",
-        "ref": "refs/heads/main",
-        "repo_name": "hello-world",
-        "commit_author_email": "committer.email@example.com",
-        "checkout_sha": "850a1519f25d14e968649cc420d1bd381715c05c",
-        "commit_timestamp": "2022-04-13T11:10:16+00:00",
-        "commit_sha": "850a1519f25d14e968649cc420d1bd381715c05c"
-      },
-      "git": {
-        "tag": "",
-        "checkout_sha": "850a1519f25d14e968649cc420d1bd381715c05c",
-        "ref": "refs/heads/main",
-        "branch": "main",
-        "checkout_url": "git@gitlab.com:circleci/hello-world.git"
-      },
-      "circleci": {
-        "event_time": "2022-04-13T11:10:18.349Z",
-        "actor_id": "6a19122c-40e0-4d56-a875-aac6ccc27700",
-        "event_type": "push",
-        "trigger_type": "gitlab"
-      }
-    }
-  },
-  "project": {
-    "id": "2a68fe5f-2fe5-4d4f-91e1-15f111116743",
-    "name": "hello-world",
-    "slug": "circleci/DdaVtNusHqi24D4YT3X4eu/6EkDPZoN4ZdMKKZtBkRodt"
-  },
-  "organization": {
-    "id": "66491562-90a9-4065-9249-4b0ce3b77452",
-    "name": "circleci"
-  }
-}
-```

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -368,8 +368,10 @@ en:
           link: managing-api-tokens
         - name: Status badges
           link: status-badges
-        - name: Webhooks
+        - name: Webhooks overview
           link: webhooks
+        - name: Webhooks reference
+          link: webhooks-reference
         - name: Using credits
           link: credits
     - name: security


### PR DESCRIPTION
# Description
The webhooks guide is a mix of content. This PR refreshes the structure, removes some unwanted content, and pulls out reference material into a separate page.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
