### PR TITLE
[WEB-1410] Extend Crowdin Config (adds server overview, operator)

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -27,11 +27,11 @@ files:
     translation: /jekyll/_cci2_%two_letters_code%/server/installation/%original_file_name%
     update_option: update_as_unapproved
 
-  # - source: /jekyll/_cci2/server/operator/*.adoc
-  #   translation: /jekyll/_cci2_%two_letters_code%/server/operator/%original_file_name%
+  - source: /jekyll/_cci2/server/operator/*.adoc
+    translation: /jekyll/_cci2_%two_letters_code%/server/operator/%original_file_name%
 
-  # - source: /jekyll/_cci2/server/overview/*.adoc
-  #   translation: /jekyll/_cci2_%two_letters_code%/server/overview/%original_file_name%
+  - source: /jekyll/_cci2/server/overview/*.adoc
+    translation: /jekyll/_cci2_%two_letters_code%/server/overview/%original_file_name%
 
   # - source: /jekyll/_cci2/images/linux-vm/*.md
   #   translation: /jekyll/_cci2_%two_letters_code%/images/linux-vm/%original_file_name%


### PR DESCRIPTION
Expanding on the pared-down minimal Crowdin config from #7819, this adds back (by uncommenting) a couple more sets of docs pages:

- `/server/operator/*`
- `/server/overview/*`
