### PR TITLE
use xref

### DIFF
--- a/jekyll/_cci2/variables.adoc
+++ b/jekyll/_cci2/variables.adoc
@@ -21,7 +21,7 @@ This page is a reference for all built-in values available for use in your Circl
 
 The following built-in environment variables are available for all CircleCI projects. Environment variables are scoped at the job level. They can be used within the context of a job but do not exist at a pipeline level, therefore they cannot be used for any logic at the pipeline or workflow level.
 
-NOTE: You cannot use a built-in environment variable to define another environment variable. Instead, you must use a `run` step to export the new environment variables using `BASH_ENV`. For more details, see link:set-environment-variable#set-an-environment-variable-in-a-shell-command[Setting an Environment Variable in a Shell Command].
+NOTE: You cannot use a built-in environment variable to define another environment variable. Instead, you must use a `run` step to export the new environment variables using `BASH_ENV`. For more details, see xref:set-environment-variable#set-an-environment-variable-in-a-shell-command[Setting an Environment Variable in a Shell Command].
 
 include::../_includes/snippets/built-in-env-vars.adoc[]
 
@@ -52,4 +52,4 @@ jobs:
       - run: echo $CIRCLE_COMPARE_URL
 ```
 
-When using the above method to set the variables in the `environment` key, note that if the pipeline variable is empty it will be set to `<nil>`. If you need an empty string instead, link:set-environment-variable#set-an-environment-variable-in-a-shell-command[set the variable in a shell command].
+When using the above method to set the variables in the `environment` key, note that if the pipeline variable is empty it will be set to `<nil>`. If you need an empty string instead, xref:set-environment-variable#set-an-environment-variable-in-a-shell-command[set the variable in a shell command].


### PR DESCRIPTION
# Description
Fixes #7820 

# Reasons
I'm not 100% sure why using `link:` wasn't working correctly but using xref works well in test and this is the best-practice. I'll explore the link issue outside this PR.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
