### PR TITLE
Move content from GHA to intro page

### DIFF
--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server 3.x
@@ -13,18 +13,6 @@ contentTags:
 :toc-title:
 
 This document provides an overview of how to migrate from GitHub Actions to CircleCI.
-
-[#why-migrate-to-circleci]
-== Why migrate to CircleCI?
-
-CircleCI is a first-class CI tool. CI/CD has been our specialization since the company's founding 8 years ago. On top of the features you would expect from any CI/CD tool, what sets us apart are the following productivity-boosting features:
-
-1. **Advanced Caching** - On top of https://circleci.com/docs/caching/#full-example-of-saving-and-restoring-cache[normal dependency caching], CircleCI offers caching specific to https://circleci.com/docs/docker-layer-caching/[Docker image layers]. This means subsequent builds of your Docker images will run faster, cutting even more time off your commit-to-deploy workflows.
-2. **SSH Into Builds** - CircleCI offers the ability to https://circleci.com/docs/ssh-access-jobs/[securely SSH into an execution environment] to tail logs, work with files, and directly interact with an environment. This is highly useful for debugging failing builds.
-3. **Resource Classes** - you can use various different https://circleci.com/docs/optimizations/#resource-class[sizes of executor] on our platform, great for adjusting according to lighter or heavier workloads on a node.
-4. **Test Parallelism** - our platform provides not only https://circleci.com/docs/workflows/[concurrent job execution] but also the ability to split tests between parallel environments. You can dramatically cut build times by https://circleci.com/docs/parallelism-faster-jobs/#using-the-circleci-cli-to-split-tests[splitting workloads between different containers].
-
-We have various other features that set our solution apart. https://circleci.com/signup/[Sign up for a free account today] and try us out, or if you are interested in CircleCI for your team, https://circleci.com/talk-to-us/?source-button=MigratingFromGitHubActionsDoc[contact our sales team] to set up a trial.
 
 [#concepts]
 == Concepts

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -4,7 +4,7 @@ contentTags:
   - Cloud
   - Server 3.x
 ---
-= Migrate from Github Actions
+= Migrate from GitHub Actions
 :page-layout: classic-docs
 :page-liquid:
 :page-description: An overview of how to migrate from GitHub Actions to CircleCI.

--- a/jekyll/_cci2/migration-intro.adoc
+++ b/jekyll/_cci2/migration-intro.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v3.x
@@ -12,19 +12,21 @@ contentTags:
 :toc: macro
 :toc-title:
 
-Before you start your migration process, it is helpful to have a basic understanding of how CircleCI works. 
+[#why-migrate-to-circleci]
+== Why migrate to CircleCI?
 
-Here are some basic resources to get you started:
+CircleCI is a first-class CI tool. CI/CD has been CircleCI's specialization since the company's founding over a decade ago. On top of the features you would expect from any CI/CD tool, what sets CircleCI apart are the following productivity-boosting features:
 
-- https://circleci.com/continuous-integration/[Continuous Integration Basics]
-- <<concepts#,CircleCI Concepts>>
-- <<hello-world#,Hello World in CircleCI>>
-- <<getting-started#,A Step-By-Step Tutorial>>
-- <<about-circleci#,About CircleCI>>
+1. **Advanced Caching** - On top of xref:caching#full-example-of-saving-and-restoring-cache[normal dependency caching], CircleCI offers caching specific to xref:docker-layer-caching#[Docker image layers]. This means subsequent builds of your Docker images will run faster, cutting even more time off your commit-to-deploy workflows.
+2. **SSH Into Builds** - CircleCI offers the ability to xref:ssh-access-jobs#[securely SSH into an execution environment] to tail logs, work with files, and directly interact with an environment. This is highly useful for debugging failing builds.
+3. **Resource Classes** - You can use various different xref:optimizations#resource-class[sizes of executor] on our platform, great for adjusting according to lighter or heavier workloads on a node.
+4. **Test Parallelism** - CircleCI's platform provides not only xref:concurrency#[concurrent job execution], but also the ability to split tests between parallel environments. You can dramatically cut build times by xref:parallelism-faster-jobs#using-the-circleci-cli-to-split-tests[splitting workloads] between different containers.
+
+https://circleci.com/signup/[Sign up for a free account today], or if you are interested in CircleCI for your team, https://circleci.com/talk-to-us/?source-button=MigratingFromGitHubActionsDoc[contact our sales team] to set up a trial.
 
 You can also enroll in the link:https://academy.circleci.com/arm-course?access_code=public-2021[migrations course] with CircleCI Academy to learn more about migrating to CircleCI.
 
-NOTE: If you have Premium or Advanced Support, please reach out to customersuccess@circleci.com for a more tailored migration plan with Gantt charts, custom trainings etc.
+NOTE: If you have Premium or Advanced Support, please reach out to mailto:customersuccess@circleci.com[customersuccess@circleci.com] for a more tailored migration plan with Gantt charts, custom trainings etc.
 
 [#project-migration-methodology]
 == Project migration methodology
@@ -67,7 +69,7 @@ Some things consider during this phase:
 [#planning-phase]
 ==  Planning phase
 
-Ensure that your VCS org is linked to your CircleCI account and that your plan is applied. Log in using your VCS credentials as described on the <<first-steps#,Sign Up and Try CircleCI>> page. 
+Ensure that your VCS org is linked to your CircleCI account and that your plan is applied. Log in using your VCS credentials as described on the <<first-steps#,Sign Up and Try CircleCI>> page.
 
 If using the Server product, ensure that you have been provided with your trial license and that all prerequisites are met as described https://circleci.com/docs/server-3-install-prerequisites/[here].
 
@@ -82,22 +84,22 @@ With your plan and estimated timelines in place, start socializing the details o
 [#build-your-runbook-and-timeline]
 === Build your runbook and timeline
 
-Put together a runbook or step-by-step checklist to cover: 
+Put together a runbook or step-by-step checklist to cover:
 
-* What needs to happen when 
+* What needs to happen when
 * Supporting instructions
-* List of owners for each task 
-* How long each step will take 
+* List of owners for each task
+* How long each step will take
 
 Document which steps are dependent on each other, and which have the potential to become blockers. At the end of your runbook, include a mitigation plan with owners in case you need to roll anything back.
 
 [#testing-phase]
 == Testing phase
 
-In this phase you will: 
+In this phase you will:
 
 * Do a test run and make sure everything is in order
-* Figure out how long the migration will take 
+* Figure out how long the migration will take
 * Uncover any issues before the production migration
 
 [#test-migration]
@@ -120,7 +122,7 @@ With final timelines and owners in place, communicate the official plan to your 
 -   Ask end users to avoid changing anything during the transition
 -   Detail what will happen to the current CI solution after migrating, for example, will it still be accessible or readable?
 -  Details of what CircleCI onboarding materials are available
-   
+
 Keep in mind that there may be issues that occur during the migration that you need to troubleshoot, so call out an adjustment period to your end users to get everything cleaned up and working as planned.
 
 [#migration-phase]


### PR DESCRIPTION
# Description

- Move the "why migrate to CircleCI" from the GHA migrate page to the intro migration page.
- Minor updates to the content
- Fix link style

# Reasons
Copy was outdated and didn't really belong on the GHA migration page specifically.
[JIRA ticket](https://circleci.atlassian.net/jira/software/c/projects/DOCSS/boards/554?modal=detail&selectedIssue=DOCSS-921)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.


[DOCSS-921]: https://circleci.atlassian.net/browse/DOCSS-921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ