### PR TITLE
Remove config reference from JA Reference section

### DIFF
--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -1235,7 +1235,7 @@ ja:
       children:
         - name: Configuration reference
           link: ja/configuration-reference
-          i18n_name: 設定リファレンス
+          i18n_name: 設定ファイルリファレンス
         - name: Reusing configuration
           link: ja/reusing-config
           i18n_name: 設定ファイル再利用(Orb)
@@ -1605,9 +1605,6 @@ ja:
   i18n_name: リファレンス
   children:
     - children:
-      - name: Configuration Reference
-        link: ja/configuration-reference
-        i18n_name: 設定ファイルリファレンス
       - name: API v2 Reference
         link: https://circleci.com/docs/api/v2
         i18n_name: API v2リファレンス
@@ -1626,9 +1623,6 @@ ja:
       - name: Project values and variables
         link: ja/variables
         i18n_name: プロジェクトの値と変数
-      - name: Prebuilt images
-        link: ja/circleci-images
-        i18n_name: CircleCI公式イメージ
       - name: Help and support
         link: ja/help-and-support
         i18n_name: ヘルプとサポート


### PR DESCRIPTION
# Description
As part of the sidebar reorg, on the EN site, the [Config Reference](https://circleci.com/docs/configuration-reference/) currently lives under the Developer Toolkit section, whereas on the JA site it can be found under both the Configuration (設定ファイル) as well as Reference (リファレンス) sections. The Reference section has been removed/reorganized in the EN site. The JA site does not yet have the new Developer Toolkit section.

As we are progressing through the sidebar reorg and trying to sync the JA site, we'll keep the JA Config Reference under the "Configuration" section for now.

# Reasons
Currently our sidebar does not consistently open to the correct section if a page happens to be added to multiple sections.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
