### PR TITLE
add warning that orbs cannot be deleted

### DIFF
--- a/jekyll/_cci2/create-an-orb.adoc
+++ b/jekyll/_cci2/create-an-orb.adoc
@@ -44,6 +44,8 @@ $ circleci version
 [#create-your-orb]
 == Create your orb
 
+WARNING: Once an orb is created it cannot be deleted. Orbs are link:https://semver.org/[semver compliant], and each published version is immutable. Publicly released orbs are potential dependencies for other projects. Therefore, allowing orb deletion would make users susceptible to unexpected loss of functionality.
+
 [#create-a-new-repo]
 === 1. Create a new repo
 

--- a/jekyll/_cci2/orb-author-intro.md
+++ b/jekyll/_cci2/orb-author-intro.md
@@ -5,7 +5,7 @@ short-title: "Authoring Orbs Introduction"
 description: "Starting point for how to author an orb"
 categories: [getting-started]
 order: 1
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -32,6 +32,9 @@ Practice with [inline orbs]({{site.baseurl}}/reusing-config/#writing-inline-orbs
 
 Orb authors automatically agree to the CircleCI [Code Sharing Terms of Service](https://circleci.com/legal/code-sharing-terms/). All publicly published orbs are made available on the Orb Registry under the [MIT License agreement](https://opensource.org/licenses/MIT). For more information, see [Orb Licensing](https://circleci.com/developer/orbs/licensing).
 {: class="alert alert-success"}
+
+Once an orb is created it cannot be deleted. Orbs are [semver compliant](https://semver.org/), and each published version is immutable. Publicly released orbs are potential dependencies for other projects. Therefore, allowing orb deletion would make users susceptible to unexpected loss of functionality.
+{: class="alert alert-warning"}
 
 ## Getting started
 {: #getting-started }


### PR DESCRIPTION
# Description
Add a warning to a couple of orb authoring pages to let readers know that orbs cannot be deleted once created

# Reasons
Give readers warning before they create an orb. Previously customers have been frustrated that they have only found this information after they have created an orb.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
