### PR TITLE
match crowdin content to fix branch

### DIFF
--- a/jekyll/_cci2_ja/new-relic-integration.adoc
+++ b/jekyll/_cci2_ja/new-relic-integration.adoc
@@ -1,4 +1,5 @@
 ---
+
 contentTags:
   platform:
   - クラウド


### PR DESCRIPTION
# Description
there is a gap at the top of frontmatter in crowdin. I removed the space but the page is showing as a new page in the autogenerated PR from crowdin even though it already exists. I'm adding the space back in to see if that removes this page from the crowdin PR. If this works this will be a good way to fix the process, or at least simplify it.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
