### PR TITLE
Create troubleshoot/faq clean up

### DIFF
--- a/jekyll/_cci2/scheduled-pipelines.adoc
+++ b/jekyll/_cci2/scheduled-pipelines.adoc
@@ -54,6 +54,65 @@ The form also provides the option of adding xref:pipeline-variables#[pipeline pa
 
 If you would like to manage common schedules for multiple workflows, you will need to manually set this in your `.circleci/config.yml` file. See the xref:schedule-pipelines-with-multiple-workflows#[Schedule pipelines with multiple workflows] page for examples.
 
+[#use-scheduled-pipelines-orb]
+=== Use the scheduled pipelines orb
+
+The CircleCI scheduled pipelines orb lets you easily manage a project's schedules. The orb uses the list of schedules you provide to create, update, or delete schedules in your project's pipeline. As a result, you can easily manage all of your pipeline's schedules from a single `json` file and any changes will be automatically updated.
+
+. In the CircleCI web app, have your CCI token ready, or create a new token by following the steps on the xref:managing-api-tokens#[Managing API tokens] page. Add an environment variable with `CIRCLE_TOKEN` as the key and your CCI token as the value. This can be done through **Project Settings > Environment Variables** or added to a `context` in **Organization Settings > Contexts**.
+. Create a `json` file with a list of your schedules in any directory of your project's repository. The list is a `json` object with an array of `schedules`. Each element in the array is a valid schedule payload for a `POST` request to the CircleCI Schedule's API. You can have a maximum of 50 schedules. You can find more details about the link:https://circleci.com/docs/api/v2/index.html#operation/createSchedule[payload schema] in the API docs.
++
+[source,json]
+----
+{
+    "schedules": [{
+        "name": "string",
+        "timetable": {
+            "per-hour": 0,
+            "hours-of-day": [
+            0
+            ],
+            "days-of-week": [
+            "TUE"
+            ],
+            "days-of-month": [
+            0
+            ],
+            "months": [
+            "MAR"
+            ]
+        },
+        "attribution-actor": "current",
+        "parameters": {
+            "deploy_prod": true,
+            "branch": "feature/design-new-api"
+        },
+        "description": "string"
+        }
+    ]
+}
+----
++
+NOTE: In the timetable key, `days-of-week` and `days-of-month` are mutually exclusive and cannot be used together.
++
+. In your project's `.circleci/config.yml` file, import the `scheduled-pipelines` orb with the `orb` parameter. Add the `scheduled-pipelines/update-schedules` job to your workflow. The job requires the `schedule-path` parameter, which is the file path to the `json` file containing your schedules. If you added your CCI token to a context, you will also need to provide the name of the context with the `context` parameter.
++
+[source,yaml]
+----
+  description: >
+    This is a simple example of updating pipeline schedules using the update-schedules job.
+  usage:
+    version: 2.1
+    orbs:
+      scheduled-pipelines: circleci/scheduled-pipelines@1.0
+    workflows:
+      update-pipeline-schedules:
+        jobs:
+          - orb-scheduled-pipelines/update-schedules:
+              schedule-path: ./path/to/schedules.json
+              context: "context-with-access-token"
+----
+
 [#use-the-api]
 === Use the API
 

--- a/jekyll/_includes/snippets/faq/self-hosted-runner-faq-snip.adoc
+++ b/jekyll/_includes/snippets/faq/self-hosted-runner-faq-snip.adoc
@@ -122,7 +122,7 @@ No, runner resource classes cannot be used by jobs that are not associated with 
 
 On self-hosted runners, `circleci-agent` is used for all commands in which you may use either `circleci-agent` or `circleci` on CircleCI cloud (such as test splitting and step halt commands). Please note, `circleci` is not to be confused with the xref:local-cli#[local CircleCI CLI], and is simply an alias of `circleci-agent`.
 
-If you would like to use the local CircleCI CLI in your self-hosted runner jobs, which can proxy test commands to `circleci-agent`, you can install the CLI via a job step. Install the CLI as a <<how-do-i-install-dependencies-needed-for-my-jobs#,dependency>> on your machine for machine runner, or include it in a Docker image for container runner.
+If you would like to use the local CircleCI CLI in your self-hosted runner jobs, which can proxy test commands to `circleci-agent`, you can install the CLI via a job step. Install the CLI as a <<#how-do-i-install-dependencies-needed-for-my-jobs,dependency>> on your machine for machine runner, or include it in a Docker image for container runner.
 
 [#container-runner-specific-faqs]
 === Container runner specific FAQs


### PR DESCRIPTION
# Description
- Convert remaining FAQs to adoc
- Add existing FAQ snippets to main FAQ page
- Identify troubleshooting questions masked as FAQ
- Clean up some of the FAQ pages

# Reasons
This is the next step in standardizing/organizing the FAQ and Troubleshooting sections.

This should not be merged without additional PRs being marked as ready (will update when those exist).

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
