### PR TITLE
Fix indentation and typographic quotation in OIDC yaml example

### DIFF
--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -128,33 +128,33 @@ Below is an example of a complete configuration with a job that configures a pro
 ```yaml
 version: '2.1'
 orbs:
- # import CircleCI's aws-cli orb
- aws-cli: circleci/aws-cli@3.1
+  # import CircleCI's aws-cli orb
+  aws-cli: circleci/aws-cli@3.1
 jobs:
- aws-example:
-   docker:
-     - image: cimg/aws:2022.06
-   steps:
-     - checkout
-     # run the aws-cli/setup command from the orb
-     - aws-cli/setup:
-         role-arn: 'arn:aws:iam::123456789012:role/OIDC-ROLE'
-         aws-region: "us-west-1"
-         # optional parameters
-         profile-name: "OIDC-PROFILE"
-         role-session-name: “example-session”
-         session-duration: 1800
-     - run:
-       name: Log-into-AWS-ECR
-       command: |
-         # must use same profile specified in the step above       
-         aws ecr get-login-password --profile "OIDC-PROFILE"
+  aws-example:
+    docker:
+      - image: cimg/aws:2022.06
+    steps:
+      - checkout
+      # run the aws-cli/setup command from the orb
+      - aws-cli/setup:
+          role-arn: 'arn:aws:iam::123456789012:role/OIDC-ROLE'
+          aws-region: "us-west-1"
+          # optional parameters
+          profile-name: "OIDC-PROFILE"
+          role-session-name: "example-session"
+          session-duration: 1800
+      - run:
+        name: Log-into-AWS-ECR
+        command: |
+          # must use same profile specified in the step above
+          aws ecr get-login-password --profile "OIDC-PROFILE"
 workflows:
- OIDC-with-AWS:
-   jobs:
-     - aws-example:
-         # must use a valid CircleCI context
-         context: aws
+  OIDC-with-AWS:
+    jobs:
+      - aws-example:
+          # must use a valid CircleCI context
+          context: aws
 ```
 
 [#advanced-usage]


### PR DESCRIPTION
# Description
Fix indentation and typographic quotation in OIDC yaml example

# Reasons
* Indentation fix : yaml is valid, but cumbersome to use as a copy-paste source in your own config
* Typographic quotation : I don't even want to know what a Yaml parser woud do with those. Probably consider them as part of the string ? Either way, better replace them.

# Content Checklist
N/A