### PR TITLE
Remove reference section

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -588,17 +588,6 @@ en:
         - name: Publish to NPM registry
           link: deploy-to-npm-registry
 
-- name: Reference
-  icon: icons/sidebar/folder-open.svg
-  children:
-    - children:
-      - name: Project values and variables
-        link: variables
-      - name: Prebuilt images
-        link: circleci-images
-      - name: Help and support
-        link: help-and-support
-
 - name: Server administration v4.x
   icon: icons/sidebar/admin-new.svg
   children:


### PR DESCRIPTION
# Description
Remove reference section from sidenav

# Reasons
The reference section is being removed as part of the side nav re-org and the rest of the pages are duplicate pages. Help and support is being redirected in the docs platform PR.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
