### PR TITLE
Fix: Bring back Algolia indexer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,12 @@ parameters:
 # build artifacts and files across jobs. For example, we build our Javascript
 # persist it to a workspace to be made available when the Jekyll site builds.
 references:
-  workspace_root: &workspace_root /tmp/workspace
+  workspace_root: &workspace_root
+    /tmp/workspace
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
+
 
 # Several steps in this config use the same, specialized ruby-caching steps.
 # Commands can be used to extract a common set of steps into a reusable-block.
@@ -46,7 +48,8 @@ commands:
           key: circleci-docs-v1-{{ .Branch }}-<< parameters.dir >>-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install Ruby dependencies
-          command: |
+          command:
+            |
             if [[ "<< parameters.dir >>" != "" ]]; then
               cd << parameters.dir >>
             fi
@@ -85,8 +88,9 @@ commands:
 # Workflows orchestrate a set of jobs to be run;
 # the jobs for this pipeline are # configured below
 workflows:
+
   build-deploy:
-    when:
+    when: 
       not: << pipeline.parameters.run-schedule >>
     jobs:
       - build_server_pdfs:
@@ -98,17 +102,17 @@ workflows:
           requires:
             - build_server_pdfs
             - build_api_docs
-      - reindex-search
-      # - reindex-search:
-      #     filters:
-      #       branches:
-      #         only: master
+      - reindex-search:
+          filters:
+            branches:
+              only: master
       - deploy:
           requires:
             - build
           filters:
             branches:
               only: master
+
 
   # We run a nightly build to refresh content and build docs-platform
   # at least once every day. Triggered every day at 08:00 AM on master branch
@@ -118,6 +122,7 @@ workflows:
       - trigger-deploy
 
 jobs:
+
   build_server_pdfs: # this job builds server-related pdf documentation, persisting it to the workspace as well.
     docker:
       - image: asciidoctor/docker-asciidoctor
@@ -136,7 +141,7 @@ jobs:
   build_api_docs: # a job to manage building our api documentation and persisting it to the workspace.
     executor:
       name: ruby/default
-      tag: "2.7.4-browsers"
+      tag: '2.7.4-browsers'
     steps:
       - checkout
       - *attach_workspace
@@ -172,7 +177,7 @@ jobs:
   build:
     executor:
       name: ruby/default
-      tag: "2.7.4-browsers"
+      tag: '2.7.4-browsers'
     resource_class: medium+
     working_directory: ~/circleci-docs
     environment:
@@ -194,9 +199,7 @@ jobs:
       - ruby-deps
       - node/install-packages:
           pkg-manager: yarn
-          cache-version:
-            &npm-cache-version # Gets cache version from project environment variable (E.g v1)
-
+          cache-version: &npm-cache-version # Gets cache version from project environment variable (E.g v1)
       - run:
           name: Run markdownlint with pronto
           command: bundle exec pronto run -f github_pr -c origin/master
@@ -250,11 +253,11 @@ jobs:
           root: ~/circleci-docs/jekyll/
           paths:
             - _site/*
-
+  
   reindex-search:
     executor:
       name: ruby/default
-      tag: "2.7.4-browsers"
+      tag: '2.7.4-browsers'
     working_directory: ~/circleci-docs
     environment:
       JEKYLL_ENV: production
@@ -283,3 +286,4 @@ jobs:
       - image: cibuilds/aws:1.16.185
     steps:
       - trigger-docs-platform-build
+      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,10 @@ parameters:
 # build artifacts and files across jobs. For example, we build our Javascript
 # persist it to a workspace to be made available when the Jekyll site builds.
 references:
-  workspace_root: &workspace_root
-    /tmp/workspace
+  workspace_root: &workspace_root /tmp/workspace
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
-
 
 # Several steps in this config use the same, specialized ruby-caching steps.
 # Commands can be used to extract a common set of steps into a reusable-block.
@@ -48,8 +46,7 @@ commands:
           key: circleci-docs-v1-{{ .Branch }}-<< parameters.dir >>-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install Ruby dependencies
-          command:
-            |
+          command: |
             if [[ "<< parameters.dir >>" != "" ]]; then
               cd << parameters.dir >>
             fi
@@ -88,9 +85,8 @@ commands:
 # Workflows orchestrate a set of jobs to be run;
 # the jobs for this pipeline are # configured below
 workflows:
-
   build-deploy:
-    when: 
+    when:
       not: << pipeline.parameters.run-schedule >>
     jobs:
       - build_server_pdfs:
@@ -102,17 +98,17 @@ workflows:
           requires:
             - build_server_pdfs
             - build_api_docs
-      - reindex-search:
-          filters:
-            branches:
-              only: master
+      - reindex-search
+      # - reindex-search:
+      #     filters:
+      #       branches:
+      #         only: master
       - deploy:
           requires:
             - build
           filters:
             branches:
               only: master
-
 
   # We run a nightly build to refresh content and build docs-platform
   # at least once every day. Triggered every day at 08:00 AM on master branch
@@ -122,7 +118,6 @@ workflows:
       - trigger-deploy
 
 jobs:
-
   build_server_pdfs: # this job builds server-related pdf documentation, persisting it to the workspace as well.
     docker:
       - image: asciidoctor/docker-asciidoctor
@@ -141,7 +136,7 @@ jobs:
   build_api_docs: # a job to manage building our api documentation and persisting it to the workspace.
     executor:
       name: ruby/default
-      tag: '2.7.4-browsers'
+      tag: "2.7.4-browsers"
     steps:
       - checkout
       - *attach_workspace
@@ -177,7 +172,7 @@ jobs:
   build:
     executor:
       name: ruby/default
-      tag: '2.7.4-browsers'
+      tag: "2.7.4-browsers"
     resource_class: medium+
     working_directory: ~/circleci-docs
     environment:
@@ -199,7 +194,9 @@ jobs:
       - ruby-deps
       - node/install-packages:
           pkg-manager: yarn
-          cache-version: &npm-cache-version # Gets cache version from project environment variable (E.g v1)
+          cache-version:
+            &npm-cache-version # Gets cache version from project environment variable (E.g v1)
+
       - run:
           name: Run markdownlint with pronto
           command: bundle exec pronto run -f github_pr -c origin/master
@@ -253,11 +250,11 @@ jobs:
           root: ~/circleci-docs/jekyll/
           paths:
             - _site/*
-  
+
   reindex-search:
     executor:
       name: ruby/default
-      tag: '2.7.4-browsers'
+      tag: "2.7.4-browsers"
     working_directory: ~/circleci-docs
     environment:
       JEKYLL_ENV: production
@@ -286,4 +283,3 @@ jobs:
       - image: cibuilds/aws:1.16.185
     steps:
       - trigger-docs-platform-build
-      

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'htmlentities', '~> 4.3', '>= 4.3.4'
 group :jekyll_plugins do
   gem 'jekyll-sitemap'
   gem 'jekyll-asciidoc', github: "asciidoctor/jekyll-asciidoc"
+  gem 'jekyll-algolia', '~> 1.0' # Used by `Update Algolia Index` CI step
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,25 +85,10 @@ GEM
       nokogiri (~> 1.6)
       progressbar (~> 1.9)
       verbal_expressions (~> 0.1.5)
-    jekyll-include-cache (0.2.1)
-      jekyll (>= 3.7, < 5.0)
-    jekyll-last-modified-at (1.3.0)
-      jekyll (>= 3.7, < 5.0)
-      posix-spawn (~> 0.3.9)
-    jekyll-redirect-from (0.16.0)
-      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-target-blank (2.0.0)
-      jekyll (>= 3.0, < 5.0)
-      nokogiri (~> 1.10)
-    jekyll-timeago (0.14.0)
-      mini_i18n (>= 0.8.0)
-    jekyll-toc (0.17.1)
-      jekyll (>= 3.9)
-      nokogiri (~> 1.11)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.5.1)
@@ -121,7 +106,6 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mini_i18n (0.8.0)
     mini_portile2 (2.8.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -137,7 +121,6 @@ GEM
     parallel (1.20.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    posix-spawn (0.3.15)
     progressbar (1.11.0)
     pronto (0.11.0)
       gitlab (~> 4.4, >= 4.4.0)
@@ -189,13 +172,7 @@ DEPENDENCIES
   jekyll (~> 4.2.0)!
   jekyll-algolia (~> 1.0)
   jekyll-asciidoc!
-  jekyll-include-cache
-  jekyll-last-modified-at
-  jekyll-redirect-from
   jekyll-sitemap
-  jekyll-target-blank
-  jekyll-timeago
-  jekyll-toc
   kramdown-parser-gfm
   liquid-c
   nokogiri (~> 1.13)


### PR DESCRIPTION
# Description
- Add back `jekyll-algolia` gem

# Reasons
`jekyll-algolia` was inadvertently removed with https://github.com/circleci/circleci-docs/pull/7862 but is needed by the `Update Algolia Index` CI step

# Content Checklist
N/A