### PR TITLE
[SNC-197] add documentation for `enable_hard`

### DIFF
--- a/jekyll/_cci2/config-policies-for-self-hosted-runner.adoc
+++ b/jekyll/_cci2/config-policies-for-self-hosted-runner.adoc
@@ -63,9 +63,7 @@ import data.circleci.config
 
 policy_name["runner_policies"]
 
-enable_rule["resource_class_check"]
-
-hard_fail["resource_class_check"]
+enable_hard["resource_class_check"]
 
 resource_class_check = config.resource_class_by_project({ "namespace/resource_class": {"project_UUIDs"}})
 ----
@@ -119,9 +117,7 @@ import data.circleci.config
 
 policy_name["runner_policies"]
 
-enable_rule["resource_class_check"]
-
-hard_fail["resource_class_check"]
+enable_hard["resource_class_check"]
 
 resource_class_check = config.resource_class_by_project({ 
   "my-namespace/runner-test1": {

--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -250,6 +250,21 @@ To enable a rule, add the rule as a key in the `enable_rule` object. For example
 enable_rule["use_official_docker_image"]
 ----
 
+Additionally, `enable_hard` is a shorthand to enable a rule and set its enforcement level to `hard` in single statement.
+
+Therefore, following statements are equivalent
+[source,rego]
+----
+enable_hard["use_official_docker_image"]
+----
+
+[source,rego]
+----
+enable_rule["use_official_docker_image"]
+
+hard_fail["use_official_docker_image"]
+----
+
 [#using-pipeline-metadata]
 === Using pipeline metadata
 
@@ -353,9 +368,7 @@ docker_images := {image | walk(input, [path, value])  # walk the entire config t
                           path[_] == "docker"         # find any settings that match 'docker'
                           image := value[_].image}    # grab the images from that section
 
-hard_fail["use_official_docker_image"]
-
-enable_rule["use_official_docker_image"]
+enable_hard["use_official_docker_image"]
 ----
 
 [#next-steps]

--- a/jekyll/_cci2/config-policy-reference.adoc
+++ b/jekyll/_cci2/config-policy-reference.adoc
@@ -91,9 +91,7 @@ policy_name["example"]
 
 ban_orbs = config.ban_orbs(["evilcorp/evil"])
 
-enable_rule["ban_orbs"]
-
-hard_fail["ban_orbs"]
+enable_hard["ban_orbs"]
 ----
 
 [#ban-orbs-version]
@@ -123,9 +121,7 @@ policy_name["example"]
 
 ban_orbs_versioned = config.ban_orbs_version(["evilcorp/evil@1.2.3", "foo/bar@4.5.6"])
 
-enable_rule["ban_orbs_versioned"]
-
-hard_fail["ban_orbs_versioned"]
+enable_hard["ban_orbs_versioned"]
 ----
 
 [#resource-class-by-project]
@@ -162,9 +158,7 @@ check_resource_class = config.resource_class_by_project({
   "large": {"$PROJECT_UUID_A","$PROJECT_UUID_B"},
 })
 
-enable_rule["check_resource_class"]
-
-hard_fail["check_resource_class"]
+enable_hard["check_resource_class"]
 ----
 
 [#contexts-allowed-by-project-ids]
@@ -208,9 +202,7 @@ rule_contexts_allowed_by_project_ids = config.contexts_allowed_by_project_ids(
   ["${ALLOWED_CONTEXT_NAME_1}","${ALLOWED_CONTEXT_NAME_2}"]
 )
 
-enable_rule["rule_contexts_allowed_by_project_ids"]
-
-hard_fail["rule_contexts_allowed_by_project_ids"]
+enable_hard["rule_contexts_allowed_by_project_ids"]
 ----
 
 [#contexts-blocked-by-project-ids]
@@ -254,9 +246,7 @@ rule_contexts_blocked_by_project_ids = config.contexts_blocked_by_project_ids(
   ["${BLOCKED_CONTEXT_1}","${BLOCKED_CONTEXT_2}"]
 )
 
-enable_rule["rule_contexts_blocked_by_project_ids"]
-
-hard_fail["rule_contexts_blocked_by_project_ids"]
+enable_hard["rule_contexts_blocked_by_project_ids"]
 ----
 
 
@@ -301,9 +291,7 @@ rule_contexts_reserved_by_project_ids = config.contexts_reserved_by_project_ids(
   ["${RESERVED_CONTEXT_1}","${RESERVED_CONTEXT_2}"]
 )
 
-enable_rule["rule_contexts_reserved_by_project_ids"]
-
-hard_fail["rule_contexts_reserved_by_project_ids"]
+enable_hard["rule_contexts_reserved_by_project_ids"]
 ----
 
 
@@ -348,7 +336,5 @@ rule_contexts_reserved_by_branches = config.contexts_reserved_by_branches(
   ["${RESERVED_CONTEXT_1}","${RESERVED_CONTEXT_2}"]
 )
 
-enable_rule["rule_contexts_reserved_by_branches"]
-
-hard_fail["rule_contexts_reserved_by_branches"]
+enable_hard["rule_contexts_reserved_by_branches"]
 ----

--- a/jekyll/_cci2/create-and-manage-config-policies.adoc
+++ b/jekyll/_cci2/create-and-manage-config-policies.adoc
@@ -98,11 +98,9 @@ package org
 policy_name["example"]
 
 # signal to circleci that check_version is enabled and must be included when making a decision
-enable_rule["check_version"]
-
-# signal to circleci that check_version is a hard_failure condition and that builds should be
+# Also, signal to circleci that check_version is a hard_failure condition and that builds should be
 # stopped if this rule is not satisfied.
-hard_fail["check_version"]
+enable_hard["check_version"]
 
 # define check version
 check_version = reason {

--- a/jekyll/_cci2/test-config-policies.adoc
+++ b/jekyll/_cci2/test-config-policies.adoc
@@ -199,10 +199,8 @@ policy_name["docker"]
 minimum_remote_docker_version := "20.10.11"
 
 # Mark the rule as enabled. This causes circleci to take this rule into account when making decisions.
-enable_rule["check_min_remote_docker_version"]
-
-# Mark this rule as a hard violation level rule. This will stop offending builds from running in production.
-hard_fail["check_min_remote_docker_version"]
+# Also, mark this rule as a hard violation level rule. This will stop offending builds from running in production.
+enable_hard["check_min_remote_docker_version"]
 
 check_min_remote_docker_version[reason] {
 	some job_name, job_info in input.jobs


### PR DESCRIPTION
# Description
Add documentation for `enable_hard` helper, which is a shorthand for `enable_rule`+`hard_fail`.

# Reasons
https://circleci.atlassian.net/browse/SNC-197

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
