### PR TITLE
Docker multi container setup clarifications

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -695,7 +695,7 @@ Configured by `docker` key which takes a list of maps:
 Key | Required | Type | Description
 ----|-----------|------|------------
 image | Y | String | The name of a custom docker image to use. The first `image` listed under a job defines the job's own primary container image where all steps will run.
-name | N | String | `name` defines the the hostname for the container (default: localhost), used for reaching secondary, service containers. By default, all services are exposed directly on `localhost`. This field is appropriate if you would rather have a different hostname instead of `localhost`, for example, if you are starting multiple versions of the same service.
+name | N | String | `name` defines the the hostname for the container (the default is `localhost`), used for reaching secondary, service containers. By default, all services are exposed directly on `localhost`. This field is appropriate if you would rather have a different hostname instead of `localhost`, for example, if you are starting multiple versions of the same service.
 entrypoint | N | String or List | The command used as executable when launching the container. `entrypoint` overrides the image's [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint).
 command | N | String or List | The command used as pid 1 (or args for entrypoint) when launching the container. `command` overrides the image's `COMMAND`. It will be used as arguments to the image `ENTRYPOINT` if it has one, or as the executable if the image has no `ENTRYPOINT`.
 user | N | String | Which user to run commands as within the Docker container

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -695,7 +695,7 @@ Configured by `docker` key which takes a list of maps:
 Key | Required | Type | Description
 ----|-----------|------|------------
 image | Y | String | The name of a custom docker image to use. The first `image` listed under a job defines the job's own primary container image where all steps will run.
-name | N | String | `name` defines the name for reaching the secondary service containers.  By default, all services are exposed directly on `localhost`.  The field is appropriate if you would rather have a different host name instead of localhost, for example, if you are starting multiple versions of the same service.
+name | N | String | `name` defines the the hostname for the container (default: localhost), used for reaching secondary, service containers. By default, all services are exposed directly on `localhost`. This field is appropriate if you would rather have a different hostname instead of `localhost`, for example, if you are starting multiple versions of the same service.
 entrypoint | N | String or List | The command used as executable when launching the container. `entrypoint` overrides the image's [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint).
 command | N | String or List | The command used as pid 1 (or args for entrypoint) when launching the container. `command` overrides the image's `COMMAND`. It will be used as arguments to the image `ENTRYPOINT` if it has one, or as the executable if the image has no `ENTRYPOINT`.
 user | N | String | Which user to run commands as within the Docker container

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -695,7 +695,7 @@ Configured by `docker` key which takes a list of maps:
 Key | Required | Type | Description
 ----|-----------|------|------------
 image | Y | String | The name of a custom docker image to use. The first `image` listed under a job defines the job's own primary container image where all steps will run.
-name | N | String | `name` defines the the hostname for the container (the default is `localhost`), used for reaching secondary, service containers. By default, all services are exposed directly on `localhost`. This field is appropriate if you would rather have a different hostname instead of `localhost`, for example, if you are starting multiple versions of the same service.
+name | N | String | `name` defines the the hostname for the container (the default is `localhost`), which is used for reaching secondary (service) containers. By default, all services are exposed directly on `localhost`. This field is useful if you would rather have a different hostname instead of `localhost`, for example, if you are starting multiple versions of the same service.
 entrypoint | N | String or List | The command used as executable when launching the container. `entrypoint` overrides the image's [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint).
 command | N | String or List | The command used as pid 1 (or args for entrypoint) when launching the container. `command` overrides the image's `COMMAND`. It will be used as arguments to the image `ENTRYPOINT` if it has one, or as the executable if the image has no `ENTRYPOINT`.
 user | N | String | Which user to run commands as within the Docker container

--- a/jekyll/_cci2/using-docker.md
+++ b/jekyll/_cci2/using-docker.md
@@ -165,7 +165,7 @@ It is possible to specify multiple images for your job. Each image will be used 
 
 Using multiple containers for a job will be useful if you need to use a database for your tests, or for some other required service.
 
-When using a multi-container job setup, all containers run in a common network and every exposed port will be available on `localhost`. All containers can communicate with one another. It is also possible to change this hostname using the `name` key. For a full list of options, see the [Configuration reference](configuration-reference/#docker).
+When using a multi-container job setup, all containers run in a common network and every exposed port will be available on `localhost`. All containers can communicate with one another. It is also possible to change this hostname using the `name` key. For a full list of options, see the [Configuration reference](/configuration-reference/#docker).
 
 **In a multi-image configuration job, all steps are executed in the container created by the first image listed**.
 

--- a/jekyll/_cci2/using-docker.md
+++ b/jekyll/_cci2/using-docker.md
@@ -161,7 +161,11 @@ More details on the Docker executor are available in the [Configuring CircleCI](
 ## Using multiple Docker images
 {: #using-multiple-docker-images }
 
-It is possible to specify multiple images for your job. Specify multiple images if, for example, you need to use a database for your tests or for some other required service. All containers run in a common network and every exposed port will be available on `localhost` from a [primary container]({{ site.baseurl }}/glossary/#primary-container).
+It is possible to specify multiple images for your job. Each image will be used to spin up a separate container for your job.
+
+Using multiple containers for a job will be useful if you need to use a database for your tests, or for some other required service.
+
+When using a multi-container job setup, all containers run in a common network and every exposed port will be available on `localhost`. All containers can communicate with one another. It is also possible to change this hostname using the `name` key. For a full list of options, see the [Configuration reference](configuration-reference/#docker).
 
 **In a multi-image configuration job, all steps are executed in the container created by the first image listed**.
 

--- a/jekyll/_cci2/using-docker.md
+++ b/jekyll/_cci2/using-docker.md
@@ -161,7 +161,7 @@ More details on the Docker executor are available in the [Configuring CircleCI](
 ## Using multiple Docker images
 {: #using-multiple-docker-images }
 
-It is possible to specify multiple images for your job. Each image will be used to spin up a separate container for your job.
+It is possible to specify multiple images for your job. Each image will be used to spin up a separate container.
 
 Using multiple containers for a job will be useful if you need to use a database for your tests, or for some other required service.
 


### PR DESCRIPTION
# Description
Fixes #7800 and #7729 

# Reasons
* Not clear that all containers can communicate with eachother when using multiple containers for a job
* Use of name rather than hostname for defining the `name` key was not clear

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
