### PR TITLE
[SERVER-2220] Clarification around adding custom Telegraf config

### DIFF
--- a/jekyll/_cci2/server/v4.1/operator/using-metrics.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/using-metrics.adoc
@@ -29,12 +29,12 @@ Your CircleCI server installation collects a number of metrics and logs by defau
 [#telegraf]
 === Telegraf
 Most services running on server report StatsD metrics to the https://www.influxdata.com/time-series-platform/telegraf/[Telegraf] pod running in server.
-The configuration is fully customizable, so you can forward your metrics from Telegraf to any output supported by Telegraf through https://docs.influxdata.com/telegraf/v1.24/plugins/#output-plugins[output plugins]. By default, it will provide a metrics endpoint for Prometheus to scrape.
+The configuration is fully customizable. Metrics can be forwarded from Telegraf to any output supported by Telegraf through https://docs.influxdata.com/telegraf/v1.24/plugins/#output-plugins[output plugins]. By default, it will provide a metrics endpoint for Prometheus to scrape.
 
 [#use-telegraf-to-forward-metrics-to-datadog]
 === Use Telegraf to forward metrics to Datadog
 
-As mentioned earlier, Telegraf ships configured to collect statsd metrics using the https://docs.influxdata.com/telegraf/v1.24/plugins/#input-statsd[statsd] input plugin and serves these metrics in Prometheus format on the `/metrics` endpoint using the https://docs.influxdata.com/telegraf/v1.24/plugins/#output-prometheus_client[Prometheus] output plugin. Refer to the `telegraf.config` block in the default `values.yaml` for details on how Telegraf is configured in Server. For details around the different Telegraf configuration options refer to the official https://github.com/influxdata/helm-charts/tree/master/charts/telegraf[Telegraf] Helm chart from Influxdata.
+Telegraf ships configured to collect statsd metrics using the https://docs.influxdata.com/telegraf/v1.24/plugins/#input-statsd[statsd] input plugin and serves these metrics in the Prometheus format on the `/metrics` endpoint using the https://docs.influxdata.com/telegraf/v1.24/plugins/#output-prometheus_client[Prometheus] output plugin. Refer to the `telegraf.config` block in the default `values.yaml` for details on how Telegraf is configured in Server. For details around the different Telegraf configuration options refer to the official https://github.com/influxdata/helm-charts/tree/master/charts/telegraf[Telegraf] Helm chart from Influxdata.
 
 The following example shows how to configure Telegraf to output metrics to Datadog:
 

--- a/jekyll/_cci2/server/v4.1/operator/using-metrics.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/using-metrics.adoc
@@ -34,7 +34,7 @@ The configuration is fully customizable. Metrics can be forwarded from Telegraf 
 [#use-telegraf-to-forward-metrics-to-datadog]
 === Use Telegraf to forward metrics to Datadog
 
-Telegraf ships configured to collect statsd metrics using the https://docs.influxdata.com/telegraf/v1.24/plugins/#input-statsd[statsd] input plugin and serves these metrics in the Prometheus format on the `/metrics` endpoint using the https://docs.influxdata.com/telegraf/v1.24/plugins/#output-prometheus_client[Prometheus] output plugin. Refer to the `telegraf.config` block in the default `values.yaml` for details on how Telegraf is configured in Server. For details around the different Telegraf configuration options refer to the official https://github.com/influxdata/helm-charts/tree/master/charts/telegraf[Telegraf] Helm chart from Influxdata.
+By default, Telegraf is configured to collect statsd metrics using the link:https://docs.influxdata.com/telegraf/v1.24/plugins/#input-statsd[statsd] input plugin, and serves these metrics in the Prometheus format on the `/metrics` endpoint using the https://docs.influxdata.com/telegraf/v1.24/plugins/#output-prometheus_client[Prometheus] output plugin. Refer to the `telegraf.config` block in the default `values.yaml` for details on how Telegraf is configured in CircleCI server. For details on the different Telegraf configuration options, refer to the official link:https://github.com/influxdata/helm-charts/tree/master/charts/telegraf[Telegraf] Helm chart from Influxdata.
 
 The following example shows how to configure Telegraf to output metrics to Datadog:
 

--- a/jekyll/_cci2/server/v4.1/operator/using-metrics.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/using-metrics.adoc
@@ -29,68 +29,14 @@ Your CircleCI server installation collects a number of metrics and logs by defau
 [#telegraf]
 === Telegraf
 Most services running on server report StatsD metrics to the https://www.influxdata.com/time-series-platform/telegraf/[Telegraf] pod running in server.
-The configuration is fully customizable, so you can forward your metrics from Telegraf to any output supported by Telegraf through https://docs.influxdata.com/telegraf/v1.17/plugins/#output-plugins[output plugins]. By default, it will provide a metrics endpoint for Prometheus to scrape.
+The configuration is fully customizable, so you can forward your metrics from Telegraf to any output supported by Telegraf through https://docs.influxdata.com/telegraf/v1.24/plugins/#output-plugins[output plugins]. By default, it will provide a metrics endpoint for Prometheus to scrape.
 
 [#use-telegraf-to-forward-metrics-to-datadog]
 === Use Telegraf to forward metrics to Datadog
+
+As mentioned earlier, Telegraf ships configured to collect statsd metrics using the https://docs.influxdata.com/telegraf/v1.24/plugins/#input-statsd[statsd] input plugin and serves these metrics in Prometheus format on the `/metrics` endpoint using the https://docs.influxdata.com/telegraf/v1.24/plugins/#output-prometheus_client[Prometheus] output plugin. Refer to the `telegraf.config` block in the default `values.yaml` for details on how Telegraf is configured in Server. For details around the different Telegraf configuration options refer to the official https://github.com/influxdata/helm-charts/tree/master/charts/telegraf[Telegraf] Helm chart from Influxdata.
+
 The following example shows how to configure Telegraf to output metrics to Datadog:
-
-In your custom `values.yaml` for your CircleCI server install you may already have a section for Telegraf as below. If not you can add it now.
-
-[source,yaml]
-----
-...
-telegraf:
-  args:
-    - --config
-    - /etc/telegraf/telegraf.d/telegraf_custom.conf
-  config:
-    custom_config_file: |
-      [agent]
-        collection_jitter = "0s"
-        debug = false
-        flush_interval = "10s"
-        flush_jitter = "0s"
-        hostname = "$HOSTNAME"
-        interval = "30s"
-        logfile = ""
-        metric_batch_size = 1000
-        metric_buffer_limit = 10000
-        omit_hostname = true
-        precision = ""
-        quiet = false
-        round_interval = true
-
-      [[processors.enum]]
-        [[processors.enum.mapping]]
-          dest = "status_code"
-          field = "status"
-          [processors.enum.mapping.value_mappings]
-              critical = 3
-              healthy = 1
-              problem = 2
-
-      [[inputs.statsd]]
-        datadog_extensions = true
-        metric_separator = "."
-        percentile_limit = 1000
-        percentiles = [
-          50,
-          95,
-          99
-        ]
-        service_address = ":8125"
-      [[inputs.internal]]
-        collect_memstats = false
-
-      [[outputs.file]]
-        files = ["stdout"]
-
-      [[outputs.prometheus_client]]
-        listen = ":9273"
-        path = "/metrics"
-...
-----
 
 In the `telgraf.config.custom_config_file` block of your helm `values.yaml`, add the `[[outputs.datadog]]` as seen below to the bottom of the config block, replacing `"my-secret-key"` with your datadog API key.
 
@@ -106,7 +52,7 @@ telegraf:
       ...
 ----
 
-NOTE: For more options, see the https://docs.influxdata.com/telegraf/v1.17/plugins/#output-datadog[Telegraf docs].
+NOTE: For more options, see the https://docs.influxdata.com/telegraf/v1.24/plugins/#output-datadog[Telegraf docs].
 
 Finally, you will need to apply the changes via helm update.
 


### PR DESCRIPTION
# Description

The default Telegraf configuration has changed, just slightly. This PR clarifies adding custom configuration using the `telgraf.config.custom_config_file` block in `values.yaml`. 

# Reasons

See https://circleci.atlassian.net/browse/SERVER-2220.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
