### PR TITLE
Remove policy service failure warning

### DIFF
--- a/jekyll/_cci2/create-and-manage-config-policies.adoc
+++ b/jekyll/_cci2/create-and-manage-config-policies.adoc
@@ -13,7 +13,6 @@ contentTags:
 
 NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 
-CAUTION: While the config policies feature is in **open preview**, a service failure will result in build configurations **not** being evaluated against policies. This should be taken into consideration before using config policies for compliance purposes.
 
 Follow the how-to guides on this page to learn how to create and use config policies.
 


### PR DESCRIPTION
# Description
Removed the CAUTION banner describing policy service failure.

# Reasons
In the rare occurrence of a policy service failure, pipelines will now be blocked by default. Admins may temporarily disable policies if necessary in this scenario to unblock their teams.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
