### PR TITLE
Add runner 1.0 deprecation banner

### DIFF
--- a/jekyll/_cci2/runner-api.adoc
+++ b/jekyll/_cci2/runner-api.adoc
@@ -13,9 +13,9 @@ contentTags:
 :toc: macro
 :toc-title:
 
-This document contains all the external facing endpoints for the CircleCI's self-hosted runner API.
+{% include snippets/runner-1.0-deprecation-first.adoc %}
 
-toc::[]
+This document contains all the external facing endpoints for the CircleCI's self-hosted runner API.
 
 [#authentication-methods]
 == Authentication methods

--- a/jekyll/_cci2/runner-concepts.adoc
+++ b/jekyll/_cci2/runner-concepts.adoc
@@ -13,7 +13,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-toc::[]
+{% include snippets/runner-1.0-deprecation-first.adoc %}
 
 [#namespaces-and-resource-classes]
 == Namespaces and resource classes

--- a/jekyll/_cci2/runner-config-reference.adoc
+++ b/jekyll/_cci2/runner-config-reference.adoc
@@ -12,7 +12,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-toc::[]
+{% include snippets/runner-1.0-deprecation-first.adoc %}
 
 [#self-hosted-runner-configuration-reference]
 == Machine runner configuration reference

--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -13,6 +13,8 @@ contentTags:
 :toc: macro
 :toc-title:
 
+{% include snippets/runner-1.0-deprecation-first.adoc %}
+
 This page answers frequently asked questions for CircleCI's self-hosted container and machine runners.
 
 [#self-hosted-runner-faqs]

--- a/jekyll/_cci2/runner-installation-cli.adoc
+++ b/jekyll/_cci2/runner-installation-cli.adoc
@@ -13,6 +13,8 @@ contentTags:
 :toc: macro
 :toc-title:
 
+{% include snippets/runner-1.0-deprecation-first.adoc %}
+
 This page describes how to install **machine self-hosted runners** through the CLI. If you are interested in container runner on Kubernetes, please see the <<container-runner#,Container runner>> page.
 
 NOTE: Installing self-hosted runners is available directly in the https://app.circleci.com/[CircleCI web app] for Linux, macOS, Docker, and Windows. You will need to agree to the <<#self-hosted-runner-terms-agreement,Runner Terms>> before this option is available to you in the UI.

--- a/jekyll/_cci2/runner-installation-docker.adoc
+++ b/jekyll/_cci2/runner-installation-docker.adoc
@@ -13,6 +13,8 @@ contentTags:
 :toc: macro
 :toc-title:
 
+{% include snippets/runner-1.0-deprecation-first.adoc %}
+
 This page describes how to install CircleCI's machine runner with the Docker executor. If you are looking to set up self-hosted runners in a private Kubernetes cluster, please visit the <<container-runner#,Container runner>> page.
 
 [#new-recommended-method-container-runner]

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -13,6 +13,8 @@ contentTags:
 :toc: macro
 :toc-title:
 
+{% include snippets/runner-1.0-deprecation-first.adoc %}
+
 This page describes how to install CircleCI's machine runner on Linux.
 
 {% include snippets/runner-platform-prerequisites.adoc %}

--- a/jekyll/_cci2/runner-installation-mac.adoc
+++ b/jekyll/_cci2/runner-installation-mac.adoc
@@ -13,6 +13,8 @@ contentTags:
 :toc: macro
 :toc-title:
 
+{% include snippets/runner-1.0-deprecation-first.adoc %}
+
 This page describes how to install CircleCI's machine runner on macOS.
 
 {% include snippets/runner-platform-prerequisites.adoc %}

--- a/jekyll/_cci2/runner-installation-windows.adoc
+++ b/jekyll/_cci2/runner-installation-windows.adoc
@@ -13,6 +13,8 @@ contentTags:
 :toc: macro
 :toc-title:
 
+{% include snippets/runner-1.0-deprecation-first.adoc %}
+
 This page describes how to install CircleCI's machine runner on Windows. This has been tested for Windows Server 2019 and Windows Server 2016, both in Datacenter Edition. Other Server SKUs with Desktop Experience and Remote Desktop Services should also work.
 
 {% include snippets/runner-platform-prerequisites.adoc %}

--- a/jekyll/_cci2/runner-installation.adoc
+++ b/jekyll/_cci2/runner-installation.adoc
@@ -11,11 +11,11 @@ contentTags:
 :toc: macro
 :toc-title:
 
+{% include snippets/runner-1.0-deprecation-first.adoc %}
+
 This page describes how to install self-hosted through the CircleCI web app. If you are interested in self-hosted runner on server, see the <<runner-installation-cli#,Self-hosted runners with the CLI>> page.
 
 NOTE: Installing runners is available directly in the https://app.circleci.com/[CircleCI web app] for container runner, Linux, macOS, and Windows. You will need to agree to the <<#self-hosted-runner-terms-agreement,Runner Terms>> before this option is available to you in the UI.
-
-toc::[]
 
 [#container-runner-prerequisites]
 == Container runner prerequisites

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -13,7 +13,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-toc::[]
+{% include snippets/runner-1.0-deprecation-first.adoc %}
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/runner-scaling.adoc
+++ b/jekyll/_cci2/runner-scaling.adoc
@@ -14,6 +14,8 @@ contentTags:
 :toc-title:
 toc::[]
 
+{% include snippets/runner-1.0-deprecation-first.adoc %}
+
 [#introduction]
 == Introduction
 

--- a/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
+++ b/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
@@ -11,6 +11,8 @@ contentTags:
 :toc: macro
 :toc-title:
 
+{% include snippets/runner-1.0-deprecation-first.adoc %}
+
 This page describes errors and troubleshooting methods for container and machine runners.
 
 include::../_includes/snippets/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc[]

--- a/jekyll/_cci2/upgrading-circleci-machine-runner-on-cloud.adoc
+++ b/jekyll/_cci2/upgrading-circleci-machine-runner-on-cloud.adoc
@@ -11,9 +11,9 @@ contentTags:
 :toc: macro:
 :toc-tittle:
 
-This page describes how to update the CircleCI **machine runner** on CircleCI cloud.
+CAUTION: **Self-hosted runner version 1.0 will sunset on July 27, 2023,** and will be temporarily unavailable on June 28, 2023. **Update to 1.1.**
 
-toc::[]
+This page describes how to update the CircleCI **machine runner** on CircleCI cloud.
 
 [#check-current-version]
 == Checking current machine runner version

--- a/jekyll/_includes/snippets/runner-1.0-deprecation-first.adoc
+++ b/jekyll/_includes/snippets/runner-1.0-deprecation-first.adoc
@@ -1,0 +1,1 @@
+CAUTION: **Self-hosted runner version 1.0 will sunset on July 27, 2023,** and will be temporarily unavailable on June 28, 2023. xref:upgrading-circleci-machine-runner-on-cloud#[Update to 1.1.]


### PR DESCRIPTION
# Description
This PR adds a banner informing readers that runner 1.0 will be sunset in July and will have a planned brownout in June.
![image](https://user-images.githubusercontent.com/36839689/234884591-99a2d0c8-c815-4fe2-9876-88b1fc92b172.png)

The banner will be saved as a snippet and added to the following pages:
https://circleci.com/docs/runner-overview/
https://circleci.com/docs/runner-concepts/
https://circleci.com/docs/runner-installation/
https://circleci.com/docs/runner-installation-cli/
https://circleci.com/docs/runner-installation-docker/
https://circleci.com/docs/runner-installation-linux/
https://circleci.com/docs/runner-installation-mac/
https://circleci.com/docs/runner-installation-windows/
https://circleci.com/docs/runner-api/
https://circleci.com/docs/runner-faqs/
https://circleci.com/docs/troubleshoot-self-hosted-runner/
https://circleci.com/docs/runner-config-reference/
https://circleci.com/docs/runner-scaling/

# Reasons
Inform users regarding deprecation timeline
DOCSS-1107

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
