### PR TITLE
Remove db optimization as cimq/postgres do not support ramdisk 

### DIFF
--- a/jekyll/_cci2/databases.md
+++ b/jekyll/_cci2/databases.md
@@ -99,12 +99,6 @@ When the database service spins up, it automatically creates the database `circl
 
 This section describes additional optional configuration for further customizing your build and avoiding race conditions.
 
-### Optimizing PostgreSQL images
-{: #optimizing-postgresql-images }
-{:.no_toc}
-
-The `cimg/postgres` Docker image uses regular persistent storage on disk. Storing the database in a ramdisk may improve performance. This can be done by setting the `PGDATA: /dev/shm/pgdata/data` environment variable in the service container image config.
-
 ### Using binaries
 {: #using-binaries }
 {:.no_toc}


### PR DESCRIPTION

# Description
Deleting ramdisk optimization options

# Reasons
`circleci/postgres` had an option to support ramdisk `PGDATA: /dev/shm/pgdata/data` but when we switched to a new convenience image `cimg/postgres` it was discussed on https://github.com/CircleCI-Public/cimg-postgres/issues/2 that ramdisk will not be supported.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
