### PR TITLE
Crowdin Minimal Config

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -16,8 +16,6 @@ files:
     translation: /jekyll/_cci2_%two_letters_code%/server/overview/%original_file_name%
   - source: /jekyll/_data/sidenav.yml
     translation: /jekyll/_data/%two_letters_code%/sidenav.yml
-  - source: /jekyll/_data/sidenavstyle.yml
-    translation: /jekyll/_data/%two_letters_code%/sidenavstyle.yml
   - source: /jekyll/_includes/edit-on-github.html
     translation: /jekyll/_includes/%two_letters_code%/edit-on-github.html
   - source: /jekyll/_includes/license-notice.html

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,25 +1,34 @@
 files:
-  - source: /jekyll/_cci2/*.md
-    translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
-  - source: /jekyll/_cci2/*.adoc
-    translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
-  - source: /jekyll/_cci2/server/*.adoc
-    translation: /jekyll/_cci2_%two_letters_code%/server/%original_file_name%
-  - source: /jekyll/_cci2/server/installation/*.adoc
-    translation: /jekyll/_cci2_%two_letters_code%/server/installation/%original_file_name%
-  - source: /jekyll/_cci2/server/operator/*.adoc
-    translation: /jekyll/_cci2_%two_letters_code%/server/operator/%original_file_name%
-  - source: /jekyll/_cci2/server/overview/*.adoc
-    translation: /jekyll/_cci2_%two_letters_code%/server/overview/%original_file_name%
   - source: /jekyll/_data/sidenav.yml
     translation: /jekyll/_data/%two_letters_code%/sidenav.yml
+
   - source: /jekyll/_includes/edit-on-github.html
     translation: /jekyll/_includes/%two_letters_code%/edit-on-github.html
+
   - source: /jekyll/_includes/license-notice.html
     translation: /jekyll/_includes/%two_letters_code%/license-notice.html
+
   - source: /jekyll/_includes/snippets/*.md
     translation: /jekyll/_includes/snippets/%two_letters_code%/%original_file_name%
   - source: /jekyll/_includes/snippets/*.adoc
     translation: /jekyll/_includes/snippets/%two_letters_code%/%original_file_name%
+
+  - source: /jekyll/_cci2/*.md
+    translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
+  - source: /jekyll/_cci2/*.adoc
+    translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
+
+  - source: /jekyll/_cci2/server/*.adoc
+    translation: /jekyll/_cci2_%two_letters_code%/server/%original_file_name%
+
+  - source: /jekyll/_cci2/server/installation/*.adoc
+    translation: /jekyll/_cci2_%two_letters_code%/server/installation/%original_file_name%
+
+  - source: /jekyll/_cci2/server/operator/*.adoc
+    translation: /jekyll/_cci2_%two_letters_code%/server/operator/%original_file_name%
+
+  - source: /jekyll/_cci2/server/overview/*.adoc
+    translation: /jekyll/_cci2_%two_letters_code%/server/overview/%original_file_name%
+
   - source: /jekyll/_cci2/images/linux-vm/*.md
     translation: /jekyll/_cci2_%two_letters_code%/images/linux-vm/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,6 @@
 files:
-  - source: /jekyll/_data/sidenav.yml
-    translation: /jekyll/_data/%two_letters_code%/sidenav.yml
+  # - source: /jekyll/_data/sidenav.yml
+  #   translation: /jekyll/_data/%two_letters_code%/sidenav.yml
 
   - source: /jekyll/_includes/edit-on-github.html
     translation: /jekyll/_includes/%two_letters_code%/edit-on-github.html
@@ -8,27 +8,27 @@ files:
   - source: /jekyll/_includes/license-notice.html
     translation: /jekyll/_includes/%two_letters_code%/license-notice.html
 
-  - source: /jekyll/_includes/snippets/*.md
-    translation: /jekyll/_includes/snippets/%two_letters_code%/%original_file_name%
-  - source: /jekyll/_includes/snippets/*.adoc
-    translation: /jekyll/_includes/snippets/%two_letters_code%/%original_file_name%
+  # - source: /jekyll/_includes/snippets/*.md
+  #   translation: /jekyll/_includes/snippets/%two_letters_code%/%original_file_name%
+  # - source: /jekyll/_includes/snippets/*.adoc
+  #   translation: /jekyll/_includes/snippets/%two_letters_code%/%original_file_name%
 
-  - source: /jekyll/_cci2/*.md
-    translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
-  - source: /jekyll/_cci2/*.adoc
-    translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
+  # - source: /jekyll/_cci2/*.md
+  #   translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
+  # - source: /jekyll/_cci2/*.adoc
+  #   translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
 
-  - source: /jekyll/_cci2/server/*.adoc
-    translation: /jekyll/_cci2_%two_letters_code%/server/%original_file_name%
+  # - source: /jekyll/_cci2/server/*.adoc
+  #   translation: /jekyll/_cci2_%two_letters_code%/server/%original_file_name%
 
   - source: /jekyll/_cci2/server/installation/*.adoc
     translation: /jekyll/_cci2_%two_letters_code%/server/installation/%original_file_name%
 
-  - source: /jekyll/_cci2/server/operator/*.adoc
-    translation: /jekyll/_cci2_%two_letters_code%/server/operator/%original_file_name%
+  # - source: /jekyll/_cci2/server/operator/*.adoc
+  #   translation: /jekyll/_cci2_%two_letters_code%/server/operator/%original_file_name%
 
-  - source: /jekyll/_cci2/server/overview/*.adoc
-    translation: /jekyll/_cci2_%two_letters_code%/server/overview/%original_file_name%
+  # - source: /jekyll/_cci2/server/overview/*.adoc
+  #   translation: /jekyll/_cci2_%two_letters_code%/server/overview/%original_file_name%
 
-  - source: /jekyll/_cci2/images/linux-vm/*.md
-    translation: /jekyll/_cci2_%two_letters_code%/images/linux-vm/%original_file_name%
+  # - source: /jekyll/_cci2/images/linux-vm/*.md
+  #   translation: /jekyll/_cci2_%two_letters_code%/images/linux-vm/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,3 @@
-commit_message: "New Japanese Translations"
-append_commit_message: false
-
 files:
   - source: /jekyll/_cci2/*.md
     translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,9 +4,11 @@ files:
 
   - source: /jekyll/_includes/edit-on-github.html
     translation: /jekyll/_includes/%two_letters_code%/edit-on-github.html
+    update_option: update_as_unapproved
 
   - source: /jekyll/_includes/license-notice.html
     translation: /jekyll/_includes/%two_letters_code%/license-notice.html
+    update_option: update_as_unapproved
 
   # - source: /jekyll/_includes/snippets/*.md
   #   translation: /jekyll/_includes/snippets/%two_letters_code%/%original_file_name%
@@ -23,6 +25,7 @@ files:
 
   - source: /jekyll/_cci2/server/installation/*.adoc
     translation: /jekyll/_cci2_%two_letters_code%/server/installation/%original_file_name%
+    update_option: update_as_unapproved
 
   # - source: /jekyll/_cci2/server/operator/*.adoc
   #   translation: /jekyll/_cci2_%two_letters_code%/server/operator/%original_file_name%

--- a/jekyll/_layouts/classic-docs.html
+++ b/jekyll/_layouts/classic-docs.html
@@ -11,12 +11,7 @@ layout: compress
 
 <div class="outer">
   {% assign lang = page.lang %}
-  {% if page.collection == "style" %}
-    {% assign sidenav = site.data.sidenavstyle[lang] %}
-  {% else %}
-    {% assign sidenav = site.data.sidenav[lang] %}
-  {% endif %}
-
+  {% assign sidenav = site.data.sidenav[lang] %}
   {% include_cached global-nav.html site=site page=page sidenav=sidenav current_url=current_url %}
 
   <div id="progress-bar-container">


### PR DESCRIPTION
# Summary

As discussed with the team today, this pares back the Crowdin config file to a minimal state so that we can get the workflow spun up and slowly built it back up from a minimal state.

The next steps would be:
1. merge this into `ja-localization`
2. let Crowdin pick up the config updates
3. delete Crowdin's branch and let it re-create it using the new config
4. check the resulting proposed diff, and hope it's better than what we started with
5. un-comment additional files in the config one-by-one until everything is synced up

# Changes

### Remove references to sidenavstyle.yml, no longer present in project (aafd72c)

### Remove custom commit message from Crowdin config (063b6d0)

The default commit message [1] seems more useful than the custom one that was previously set. This removes the custom config to allow the default one to be used.

[1] "New translations {fileName} ({languageName})"

### Reorganize files in Crowdin config (e40aef8)

This reorders the `files` config to group like files, place similar ones next to each other, and organize from most specific to least specific.

### Temporarily disable most types of files in Crowdin config (cbab7f6)

In an effort to get our Crowdin workflow flowing again, we decided to start over from a minimal config and slowly build it back up.

This change disables all but a few simple files in the config. This should let us get the workflow functioning again with a small subset of the backlog of translation changes, and we can slowly and selectively re-enable files/groups-of-files from here.

### Add update_as_unapproved option to Crowdin config (dc7deb7fc315148a4a74472a60af94fe35d64fe3)

This configuration option should allow stale translations to persist until they're updated, rather than reverting to the fallback language. This is the config we use on the circleci.com project.

One of the issues we're seeing is that of good Japanese translations being reverted to English in the Crowdin PR, as Crowdin invalidates those strings even for a trivial (i.e. typo fix) change.

Crowdin Docs: https://developer.crowdin.com/configuration-file/#changed-strings-update