### PR TITLE
updating container runner docs to specify what the default resource r…

### DIFF
--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -340,6 +340,17 @@ Container runner schedules a logging container if there are service containers i
 
 Logging containers require a service account token with the minimal privileges to get container logs.
 
+Container runner currently sets default resource limits and requests on the logging container, they are:
+
+```yaml
+requests:
+  cpu: 50m
+  memory: 64Mi
+limits:
+  cpu: 100m
+  memory: 128Mi
+```
+
 [#constraint-validation]
 == Constraint Validation
 


### PR DESCRIPTION
# Description
Container agent now set resource limits for the logging container, updating docs to specify the specs

# Reasons
Jira: https://circleci.atlassian.net/browse/RT-744

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
