### PR TITLE
Check datastore size is adequate before migrating to server 4

### DIFF
--- a/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
+++ b/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
@@ -22,7 +22,9 @@ Depending on the size of your data stores, the migration can take anywhere from 
 
 . Your current CircleCI server installation is v2.19x
 . You have taken a backup of your v2.19 instance. If you are using external datastores, they need to be backed up separately.
-. If using externalized datastores, Postgres must be updated to version 12.
+. Datastores:
+.. If using **externalized** datastores, Postgres must be updated to version 12.
+.. If your datastores are **internal**, ensure that the volume sizes allocated to Mongodb, Postgres and Redis in your v4.0 installation are at least the same or greater than the volumes allocated to the Mongodb, Postgres and Redis instances in your v2.19 install. You may resize your 4.x datastore volumes following link:/docs/server/operator/expanding-internal-database-volumes/[these instructions].
 . You have a new CircleCI server v4.0 link:/docs/server/installation/phase-1-prerequisites[installation].
 . You have successfully run link:https://github.com/circleci/realitycheck[realitycheck] with contexts before starting.
 . The migration script must be run from a machine with:


### PR DESCRIPTION
# Description
Add in a prereq step to check datastore size is large enough before migrating from server v2.19

# Reasons
Not doing so has caused some customers issues int he migration process

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
