### PR TITLE
Adding workload identities requirement to GCP 2x to 4x server migration.

### DIFF
--- a/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
+++ b/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
@@ -21,6 +21,7 @@ Depending on the size of your data stores, the migration can take anywhere from 
 
 . Your current CircleCI server installation is v2.19x
 . You have taken a backup of your v2.19 instance. If you are using external datastores, they need to be backed up separately.
+. If your install is in a Google Cloud Platform (GCP) environment, you are using Workload Identities, not Service Account credentials. Due to a limitation in init container volume mounting, the 2x to 4x migration process on GCP supports only workload identities. No such limitation exists in AWS environments.
 . Datastores:
 .. If using **externalized** datastores, Postgres must be updated to version 12.
 .. If your datastores are **internal**, ensure that the volume sizes allocated to Mongodb, Postgres, and Redis in your v4.0 installation are at least the same or greater than the volumes allocated to the Mongodb, Postgres, and Redis instances in your v2.19 install. You may resize your 4.x datastore volumes following link:/docs/server/operator/expanding-internal-database-volumes/[these instructions].

--- a/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
+++ b/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
@@ -19,13 +19,13 @@ Depending on the size of your data stores, the migration can take anywhere from 
 [#prerequisites]
 == Prerequisites
 
-. Your current CircleCI server installation is v2.19x
+. Your current CircleCI server installation is v2.19.x
 . You have taken a backup of your v2.19 instance. If you are using external datastores, they need to be backed up separately.
-. If your install is in a Google Cloud Platform (GCP) environment, you are using Workload Identities, not Service Account credentials. Due to a limitation in init container volume mounting, the 2x to 4x migration process on GCP supports only Workload Identities. No such limitation exists in AWS environments.
+. If your installation is in a Google Cloud Platform (GCP) environment, you must use Workload Identities, not Service Account credentials. This is due to a limitation in init container volume mounting. No such limitation exists in AWS environments.
 . Datastores:
 .. If using **externalized** datastores, Postgres must be updated to version 12.
 .. If your datastores are **internal**, ensure that the volume sizes allocated to Mongodb, Postgres, and Redis in your v4.0 installation are at least the same or greater than the volumes allocated to the Mongodb, Postgres, and Redis instances in your v2.19 install. You may resize your 4.x datastore volumes following link:/docs/server/operator/expanding-internal-database-volumes/[these instructions].
-. You have a new CircleCI server v4.0 link:/docs/server/installation/phase-1-prerequisites[installation].
+. You have a new CircleCI server v4.0.x link:/docs/server/installation/phase-1-prerequisites[installation].
 . You have successfully run link:https://github.com/circleci/realitycheck[realitycheck] with contexts before starting.
 . The migration script must be run from a machine with:
 - `kubectl` configured for the server v4.0 instance

--- a/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
+++ b/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
@@ -21,7 +21,7 @@ Depending on the size of your data stores, the migration can take anywhere from 
 
 . Your current CircleCI server installation is v2.19x
 . You have taken a backup of your v2.19 instance. If you are using external datastores, they need to be backed up separately.
-. If your install is in a Google Cloud Platform (GCP) environment, you are using Workload Identities, not Service Account credentials. Due to a limitation in init container volume mounting, the 2x to 4x migration process on GCP supports only workload identities. No such limitation exists in AWS environments.
+. If your install is in a Google Cloud Platform (GCP) environment, you are using Workload Identities, not Service Account credentials. Due to a limitation in init container volume mounting, the 2x to 4x migration process on GCP supports only Workload Identities. No such limitation exists in AWS environments.
 . Datastores:
 .. If using **externalized** datastores, Postgres must be updated to version 12.
 .. If your datastores are **internal**, ensure that the volume sizes allocated to Mongodb, Postgres, and Redis in your v4.0 installation are at least the same or greater than the volumes allocated to the Mongodb, Postgres, and Redis instances in your v2.19 install. You may resize your 4.x datastore volumes following link:/docs/server/operator/expanding-internal-database-volumes/[these instructions].


### PR DESCRIPTION
# Description
Introduces workload identities as a prerequisite for the 2x to 4x migration in GCP environments. Google service account credentials will not mount due to a limitation with init containers in the migration process.

# Reasons
[Server ticket](https://circleci.atlassian.net/browse/SERVER-2371?atlOrigin=eyJpIjoiZDc3Y2JiNzI5MWNjNDYzN2I0ZDNlMmE1YjZkNDMyZDUiLCJwIjoiaiJ9)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
