### PR TITLE
Fix link to launch-agent server compatibility chart

### DIFF
--- a/jekyll/_cci2/runner-upgrading-on-server.adoc
+++ b/jekyll/_cci2/runner-upgrading-on-server.adoc
@@ -19,7 +19,7 @@ toc::[]
 [#self-hosted-runner-for-server-compatibility]
 == Machine runner on server compatibility
 
-Refer to the xref:runner-installation.adoc#runner-for-server-compatibility[server compatibility chart] to find the runner version you need for your installation.
+Refer to the xref:runner-installation-cli#self-hosted-runners-for-server-compatibility[server compatibility chart] to find the runner version you need for your installation.
 
 [#upgrading-self-hosted-runner-on-server]
 == Upgrading machine runner on server


### PR DESCRIPTION
# Description
Previously, the link to the launch-agent server compatibility chart link to the docs on using the runner web app. However, this is unsupported on server.

This PR fixes that link.

# Reasons
The wrong link to the server compatibility chart was used in the launch-agent server docs.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
