### PR TITLE
tink is supported in server 4.x

### DIFF
--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -1233,7 +1233,7 @@ a|Session Cookie Key. NOTE: Must be exactly 16 bytes.
 |`tink.enabled`
 |bool
 |`false`
-|When enabled, Tink will be used instead of vault for contexts encryption
+|When enabled, Tink will be used instead of Vault for contexts encryption.
 
 |`tink.keyset`
 |string

--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -1230,6 +1230,16 @@ a|Session Cookie Key. NOTE: Must be exactly 16 bytes.
 |`1`
 |Number of replicas to deploy for the test-results-service deployment.
 
+|`tink.enabled`
+|bool
+|`false`
+|When enabled, Tink will be used instead of vault for contexts encryption
+
+|`tink.keyset`
+|string
+|`""`
+|The keyset generated the Tink CLI to be used for contexts encryption
+
 |`tls.certificate`
 |string
 |`""`

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -818,7 +818,7 @@ CircleCI Server will store your generated keyset in a Kubernetes secret. You may
 --
 **Option 1:** Create the Kubernetes Secret yourself
 
-Following the example below, create a kubernetes secret with the name `tink` and a key `keyset`. Apply this secret to the namespace of your CircleCI Server installation.
+Following the example below, create a Kubernetes secret with the name `tink` and a key `keyset`. Apply this secret to the namespace of your CircleCI server installation.
 
 [source,yaml]
 ----

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -841,7 +841,7 @@ You may add the keyset to your `values.yaml` under `tink` as in the example belo
 ----
 tink:
   enabled: false
-  keyset: "<your-keyset"
+  keyset: "<your-keyset>"
 ----
 --
 

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -788,7 +788,7 @@ proxy:
 
 === n. Encrypting Environment Variables
 
-All environment variables uses in a job are encrypted using either Hashicorp https://www.vaultproject.io/[Vault] or Google https://developers.google.com/tink[Tink]. By Default, CircleCI Server 4.x will use Vault to generate and store encryption keys.
+All environment variables stored in contexts are encrypted using either Hashicorp https://www.vaultproject.io/[Vault] or Google https://developers.google.com/tink[Tink]. By Default, CircleCI Server 4.x will use Vault to generate and store encryption keys.
 
 ==== Using Tink
 

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -835,7 +835,7 @@ data:
 --
 **Option 2:** CircleCI Server will create the Kubernetes Secret
 
-You may add the keyset to your `values.yaml` under tink as in the example below. CircleCI will generate the needed secret to store your keyset.
+You may add the keyset to your `values.yaml` under `tink` as in the example below. CircleCI will generate the needed secret to store your keyset.
 
 [source,yaml]
 ----

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -801,7 +801,7 @@ tink:
   keyset: ""
 ----
 
-Tink is given precedence over vault. If `tink.enabled` is true, Vault will not be deployed.
+Tink is given precedence over Vault. If `tink.enabled` is true, Vault will not be deployed.
 
 WARNING: Tink or Vault must be set once at install and cannot be changed after deployment.
 

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -845,6 +845,8 @@ tink:
 ----
 --
 
+WARNING: If your Tink keyset is somehow lost, you will need to generate a new keyset and then recreate your contexts and their associated secrets
+
 [#deploy]
 == 4. Deploy
 

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -812,7 +812,7 @@ Next you will need to generate a https://developers.google.com/tink/design/keyse
 tinkey create-keyset --key-template XCHACHA20_POLY1305
 ----
 
-CircleCI Server will store your generated keyset in a Kubernetes secret. You may generate this secret in either of the following ways:
+CircleCI server will store your generated keyset in a Kubernetes secret. You may generate this secret in either of the following ways:
 
 [.tab.gcs.create_secret]
 --

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -786,6 +786,65 @@ proxy:
     - "<vpc-or-subnet-cidr>"   # VPC or subnets to exclude from the proxy (optional)
 ----
 
+=== n. Encrypting Environment Variables
+
+All environment variables uses in a job are encrypted using either Hashicorp https://www.vaultproject.io/[Vault] or Google https://developers.google.com/tink[Tink]. By Default, CircleCI Server 4.x will use Vault to generate and store encryption keys.
+
+==== Using Tink
+
+If you wish to use Tink instead of Vault you will need to first enable it in your `values.yaml`. 
+
+[source,yaml]
+----
+tink:
+  enabled: false
+  keyset: ""
+----
+
+Tink is given precedence over vault. If `tink.enabled` is true, Vault will not be deployed.
+
+WARNING: Tink or Vault must be set once at install and cannot be changed after deployment.
+
+Next you will need to generate a https://developers.google.com/tink/design/keysets[keyset] which Tink uses to manage key rotation. The easiest way to do this is to use Google's https://developers.google.com/tink/tinkey-overview[Tinkey] CLI utility. Once https://developers.google.com/tink/install-tinkey[installed], you may use the command below.
+
+[source,shell]
+----
+tinkey create-keyset --key-template XCHACHA20_POLY1305
+----
+
+CircleCI Server will store your generated keyset in a Kubernetes secret. You may generate this secret in either of the following ways:
+
+[.tab.gcs.create_secret]
+--
+**Option 1:** Create the Kubernetes Secret yourself
+
+Following the example below, create a kubernetes secret with the name `tink` and a key `keyset`. Apply this secret to the namespace of your CircleCI Server installation.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tink
+data:
+  keyset: <your-keyset>
+----
+--
+
+[.tab.gcs.add_secret_to_values_yaml]
+--
+**Option 2:** CircleCI Server will create the Kubernetes Secret
+
+You may add the keyset to your `values.yaml` under tink as in the example below. CircleCI will generate the needed secret to store your keyset.
+
+[source,yaml]
+----
+tink:
+  enabled: false
+  keyset: "<your-keyset"
+----
+--
+
 [#deploy]
 == 4. Deploy
 


### PR DESCRIPTION
# Description
Server 4 customers now have the option to use Tink instead of Vault to manage their secret encryption

# Reasons
https://circleci.atlassian.net/browse/SERVER-2355

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
