### PR TITLE
Fix: Bring back page metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :jekyll_plugins do
   gem 'jekyll-asciidoc', github: "asciidoctor/jekyll-asciidoc"
   gem 'jekyll-algolia', '~> 1.0' # Used by `Update Algolia Index` CI step
   gem 'jekyll-last-modified-at' # Used for page metadata
-
 end
 
 group :test, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ group :jekyll_plugins do
   gem 'jekyll-sitemap'
   gem 'jekyll-asciidoc', github: "asciidoctor/jekyll-asciidoc"
   gem 'jekyll-algolia', '~> 1.0' # Used by `Update Algolia Index` CI step
+  gem 'jekyll-last-modified-at' # Used for page metadata
+
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
       nokogiri (~> 1.6)
       progressbar (~> 1.9)
       verbal_expressions (~> 0.1.5)
+    jekyll-last-modified-at (1.3.0)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
@@ -121,6 +124,7 @@ GEM
     parallel (1.20.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.15)
     progressbar (1.11.0)
     pronto (0.11.0)
       gitlab (~> 4.4, >= 4.4.0)
@@ -172,6 +176,7 @@ DEPENDENCIES
   jekyll (~> 4.2.0)!
   jekyll-algolia (~> 1.0)
   jekyll-asciidoc!
+  jekyll-last-modified-at
   jekyll-sitemap
   kramdown-parser-gfm
   liquid-c

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -23,6 +23,7 @@ exclude:
 plugins:
   - jekyll-sitemap
   - jekyll-asciidoc
+  - jekyll-last-modified-at
 
 # Approximate distance, with customizable threshold,
 # ie: at depth one 366 days becomes 1 year ago instead of 1 year and 1 day ago


### PR DESCRIPTION
# Description
- Re-add `jekyll-last-modified-at` to generate the needed page metadata 

# Reasons
Some of the metadata was missing:

![Screen Shot 2023-03-21 at 6 18 02 PM](https://user-images.githubusercontent.com/1449325/226777462-7263b1cf-72ca-4e31-827c-9146b9007dd2.png)

now:
![Screen Shot 2023-03-21 at 6 18 25 PM](https://user-images.githubusercontent.com/1449325/226777471-54baf3dc-876e-4b88-9d16-6d377555b26e.png)

# Content Checklist
N/A