### PR TITLE
Add docs for get_element_name policy helper

### DIFF
--- a/jekyll/_cci2/config-policy-reference.adoc
+++ b/jekyll/_cci2/config-policy-reference.adoc
@@ -19,7 +19,7 @@ This reference page lists a selection of _helpers_, or CircleCI-specific funtion
 
 The `circle-policy-agent` package includes built-in functions for common config policy
 use cases. All policies evaluated by the `policy-service`, the `circle-cli`, or the `circle-policy-agent`
-will be able to access these functions. This also means the package name `circleci.config` is
+will be able to access these functions. This also means the package names `circleci.config` and `circleci.utils` are
 reserved.
 
 [#circleci-rego-helpers]
@@ -74,7 +74,7 @@ be included in the provided list of orbs.
 
 [source,rego]
 ----
-ban_orbs_version([string])
+ban_orbs([string])
 returns { string: string }
 ----
 
@@ -338,3 +338,45 @@ rule_contexts_reserved_by_branches = config.contexts_reserved_by_branches(
 
 enable_hard["rule_contexts_reserved_by_branches"]
 ----
+
+[#get_element_name]
+=== `get_element_name`
+
+This function retrieves the name of an element in a config file. You can use it to retrieve the name of jobs in workflows, steps in jobs, etc. If the element is an object, this function will return the object's key.
+
+
+[#definition-get-element-name]
+==== Definition
+
+[source,rego]
+----
+get_element_name(input.<config_key>)
+returns string
+----
+
+[#usage-get-element-name]
+==== Usage
+
+[source,rego]
+----
+package org
+
+import data.circleci.utils
+
+policy_name["example"]
+
+job_name1 = utils.get_element_name(input.jobs[0])
+job_name2 = utils.get_element_name(input.jobs[1])
+----
+
+Consider the following config.yml:
+[source,yaml]
+----
+workflows:
+  main:
+    jobs:
+      - lint
+      - test:
+          context: test-vars
+----
+In the policy example above, `job_name1` would equal `lint` and `job_name2` would equal `test`.

--- a/jekyll/_cci2/config-policy-reference.adoc
+++ b/jekyll/_cci2/config-policy-reference.adoc
@@ -380,3 +380,67 @@ workflows:
           context: test-vars
 ----
 In the policy example above, `job_name1` would equal `lint` and `job_name2` would equal `test`.
+
+----
+
+[#to_array]
+=== `to_array`
+
+This function casts a value to an array. Array values are left as is and are **not** cast to Array<Array>.
+
+[#definition-to-array]
+==== Definition
+
+[source,rego]
+----
+to_array(value)
+returns array
+----
+
+[#usage-to-array]
+==== Usage
+
+[source,rego]
+----
+package org
+
+import data.circleci.utils
+
+policy_name["example"]
+
+a = utils.to_array("element")   # a is ["element"]
+b = utils.to_array(["element"]) # b is ["element"]
+----
+
+----
+
+[#to-set]
+=== `to_set`
+
+This function casts a value to a set. Array values are cast to a set and deduplicated. Set values are left as is and are **not** cast to Set<Set>.
+
+[#definition-to-set]
+==== Definition
+
+[source,rego]
+----
+to_set(value)
+returns set
+----
+
+[#usage-to-set]
+==== Usage
+
+[source,rego]
+----
+package org
+
+import data.circleci.utils
+
+policy_name["example"]
+
+a = utils.to_set("element")                      # a is {"element"}
+b = utils.to_set(["one", "one", "two", "three"]) # b is {"one", "two", "three"}
+c = utils.to_set({"element"})                    # c is {"element"}
+----
+

--- a/jekyll/_cci2/config-policy-reference.adoc
+++ b/jekyll/_cci2/config-policy-reference.adoc
@@ -22,8 +22,10 @@ use cases. All policies evaluated by the `policy-service`, the `circle-cli`, or 
 will be able to access these functions. This also means the package names `circleci.config` and `circleci.utils` are
 reserved.
 
-[#circleci-rego-helpers]
-== CircleCI rego helpers
+[#circleci-config-helpers]
+== CircleCI config helpers
+
+The following helpers are imported using `import data.circleci.config`
 
 [#orbs]
 === `orbs`
@@ -339,6 +341,11 @@ rule_contexts_reserved_by_branches = config.contexts_reserved_by_branches(
 enable_hard["rule_contexts_reserved_by_branches"]
 ----
 
+[#circleci-utility-helpers]
+== CircleCI Utility helpers
+
+The following helpers are imported using `import data.circleci.utils`
+
 [#get_element_name]
 === `get_element_name`
 
@@ -381,8 +388,6 @@ workflows:
 ----
 In the policy example above, `job_name1` would equal `lint` and `job_name2` would equal `test`.
 
-----
-
 [#to_array]
 === `to_array`
 
@@ -410,8 +415,6 @@ policy_name["example"]
 
 a = utils.to_array("element")   # a is ["element"]
 b = utils.to_array(["element"]) # b is ["element"]
-----
-
 ----
 
 [#to-set]


### PR DESCRIPTION
# Description
Add documentation for `get_element_name` helper function.

# Reasons
https://circleci.atlassian.net/browse/SNC-194

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
