### PR TITLE
save_cache example can cache sensitive information

### DIFF
--- a/jekyll/_cci2/caching-strategy.md
+++ b/jekyll/_cci2/caching-strategy.md
@@ -214,6 +214,7 @@ steps:
   - save_cache:
       paths:
         - ~/.gradle/caches
+        - ~/.gradle/wrapper
       key: gradle-repo-v1-{{ .Branch }}-{{ checksum "dependencies.lockfile" }}
 ```
 {% endraw %}

--- a/jekyll/_cci2/caching-strategy.md
+++ b/jekyll/_cci2/caching-strategy.md
@@ -213,7 +213,7 @@ steps:
         - gradle-repo-v1-
   - save_cache:
       paths:
-        - ~/.gradle
+        - ~/.gradle/caches
       key: gradle-repo-v1-{{ .Branch }}-{{ checksum "dependencies.lockfile" }}
 ```
 {% endraw %}
@@ -239,7 +239,7 @@ steps:
         - maven-repo-v1-
   - save_cache:
       paths:
-        - ~/.m2
+        - ~/.m2/repository
       key: maven-repo-v1-{{ .Branch }}-{{ checksum "pom.xml" }}
 ```
 {% endraw %}


### PR DESCRIPTION
# Description

Changed the `save_cache` to only save the necessary cache. Support got a report that it can include sensitive information that should not be leaked.

# Reasons

Customer shared that we cache ` ~/.gradle` in our documentation which can include `~/.gradle/gradle.properties` from being leaked as it can contain sensitive information. Also for `~/.m2` it can include `~/.m2/settings.xml` and also can be leaked.


# Content Checklist

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
