### PR TITLE
feat: add env subst docs for orbs

### DIFF
--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -258,7 +258,32 @@ Each usage example must present a full example including showing the orb being i
 {: #secrets-should-never-be-directly-entered }
 {:.no_toc}
 
-Any information that could be considered "secret" such as API keys, auth tokens and passwords, should never be entered directly as parameter values. Instead, the orb developer should use the [env_var_name]({{site.baseurl}}/reusing-config/#environment-variable-name) parameter type, which expects the string value of the name of the environment variable that contains the secret information.
+Any information that could be considered "secret" such as API keys, auth tokens and passwords, should never be entered directly as parameter values. Instead, the orb developer should use the [env_var_name]({{site.baseurl}}/reusing-config/#environment-variable-name) parameter type, which expects the string value of the name of the environment variable that contains the secret information. The `env_var_name` parameter type will fail validation if the parameter value is not a POSIX-compliant environment variable name. This is designed to assist in preventing users from accidentally entering the secret value directly as a string.
+
+If your orb requires an "API key", you should create a parameter named `api_key` of type `env_var_name`. The user of your orb would then pass the name of the environment variable containing the API key as the value of the `api_key` parameter.
+
+```yaml
+parameters:
+  api_key:
+    type: env_var_name
+    default: API_KEY # An environment variable named API_KEY contains the API key
+steps:
+  - run:
+      environment:
+        PARAM_API_KEY: << parameters.api_key >>
+      command: |
+        # Use the API key
+```
+In this example, the string value of `API_KEY` has been saved in the environment variable `PARAM_API_KEY`. In order to get the value of the environment variable with the name `API_KEY`, we must evaluate with [BASH parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html).
+
+```yaml
+steps:
+  - run:
+      environment:
+        PARAM_API_KEY: << parameters.api_key >>
+      command: |
+        API_KEY_VALUE=${!PARAM_API_KEY}
+```
 
 #### Parameterize the installation path
 {: #parameterize-the-installation-path }

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -287,7 +287,6 @@ steps:
 
 #### Accepting parameters as strings or environment variables
 {: #accepting-parameters-as-strings-or-environment-variables }
-{:.no_toc}
 
 When creating a parameter that accepts a non-secret string value, it is often useful to also accept an environment variable that could be reused in multiple places. For example, setting your `AWS_REGION` is likely not a secret in the traditional sense, you may want to manually entire a region, or override a default value directly. It may also be easier to reference an environment variable that contains the region, such as if you were using a [context](/docs/contexts) to store your AWS metadata for multiple projects.
 

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -260,7 +260,7 @@ Each usage example must present a full example including showing the orb being i
 
 Any information that could be considered "secret" such as API keys, auth tokens and passwords, should never be entered directly as parameter values. Instead, the orb developer should use the [env_var_name]({{site.baseurl}}/reusing-config/#environment-variable-name) parameter type, which expects the string value of the name of the environment variable that contains the secret information. The `env_var_name` parameter type will fail validation if the parameter value is not a POSIX-compliant environment variable name. This is designed to assist in preventing users from accidentally entering the secret value directly as a string.
 
-If your orb requires an "API key", you should create a parameter named `api_key` of type `env_var_name`. The user of your orb would then pass the name of the environment variable containing the API key as the value of the `api_key` parameter.
+If your orb requires an "API key", you should create a parameter named `api_key` of type `env_var_name`. The developer using of your orb would then pass the name of the environment variable containing the API key as the value of the `api_key` parameter.
 
 ```yaml
 parameters:

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -289,7 +289,7 @@ steps:
 {: #accepting-parameters-as-strings-or-environment-variables }
 {:.no_toc}
 
-When creating a parameter that accepts a non-secret string value, it is often useful to also accept an environment variable that could be reused in multiple places. For example, setting your `AWS_REGION` is likely not a secret in the traditional sense, you may want to manually entire a region, or override a default value directly. It may also be easier to reference an environment variable that contains the region, such as if you were using a [context](/contexts) to store your AWS metadata for multiple projects.
+When creating a parameter that accepts a non-secret string value, it is often useful to also accept an environment variable that could be reused in multiple places. For example, setting your `AWS_REGION` is likely not a secret in the traditional sense, you may want to manually entire a region, or override a default value directly. It may also be easier to reference an environment variable that contains the region, such as if you were using a [context](/docs/contexts) to store your AWS metadata for multiple projects.
 
 CircleCI ships with the [envsubt](/env-vars/#environment-variable-substitution) CLI built in, which allows us to evaluate environment variables in strings.
 
@@ -306,7 +306,7 @@ steps:
       command: <<include(script/your_script.sh)>>
 ```
 
-When building orbs, it is typical to [write your code in a separate file](/orb-concepts/#file-include-syntax) to avoid some of the pitfalls of YAML. In this example, we are including a script named `your_script.sh` which contains the following code:
+When building orbs, it is typical to [write your code in a separate file](/docs/orb-concepts/#file-include-syntax) to avoid some of the pitfalls of YAML. In this example, we are including a script named `your_script.sh` which contains the following code:
 
 ```bash
 REGION_VALUE=$(circleci env subst <<< "$PARAM_REGION")

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -5,22 +5,19 @@ short-title: "Best Practices for Orb Authors"
 description: "a guide to best practices for developing orbs"
 categories: [getting-started]
 order: 1
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
   - Server v3.x
 ---
 
-* TOC
-{:toc}
-
 ## General
 {: #general }
 
 #### Give your orb a descriptive name
 {: #give-your-orb-a-descriptive-name }
-{:.no_toc}
+
 
 An orb "slug" is made up of a _namespace_ and _orb_ name separated by a forward slash. The namespace represents, the individual, company, or organization that owns and maintains the orb, while the orb name itself should describe the product, service, or action provided by the individual orb.
 
@@ -32,13 +29,11 @@ An orb "slug" is made up of a _namespace_ and _orb_ name separated by a forward 
 
 #### Categorize your orb
 {: #categorize-your-orb }
-{:.no_toc}
 
 Categorizing your orb allows it to be searchable on the [Orb Registry](https://circleci.com/developer/orbs) by category. To see how you can categorize your orb using the CircleCI CLI, refer to the relevant section in the [Orb Authoring Process]({{site.baseurl}}/orb-author/#categorizing-your-orb) guide.
 
 #### Ensure all orb components include descriptions
 {: #ensure-all-orb-components-include-descriptions }
-{:.no_toc}
 
 Commands, Jobs, Executors, Examples, and Parameters can all accepts descriptions. Ensure each and every component of your orb has a helpful description and provides any additional documentation that may be needed.
 
@@ -54,7 +49,6 @@ Create detailed descriptions that fully explain the benefit and usage of the orb
 
 #### Ensure your orb-publishing context is restricted
 {: #ensure-your-orb-publishing-context-is-restricted }
-{:.no_toc}
 
 If using the Orb Developer Kit, your CircleCI Personal Access Token is saved to a context in your Organization. Ensure you restrict this context so that jobs accessing it will only run when triggered or approved by you or other approved users. For more information, see the [Using Contexts]({{site.baseurl}}/contexts/#restricting-a-context) guide.
 
@@ -68,13 +62,11 @@ The `@orb.yml` file acts as the "root" of our project and contains much of the m
 
 #### All orbs should include a description
 {: #all-orbs-should-include-a-description }
-{:.no_toc}
 
 When orbs are published to the Orb Registry they are searchable by their name and description. Besides giving your users a better idea of the purpose and functionality of your orb, good descriptions are important for search optimization.
 
 #### Include display links
 {: #include-display-links }
-{:.no_toc}
 
 Orbs utilize a special config key [`display`]({{site.baseurl}}/orb-author/#orbyml) that can hold a `source_url` for linking to your Git repository, which in turn holds the orb source code and `home_url` to link to the product or service home page if applicable.
 
@@ -89,13 +81,11 @@ display:
 
 #### Most orbs will contain at least one command
 {: #most-orbs-will-contain-at-least-one-command }
-{:.no_toc}
 
 Most orbs will contain at least a single command. Commands are used to execute shell commands and special CircleCI steps automatically on the user's behalf. In less common situations, for instance, if a tool _requires_ the use of a particular Docker container, an orb may not contain commands and only provide jobs.
 
 #### Use the minimal number of steps required.
 {: #use-the-minimal-number-of-steps-required }
-{:.no_toc}
 
 When writing a [Reusable Command]({{site.baseurl}}/reusing-config/#authoring-reusable-commands) for your orb, you may input any number of [steps]({{site.baseurl}}/configuration-reference/#steps). Each step should be properly named as it will appear in the user's UI. To limit the amount of "noise" in the UI, attempt to use as few steps as possible.
 
@@ -132,7 +122,6 @@ steps:
 
 #### Check for root
 {: #check-for-root }
-{:.no_toc}
 
 Before adding "sudo" to your commands, check to see if the user is already the root user. This can be done dynamically with environment variables.
 
@@ -149,7 +138,6 @@ $SUDO do_command
 
 #### Consider "pass-through" parameters
 {: #consider-pass-through-parameters }
-{:.no_toc}
 
 Inside your job, if you are utilizing any commands or executors, you must include a copy of each parameter from each of those components into your job. You can then "pass-through" the parameters given to the job, to each referenced component.
 
@@ -197,12 +185,11 @@ As you can see, this job utilizes an executor named `default` which accepts a `v
 
 #### A docker image parameter might be preferable to an executor
 {: #a-docker-image-parameter-might-be-preferable-to-an-executor }
-{:.no_toc}
+{:.}
 Does your orb have multiple jobs which require a specific execution environment? If so, you may choose to implement a custom executor. Will your job run on most linux platforms? Consider just using the `docker` executor directly in your job, and parameterize the image.
 
 #### Consider _post_ and _pre_ steps, and step parameters
 {: #consider-post-and-pre-steps-and-step-parameters }
-{:.no_toc}
 
 Jobs on CircleCI can have steps injected into them, either before or after the job, or somewhere in-between with the use of parameters. Jobs are often easier to set up for users than assembling commands into a custom job (where applicable). Injectable steps allow for more flexibility in jobs and may allow new functionalities in your orb.
 
@@ -215,7 +202,7 @@ See the following:
 
 #### Orbs do not always require an executor
 {: #orbs-do-not-always-require-an-executor }
-{:.no_toc}
+
 In orb development, executors are often used to either provide or utilize a specific execution environment when we have multiple jobs which can only run in that environment. For example, if your orb relies on a specific Docker container and includes two jobs and no commands, it makes sense to abstract the execution environment into a single [Reusable Executor]({{site.baseurl}}/reusing-config/#authoring-reusable-executors) to be used for both jobs.
 
 Executors are especially useful outside of orbs, as a way to create [matrix tests](https://circleci.com/blog/circleci-matrix-jobs/) for custom jobs.
@@ -235,19 +222,16 @@ Be sure to name your usage examples so they reflect the use-case they demonstrat
 
 #### All public orbs should contain at least one usage example.
 {: #all-public-orbs-should-contain-at-least-one-usage-example }
-{:.no_toc}
 
 Orbs intended for consumption by other organizations should include at least one usage example, with a description.
 
 #### Use-case based examples
 {: #use-case-based-examples }
-{:.no_toc}
 
 Each included usage example should be named for a specific use-case to instruct the user in how to accomplish a task. Example: `install_cli_and_deploy`, `scan_docker_container`, or `test_application_with_this-tool`
 
 #### Show correct orb version
 {: #show-correct-orb-version }
-{:.no_toc}
 
 Each usage example must present a full example including showing the orb being imported. The version number displayed in the usage-example should match the currently published orb. If your orb is currently on version `0.1.0`, and you were to open a pull request to publish version `1.0.0`, your usage examples should be updated to reflect version `1.0.0` of the orb in use.
 
@@ -256,11 +240,10 @@ Each usage example must present a full example including showing the orb being i
 
 #### Secrets should _never_ be directly entered
 {: #secrets-should-never-be-directly-entered }
-{:.no_toc}
 
 Any information that could be considered "secret" such as API keys, auth tokens, and passwords, should never be entered directly as a parameter value. Instead, use the [env_var_name]({{site.baseurl}}/reusing-config/#environment-variable-name) parameter type, which expects the string value of the name of the environment variable that contains the secret information. The `env_var_name` parameter type will fail validation if the parameter value is not a POSIX-compliant environment variable name. This is designed to assist in preventing users from accidentally entering the secret value directly as a string.
 
-If your orb requires an "API key", you should create a parameter named `api_key` of type `env_var_name`. The developer using of your orb would then pass the name of the environment variable containing the API key as the value of the `api_key` parameter.
+If your orb requires an "API key", you should create a parameter named `api_key` of type `env_var_name`. The developer using your orb would then pass the name of the environment variable containing the API key as the value of the `api_key` parameter.
 
 ```yaml
 parameters:
@@ -317,7 +300,6 @@ Going through this substitution process allows us to accept a string value, or a
 
 #### Parameterize the installation path
 {: #parameterize-the-installation-path }
-{:.no_toc}
 
 When installing any binary into a potentially unknown user-defined Docker image, it is hard to know what permissions will be available. Create an `install-path` parameter, ideally with a default value of `/usr/local/bin`, and install binaries to this location (if possible). This often avoids the issue of requiring "root" privileges in environments where that may not possible.
 
@@ -326,13 +308,11 @@ When installing any binary into a potentially unknown user-defined Docker image,
 
 #### Always follow strict semantic versioning
 {: #always-follow-strict-semantic-versioning }
-{:.no_toc}
 
 Semantic versioning is a critical update and release practice in which version numbers communicate either bug fixes and patches, new functionality, or breaking changes. Introducing a breaking change as a patch update, for example, can lead to users of that orb automatically receiving updates that block their CI process. Before updating your orbs, make sure you have read over and understood [semantic versioning]({{site.baseurl}}/orb-concepts/#semantic-versioning).
 
 ### Keep a changelog
 {: #keep-a-changelog }
-{:.no_toc}
 
 Keeping a concise changelog allows users of an orb to quickly see what has changed in a particular version. While git does provide a log of changes, it can be difficult to discover the difference between two versions, especially when commits don't necessarily align to a release. Changelogs should conform to the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
 
@@ -341,6 +321,5 @@ Keeping a concise changelog allows users of an orb to quickly see what has chang
 
 #### Share your orb with the community!
 {: #share-your-orb-with-the-community }
-{:.no_toc}
 
 Have you published an orb to the Orb Registry? We'd love to hear about it. Come make a post on [CircleCI Discuss](https://discuss.circleci.com/c/ecosystem/orbs).

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -258,7 +258,7 @@ Each usage example must present a full example including showing the orb being i
 {: #secrets-should-never-be-directly-entered }
 {:.no_toc}
 
-Any information that could be considered "secret" such as API keys, auth tokens and passwords, should never be entered directly as parameter values. Instead, the orb developer should use the [env_var_name]({{site.baseurl}}/reusing-config/#environment-variable-name) parameter type, which expects the string value of the name of the environment variable that contains the secret information. The `env_var_name` parameter type will fail validation if the parameter value is not a POSIX-compliant environment variable name. This is designed to assist in preventing users from accidentally entering the secret value directly as a string.
+Any information that could be considered "secret" such as API keys, auth tokens, and passwords, should never be entered directly as a parameter value. Instead, use the [env_var_name]({{site.baseurl}}/reusing-config/#environment-variable-name) parameter type, which expects the string value of the name of the environment variable that contains the secret information. The `env_var_name` parameter type will fail validation if the parameter value is not a POSIX-compliant environment variable name. This is designed to assist in preventing users from accidentally entering the secret value directly as a string.
 
 If your orb requires an "API key", you should create a parameter named `api_key` of type `env_var_name`. The developer using of your orb would then pass the name of the environment variable containing the API key as the value of the `api_key` parameter.
 

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -285,6 +285,36 @@ steps:
         API_KEY_VALUE=${!PARAM_API_KEY}
 ```
 
+#### Accepting parameters as strings or environment variables
+{: #accepting-parameters-as-strings-or-environment-variables }
+{:.no_toc}
+
+When creating a parameter that accepts a non-secret string value, it is often useful to also accept an environment variable that could be reused in multiple places. For example, setting your `AWS_REGION` is likely not a secret in the traditional sense, you may want to manually entire a region, or override a default value directly. It may also be easier to reference an environment variable that contains the region, such as if you were using a [context](/contexts) to store your AWS metadata for multiple projects.
+
+CircleCI ships with the [envsubt](/env-vars/#environment-variable-substitution) CLI built in, which allows us to evaluate environment variables in strings.
+
+```yaml
+parameters:
+  region:
+    type: string
+    default: $REGION # This value is expected to be a string, but may evaluate to an environment variable
+steps:
+  - run:
+      environment:
+        REGION: 'us-west-2'
+        PARAM_REGION: << parameters.region >>
+      command: <<include(script/your_script.sh)>>
+```
+
+When building orbs, it is typical to [write your code in a separate file](/orb-concepts/#file-include-syntax) to avoid some of the pitfalls of YAML. In this example, we are including a script named `your_script.sh` which contains the following code:
+
+```bash
+REGION_VALUE=$(circleci env subst <<< "$PARAM_REGION")
+echo "Expect REGION_VALUE to be us-west-2: $REGION_VALUE"
+```
+
+Going through this substitution process allows us to accept a string value, or an environment variable, and use it in our script. Keep in mind, it is recommended to [use the `env_var_name` parameter type for secrets](#secrets-should-never-be-directly-entered) which should never be entered directly.
+
 #### Parameterize the installation path
 {: #parameterize-the-installation-path }
 {:.no_toc}

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -288,7 +288,7 @@ steps:
 #### Accepting parameters as strings or environment variables
 {: #accepting-parameters-as-strings-or-environment-variables }
 
-When creating a parameter that accepts a non-secret string value, it is often useful to also accept an environment variable that could be reused in multiple places. For example, setting your `AWS_REGION` is likely not a secret in the traditional sense, you may want to manually entire a region, or override a default value directly. It may also be easier to reference an environment variable that contains the region, such as if you were using a [context](/docs/contexts) to store your AWS metadata for multiple projects.
+When creating a parameter that accepts a non-secret string value, it is often useful to also accept an environment variable that could be reused in multiple places. For example, setting your `AWS_REGION` is likely not a secret in the traditional sense, you may want to manually enter a region, or override a default value directly. It may also be easier to reference an environment variable that contains the region, for example, if you were using a [context](/docs/contexts) to store your AWS metadata for multiple projects.
 
 CircleCI ships with the [envsubt](/env-vars/#environment-variable-substitution) CLI built in, which allows us to evaluate environment variables in strings.
 

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -274,7 +274,8 @@ steps:
       command: |
         # Use the API key
 ```
-In this example, the string value of `API_KEY` has been saved in the environment variable `PARAM_API_KEY`. In order to get the value of the environment variable with the name `API_KEY`, we must evaluate with [BASH parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html).
+
+In this example, the string value of `API_KEY` is saved in the environment variable `PARAM_API_KEY`. In order to get the value of the environment variable with the name `API_KEY`, you must evaluate with [BASH parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html).
 
 ```yaml
 steps:

--- a/jekyll/_cci2/orbs-best-practices.md
+++ b/jekyll/_cci2/orbs-best-practices.md
@@ -306,10 +306,10 @@ steps:
       command: <<include(script/your_script.sh)>>
 ```
 
-When building orbs, it is typical to [write your code in a separate file](/docs/orb-concepts/#file-include-syntax) to avoid some of the pitfalls of YAML. In this example, we are including a script named `your_script.sh` which contains the following code:
+When building orbs, it is typical to [write your code in a separate file](/docs/orb-concepts/#file-include-syntax) to avoid some of the pitfalls of YAML, as well as gaining access to syntax highlighting and other features in your IDE. In this example, we are including a script named `your_script.sh` which contains the following code:
 
 ```bash
-REGION_VALUE=$(circleci env subst <<< "$PARAM_REGION")
+REGION_VALUE=$(circleci env subst "$PARAM_REGION")
 echo "Expect REGION_VALUE to be us-west-2: $REGION_VALUE"
 ```
 


### PR DESCRIPTION
# Description
Describe the new `env subst` usage for orbs

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
