### PR TITLE
[DOCSS-955] Update macOS docs for M1 launch and resource class deprecation

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -906,14 +906,14 @@ Key | Required | Type | Description
 xcode | Y | String | The version of Xcode that is installed on the virtual machine, see the [Supported Xcode Versions section of the Testing iOS]({{ site.baseurl }}/using-macos/#supported-xcode-versions) document for the complete list.
 {: class="table table-striped"}
 
-Example: Use a macOS virtual machine with Xcode version 12.5.1:
+Example: Use a macOS virtual machine with Xcode version 14.2.0:
 
 
 ```yaml
 jobs:
   build:
     macos:
-      xcode: "12.5.1"
+      xcode: "14.2.0"
 ```
 
 ---
@@ -1033,8 +1033,8 @@ jobs:
 jobs:
   build:
     macos:
-      xcode: "12.5.1"
-    resource_class: large
+      xcode: "14.2.0"
+    resource_class: macos.x86.medium.gen2
     steps:
       ... // other config
 ```
@@ -2465,7 +2465,7 @@ executors:
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
   macos: &macos-executor
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
 
 jobs:
   test:

--- a/jekyll/_cci2/dedicated-hosts-macos.adoc
+++ b/jekyll/_cci2/dedicated-hosts-macos.adoc
@@ -60,7 +60,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.1 # indicate our selected version of Xcode
+      xcode: 14.0.1 # indicate your selected version of Xcode
     resource_class: macos.x86.metal.gen1 # dedicated host, with 24-hour billing
     steps:
       - checkout

--- a/jekyll/_cci2/deploy-ios-applications.md
+++ b/jekyll/_cci2/deploy-ios-applications.md
@@ -55,7 +55,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -72,7 +72,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -95,11 +95,11 @@ If you want to run a macOS build on a server instance, you will need to use [sel
 jobs:
   build: # name of your job
     macos: # executor type
-      xcode: 12.5.1
+      xcode: 14.2.0
 
     steps:
       # Commands run in a macOS virtual machine environment
-      # with Xcode 12.5.1 installed
+      # with Xcode 14.2.0 installed
 ```
 
 Find out more about the macOS execution environment on the [Using macOS](/docs/using-macos/) page.

--- a/jekyll/_cci2/hello-world-macos.md
+++ b/jekyll/_cci2/hello-world-macos.md
@@ -59,7 +59,7 @@ version: 2.1
 jobs: # a basic unit of work in a run
   test: # your job name
     macos:
-      xcode: 14.1.0 # indicate our selected version of Xcode
+      xcode: 14.2.0 # indicate your selected version of Xcode
     steps: # a series of commands to run
       - checkout  # pull down code from your version control system.
       - run:
@@ -68,7 +68,7 @@ jobs: # a basic unit of work in a run
 
   build: 
     macos:
-      xcode: 14.1.0 # indicate our selected version of Xcode
+      xcode: 14.2.0 # indicate your selected version of Xcode
     steps: 
       - checkout
       - run:

--- a/jekyll/_cci2/ios-codesigning.md
+++ b/jekyll/_cci2/ios-codesigning.md
@@ -154,14 +154,14 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
       # ...
       - run: bundle exec fastlane test
 
   adhoc:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
       # ...
       - run: bundle exec fastlane adhoc
@@ -212,7 +212,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -229,7 +229,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc

--- a/jekyll/_cci2/migrating-from-aws.adoc
+++ b/jekyll/_cci2/migrating-from-aws.adoc
@@ -215,7 +215,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-azuredevops.adoc
+++ b/jekyll/_cci2/migrating-from-azuredevops.adoc
@@ -216,7 +216,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-buildkite.adoc
+++ b/jekyll/_cci2/migrating-from-buildkite.adoc
@@ -204,7 +204,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -128,7 +128,7 @@ machine: true
 
 # macOS Executor
 macos:
-  xcode: 12.5.1
+  xcode: 14.2.0
 
 # Windows Executor
 # NOTE: Orb declaration needed. See docs

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -177,7 +177,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osx-job:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -1532,7 +1532,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     parameters:
       label:
         type: string
@@ -1634,7 +1634,7 @@ jobs:
 
   test-macos:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     parameters:
       label:
         type: string
@@ -1707,7 +1707,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
       - checkout
       - run:

--- a/jekyll/_cci2/testing-ios.md
+++ b/jekyll/_cci2/testing-ios.md
@@ -21,7 +21,15 @@ There is documentation for [iOS code signing projects](/docs/ios-codesigning/) a
 ## Supported Xcode versions
 {: #supported-xcode-versions }
 
+### Supported Xcode versions for Intel
+{: #supported-xcode-versions-intel}
+
 {% include snippets/xcode-intel-vm.md %}
+
+### Supported Xcode versions for Apple Silicon
+{: #supported-xcode-versions-silicon}
+
+{% include snippets/xcode-silicon-vm.md %}
 
 For supported Xcode versions on the Dedicated Hosts resource class, please see the table in the [Dedicated hosts](/docs/dedicated-hosts-macos) documentation.
 

--- a/jekyll/_cci2/testing-macos.md
+++ b/jekyll/_cci2/testing-macos.md
@@ -65,7 +65,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
         - checkout
         - run: echo 'chruby ruby-2.7' >> ~/.bash_profile
@@ -127,7 +127,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
         - checkout
         - mac-permissions/list-permissions
@@ -161,7 +161,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
         - checkout
         - mac-permissions/list-permission-types
@@ -191,7 +191,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
         - checkout
         - mac-permissions/add-uitest-permissions
@@ -211,7 +211,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
         - checkout
         - mac-permissions/add-permission:
@@ -233,7 +233,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     steps:
         - checkout
         - mac-permissions/delete-permission:

--- a/jekyll/_cci2/using-macos.md
+++ b/jekyll/_cci2/using-macos.md
@@ -15,11 +15,11 @@ You can use the macOS execution environment to run your [jobs]({{site.baseurl}}/
 jobs:
   build:
     macos:
-      xcode: 13.4.1
+      xcode: 14.2.0
 
     steps:
       # Commands will execute in macOS container
-      # with Xcode 12.5.1 installed
+      # with Xcode 14.2.0 installed
       - run: xcodebuild -version
 ```
 
@@ -39,29 +39,9 @@ For supported Xcode versions on the Dedicated Hosts resource class, please see t
 jobs:
   build:
     macos:
-      xcode: 13.4.1
-    resource_class: large
+      xcode: "14.2.0"
+    resource_class: macos.x86.medium.gen2
 ```
-
-## macOS VM storage
-{: #macos-vm-storage }
-
-The amount of available storage on CircleCI macOS virtual machines depends on the resource class and Xcode image being used. The size of the Xcode images varies based on which tools are pre-installed. The table below indicates how much storage will be available with various Xcode/resource class combinations. Also note the exceptions to this noted below.
-
-Xcode Version | Class                 | Minimum Available Storage
---------------|-----------------------|--------------------------
-10.3.0        | medium, large         | 36GB
-10.3.0        | macos.x86.medium.gen2 | 36GB
-11.*          | medium, large         | 23GB
-11.*          | macos.x86.medium.gen2 | 23GB
-12.*          | medium, large         | 30GB
-12.*          | macos.x86.medium.gen2 | 30GB
-13.*          | medium, large         | 23GB
-13.*          | macos.x86.medium.gen2 | 89GB
-{: class="table table-striped"}
-
-If you specify Xcode 12.0.1, 12.4.0, or 12.5.1, you have a minimum 100GB of available storage.
-{: class="alert alert-info"}
 
 ## Image update cycle for the macOS executor
 {: #using-the-macos-executor }
@@ -226,7 +206,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -264,7 +244,7 @@ version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 13.4.1
+      xcode: 14.2.0
     environment:
       FL_OUTPUT_DIR: output
 

--- a/jekyll/_cci2/using-matrix-jobs.adoc
+++ b/jekyll/_cci2/using-matrix-jobs.adoc
@@ -41,7 +41,7 @@ executors:
       image: ubuntu-2004:202107-02
   macos: # macos executor running Xcode
     macos:
-      xcode: 12.5.1
+      xcode: 14.2.0
 
 jobs:
   test:

--- a/jekyll/_includes/snippets/macos-resource-table.md
+++ b/jekyll/_includes/snippets/macos-resource-table.md
@@ -7,6 +7,8 @@ macos.x86.metal.gen1 | 12 @ 3.2 GHz | 32GB
 macos.m1.large.gen1 | 8 | 12GB
 {: class="table table-striped"}
 
+The `medium` and `large` resource classes are being deprecated on October 2, 2023. See our [announcement](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891) for more details.
+{: class="alert alert-warning"}
 The `macos.x86.metal.gen1` resource requires a minimum 24-hour lease. See the [Dedicated Host for macOS]({{ site.baseurl }}/dedicated-hosts-macos) page to learn more about this resource class.
 <br />
 <br />

--- a/jekyll/_includes/snippets/macos-resource-table.md
+++ b/jekyll/_includes/snippets/macos-resource-table.md
@@ -7,7 +7,7 @@ macos.x86.metal.gen1 | 12 @ 3.2 GHz | 32GB
 macos.m1.large.gen1 | 8 | 12GB
 {: class="table table-striped"}
 
-The `medium` and `large` resource classes are being deprecated on October 2, 2023. See our [announcement](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891) for more details.
+ The `medium` and `large` resource classes are being deprecated on October 2, 2023. Xcode v14.2 is the latest version that will be supported by these macOS resources. See our [announcement](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891) for more details.
 {: class="alert alert-warning"}
 The `macos.x86.metal.gen1` resource requires a minimum 24-hour lease. See the [Dedicated Host for macOS]({{ site.baseurl }}/dedicated-hosts-macos) page to learn more about this resource class.
 <br />

--- a/jekyll/_includes/snippets/macos-resource-table.md
+++ b/jekyll/_includes/snippets/macos-resource-table.md
@@ -10,5 +10,5 @@ macos.m1.large.gen1 | 8 | 12GB
 The `macos.x86.metal.gen1` resource requires a minimum 24-hour lease. See the [Dedicated Host for macOS]({{ site.baseurl }}/dedicated-hosts-macos) page to learn more about this resource class.
 <br />
 <br />
-The `large` resource class is only available for customers with an annual contract. [Open a support ticket](https://support.circleci.com/hc/en-us/requests/new) if you would like to learn more about our annual plans.
+The `large` and `macos.m1.large.gen1` resource classes are only available for customers with an annual contract. [Open a support ticket](https://support.circleci.com/hc/en-us/requests/new) if you would like to learn more about our annual plans.
 {: class="alert alert-info"}

--- a/jekyll/_includes/snippets/macos-resource-table.md
+++ b/jekyll/_includes/snippets/macos-resource-table.md
@@ -4,6 +4,7 @@ medium | 4 @ 2.7 GHz | 8GB
 macos.x86.medium.gen2 | 4 @ 3.2 GHz | 8GB
 large | 8 @ 2.7 GHz | 16GB
 macos.x86.metal.gen1 | 12 @ 3.2 GHz | 32GB
+macos.m1.large.gen1 | 8 | 12GB
 {: class="table table-striped"}
 
 The `macos.x86.metal.gen1` resource requires a minimum 24-hour lease. See the [Dedicated Host for macOS]({{ site.baseurl }}/dedicated-hosts-macos) page to learn more about this resource class.

--- a/jekyll/_includes/snippets/xcode-intel-vm.md
+++ b/jekyll/_includes/snippets/xcode-intel-vm.md
@@ -11,3 +11,6 @@
  `12.5.1` | Xcode 12.5.1 (12E507) | 11.4.0 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v5775/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-5-1-released/40490)
  `11.7.0` | Xcode 11.7 (11E801a) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3587/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-11-7-released/37312)
  {: class="table table-striped"}
+
+ The `medium` and `large` resource classes are being deprecated on October 2, 2023. Xcode v14.2 is the latest version that will be supported by these macOS resources. See our [announcement](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891) for more details.
+ {: class="alert alert-warning"}

--- a/jekyll/_includes/snippets/xcode-silicon-vm.md
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.md
@@ -1,7 +1,7 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
- `14.2.0` | Xcode 14.2 (14C18) | 12.6.3 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11441/manifest.txt) | TBD
- `14.1.0` | Xcode 14.1 (14B47b) | 12.5.1 | Coming soon | Coming soon
- `14.0.1` | Xcode 14.0.1 (14A400) | 12.5.1 | Coming soon | Coming soon
- `13.4.1` | Xcode 13.4 (13F17a) | 12.3.1 | Coming soon | Coming soon
+ `14.2.0` | Xcode 14.2 (14C18) | 12.6.3 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11441/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/announcing-apple-silicon-m1-support-now-available/46908)
+ `14.1.0` | Xcode 14.1 (14B47b) | Coming soon | Coming soon | Coming soon
+ `14.0.1` | Xcode 14.0.1 (14A400) | Coming soon | Coming soon | Coming soon
+ `13.4.1` | Xcode 13.4 (13F17a) | Coming soon | Coming soon | Coming soon
  {: class="table table-striped"}

--- a/jekyll/_includes/snippets/xcode-silicon-vm.md
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.md
@@ -1,0 +1,7 @@
+ Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
+----------|---------------------------------|---------------|----------------------------|--------------
+ `14.2.0` | Xcode 14.2 (14C18) | 12.6.3 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11441/manifest.txt) | TBD
+ `14.1.0` | Xcode 14.1 (14B47b) | 12.5.1 | Coming soon | Coming soon
+ `14.0.1` | Xcode 14.0.1 (14A400) | 12.5.1 | Coming soon | Coming soon
+ `13.4.1` | Xcode 13.4 (13F17a) | 12.3.1 | Coming soon | Coming soon
+ {: class="table table-striped"}

--- a/jekyll/_includes/snippets/xcode-silicon-vm.md
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.md
@@ -1,7 +1,4 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
  `14.2.0` | Xcode 14.2 (14C18) | 12.6.3 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11441/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/announcing-apple-silicon-m1-support-now-available/46908)
- `14.1.0` | Xcode 14.1 (14B47b) | Coming soon | Coming soon | Coming soon
- `14.0.1` | Xcode 14.0.1 (14A400) | Coming soon | Coming soon | Coming soon
- `13.4.1` | Xcode 13.4 (13F17a) | Coming soon | Coming soon | Coming soon
  {: class="table table-striped"}


### PR DESCRIPTION
# Description
We are launching M1 support this month, as well as announcing the deprecation of the gen1 macOS resource classes (`medium` & `large`). In preparation for these changes, we want to be sure the new M1 specs are added to the docs and all examples reference relevant Xcode images and resource classes.

# Reasons
* Updated macOS available resources: provide clarity around the specs and availability for the new M1 resource class
* Updated examples: we want to be sure any macOS examples reference the latest Xcode versions and resource classes
* Remove VM storage section: the differences in available storage across macOS are going to be minimal with the addition of M1 and deprecation of gen1

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.
