### PR TITLE
Config policies feature name change

### DIFF
--- a/jekyll/_cci2/config-policies-overview.adoc
+++ b/jekyll/_cci2/config-policies-overview.adoc
@@ -1,10 +1,10 @@
 ---
-description: Config policy management for CircleCI project configurations.
+description: Config policies for CircleCI project configurations.
 contentTags:
   platform:
   - Cloud
 ---
-= Config policy management overview
+= Config policies overview - Open preview
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
@@ -15,26 +15,26 @@ NOTE: Config policy management is available on the **Scale** plan and is current
 
 CAUTION: While config policy management is in open preview stage, it should **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
 
-Use config policy management to create organization-level policies to impose rules and scopes around which configuration elements are required, allowed, not allowed etc.
+Use config policies to create organization-level policies to impose rules and scopes to govern which configuration elements are required, allowed, not allowed etc.
 
 [#introduction]
 == Introduction
 
-Config policy management allows you to create policies for governing CircleCI project configurations. In its strictest case, if a project configuration does not comply with the rules set out in the associated policy, that project's pipelines cannot be triggered until it does comply.
+Config policies allow you to create policies for governing CircleCI project configurations. In its strictest case, if a project configuration does not comply with the rules set out in the associated policy, that project's pipelines cannot be triggered until it does comply.
 
-CircleCI uses `config.yml` files to define CI/CD pipelines at the project level. This is a convenient way of developing and iterating quickly, as each pipeline can be made to meet the needs of the project as it grows. However, it can be difficult to manage and enforce organization-wide conventions and security policies. Config policy management adds in this layer of control.
+CircleCI uses `config.yml` files to define CI/CD pipelines at the project level. This is a convenient way of developing and iterating quickly, as each pipeline can be made to meet the needs of the project as it grows. However, it can be difficult to manage and enforce organization-wide conventions and security policies. Config policies adds in this layer of control.
 
 Config policy decisions are stored, and can be audited. This provides useful data about the pipeline definitions being run within your organization.
 
 [#quickstart]
 == Quickstart
 
-If you already have a link:/docs/first-steps[CircleCI account] connected to your VCS, and you would like to get started with config policy management right away, check out the steps in the xref:create-and-manage-config-policies/#create-a-policy#[Create a policy] how-to guide.
+If you already have a link:/docs/first-steps[CircleCI account] connected to your VCS, and you would like to get started with config policies right away, check out the steps in the xref:create-and-manage-config-policies/#create-a-policy#[Create a policy] how-to guide.
 
-[#how-config-policy-management-works]
-== How config policy management works
+[#how-config-policy-work]
+== How config policies work
 
-Config policy management uses a decision engine based on link:https://www.openpolicyagent.org/[Open Policy Agent (OPA)]. Policies are written in the Rego query language, as defined by OPA. Rule violations are surfaced when pipeline triggers are applied.
+Config policies use a decision engine based on link:https://www.openpolicyagent.org/[Open Policy Agent (OPA)]. Policies are written in the Rego query language, as defined by OPA. Rule violations are surfaced when pipeline triggers are applied.
 
 Policies can be developed locally and pushed to CircleCI using the CircleCI CLI. Policies can be saved to a repository within your VCS. For more information see the link:/docs/create-and-manage-config-policies[Create and manage config policies] page.
 
@@ -50,12 +50,12 @@ hard_failures:    Array<{ rule: string, reason: string }>
 
 The decision result tracks which rules were included in the making of the decision, and any violations, both soft and hard, that were found.
 
-[#use-the-cli-for-config-policy-management]
-== Use the CLI for config policy management
+[#use-the-cli-with-config-policies]
+== Use the CLI with config policies
 
-Use the CircleCI CLI to manage your organization's policies programmatically. The sub-commands to perform policy management are grouped under the `circleci policy` command.
+Use the CircleCI CLI to manage your organization's policies programmatically. Config policies sub-commands are grouped under the `circleci policy` command.
 
-The following sub-commands are currently supported within the CLI for configuration policy management:
+The following config policies sub-commands are currently supported within the CLI:
 
 * `diff` - shows the difference between local and remote policy bundles
 * `fetch` - fetches the policy bundle (or one policy, based on name) from remote
@@ -67,7 +67,7 @@ For example, running the following command activates a policy bundle stored at `
 ----
 circleci policy push ./policy_bundle_dir_path --owner-id <your-organization-ID>
 ----
-*  `settings` - used to modify config policy management settings as required.
+*  `settings` - used to modify config policies settings as required.
 +
 When the `settings` sub-command is called without any flags, current settings are fetched and printed on console.
 +

--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -11,9 +11,9 @@ contentTags:
 :toc: macro
 :toc-title:
 
-NOTE: Config policy management is available on the **Scale** plan and is currently in **open preview**. All aspects of the feature are subject to change.
+NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 
-CAUTION: While config policy management is in open preview stage, it should **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
+CAUTION: While the config policies feature is in **open preview**, a service failure will result in build configurations **not** being evaluated against policies. This should be taken into consideration before using config policies for compliance purposes.
 
 Use config policies to create organization-level policies to impose rules and scopes to govern which configuration elements are required, allowed, not allowed etc.
 

--- a/jekyll/_cci2/config-policy-reference.adoc
+++ b/jekyll/_cci2/config-policy-reference.adoc
@@ -1,6 +1,6 @@
 ---
-description: Open preview of config policy management for CircleCI
-contentTags: 
+description: Open preview of config policies for CircleCI. Reference page for function helpers.
+contentTags:
   platform:
   - Cloud
 ---
@@ -11,9 +11,9 @@ contentTags:
 :toc: macro
 :toc-title:
 
-NOTE: Config policy management is available on the **Scale** plan and is currently in **open preview**. All aspects of the feature are subject to change.
+NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 
-CAUTION: While config policy management is in open preview stage, it should **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
+CAUTION: While the config policies feature is in **open preview**, a service failure will result in build configurations **not** being evaluated against policies. This should be taken into consideration before using config policies for compliance purposes.
 
 This reference page lists a selection of _helpers_, or CircleCI-specific funtions that are likely to be useful for you when you are writing your policies. These helpers will lead to _cleaner_ policies with less boilerplate.
 
@@ -28,7 +28,7 @@ reserved.
 [#orbs]
 === `orbs`
 
-`orbs` is a Rego object containing orbs and versions present in the given config file. It 
+`orbs` is a Rego object containing orbs and versions present in the given config file. It
 can be utilized by policies related to orbs.
 
 [#definition-orbs]
@@ -66,7 +66,7 @@ my_orbs := config.orbs
 [#ban-orbs]
 === `ban_orbs`
 
-This function violates a policy if a config includes orbs based on the orb name. Versions should not 
+This function violates a policy if a config includes orbs based on the orb name. Versions should not
 be included in the provided list of orbs.
 
 [#definition-ban-orbs]

--- a/jekyll/_cci2/create-and-manage-config-policies.adoc
+++ b/jekyll/_cci2/create-and-manage-config-policies.adoc
@@ -1,5 +1,5 @@
 ---
-description: Config policy management for CircleCI project configurations.
+description: Learn how to write and manage config policies for CircleCI project configurations.
 contentTags:
   platform:
   - Cloud
@@ -11,11 +11,11 @@ contentTags:
 :toc: macro
 :toc-title:
 
-NOTE: Config policy management is available on the **Scale** plan and is currently in **open preview**. All aspects of the feature are subject to change.
+NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 
-CAUTION: While config policy management is in open preview stage, it should **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
+CAUTION: While the config policies feature is in **open preview**, a service failure will result in build configurations **not** being evaluated against policies. This should be taken into consideration before using config policies for compliance purposes.
 
-Follow the how-to guides on this page to learn how to perform various config policy management processes.
+Follow the how-to guides on this page to learn how to create and use config policies.
 
 [#config-policy-management-enablement]
 == Enable or disable policy evaluation for an organization
@@ -59,11 +59,11 @@ Example output:
 [#create-a-policy]
 == Create a policy
 
-CAUTION: Ensure you have authenticated your version of the CLI with a token, and updated the CLI, before attempting to use the CLI for config policy management. See the link:/docs/local-cli[Installing the Local CLI] page for more information.
+CAUTION: Ensure you have authenticated your version of the CLI with a token, and updated the CLI, before attempting to use the CLI with config policies. See the link:/docs/local-cli[Installing the Local CLI] page for more information.
 
 Follow these steps to create a policy that checks the `version` of CircleCI config files to ensure it is greater than or equal to `2.1`.
 
-. Enable config policy management for your organization
+. Enable config policies for your organization
 +
 [source,shell]
 ----
@@ -156,7 +156,7 @@ CircleCI policies are managed by pushing directories of policies to CircleCI via
 We recommend creating a bot account for pushing policies, and using its associated CircleCI personal API token for authentication. For maximum security the token should be stored as an environment variable within a context, and that context should be restricted to groups that are responsible for managing policies. For more information, see the link:/docs/contexts[Using Contexts] page.
 
 [set-up-a-config-policy-management-ci-pipeline]
-=== Set up a config policy management CI pipeline
+=== Set up a config policies CI/CD pipeline
 
 . Set up repository in your VCS to manage policies.
 

--- a/jekyll/_cci2/test-config-policies.adoc
+++ b/jekyll/_cci2/test-config-policies.adoc
@@ -1,5 +1,5 @@
 ---
-description: Open preview of config policy management for CircleCI, learn about testing policies
+description: Open preview of config policies for CircleCI. Learn about testing your policies.
 contentTags:
   platform:
   - Cloud
@@ -11,20 +11,20 @@ contentTags:
 :toc: macro
 :toc-title:
 
-NOTE: Config policy management is available on the **Scale** plan and is currently in **open preview**. All aspects of the feature are subject to change.
+NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 
-CAUTION: While config policy management is in open preview stage, it should **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
+CAUTION: While the config policies feature is in **open preview**, a service failure will result in build configurations **not** being evaluated against policies. This should be taken into consideration before using config policies for compliance purposes.
 
 Follow the how-to guides on this page to write and set up tests for your config policies.
 
-This guide assumes you are familiar with writing config policies. If you would like more information on configuration policies, or the process of creating policies, see the xref:config-policy-management-overview.adoc[Config policy management overview] and xref:create-and-manage-config-policies#[Create and manage config policies] pages.
+This guide assumes you are familiar with writing config policies. If you would like more information on configuration policies, or the process of creating policies, see the xref:config-policy-management-overview.adoc[Config policies overview] and xref:create-and-manage-config-policies#[Create and manage config policies] pages.
 
 [#prerequisites]
 == Prerequisites
 
 The instructions on this page assume you have followed and completed the xref:/docs/use-the-cli-and-vcs-for-config-policy-management/#create-a-policy#[Create a policy] guide, through which you will have done the following:
 
-* Enabled config policy management for your organization
+* Enabled config policies for your organization
 * Created a simple policy to check CircleCI config versions within your org. You will have the following file structure: `./config-policies/version.rego`
 
 [#write-a-policy-test]

--- a/jekyll/_cci2/use-the-cli-for-config-and-policy-development.adoc
+++ b/jekyll/_cci2/use-the-cli-for-config-and-policy-development.adoc
@@ -1,5 +1,5 @@
 ---
-description: Config policy management for CircleCI project configurations.
+description: Learn about developing your config policies.
 contentTags:
   platform:
   - Cloud
@@ -11,11 +11,11 @@ contentTags:
 :toc: macro
 :toc-title:
 
-NOTE: Config policy management is available on the **Scale** plan and is currently in **open preview**. All aspects of the feature are subject to change.
+NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 
-CAUTION: While config policy management is in open preview stage, it should **not** be used for compliance purposes. The feature might become unavailable occasionally during **open preview**, during which build configurations may **not** be evaluated against policies.
+CAUTION: While the config policies feature is in **open preview**, a service failure will result in build configurations **not** being evaluated against policies. This should be taken into consideration before using config policies for compliance purposes.
 
-CAUTION: Ensure you have authenticated your version of the CLI with a token, and updated the CLI, before attempting to use the CLI for config policy management. See the link:/docs/local-cli[Installing the Local CLI] page for more information.
+CAUTION: Ensure you have authenticated your version of the CLI with a token, and updated the CLI, before attempting to use the CLI with config policies. See the link:/docs/local-cli[Installing the Local CLI] page for more information.
 
 [#develop-configs]
 == Develop configs

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -357,8 +357,8 @@ en:
           link: security-recommendations
     - name: Config policy management
       children:
-        - name: Config policy management overview (Open preview)
-          link: config-policy-management-overview
+        - name: Config policies overview (Open preview)
+          link: config-policies-overview
     - name: Authentication
       children:
         - name: Use OpenID Connect tokens in jobs


### PR DESCRIPTION
# Description
This PR updates use of "config policy management" to "config policies". Also the warning around open preview is reduced in severity.

# Reasons
The feature has changed name, now config policies, not config policy management. Also severity of issues due to open preview has reduced.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
