### PR TITLE
Add menu to troubleshoot page

### DIFF
--- a/jekyll/_cci2/troubleshoot.adoc
+++ b/jekyll/_cci2/troubleshoot.adoc
@@ -14,7 +14,18 @@ contentTags:
 :toc: macro
 :toc-title:
 
-This page offers troubleshooting suggestions for various aspects of CircleCI.
+This page offers troubleshooting suggestions for the following aspects of CircleCI:
+
+[.table]
+[cols=2*]
+|===
+| <<#orbs,Orbs>>
+| <<#container-runner,Container runner>>
+
+| <<#pipelines,Pipelines>>
+| <<#machine-runner,Machine runner>>
+
+|===
 
 == Orbs
 

--- a/jekyll/_includes/snippets/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
+++ b/jekyll/_includes/snippets/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
@@ -1,4 +1,4 @@
-[#troubleshoot-container-runner]
+[#container-runner]
 == Container runner
 
 The following are errors you could encounter using container runner.
@@ -106,7 +106,7 @@ We suggest connecting to the pod using the command `kubectl exec --stdin --tty -
 
 There are also external tools for monitoring resource usage on the link:https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-usage-monitoring/[Kubernetes documentation].
 
-[#troubleshoot-machine-runner]
+[#machine-runner]
 == Machine runner
 
 The following are errors you could encounter using machine runner.


### PR DESCRIPTION
# Description
- Add the same menu to the top of Troubleshoot that exists in FAQ
- Fix the self-hosted runner troubleshoot link tags

# Reasons
To standardize the experience across these larger pages. (Note, the link tag #orbs is also not working here, both in the menu and the ToC. I'm wondering if there is a character limit? It makes no sense that "orbs" specifically causing problems on two pages).

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
