### PR TITLE
server-2181/update-buildagent-attribute

### DIFF
--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -718,7 +718,7 @@ a|GCP Authentication Config.
 |`nomad.server.gossip.encryption.key`
 |string
 |`""`
-|By default, Dockerhub is assumed to be the image registry unless otherwise specified eg: `registry.example.com/organization/repository`
+|By default, Dockerhub is assumed to be the image registry unless otherwise specified, for example, `registry.example.com/organization/repository`
 
 |`nomad.server.replicas`
 |int

--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -718,7 +718,7 @@ a|GCP Authentication Config.
 |`nomad.server.gossip.encryption.key`
 |string
 |`""`
-|
+|By default, Dockerhub is assumed to be the image registry unless otherwise specified eg: `registry.example.com/organization/repository`
 
 |`nomad.server.replicas`
 |int


### PR DESCRIPTION
# Description
the nomad.buildAgentImage attribute in our values.yaml assumes the image will be pulled from dockerhub which will not work in environments where dockerhub cannot be reached. This PR adds a note that the full image reference including registry is needed when not pulling from dockerhub

# Reasons
https://circleci.atlassian.net/browse/SERVER-2181

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
