### PR TITLE
Added missing portion (gitlab adoc JA)

### DIFF
--- a/jekyll/_cci2_ja/gitlab-integration.adoc
+++ b/jekyll/_cci2_ja/gitlab-integration.adoc
@@ -120,6 +120,37 @@ NOTE: GitLab 連携では、以下のプロジェクト設定の機能の違い�
 
 プロジェクトを作成すると、 SSH キーが作成され、リポジトリからコードをチェックアウトする際にに使用されます。 作成した設定ファイルごとに、その設定ファイルに関連づけられたリポジトリのコードにアクセスするための新しい SSH キーが生成されます。 現時点では、GitLab プロジェクトには **Additional SSH Keys (追加 SSH キー)** のみが適用されます。 SSH キーに関する詳細は、<<add-ssh-key#,CircleCI への SSH キーの追加>> をご覧ください。
 
+[#create-gitlab-ssh-key]
+==== GitLab SSH キーを作成
+
+. link:https://docs.gitlab.com/ee/user/ssh.html[GitLab の説明] に従って、SSH キーペアを作成します。パスワードを入力するよう求められた場合、入力しないでください（以下はmacOSでキーを生成するコマンドの一例です）。
++
+```shell
+  ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+. link:https://gitlab.com/[GitLab]のプロジェクトにアクセスし、**Settings > Repository**に移動し、**Deploy keys**セクションを展開してください。Title フィールドにタイトルを入力し、手順 1 で作成したパブリックキーをコピー＆ペーストします。**Grant write permissions to this key**にチェックを入れ、**キーを追加(Add Key)**をクリックします。
+
+. CircleCI アプリのプロジェクトの設定にアクセスし、**SSH Keys** と **Add SSH key** を選択します。Hostname のフィールドには、`gitlab.com` を入力し、手順 1 で作成したプライベートキーを追加します。
+
+. `.circleci/config.yml` ファイルで、`add_ssh_keys` キーを使用してジョブにフィンガープリントを追加します。
++
+```yaml
+  version: 2.1
+
+  jobs:
+    deploy-job:
+      steps:
+        - add_ssh_keys:
+            fingerprints:
+              - "SO:ME:FIN:G:ER:PR:IN:T"
+```
+
+ジョブから GitHub リポジトリにプッシュすると、CircleCI は追加された SSH キーを使用します。
+
+
+SSH キーに関する詳細は、 xref:add-ssh-key#[CircleCI への SSH キーの追加] をご覧ください。
+
 [#organization-settings]
 == 組織設定
 


### PR DESCRIPTION
# Description
Crowdin wouldn't add it despite adding the translation there for missing portion in the live page. 
This was creating rather not up-to-date gitlab integration doc for Japanese. 

I went ahead and added the missing portion here. Hopefully this forces it to be aligned with updated version on Crowdin.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
