### PR TITLE
fix: correct link to building-container-images

### DIFF
--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -173,7 +173,7 @@ An organization’s runner concurrency limit is shared with any existing `machin
 [#build-docker-images-with-container-agent]
 === Can I build Docker images with container runner either via Remote Docker or Docker in Docker (DIND)?
 
-See <<building-container-images,building container images>> for details.
+See link:https://circleci.com/docs/container-runner/#building-container-images[building container images] for details.
 
 [#can-i-use-something-other-than-kubernetes]
 === Can I use something other than Kubernetes with container runner?

--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -173,7 +173,7 @@ An organization’s runner concurrency limit is shared with any existing `machin
 [#build-docker-images-with-container-agent]
 === Can I build Docker images with container runner either via Remote Docker or Docker in Docker (DIND)?
 
-See link:https://circleci.com/docs/container-runner/#building-container-images[building container images] for details.
+See xref:container-runner#building-container-images[building container images] for details.
 
 [#can-i-use-something-other-than-kubernetes]
 === Can I use something other than Kubernetes with container runner?


### PR DESCRIPTION
# Description
The previous link tried to access a heading within the same page, returning the user to the top of runner-faqs.

# Reasons
This links to the correct page and information.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
