### PR TITLE
[SERVER-2337] point to GCP docs on how to reserver an IP address

### DIFF
--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -291,7 +291,7 @@ It is recommended to provision a static IP address to assign to the load balance
 ifndef::env-gcp[]
 [#gcp-reserve-a-static-external-ip-address]
 === GCP - Reserve a static external IP address
-link:https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#external-ip[Google Cloud docs] provides information on how reserve an IP.
+The link:https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#external-ip[Google Cloud docs] provide information on how reserve an IP address.
 
 Make note of the returned IPv4 address for use later in the values.yaml file.
 

--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -291,12 +291,7 @@ It is recommended to provision a static IP address to assign to the load balance
 ifndef::env-gcp[]
 [#gcp-reserve-a-static-external-ip-address]
 === GCP - Reserve a static external IP address
-To reserve a new static IP address in GCP, run the following gcloud command in your desired environment. More information is available on the link:https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address[Google Cloud docs].
-
-[source,shell]
-----
-gcloud compute addresses create circleci-server --global --ip-version IPV4
-----
+link:https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#external-ip[Google Cloud docs] provides information on how reserve an IP.
 
 Make note of the returned IPv4 address for use later in the values.yaml file.
 


### PR DESCRIPTION
The command we had provided was not guaranteed to work based on the customers specific environment.  It is is best to instead point to GCP's docs which will provided the full context and information a customer needs to make a good decision.