### PR TITLE
Fix typo in create-project.adoc

### DIFF
--- a/jekyll/_cci2_ja/create-project.adoc
+++ b/jekyll/_cci2_ja/create-project.adoc
@@ -53,7 +53,7 @@ image::cci-organizations.png[Select Organization]
 +
 CI スターターパイプラインを選択すると、 `config.yml` のサンプルファイルが作成され、リポジトリの `circleci-project-setup` ブランチにコミットされます。
 +
-`config.yml` ファイルの作成については、 <<config-intro#,設定ふファイルの概要>> を参照してください。
+`config.yml` ファイルの作成については、 <<config-intro#,設定ファイルの概要>> を参照してください。
 . 青色の **Set Up Project** ボタンをクリックします。
 
 これで CircleCI は指定された `config.yml` ファイルを使ってパイプラインを実行するようになりました。 その出力は、CircleCI ダッシュボードで確認できます。


### PR DESCRIPTION
# Description

Fix japanese typo.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
