### PR TITLE
Remove three audit log events

### DIFF
--- a/jekyll/_cci2/audit-logs.adoc
+++ b/jekyll/_cci2/audit-logs.adoc
@@ -42,9 +42,6 @@ The following are the system events that are logged. See `action` in the Field s
 - schedule.create
 - schedule.update
 - schedule.delete
-- user.create
-- user.logged_in
-- user.logged_out
 - workflow.job.approve
 - workflow.job.finish
 - workflow.job.scheduled


### PR DESCRIPTION
# Description
Remove three audit log events.

# Reasons
These events do not actually get logged and therefore should not exist on this list.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
