### PR TITLE
Update runner-installation-linux.adoc

### DIFF
--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -102,7 +102,7 @@ sudo mkdir -p /etc/opt/circleci && sudo touch /etc/opt/circleci/launch-agent-con
 ```
 
 ```shell
-sudo chown -R circleci /etc/opt/circleci
+sudo chown -R circleci: /etc/opt/circleci
 ```
 
 ```shell

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -102,7 +102,7 @@ sudo mkdir -p /etc/opt/circleci && sudo touch /etc/opt/circleci/launch-agent-con
 ```
 
 ```shell
-sudo chown circleci: /etc/opt/circleci/launch-agent-config.yaml
+sudo chown -R circleci /etc/opt/circleci
 ```
 
 ```shell


### PR DESCRIPTION
# Description
Tweak folder ownership, as the service running as the circleci user doesn't have access to necessary folders/files when running in a hardened Linux environment.

# Reasons
When I was trying to run a machine runner on a hardened AWS image, the service would fail to start due to permissions errors. I tracked the issue down to the config file not being accessible, due to the file being within a directory that the `circleci` user has no access to.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
