### PR TITLE
Updating runner docs with support for s390x and ppc64le Machine Runner

### DIFF
--- a/jekyll/_cci2/runner-installation-cli.adoc
+++ b/jekyll/_cci2/runner-installation-cli.adoc
@@ -128,6 +128,12 @@ sudo cp "${file}" "${prefix}/circleci-launch-agent" || echo "Invalid checksum fo
 | For Linux ARM64
 | `platform=linux/arm64`
 
+| For Linux s390x
+| `platform=linux/s390x`
+
+| For Linux ppc64le
+| `platform=linux/ppc64le`
+
 | For macOS x86_64
 | `platform=darwin/amd64`
 

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -20,7 +20,7 @@ This page describes how to install CircleCI's machine runner on Linux.
 [#download-the-launch-agent-script]
 == Download the machine runner launch-agent script
 
-Save the link:https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh[launch-agent.sh] script file to an easily accessible location. From that location, install the launch-agent binary for your target platform, either x86_64, or ARM64:
+Save the link:https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh[launch-agent.sh] script file to an easily accessible location. From that location, install the launch-agent binary for your target platform, either x86_64, ARM64, s390x or ppc64le:
 
 ```shell
 curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh --output ./download-launch-agent.sh
@@ -38,6 +38,16 @@ export platform=linux/amd64 && sh ./download-launch-agent.sh
 ```shell
 # For Linux ARM64:
 export platform=linux/arm64 && sh ./download-launch-agent.sh
+```
+
+```shell
+# For Linux s390x:
+export platform=linux/s390x && sh ./download-launch-agent.sh
+```
+
+```shell
+# For Linux ppc64le:
+export platform=linux/ppc64le && sh ./download-launch-agent.sh
 ```
 
 After successful installation, the download-launch-agent.sh file can be deleted.

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -66,7 +66,7 @@ Machine runner is installed either in a virtual machine, or natively on a physic
 
 If you do not use Kubernetes but still want to run your CI job in a container on a self-hosted runner, you can install the machine runner in Docker.
 
-Machine runner is not compatible with CircleCI's convienience images or custom Docker images.
+Machine runner is not compatible with CircleCI's convenience images or custom Docker images.
 
 [#getting-started]
 == Getting started
@@ -106,7 +106,7 @@ With a supported platform, users receive the following:
 
 * macOS X 11.2+ (Intel, Apple M1)
 * Windows Server 2019, 2016 (x86_64)
-* Linux distributions - RHEL8, SUSE, Debian, etc (x86_64, ARM64)
+* Linux distributions - RHEL8, SUSE, Debian, etc (x86_64, ARM64, s390x, ppc64le)
 
 CircleCI sometimes offers a **preview** level platform when a new platform for self-hosted runner is in active development. If there is a platform in a preview level, this section will be updated with information and limitations for that platform.
 


### PR DESCRIPTION
# Description
CircleCI is enabling support for `s390x` and `ppc64le` machine runners. Documentation needs to reflect the support so customers can utilize the new runner binaries.

# Reasons
Link to JIRA ticket:  [RT-555](https://circleci.atlassian.net/browse/RT-555)

Enabling `s390x` and `ppc64le` allows us to better serve the open source community and more enterprise customers.

Additionally, the PR also includes a spelling fix on runner overview page.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.


[RT-555]: https://circleci.atlassian.net/browse/RT-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ