### PR TITLE
SSH keys update

### DIFF
--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -17,7 +17,7 @@ If deploying to your servers requires SSH access, you will need to add SSH keys 
 ## Overview
 {: #overview }
 
-If you are looking to set up an SSH key in order to deploy to GitHub or Bitbucket, refer to the [GitHub](/docs/github-integration/#enable-your-project-to-check-out-additional-private-repositories) or [Bitbucket](/docs/bitbucket-integration/#enable-your-project-to-check-out-additional-private-repositories) integration pages.
+If you are looking to set up an SSH key in order to check out code from GitHub or Bitbucket, refer to the [GitHub](/docs/github-integration/#enable-your-project-to-check-out-additional-private-repositories) or [Bitbucket](/docs/bitbucket-integration/#enable-your-project-to-check-out-additional-private-repositories) integration pages.
 
 If you are using GitLab as your VCS, or if you need additional SSH keys to access other services, follow the steps below for the version of CircleCI you are using to add an SSH key to your project.
 

--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -27,7 +27,7 @@ You may need to add the public key to `~/.ssh/authorized_keys` in order to add S
 ## Steps to add additional SSH keys
 {: #steps-to-add-additional-ssh-keys }
 
-Since CircleCI cannot decrypt SSH keys, every new key must have an empty passphrase.
+Since CircleCI cannot decrypt SSH keys, every new key must have an empty passphrase. The below examples are for macOS. See [GitHub](https://help.github.com/articlesgenerating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) or [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/configure-ssh-and-two-step-verification/) documentation for additional details on creating SSH keys.
 
 ### CircleCI cloud or server 3.x / server 4.x
 {: #circleci-cloud-or-server-3-x-4-x }
@@ -36,7 +36,7 @@ Since CircleCI cannot decrypt SSH keys, every new key must have an empty passphr
 
 2. In the CircleCI application, go to your project's settings by clicking the the **Project Settings** button (top-right on the **Pipelines** page of the project).
 
-3. On the **Project Settings** page, click on **SSH Keys** (vertical menu on the left).
+3. On the **Project Settings** page, click on **SSH Keys**.
 
 4. Scroll down to the **Additional SSH Keys** section.
 

--- a/jekyll/_cci2/add-ssh-key.md
+++ b/jekyll/_cci2/add-ssh-key.md
@@ -1,10 +1,10 @@
 ---
 layout: classic-docs
-title: "Adding an SSH Key to CircleCI"
-short-title: "Adding an SSH Key"
-description: "How to Add an SSH Key to CircleCI"
+title: Add additional SSH keys to CircleCI
+short-title: Add an SSH Key
+description: How to add additional SSH keys to CircleCI
 order: 20
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -17,24 +17,20 @@ If deploying to your servers requires SSH access, you will need to add SSH keys 
 ## Overview
 {: #overview }
 
-There are two reasons to add SSH keys to CircleCI:
+If you are looking to set up an SSH key in order to deploy to GitHub or Bitbucket, refer to the [GitHub](/docs/github-integration/#enable-your-project-to-check-out-additional-private-repositories) or [Bitbucket](/docs/bitbucket-integration/#enable-your-project-to-check-out-additional-private-repositories) integration pages.
 
-1. To check out code from version control systems.
-2. To enable running processes to access other services.
+If you are using GitLab as your VCS, or if you need additional SSH keys to access other services, follow the steps below for the version of CircleCI you are using to add an SSH key to your project.
 
-If you are adding an SSH key for the first reason, refer to the [GitHub and Bitbucket Integration]({{ site.baseurl }}/gh-bb-integration/#enable-your-project-to-check-out-additional-private-repositories) document.
+You may need to add the public key to `~/.ssh/authorized_keys` in order to add SSH keys.
+{: class="alert alert-info" }
 
-Otherwise, follow the steps below for the version of CircleCI you are using to add an SSH key to your project.
+## Steps to add additional SSH keys
+{: #steps-to-add-additional-ssh-keys }
 
-**Note:** You may need to add the public key to `~/.ssh/authorized_keys` in order to add SSH keys.
+Since CircleCI cannot decrypt SSH keys, every new key must have an empty passphrase.
 
-## Steps
-{: #steps }
-
-**Note:** Since CircleCI cannot decrypt SSH keys, every new key must have an empty passphrase.
-
-### CircleCI cloud or server 3.x
-{: #circleci-cloud-or-server-3-x }
+### CircleCI cloud or server 3.x / server 4.x
+{: #circleci-cloud-or-server-3-x-4-x }
 
 1. In a terminal, generate the key with `ssh-keygen -t ed25519 -C "your_email@example.com"`. See [Secure Shell documentation](https://www.ssh.com/ssh/keygen/) for additional details.
 
@@ -69,18 +65,18 @@ Otherwise, follow the steps below for the version of CircleCI you are using to a
 
 6. Click the **Add SSH Key** button.
 
-## Adding SSH Keys to a Job
-{: #adding-ssh-keys-to-a-job }
+## Add SSH Keys to a Job
+{: #add-ssh-keys-to-a-job }
 
 Even though all CircleCI jobs use `ssh-agent` to automatically sign all added SSH keys, you **must** use the `add_ssh_keys` key to actually add keys to a container.
 
-To add a set of SSH keys to a container, use the `add_ssh_keys` [special step]({{site.baseurl}}/configuration-reference/#add_ssh_keys) within the appropriate [job]({{ site.baseurl }}/jobs-steps/) in your configuration file.
+To add a set of SSH keys to a container, use the `add_ssh_keys` [special step](/docs/configuration-reference/#add_ssh_keys) within the appropriate [job](/docs/jobs-steps/) in your configuration file.
 
 For a self-hosted runner, ensure that you have an `ssh-agent` on your system to successfully use the `add_ssh_keys` step. The SSH key is written to `$HOME/.ssh/id_rsa_<fingerprint>`, where `$HOME` is the home directory of the user configured to execute jobs, and `<fingerprint>` is the fingerprint of the key. A host entry is also appended to `$HOME/.ssh/config`, along with a relevant `IdentityFile` option to use the key.
 {: class="alert alert-info"}
 
 ```yaml
-version: 2
+version: 2.1
 jobs:
   deploy-job:
     steps:
@@ -89,7 +85,8 @@ jobs:
             - "SO:ME:FIN:G:ER:PR:IN:T"
 ```
 
-**Note:** All fingerprints in the `fingerprints` list must correspond to keys that have been added through the CircleCI application.
+All fingerprints in the `fingerprints` list must correspond to keys that have been added through the CircleCI application.
+{: class="alert alert-info" }
 
 ## Adding multiple keys with blank hostnames
 {: #adding-multiple-keys-with-blank-hostnames }

--- a/jekyll/_cci2/bitbucket-integration.adoc
+++ b/jekyll/_cci2/bitbucket-integration.adoc
@@ -108,7 +108,7 @@ This SSH user key will have a "PREFERRED" label. If the project also has a deplo
 
 If you need additional SSH keys to access other services, you can create additional keys by following the steps below.
 
-In this example, the Bitbucket repository is `https://bitbucket.org/you/test-repo/src/main/`, and the CircleCI project is `https://circleci.com/bitbucket/you/test-repo`.
+In this example, the Bitbucket repository is `https://bitbucket.org/you/test-repo/src/main/`, and the CircleCI project is `https://app.circleci.com/pipelines/bitbucket/you/test-repo`.
 
 . Create an SSH key-pair by following the link:https://support.atlassian.com/bitbucket-cloud/docs/configure-ssh-and-two-step-verification/[Bitbucket instructions]. When prompted to enter a passphrase, do **not** enter one (below is one example command to generate a key on macOS):
 +

--- a/jekyll/_cci2/bitbucket-integration.adoc
+++ b/jekyll/_cci2/bitbucket-integration.adoc
@@ -11,8 +11,6 @@ contentTags:
 :toc: macro
 :toc-title:
 
-toc::[]
-
 [#overview]
 == Overview
 
@@ -78,7 +76,7 @@ Next you will need to set up the necessary permissions to run your projects on C
 
 **What is a deploy key?**
 
-When you add a new project, CircleCI creates a deployment key on Bitbucket for your project. A deploy key is an SSH key-pair, one public, one private.  Bitbucket stores the public key, and CircleCI stores the private key. The deployment key gives CircleCI access to a single repository. To prevent CircleCI from pushing to your repository, this deployment key is read-only.
+When you add a new project, CircleCI creates a deployment key on Bitbucket for your project. A deploy key is an SSH key-pair, one public, one private. Bitbucket stores the public key, and CircleCI stores the private key. The deployment key gives CircleCI access to a single repository. To prevent CircleCI from pushing to your repository, this deployment key is read-only.
 
 **What is a user key?**
 
@@ -104,6 +102,38 @@ Bitbucket does not currently provide CircleCI with an API to create user keys. H
 7. Add the key to Bitbucket by following Bitbucket's guide on link:https://support.atlassian.com/bitbucket-cloud/docs/set-up-an-ssh-key/[setting up SSH keys].
 
 This SSH user key will have a "PREFERRED" label. If the project also has a deploy key, the SSH user key will be used first.
+
+[#create-additional-bitbucket-ssh-keys]
+=== Create additional Bitbucket SSH keys
+
+If you need additional SSH keys to access other services, you can create additional keys by following the steps below.
+
+In this example, the Bitbucket repository is `https://bitbucket.org/you/test-repo/src/main/`, and the CircleCI project is `https://circleci.com/bitbucket/you/test-repo`.
+
+. Create an SSH key-pair by following the link:https://support.atlassian.com/bitbucket-cloud/docs/configure-ssh-and-two-step-verification/[Bitbucket instructions]. When prompted to enter a passphrase, do **not** enter one (below is one example command to generate a key on macOS):
++
+```shell
+  ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+. Go to `https://bitbucket.org/you/test-repo/admin/access-keys/`, and click **Add key**. Enter a label in the "Label" field, then copy and paste the public key you created in step 1. Click **Add SSH key**.
+
+. Go to your project settings in the CircleCI app, select **SSH Keys**, and **Add SSH key**. In the "Hostname" field, enter `bitbucket.com` and add the private key you created in step 1. Then click **Add SSH Key**.
+
+. In your `.circleci/config.yml` file, add the fingerprint to a job using the `add_ssh_keys` key:
++
+```yaml
+  version: 2.1
+
+  jobs:
+    deploy-job:
+      steps:
+        - add_ssh_keys:
+            fingerprints:
+              - "SO:ME:FIN:G:ER:PR:IN:T"
+```
+
+When you push to your Bitbucket repository from a job, CircleCI will use the SSH key you added.
 
 [#how-are-private-keys-used]
 === How are private keys used?

--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -91,7 +91,7 @@ To achieve fine-grained access to more than one repo, consider creating what Git
 
 If you need additional SSH keys to access other services, you can create additional keys by following the steps below.
 
-In this example, the GitHub repository is `https://github.com/you/test-repo`, and the CircleCI project is `https://circleci.com/github/you/test-repo`.
+In this example, the GitHub repository is `https://github.com/you/test-repo`, and the CircleCI project is `https://app.circleci.com/pipelines/github/you/test-repo`.
 
 . Create an SSH key-pair by following the link:https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/[GitHub instructions]. When prompted to enter a passphrase, do **not** enter one (below is one example command to generate a key on macOS):
 +

--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -12,8 +12,6 @@ redirect_from: /gh-bb-integration/
 :toc: macro
 :toc-title:
 
-toc::[]
-
 [#overview]
 == Overview
 
@@ -93,9 +91,9 @@ To achieve fine-grained access to more than one repo, consider creating what Git
 
 If you need additional SSH keys to access other services, you can create additional keys by following the steps below.
 
-In this example, the GitHub repository is `https://github.com/you/test-repo`, and the CircleCI project is `https://circleci.com/gh/you/test-repo`.
+In this example, the GitHub repository is `https://github.com/you/test-repo`, and the CircleCI project is `https://circleci.com/github/you/test-repo`.
 
-. Create an SSH key-pair by following the link:https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/[GitHub instructions]. When prompted to enter a passphrase, do **not** enter one:
+. Create an SSH key-pair by following the link:https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/[GitHub instructions]. When prompted to enter a passphrase, do **not** enter one (below is one example command to generate a key on macOS):
 +
 ```shell
   ssh-keygen -t ed25519 -C "your_email@example.com"

--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -69,12 +69,8 @@ In the link:https://app.circleci.com/[CircleCI web app], select the organization
 
 Next you will need to set up the necessary permissions to run your projects on CircleCI.
 
-[#user-keys-and-deploy-keys]
-== User keys and deploy keys
-
-**What is a user key?**
-
-A user key is user-specific an SSH key-pair. Github stores the public key, and CircleCI stores the private key. Possession of the private key gives the ability to act as that user, for purposes of 'git' access to projects.
+[#deploy-keys-and-user-keys]
+== Deploy keys and user keys
 
 **What is a deploy key?**
 
@@ -82,38 +78,44 @@ When you add a new project, CircleCI creates a deployment key on GitHub for your
 
 If you want to push to the repository from your builds, you will need a deployment key with write access. See the below section for GitHub-specific instructions to create a deployment key.
 
-**What is the difference between user keys and deploy keys?**
+**What is a user key?**
 
-User keys and deploy keys are the only key types that GitHub supports. Deploy keys are globally unique (for example, no mechanism exists to make a deploy key with access to multiple repositories) and user keys have no notion of _scope_ separate from the user associated with them.
+A user key is user-specific an SSH key-pair. Github stores the public key, and CircleCI stores the private key. Possession of the private key gives the ability to act as that user, for purposes of 'git' access to projects.
+
+**What is the difference between deploy keys and user keys?**
+
+Deploy keys and user keys are the only key types that GitHub supports. Deploy keys are globally unique (for example, no mechanism exists to make a deploy key with access to multiple repositories) and user keys have no notion of _scope_ separate from the user associated with them.
 
 To achieve fine-grained access to more than one repo, consider creating what GitHub calls a <<#controlling-access-via-a-machine-user,machine user>>. Give this user exactly the permissions your build requires, and then associate its user key with your project on CircleCI.
 
-[#create-a-github-deploy-key]
-=== Create a GitHub deploy key
+[#create-additional-github-ssh-keys]
+=== Create additional GitHub SSH keys
+
+If you need additional SSH keys to access other services, you can create additional keys by following the steps below.
 
 In this example, the GitHub repository is `https://github.com/you/test-repo`, and the CircleCI project is `https://circleci.com/gh/you/test-repo`.
 
-1. Create an SSH key-pair by following the link:https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/[GitHub instructions]. When prompted to enter a passphrase, do **not** enter one:
-
+. Create an SSH key-pair by following the link:https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/[GitHub instructions]. When prompted to enter a passphrase, do **not** enter one:
++
 ```shell
-ssh-keygen -t ed25519 -C "your_email@example.com"
+  ssh-keygen -t ed25519 -C "your_email@example.com"
 ```
 
-1. Go to `https://github.com/you/test-repo/settings/keys`, and click **Add Deploy Key**. Enter a title in the "Title" field, then copy and paste the public key you created in step 1. Check **Allow write access**, then click **Add key**.
+. Go to `https://github.com/you/test-repo/settings/keys`, and click **Add Deploy Key**. Enter a title in the "Title" field, then copy and paste the public key you created in step 1. Check **Allow write access**, then click **Add key**.
 
-2. Go to your project settings in the CircleCI app, select **SSH Keys**, and **Add SSH key**. In the "Hostname" field, enter `github.com` and add the private key you created in step 1. Then click **Add SSH Key**.
+. Go to your project settings in the CircleCI app, select **SSH Keys**, and **Add SSH key**. In the "Hostname" field, enter `github.com` and add the private key you created in step 1. Then click **Add SSH Key**.
 
-3. In your `.circleci/config.yml` file, add the fingerprint to a job using the `add_ssh_keys` key:
-
+. In your `.circleci/config.yml` file, add the fingerprint to a job using the `add_ssh_keys` key:
++
 ```yaml
-version: 2.1
+  version: 2.1
 
-jobs:
-  deploy-job:
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "SO:ME:FIN:G:ER:PR:IN:T"
+  jobs:
+    deploy-job:
+      steps:
+        - add_ssh_keys:
+            fingerprints:
+              - "SO:ME:FIN:G:ER:PR:IN:T"
 ```
 
 When you push to your GitHub repository from a job, CircleCI will use the SSH key you added.

--- a/jekyll/_cci2/gitlab-integration.adoc
+++ b/jekyll/_cci2/gitlab-integration.adoc
@@ -108,16 +108,47 @@ image::{{site.baseurl}}/assets/img/docs/gl-preview/gitlab-preview-project-settin
 NOTE: Also note the differences in functionality with the project settings below for GitLab support.
 
 [#project-settings-advanced]
-=== **Advanced**
+=== Advanced
 
 - You can enable dynamic configuration using setup workflows in CircleCI. To learn about dynamic configuration, read the xref:dynamic-config#[Dynamic configuration] guide.
 - At this time, the **Free and Open Source** setting is not currently supported, but there are plans to make this available in the future.
 - At this time, auto-cancel redundant workflows is not supported. Refer to the xref:skip-build#auto-cancelling[Auto cancelling] section of the `skip` or `cancel` jobs and workflows page for more details.
 
 [#project-settings-ssh-keys]
-=== **SSH Keys**
+=== Project SSH keys
 
-When creating a project, an SSH key is created which is used to checkout code from your repo. Each configuration you create generates a new SSH key to access the code in the repo associated with that configuration. At this time, only **Additional SSH Keys** are applicable to GitLab projects. For more information on SSH keys, please visit the xref:add-ssh-key#[Adding an SSH key to CircleCI] page.
+When creating a project, an SSH key is created which is used to checkout code from your repo. Each configuration you create generates a new SSH key to access the code in the repo associated with that configuration. At this time, only **Additional SSH Keys** are applicable to GitLab projects.
+
+[#create-gitlab-ssh-key]
+==== Create GitLab SSH key
+
+. Create an SSH key-pair by following the link:https://docs.gitlab.com/ee/user/ssh.html[GitLab instructions]. When prompted to enter a passphrase, do **not** enter one (below is one example command to generate a key on macOS):
++
+```shell
+  ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+. Go to your project on link:https://gitlab.com/[GitLab] and navigate to **Settings > Repository**, and expand the **Deploy keys** section. Enter a title in the "Title" field, then copy and paste the public key you created in step 1. Check **Grant write permissions to this key** box, then click **Add key**.
+
+. Go to your project settings in the CircleCI app, select **SSH Keys**, and **Add SSH key**. In the "Hostname" field, enter `github.com` and add the private key you created in step 1. Then click **Add SSH Key**.
+
+. In your `.circleci/config.yml` file, add the fingerprint to a job using the `add_ssh_keys` key:
++
+```yaml
+  version: 2.1
+
+  jobs:
+    deploy-job:
+      steps:
+        - add_ssh_keys:
+            fingerprints:
+              - "SO:ME:FIN:G:ER:PR:IN:T"
+```
+
+When you push to your GitHub repository from a job, CircleCI will use the SSH key you added.
+
+
+For more information on SSH keys, please visit the xref:add-ssh-key#[Adding an SSH key to CircleCI] page.
 
 [#organization-settings]
 == Organization settings

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -409,7 +409,7 @@ en:
           link: settings
         - name: Enabling GitHub Checks
           link: enable-checks
-        - name: Adding SSH keys
+        - name: Add additional SSH keys
           link: add-ssh-key
         - name: Open source projects
           link: oss


### PR DESCRIPTION
# Description
Clarification around automatic SSH key pairing vs additional SSH keys for other sources. Updates GitHub, Bitbucket, GitLab Integration pages as well as the Add SSH key page. A snippet did not make sense here as the instructions slightly vary per VCS.

# Reasons
Users can be confused about whether or not they need to actually use the instructions to create additional SSH keys, not understanding that CircleCI automatically creates deploy keys for GitHub and Bitbucket.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
