### PR TITLE
docs: fix wording around TLS options for Server 4.x

### DIFF
--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -431,7 +431,7 @@ endif::env-aws[]
 
 [#tls]
 === j. TLS
-For TLS, you have 4 options:
+For TLS, you have the following options:
 
 [.tab.tls.Do_nothing]
 --


### PR DESCRIPTION
# Description

There has been an update to the TLS options.
https://github.com/circleci/circleci-docs/pull/7638

Since this is no longer 4 options, I think keeping the copy future-proof may be best this way.

# Reasons

I encountered this while noting a discrepancy in this TLS section between our official 🇺🇸 vs 🇯🇵 version.
The discrepancy on 🇯🇵 version is that the PR above has yet to be reflected on our 🇯🇵 version.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
