### PR TITLE
link to setting an env var how to guide

### DIFF
--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -223,5 +223,6 @@ You can further restrict access to environment variables using [contexts]({{site
 ## See also
 {: #see-also }
 
-- [Security recommendations]({{site.baseurl}}/security-recommendations)
-- [Inject variables using the CircleCI API]({{site.baseurl}}/inject-environment-variables-with-api/)
+- [Security recommendations](/docs/security-recommendations)
+- [Set an environment variable](/docs/set-environment-variable/)
+- [Inject variables using the CircleCI API](/docs/inject-environment-variables-with-api/)

--- a/jekyll/_cci2/env-vars.md
+++ b/jekyll/_cci2/env-vars.md
@@ -21,7 +21,7 @@ suggested:
 ## Introduction
 {: #introduction }
 
-Use environment variables to set up various configuration options, and keep your set-up secure with secrets, private keys, and contexts. Environment variables in CircleCI are governed by an [order of precedence](#order-of-precedence), allowing control at each level in your configuration.
+Use environment variables to set up various configuration options, and keep your set-up secure with secrets, private keys, and contexts. Environment variables in CircleCI are governed by an [order of precedence](#order-of-precedence), allowing control at each level in your configuration. See the [Set an environment variable](/docs/set-environment-variable/) page for guidance on the different ways to set an environment variable.
 
 If you have existing environment variables (or contexts) and you would like to rename your organization or repository, please follow the [Rename organizations and repositories]({{site.baseurl}}/rename-organizations-and-repositories) guide to make sure you do not lose access to environment variables or contexts in the process.
 


### PR DESCRIPTION
# Description
Add link to how-to

# Reasons
The env var docs are one of our highest ranking pages. After the recent split of the page we need to ensure people can find the how-to section that was previously part of the main page. It is linked to from the "order of precedence" section but should also be in the "see also" list and the intro.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
