### PR TITLE
fix: Let's Encrypt is not default in server 4.x

### DIFF
--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -437,7 +437,26 @@ For TLS, you have 4 options:
 --
 *Do nothing*
 
-Do nothing. https://letsencrypt.org/[Let's Encrypt] will automatically request and manage certificates for you.  This is a good option for trials but not recommended for production use.
+Do nothing. Self-signed certificates will automatically be generated for you.  This is a good option for trials but not recommended for production use.
+
+NOTE: These self-signed certificates will not be trusted by your browser.  You will need to add an exception to your browser to access the application. Additionally, the certificates will be updated with new self-signed certificates when an update is pushed.
+--
+
+[.tab.tls.Lets_Encrypt]
+--
+*Let's Encrypt*
+
+https://letsencrypt.org/[Let's Encrypt] will request and manage certificates for you.  This is a good option when the load balancer is publicly accessible. The following snippet (using your own email) can be added to `values.yaml`:
+
+[source,yaml]
+----
+kong:
+  acme:
+    enabled: true
+    email: contact@example.com
+----
+
+NOTE: Let's Encrypt may take up to 30 minutes to be reflected in your browser.
 --
 
 [.tab.tls.Supply_private_key_and_certificate]
@@ -486,7 +505,7 @@ You will need to update your DNS records to the new loadbalancer once you have r
 ====
 --
 
-[.tab.tls.Termiate_TLS_upstream]
+[.tab.tls.Terminate_TLS_upstream]
 --
 *Disable TLS within CircleCI*
 


### PR DESCRIPTION
SERVER-2214

# Description
Updating the doc to reference the default self-signed certificate behavior.

# Reasons
https://circleci.atlassian.net/browse/SERVER-2214

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
