### PR TITLE
docs: xarg typo in jest fail fast example

### DIFF
--- a/jekyll/_cci2/fail-fast.adoc
+++ b/jekyll/_cci2/fail-fast.adoc
@@ -122,7 +122,7 @@ Run link:https://jestjs.io/[jest] (JavaScript/TypeScript) tests in three batches
 
 ```yaml
 npx jest --listTests | circleci tests run
-  --command="xarg yarn tests"
+  --command="xargs yarn tests"
   --batch-count=3
   --fail-fast
   --test-results-path="test-results"


### PR DESCRIPTION
# Description
The jest example using `--fail-fast` uses `xarg` instead of `xargs`. `xarg` is not a valid bash command afaik. 

# Reasons
Simple typo I ran across after copy pasting this code 😅 