### PR TITLE
Remove `--job` argument from circleci local execute calls

### DIFF
--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -231,14 +231,14 @@ You will need to have link:https://www.docker.com/products/docker-desktop[Docker
 The CLI allows you to run a single job from CircleCI on your desktop using Docker with the following command:
 
 ```shell
-$ circleci local execute --job JOB_NAME
+$ circleci local execute JOB_NAME
 ```
 
 If your CircleCI configuration is set to version 2.1 or greater, you must first export your configuration to `process.yml`, and specify it when executing with the following commands:
 
 ```shell
 circleci config process .circleci/config.yml > process.yml
-circleci local execute -c process.yml --job JOB_NAME
+circleci local execute -c process.yml JOB_NAME
 ```
 
 The following commands will run an example build on your local machine on one of CircleCI's demo applications:
@@ -246,7 +246,7 @@ The following commands will run an example build on your local machine on one of
 ```shell
 git clone https://github.com/CircleCI-Public/circleci-demo-go.git
 cd circleci-demo-go
-circleci local execute --job build
+circleci local execute build
 ```
 
 The commands above will run the entire `build` job (only jobs, not workflows, can be run locally). The CLI will use Docker to pull down the requirements for the build and then execute your CI steps locally. In this case, Golang and Postgres Docker images are pulled down, allowing the build to install dependencies, run the unit tests, test the service is running, and so on.

--- a/jekyll/_cci2/run-a-job-in-a-container.adoc
+++ b/jekyll/_cci2/run-a-job-in-a-container.adoc
@@ -26,14 +26,14 @@ You will need to have link:https://www.docker.com/products/docker-desktop[Docker
 The CLI allows you to run a single job from CircleCI on your desktop using Docker with the following command:
 
 ```shell
-$ circleci local execute --job JOB_NAME
+$ circleci local execute JOB_NAME
 ```
 
 If your CircleCI configuration is set to version 2.1 or greater, you must first export your configuration to `process.yml`, and specify it when executing with the following commands:
 
 ```shell
 circleci config process .circleci/config.yml > process.yml
-circleci local execute -c process.yml --job JOB_NAME
+circleci local execute -c process.yml JOB_NAME
 ```
 
 The following commands will run an example build on your local machine on one of CircleCI's demo applications:
@@ -41,7 +41,7 @@ The following commands will run an example build on your local machine on one of
 ```shell
 git clone https://github.com/CircleCI-Public/circleci-demo-go.git
 cd circleci-demo-go
-circleci local execute --job build
+circleci local execute build
 ```
 
 The commands above will run the entire `build` job (only jobs, not workflows, can be run locally). The CLI will use Docker to pull down the requirements for the build and then execute your CI steps locally. In this case, Golang and Postgres Docker images are pulled down, allowing the build to install dependencies, run the unit tests, test the service is running, and so on.

--- a/jekyll/_cci2/testing-orbs.md
+++ b/jekyll/_cci2/testing-orbs.md
@@ -76,7 +76,7 @@ $ yamllint ./src
 Using CircleCI's Local Execute:
 
 ```shell
-circleci local execute --job orb-tools/lint
+circleci local execute orb-tools/lint
 ```
 
 
@@ -105,7 +105,7 @@ circleci orb validate orb.yml
 
 Or, using CircleCI's Local Execute:
 ```shell
-circleci local execute --job orb-tools/pack
+circleci local execute orb-tools/pack
 ```
 ### Shellcheck
 {: #shellcheck }
@@ -127,7 +127,7 @@ shellcheck src/scripts/*.sh
 
 Or, using CircleCI's Local Execute:
 ```shell
-circleci local execute --job shellcheck/check
+circleci local execute shellcheck/check
 ```
 
 ### Review

--- a/jekyll/_cci2_ja/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2_ja/how-to-use-the-circleci-local-cli.adoc
@@ -234,14 +234,14 @@ CLI を使用すると、Docker を使用して設定ファイル内のジョブ
 CLI では、次のコマンドで Docker を使用してデスクトップ上の CircleCI から単一のジョブを実行できます。
 
 ```shell
-$ circleci local execute --job JOB_NAME
+$ circleci local execute JOB_NAME
 ```
 
 CircleCI の設定ファイルをバージョン 2.1 以上に設定している場合、まず設定ファイルを `process.yml` にエクスポートし、次のコマンドを使用して実行するときにそのファイルを指定する必要があります。
 
 ```shell
 circleci config process .circleci/config.yml > process.yml
-circleci local execute -c process.yml --job JOB_NAME
+circleci local execute -c process.yml JOB_NAME
 ```
 
 次のコマンドは、CircleCI のデモアプリケーションのいずれかを使って、ローカルのマシン上でビルドのサンプルを実行します。
@@ -249,7 +249,7 @@ circleci local execute -c process.yml --job JOB_NAME
 ```shell
 git clone https://github.com/CircleCI-Public/circleci-demo-go.git
 cd circleci-demo-go
-circleci local execute --job build
+circleci local execute build
 ```
 
 上記のコマンドは、`build` ジョブ全体を実行します (ローカルではジョブのみを実行でき、ワークフローは実行できません)。 CLI は、Docker を使用してビルドの要件をプルダウンしてから、CI ステップをローカルで実行します。 この例では、Golang および Postgres の Docker イメージをプルダウンして、ビルド中に依存関係のインストール、単体テストの実行、サービスの実行テストなどを行えるようにしています。

--- a/jekyll/_cci2_ja/run-a-job-in-a-container.adoc
+++ b/jekyll/_cci2_ja/run-a-job-in-a-container.adoc
@@ -28,14 +28,14 @@ link:https://circleci-public.github.io/circleci-cli/[CLI] により、Docker を
 CLI により、以下のコマンドを使って Docker を使用してデスクトップ上の CircleCI から単一のジョブを実行することができます。
 
 ```shell
-$ circleci local execute --job JOB_NAME
+$ circleci local execute JOB_NAME
 ```
 
 CircleCI の設定ファイルをバージョン 2.1 以上に設定している場合は、まず設定ファイルを `process.yml` にエクスポートし、以下のコマンドで実行する際にそのファイルを指定する必要があります。
 
 ```shell
 circleci config process .circleci/config.yml > process.yml
-circleci local execute -c process.yml --job JOB_NAME
+circleci local execute -c process.yml JOB_NAME
 ```
 
 以下のコマンドにより、CircleCI のデモアプリケーションのいずれかを使って、ローカルマシン上でサンプルビルドを実行します。
@@ -43,7 +43,7 @@ circleci local execute -c process.yml --job JOB_NAME
 ```shell
 git clone https://github.com/CircleCI-Public/circleci-demo-go.git
 cd circleci-demo-go
-circleci local execute --job build
+circleci local execute build
 ```
 
 これらのコマンドは、`build` ジョブ全体を実行します (ローカルではジョブのみを実行でき、ワークフローは実行できません)。 CLI は、Docker を使用してビルドの要件をプルダウンしてから、CI ステップをローカルで実行します。 この例では、Golang および Postgres の Docker イメージをプルダウンして、ビルド中に依存関係のインストール、単体テストの実行、サービスの実行テストなどを行えるようにしています。

--- a/jekyll/_cci2_ja/testing-orbs.md
+++ b/jekyll/_cci2_ja/testing-orbs.md
@@ -78,7 +78,7 @@ $ yamllint ./src
 CircleCI の Local Execute を使用する場合:
 
 ```shell
-circleci local execute --job orb-tools/lint
+circleci local execute orb-tools/lint
 ```
 
 
@@ -107,7 +107,7 @@ circleci orb validate orb.yml
 
 または、CircleCI の Local Execute を使用します。
 ```shell
-circleci local execute --job orb-tools/pack
+circleci local execute orb-tools/pack
 ```
 ### ShellCheck
 {: #shellcheck }
@@ -129,7 +129,7 @@ shellcheck src/scripts/*.sh
 
 または、CircleCI の Local Execute を使用します。
 ```shell
-circleci local execute --job shellcheck/check
+circleci local execute shellcheck/check
 ```
 
 ### レビュー


### PR DESCRIPTION

# Description
Since https://github.com/CircleCI-Public/circleci-cli/pull/825, local execution now occurs without the `--job` argument, instead making the job name mandatory and this command's first argument, e.g.:

    circleci local execute orb-tools/pack

This change updates all documentation where the previous form was used.

# Reasons
https://github.com/CircleCI-Public/circleci-cli/pull/825 changed how `circleci`'s CLI tool is called.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
