### PR TITLE
Fixing the layout of built-in-env-vars.adoc

### DIFF
--- a/jekyll/_includes/snippets/built-in-env-vars.adoc
+++ b/jekyll/_includes/snippets/built-in-env-vars.adoc
@@ -52,6 +52,7 @@
 | An OpenID Connect token signed by CircleCI which includes details about the current job. Available in jobs that use a context.
 
 | `CIRCLE_OIDC_TOKEN_V2`
+| GitHub, Bitbucket, GitLab
 | String
 | An OpenID Connect token signed by CircleCI which includes details about the current job. Available in jobs that use a context.
 


### PR DESCRIPTION
# Description
The value for `VCS` column is missing for this row, which breaks the layout for all rows below. Not sure if `GitHub, Bitbucket, GitLab` is the correct list of supported VCSs, so please adjust if it's incorrect.