### PR TITLE
docs: update Server 4.1.x prereqs for k8s version

### DIFF
--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -122,7 +122,7 @@ There are no requirements regarding VPC setup or disk size for your cluster. It 
 | CircleCI Version
 | Kubernetes Version
 
-| 4.0.0
+| 4.1.x
 | 1.22 - 1.23
 |===
 


### PR DESCRIPTION
# Description

Noticed the 4.1.x docs mentioning 4.0.0 still for k8s version.
I've confirmed with @ryanwohara that k8s v1.22 - v.123 is still the required versions for 4.1.x.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
