### PR TITLE
Update rotate-project-ssh-keys.adoc to fix formatting

### DIFF
--- a/jekyll/_cci2/rotate-project-ssh-keys.adoc
+++ b/jekyll/_cci2/rotate-project-ssh-keys.adoc
@@ -58,7 +58,7 @@ If you have set up user keys for your project, follow these steps:
 . Take note of the current key information to rotate, including the fingerprint. You can also click the keyname to open the related GitHub page that should list the public key.
 . Delete the user key by clicking the **X**.
 . Add a new user key by clicking **Add User Key**.
-. Go to GitHub’s User settings to delete the matching public key. The GitHub URL is typically `https://github.com/settings/keys`or you may already have the page open if you clicked on the keyname in step 1. Removing any key titled `CircleCI` created before this rotation is recommended. The new public SSH key will be automatically added once the old key is deleted (page may need to be refreshed to view the key).
+. Go to GitHub’s User settings to delete the matching public key. The GitHub URL is typically `https://github.com/settings/keys` or you may already have the page open if you clicked on the keyname in step 1. Removing any key titled `CircleCI` created before this rotation is recommended. The new public SSH key will be automatically added once the old key is deleted (page may need to be refreshed to view the key).
 
 CAUTION: The user key name contains the project name, however, a user key may give access to more projects within the organization.
 


### PR DESCRIPTION
Add a space after the closing ` to correct the formatting of the text.

# Description
There was no space between the closing back-tick and the word "or" so the formatting applied to more text than necessary.

Here is the url for the page:
https://circleci.com/docs/rotate-project-ssh-keys/#rotate-a-user-key-github

# Reasons
Adding the space improves the readability of the sentence.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
