### PR TITLE
Remove container runner Alpine images on MicroK8s limitation [RT-744]

### DIFF
--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -485,7 +485,6 @@ You can then follow the same instructions as <<#using-the-buildah-image,Using th
 * There is no support for container environments other than Kubernetes at this time.
 * Container runner does not yet work on link:https://circleci.com/pricing/server/[CircleCI's server offering]
 * <<building-docker-images#,`setup_remote_docker`>> as a command is not supported with container runner.  See <<#building-container-images,Building Container Images>>.
-* There is a known limitation when using an link:https://hub.docker.com/_/alpine[alpine-based image] with link:https://microk8s.io/[microk8s] where error code 139 is returned. The recommendation at this time is to build your own image using CircleCI's link:https://circleci.com/developer/images/image/cimg/base[base image], and to manually install any additional customizations needed that were present in the alpine-based image. See this link:https://discuss.circleci.com/t/container-agent-fails-to-start-task-agent-exit-code-139-segmentation-fault/45232[Discuss post] for more information.
 
 [#faqs]
 == FAQs


### PR DESCRIPTION
# Description
This was fixed in release `3.0.4` of container runner: https://circleci.com/changelog/self-hosted-runner/#container-runner-version-3-0-4

# Reasons
Jira: https://circleci.atlassian.net/browse/RT-744

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
