### PR TITLE
Define correct attribute mapping for OIDC GCP

### DIFF
--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -216,19 +216,19 @@ After navigating to the **Grant Access** section of the GCP web UI, follow these
   * The issuer is `\https://oidc.circleci.com/org/ORG_ID`, where `ORG_ID` is your CircleCI organization ID.
 . Click **Continue** to configure provider attributes.
 +
-Configuring the provider attributes provides an opportunity to map claims in CircleCI's Token to Google's "understanding." For example:
+Configuring the provider attributes provides an opportunity to map claims in CircleCI's Token to Google's "understanding". Use this mapping:
 +
 [.table.table-striped]
 [cols=2*, stripes=even]
 
 |===
 | google.subject
-| attribute.project_id
+| assertion.sub
 
-| attribute.org_id
+| attribute.aud
 | assertion.aud
 
-| assertion.sub
+| attribute.project
 | assertion['oidc.circleci.com/project-id']
 |===
 +


### PR DESCRIPTION
# Description
Changed the OIDC GCP docs by providing a useful attribute mapping for the OIDC provider setup.

# Reasons
The current docs are pretty vague about which attribute mappings are needed for the OIDC provider in GCP. The ones provided as example don't work (they can't even be saved because one of them seems to be invalid). This makes this already complex setup process even harder and it took me quite some googling and trial and error to figure out a mapping that actually works with the provided example config-file.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
