### PR TITLE
server-2302/update-pg-vol-expansion-docs

### DIFF
--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -846,12 +846,12 @@ a|AWS Authentication Config.
 |`true`
 |
 
-|`postgresql.persistence.existingClaim`
+|`postgresql.primary.persistence.existingClaim`
 |string
 |`""`
 |
 
-|`postgresql.persistence.size`
+|`postgresql.primary.persistence.size`
 |string
 |`"8Gi"`
 |

--- a/jekyll/_cci2/server/operator/expanding-internal-database-volumes.adoc
+++ b/jekyll/_cci2/server/operator/expanding-internal-database-volumes.adoc
@@ -192,8 +192,9 @@ Now you need to upgrade the server installation by modifying the PVC size in the
 [source,yaml]
 ----
 postgresql:
-  persistence:
-    size: 10Gi
+  primary:
+    persistence:
+      size: 10Gi
 ----
 
 * **MongoDB**


### PR DESCRIPTION
# Description
A brief description of the changes.
Our postgres volume expansion docs are outdated. They should have been updated when we updated the PG chart
https://circleci.atlassian.net/browse/SERVER-2302

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
