### PR TITLE
chore: Remove DNS suggestions

### DIFF
--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -807,12 +807,6 @@ You need the IP address, or, if using AWS, the DNS name of the NGINX load balanc
 kubectl get service circleci-proxy
 ----
 
-For more information on adding a new DNS record, see the following documentation:
-
-* link:https://cloud.google.com/dns/docs/records#adding_a_record[Managing Records] (GCP)
-
-* link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-creating.html[Creating records by using the Amazon Route 53 Console] (AWS)
-
 [#validation]
 == 6. Validation
 


### PR DESCRIPTION
SERVER-2215

The DNS documentation can apparently be confusing for folks that are not using GCP or AWS as their DNS provider. Instead of trying to enumerate all the possible methods and providers of managing DNS, we are going to remove it and assume a given organization has a process to follow.