### PR TITLE
Move glossary/config ref

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -452,12 +452,12 @@ en:
           link: how-to-use-the-circleci-local-cli
     - name: Reference
       children:
+        - name: Configuration reference
+          link: configuration-reference
         - name: API v2 reference
           link: https://circleci.com/docs/api/v2
         - name: API v1 reference
           link: https://circleci.com/docs/api/v1
-        - name: Configuration reference
-          link: configuration-reference
 
 - name: Examples and guides
   icon: icons/sidebar/config.svg

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -10,6 +10,8 @@ en:
           link: benefits-of-circleci
         - name: Concepts
           link: concepts
+        - name: Glossary
+          link: glossary
         - name: Web app introduction
           link: introduction-to-the-circleci-web-app
         - name: FAQ
@@ -563,8 +565,6 @@ en:
         link: variables
       - name: Prebuilt images
         link: circleci-images
-      - name: Glossary
-        link: glossary
       - name: Help and support
         link: help-and-support
 

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -214,8 +214,6 @@ en:
           link: config-editor
     - name: Reference
       children:
-        - name: Reusing configuration
-          link: reusing-config
         - name: Advanced configuration
           link: adv-config
         - name: Sample configuration

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -236,8 +236,6 @@ en:
           link: config-editor
     - name: Reference
       children:
-        - name: Configuration reference
-          link: configuration-reference
         - name: Reusing configuration
           link: reusing-config
         - name: Advanced configuration
@@ -324,8 +322,6 @@ en:
           link: orbs-faq
         - name: Orb author FAQ
           link: orb-author-faq
-        - name: Configuration reference
-          link: configuration-reference
         - name: Reusing configuration
           link: reusing-config
 
@@ -460,6 +456,8 @@ en:
           link: https://circleci.com/docs/api/v2
         - name: API v1 reference
           link: https://circleci.com/docs/api/v1
+        - name: Configuration reference
+          link: configuration-reference
 
 - name: Examples and guides
   icon: icons/sidebar/config.svg
@@ -559,8 +557,6 @@ en:
   icon: icons/sidebar/folder-open.svg
   children:
     - children:
-      - name: Configuration reference
-        link: configuration-reference
       - name: Project values and variables
         link: variables
       - name: Prebuilt images


### PR DESCRIPTION
# Description
- Move glossary to About
- Move Config ref to Dev Toolkit, remove all duplicate entries

# Reasons
The glossary was overlooked in the re-org, and we are starting to work on removing the Reference section completely.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
