### PR TITLE
Add missing anchors for postgres in v4.1 docs

### DIFF
--- a/jekyll/_cci2/server/v4.1/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/phase-2-core-services.adoc
@@ -166,7 +166,10 @@ keyset:
 ----
 --
 
+[#postgres]
 === d. Postgres
+
+[#postgres-credentials]
 ==== Credentials
 The application requires a Kubernetes Secret containing Postgres credentials.  This is true when using either the internal (default) or an externally hosted instance of Postgres. CircleCI will not be able to recover the values if lost. Based on how you prefer to manage Kubernetes Secrets there are two options.
 
@@ -204,6 +207,7 @@ postgresql:
 ----
 --
 
+[#postgres-tls]
 ==== TLS
 Postgres may be extended to use TLS encrpted traffic. When deployed internally, this option is disabled by default but may be enabled by adding the following to your postgresql block of your `values.yaml`
 


### PR DESCRIPTION
# Description

When trying to access the [TLS](https://circleci.com/docs/server/v4.1/installation/phase-2-core-services/#tls) section in v4.1, the link incorrectly brings up the Postgres TLS section instead of the actual TLS settings for CircleCI server. 

The [Phase 2 - Core Services](https://circleci.com/docs/server/installation/phase-2-core-services/) page for v4.0 works as expected since it seems to have anchors defined for `#postgres`, `#postgres-credentials`, and `#postgres-tls`.


# Reasons

The change will bring consistency across multiple versions of v4 (4.0 and 4.1) and direct users to the right section when looking for `postgres-tls` and `TLS` sections when installing/managing server. 

Both v4.1 and v4.0 will work as expected when a user tries to access `postgres` vs `TLS` related documentation. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
