### PR TITLE
docs: aws-cli/setup aws-region value to be env_var_name type value.

### DIFF
--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -139,7 +139,7 @@ jobs:
      # run the aws-cli/setup command from the orb
      - aws-cli/setup:
          role-arn: 'arn:aws:iam::123456789012:role/OIDC-ROLE'
-         aws-region: "us-west-1"
+         aws-region: YOUR_AWS_REGION
          # optional parameters
          profile-name: "OIDC-PROFILE"
          role-session-name: “example-session”


### PR DESCRIPTION
# Description
According to [docs](https://circleci.com/developer/ja/orbs/orb/circleci/aws-cli\#commands-setup), aws-cli/setup command's aws-region parameter accept `env_var_name` type.
I passed `"ap-northeast-1"` (string type) as aws-region's value , then I got an error like below.
`Type error for argument aws-region: expected type: env_var_name, actual value: "ap-northeast-1" (type string)`

Therefore I changed  a string value (`"us-west-1"` ) in docs to an env_var_name type value.


# Reasons

same as Description.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
