### PR TITLE
Fix non-working OIDC config example

### DIFF
--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -132,18 +132,20 @@ orbs:
  aws-cli: circleci/aws-cli@3.1
 jobs:
  aws-example:
+   environment:
+      AWS_REGION: us-west-1
    docker:
      - image: cimg/aws:2022.06
    steps:
      - checkout
      # run the aws-cli/setup command from the orb
      - aws-cli/setup:
-         role-arn: 'arn:aws:iam::123456789012:role/OIDC-ROLE'
-         aws-region: "us-west-1"
+         role-arn: "arn:aws:iam::123456789012:role/OIDC-ROLE"
+         aws-region: AWS_REGION
          # optional parameters
          profile-name: "OIDC-PROFILE"
-         role-session-name: “example-session”
-         session-duration: 1800
+         role-session-name: "example-session"
+         session-duration: "1800"
      - run:
        name: Log-into-AWS-ECR
        command: |


### PR DESCRIPTION
Fixing the example on how to setup the AWS CLI with STS / OIDC correctly:
- session-duration must be a string value
- aws-region needs an env-var, not the region name
- role-session-name used wrong double quotes
- Aligning the use of double quotes

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
