### PR TITLE
Remove Ruby Native snippets [DOCSS-983]

### DIFF
--- a/scripts/build_api_docs.sh
+++ b/scripts/build_api_docs.sh
@@ -23,7 +23,7 @@ build_api_v2() {
     echo "Fetching OpenAPI spec."
     curl https://circleci.com/api/v2/openapi.json > openapi.json
     echo "Adding code samples to openapi.json spec."
-    ./node_modules/.bin/snippet-enricher-cli --targets="node_request,python_python3,go_native,shell_curl,ruby_native" --input=openapi.json  > openapi-with-examples.json
+    ./node_modules/.bin/snippet-enricher-cli --targets="node_request,python_python3,go_native,shell_curl" --input=openapi.json  > openapi-with-examples.json
     echo "Merging in JSON patches to correct and augment the OpenAPI spec."
     jq -s '.[0] * .[1]' openapi-with-examples.json openapi-patch.json > openapi-final.json
     echo "Bundling with redoc cli."


### PR DESCRIPTION
# Description
Temporarily removes Ruby Native code examples from https://circleci.com/docs/api/v2/index.html

# Reasons
The Ruby Native examples provided use a "disable SSL" option, which would make the API implementation susceptible to MITM attacks. We are working on figuring out how to be able to customize the code examples provided in our API reference docs, which are currently generated using a third party library. While working on a solution, the fastest way to prevent users from copying these examples is to temporarily pull them from our docs.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
