### PR TITLE
Move built-in env vars table out of GitLab SaaS doc

### DIFF
--- a/jekyll/_cci2/gitlab-integration.adoc
+++ b/jekyll/_cci2/gitlab-integration.adoc
@@ -623,60 +623,7 @@ The ability to connect to multiple account integrations on CircleCI allows you t
 [#deprecated-system-environment-variables]
 == Deprecated system environment variables
 
-GitLab-based projects do not have the following system environment variables available. If your pipelines need these environment variables, we recommend you use suitable replacements from the available <<pipeline-variables#,pipeline values>>.
-
-[.table.table-striped]
-[cols=2*, options="header"]
-|===
-| Name
-| Description
-
-| `CI_PULL_REQUESTS`
-| Comma-separated list of URLs of the current build’s associated pull requests.
-
-| `CI_PULL_REQUEST`
-| The URL of the associated pull request. If there are multiple associated pull requests, one URL is randomly chosen.
-
-| `CIRCLE_PR_NUMBER`
-| The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
-
-| `CIRCLE_PR_USERNAME`
-| The GitHub or Bitbucket username of the user who created the pull request. Only available on forked PRs.
-
-| `CIRCLE_PR_REPONAME`
-| The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
-
-| `CIRCLE_PROJECT_USERNAME`
-| The GitHub or Bitbucket username of the current project.
-
-| `CIRCLE_PROJECT_REPONAME`
-| The name of the repository of the current project.
-
-| `CIRCLE_REPOSITORY_URL`
-| The URL of your GitHub or Bitbucket repository.
-
-| `CIRLCE_SHA1`
-| The SHA1 hash of the last commit of the current build.
-
-| `CIRCLE_TAG`
-| The name of the git tag, if the current build is tagged. For more information, see the xref:workflows#executing-workflows-for-a-git-tag[Git tag job execution] section of the Using workflows to orchestrate jobs page.
-
-|===
-
-If you must use these as environment variables in your pipelines, you can do so by using the xref:env-vars#environment-variable-usage-options[`environment` key] in your configuration and providing your own mappings:
-
-```yaml
-build:
-  docker:
-    - image: cimg/node:17.0
-      auth:
-        username: mydockerhub-user
-        password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-  environment:
-    CIRCLE_PROJECT_REPONAME: << pipeline.trigger_parameters.gitlab.repo_name >>
-  steps:
-    - run: echo $CIRCLE_PROJECT_REPONAME
-```
+There are a number of xref:variables#built-in-environment-variables[built-in environment variables] that are not available in GitLab-based projects. If your pipelines need these environment variables, we recommend you use suitable replacements from the available xref:pipeline-variables#[pipeline values].
 
 [#coming-soon]
 == Coming soon

--- a/jekyll/_cci2/variables.adoc
+++ b/jekyll/_cci2/variables.adoc
@@ -19,7 +19,9 @@ This page is a reference for all built-in values available for use in your Circl
 [#built-in-environment-variables]
 == Built-in environment variables
 
-The following built-in environment variables are available for all CircleCI projects. Environment variables are scoped at the job level. They can be used within the context of a job but do not exist at a pipeline level, therefore they cannot be used for any logic at the pipeline or workflow level.
+The following built-in environment variables are available for CircleCI projects. A few environment variables are available for GitHub and Bitbucket projects that have been deprecated for GitLab SaaS support. If you must continue to use those as environment variables in your GitLab pipelines, refer to the workaround described after the list below.
+
+Environment variables are scoped at the job level. They can be used within the context of a job but do not exist at a pipeline level, therefore they cannot be used for any logic at the pipeline or workflow level.
 
 NOTE: You cannot use a built-in environment variable to define another environment variable. Instead, you must use a `run` step to export the new environment variables using `BASH_ENV`. For more details, see xref:set-environment-variable#set-an-environment-variable-in-a-shell-command[Setting an Environment Variable in a Shell Command].
 

--- a/jekyll/_includes/snippets/built-in-env-vars.adoc
+++ b/jekyll/_includes/snippets/built-in-env-vars.adoc
@@ -2,110 +2,137 @@
 [cols=3*, options="header", stripes=even]
 |===
 | Variable
+| VCS
 | Type
 | Value
 
 | `CI`
+| GitHub, Bitbucket, GitLab
 | Boolean
 | `true` (represents whether the current environment is a CI environment)
 
 | `CIRCLECI`
+| GitHub, Bitbucket, GitLab
 | Boolean
 | `true` (represents whether the current environment is a CircleCI environment)
 
 | `CIRCLE_BRANCH`
+| GitHub, Bitbucket, GitLab
 | String
 | The name of the Git branch currently being built.
 
 | `CIRCLE_BUILD_NUM`
+| GitHub, Bitbucket, GitLab
 | Integer
 | The number of the current job. Job numbers are unique for each job.
 
 | `CIRCLE_BUILD_URL`
+| GitHub, Bitbucket, GitLab
 | String
 | The URL for the current job on CircleCI.
 
 | `CIRCLE_JOB`
+| GitHub, Bitbucket, GitLab
 | String
 | The name of the current job.
 
 | `CIRCLE_NODE_INDEX`
+| GitHub, Bitbucket, GitLab
 | Integer
 | For jobs that run with parallelism enabled, this is the index of the current parallel run. The value ranges from 0 to (`CIRCLE_NODE_TOTAL` - 1)
 
 | `CIRCLE_NODE_TOTAL`
+| GitHub, Bitbucket, GitLab
 | Integer
 | For jobs that run with parallelism enabled, this is the number of parallel runs. This is equivalent to the value of `parallelism` in your config file.
 
 | `CIRCLE_OIDC_TOKEN`
+| GitHub, Bitbucket, GitLab
 | String
 | An OpenID Connect token signed by CircleCI which includes details about the current job. Available in jobs that use a context.
 
 | `CIRCLE_PR_NUMBER`
+| GitHub, Bitbucket
 | Integer
 | The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
 
 | `CIRCLE_PR_REPONAME`
+| GitHub, Bitbucket
 | String
 | The name of the GitHub or Bitbucket repository where the pull request was created. Only available on forked PRs.
 
 | `CIRCLE_PR_USERNAME`
+| GitHub, Bitbucket
 | String
 | The GitHub or Bitbucket username of the user who created the pull request. Only available on forked PRs.
 
 | `CIRCLE_PREVIOUS_BUILD_NUM`
+| GitHub, Bitbucket, GitLab
 | Integer
 | The largest job number in a given branch that is less than the current job number. **Note**: The variable is not always set, and is not deterministic. It is also not set on runner executors. This variable is likely to be deprecated, and CircleCI recommends users to avoid using it.
 
 | `CIRCLE_PROJECT_REPONAME`
+| GitHub, Bitbucket
 | String
 | The name of the repository of the current project.
 
 | `CIRCLE_PROJECT_USERNAME`
+| GitHub, Bitbucket
 | String
 | The GitHub or Bitbucket username of the current project.
 
 | `CIRCLE_PULL_REQUEST`
+| GitHub, Bitbucket
 | String
 | The URL of the associated pull request. If there are multiple associated pull requests, one URL is randomly chosen.
 
 | `CIRCLE_PULL_REQUESTS`
+| GitHub, Bitbucket
 | List
 | Comma-separated list of URLs of the current build's associated pull requests.
 
 | `CIRCLE_REPOSITORY_URL`
+| GitHub, Bitbucket
 | String
 | The URL of your GitHub or Bitbucket repository.
 
 | `CIRCLE_SHA1`
+| GitHub, Bitbucket
 | String
 | The SHA1 hash of the last commit of the current build.
 
 | `CIRCLE_TAG`
+| GitHub, Bitbucket
 | String
 | The name of the git tag, if the current build is tagged. For more information, see the <<workflows#executing-workflows-for-a-git-tag,Git Tag Job Execution section>> of the Workflows page.
 
 | `CIRCLE_USERNAME`
+| GitHub, Bitbucket, GitLab
 | String
 | The GitHub or Bitbucket username of the user who triggered the pipeline (only if the user has a CircleCI account).
 
 | `CIRCLE_WORKFLOW_ID`
+| GitHub, Bitbucket, GitLab
 | String
 | A unique identifier for the workflow instance of the current job. This identifier is the same for every job in a given workflow instance.
 
 | `CIRCLE_WORKFLOW_JOB_ID`
+| GitHub, Bitbucket, GitLab
 | String
 | A unique identifier for the current job.
 
 | `CIRCLE_WORKFLOW_WORKSPACE_ID`
+| GitHub, Bitbucket, GitLab
 | String
 | An identifier for the <<glossary#workspace,workspace>> of the current job. This identifier is the same for every job in a given workflow.
 
 | `CIRCLE_WORKING_DIRECTORY`
+| GitHub, Bitbucket, GitLab
 | String
 | The value of the `working_directory` key of the current job.
 
 | `CIRCLE_INTERNAL_TASK_DATA`
+| GitHub, Bitbucket, GitLab
 | String
 | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.
 |===

--- a/jekyll/_includes/snippets/built-in-env-vars.adoc
+++ b/jekyll/_includes/snippets/built-in-env-vars.adoc
@@ -1,5 +1,5 @@
 [.table.table-striped]
-[cols=3*, options="header", stripes=even]
+[cols=4*, options="header", stripes=even]
 |===
 | Variable
 | VCS
@@ -136,3 +136,18 @@
 | String
 | **Internal**. A directory where internal data related to the job is stored. We do not document the contents of this directory; the data schema is subject to change.
 |===
+
+If you must use the environment variables that are deprecated for GitLab SaaS in your GitLab pipelines, you can do so by using the xref:env-vars#environment-variable-usage-options[`environment` key] in your configuration and providing your own mappings with suitable pipeline values:
+
+```yaml
+build:
+  docker:
+    - image: cimg/node:17.0
+      auth:
+        username: mydockerhub-user
+        password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+  environment:
+    CIRCLE_PROJECT_REPONAME: << pipeline.trigger_parameters.gitlab.repo_name >>
+  steps:
+    - run: echo $CIRCLE_PROJECT_REPONAME
+```


### PR DESCRIPTION
# Description
This PR consolidates built-in env vars information by removing the list of deprecated built-in env vars from GitLab and adding a VCS support column to the built-in env vars snippet.

# Reasons
As we have continued to build up GitLab SaaS support, we can begin to integrate content that we previously presented to GitLab users only, into the rest of our docs.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
