### PR TITLE
remove examples and guides section

### DIFF
--- a/jekyll/_cci2/databases.md
+++ b/jekyll/_cci2/databases.md
@@ -1,10 +1,8 @@
 ---
 layout: classic-docs
-title: "Configuring Databases"
-short-title: "Configuring Databases"
+title: "Configure Databases"
 description: "This document describes how to use the official CircleCI pre-built Docker container images for a database service in CircleCI."
-order: 35
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x

--- a/jekyll/_cci2/language-javascript.md
+++ b/jekyll/_cci2/language-javascript.md
@@ -1,11 +1,8 @@
 ---
 layout: classic-docs
-title: "Configuring a Node.js Application on CircleCI"
-short-title: "JavaScript"
+title: "Configure a Node.js application on CircleCI"
 description: "Building and Testing with JavaScript and Node.js on CircleCI"
-categories: [language-guides]
-order: 5
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x

--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -1,11 +1,8 @@
 ---
 layout: classic-docs
-title: "Configuring a Python Application on CircleCI"
-short-title: "Python"
+title: "Configure a Python application on CircleCI"
 description: "Continuous integration with Python on CircleCI"
-categories: [language-guides]
-order: 7
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v3.x

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -26,12 +26,6 @@ en:
             link: introduction-to-yaml-configurations
           - name: In-app configuration editor
             link: config-editor
-      - name: Languages
-        children:
-          - name: Node quickstart
-            link: language-javascript
-          - name: Python quickstart
-            link: language-python
       - name: VCS integration
         children:
           - name: GitHub integration overview
@@ -64,6 +58,10 @@ en:
         children:
           - name: Quickstart guide
             link: getting-started
+          - name: Node quickstart
+            link: language-javascript
+          - name: Python quickstart
+            link: language-python
           - name: Configuration tutorial
             link: config-intro
           - name: Set up the Slack orb

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -26,6 +26,12 @@ en:
             link: introduction-to-yaml-configurations
           - name: In-app configuration editor
             link: config-editor
+      - name: Languages
+        children:
+          - name: Node quickstart
+            link: language-javascript
+          - name: Python quickstart
+            link: language-python
       - name: VCS integration
         children:
           - name: GitHub integration overview
@@ -114,6 +120,8 @@ en:
             link: schedule-pipelines-with-multiple-workflows
           - name: Set a nightly scheduled pipeline
             link: set-a-nightly-scheduled-pipeline
+          - name: Configure databases
+            link: databases
           - name: Migrate from deploy to run
             link: migrate-from-deploy-to-run
       - name: Reference
@@ -457,6 +465,8 @@ en:
             link: examples-and-guides-overview
           - name: Sample config.yml files
             link: sample-config
+          - name: Database examples
+            link: postgres-config
       - name: How-to guides
         children:
           - name: How to use the CircleCI local CLI
@@ -467,22 +477,6 @@ en:
             link: https://circleci.com/docs/api/v2
           - name: API v1 reference
             link: https://circleci.com/docs/api/v1
-
-  - name: Examples and guides
-    icon: icons/sidebar/config.svg
-    children:
-      - name: Languages
-        children:
-          - name: Node
-            link: language-javascript
-          - name: Python
-            link: language-python
-      - name: Databases
-        children:
-          - name: Configuring databases
-            link: databases
-          - name: Database examples
-            link: postgres-config
 
   - name: Test
     icon: icons/sidebar/passed.svg


### PR DESCRIPTION
# Description
Remove examples and guides section from sidebar, and move pages to correct sections

# Reasons
Sidebar reorg project

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
