### PR TITLE
(DOCSS-1035) Remove v1 deprecation banner, leave styling

### DIFF
--- a/src-api/source/layouts/layout.erb
+++ b/src-api/source/layouts/layout.erb
@@ -832,9 +832,6 @@ end
     <div class="page-wrapper">
       <div class="dark-box"></div>
       <div class="content">
-        <aside class="v2-banner notice">
-          v1 APIs will be deprecated within the next year. We recommend switching to the <a target="_blank" href="https://circleci.com/docs/api/v2/">v2 APIs</a>.
-        </aside>
         <div class="header-links">
           <a class="content-link" target="_blank" href="https://circleci.com/docs/2.0">
             Documentation


### PR DESCRIPTION
# Description
- Removes the v1 API deprecation banner per discussion with Product
- Leaves the styling in place (v2-banner class) for the reintroduction of a new banner at some future point with revised language.

# Reasons
- [Ticket: DOCSS-1035](https://circleci.atlassian.net/browse/DOCSS-1035)
- [Slack Thread](https://circleci.slack.com/archives/C04ML0S9J66/p1678311676418189)

We originally published a 1-year deprecation warning about the v1 API in December of 2021, but weren't actually prepared in some ways to undertake that deprecation. We should remove that deprecation warning until we have a more concrete plan of action and timetable for it. In discussion with folks including Product, it could be nice to decouple removing the deprecation warnings on v1 from the work around how we message moving folks over to the v2 API (and work we want to do on that API to get it ready for everyone from v1) 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ X] Break up walls of text by adding paragraph breaks.
- [ X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ X] Keep the title between 20 and 70 characters.
- [ X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ X] Include relevant backlinks to other CircleCI docs/pages.
