### PR TITLE
[WEB-1410] Re-enable adoc translation in Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -21,9 +21,9 @@ files:
   # - source: /jekyll/_cci2/*.md
   #   translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
   #   update_option: update_as_unapproved
-  # - source: /jekyll/_cci2/*.adoc
-  #   translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
-  #   update_option: update_as_unapproved
+  - source: /jekyll/_cci2/*.adoc
+    translation: /jekyll/_cci2_%two_letters_code%/%original_file_name%
+    update_option: update_as_unapproved
 
   - source: /jekyll/_cci2/server/*.adoc
     translation: /jekyll/_cci2_%two_letters_code%/server/%original_file_name%


### PR DESCRIPTION
# Description
Re-enable adoc translation in Crowdin

# Reasons
Issues with other files have been resolved, re-enabling adoc translation in Crowdin should be more manageable now. 

**Ticket**: [WEB-1410](https://circleci.atlassian.net/browse/WEB-1410)

### Considerations
~I'm not sure if this change will have an effect on `master` or if it will need to be brought into the `ja-localiation` branch~ 
Todd confirmed these will need to be merged into `ja-localization` to have an effect, since my branch is based on `master` it would include other changes if merged directly into `ja-localization`. I imagine the desired flow here is to merge  into `master` first, then bring that change into `ja-localization`. If I'm wrong about that I can open a new PR that is based off the current `ja-localization` instead.

I will open a seperate PR for re-enabling `.md` files, they can be merged in what ever order is preferred, though I recommend merging and resolving a single file type at a time.

# Content Checklist
n/a

[WEB-1410]: https://circleci.atlassian.net/browse/WEB-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ