### PR TITLE
Update 4.0.3 references to 4.0.4 in the server v3 -> v4 migration doc

### DIFF
--- a/jekyll/_cci2/server/installation/migrate-from-server-3-to-server-4.adoc
+++ b/jekyll/_cci2/server/installation/migrate-from-server-3-to-server-4.adoc
@@ -95,7 +95,7 @@ helm registry login cciserver.azurecr.io --username <image-registry-username>
 The Helm Diff tool is used to verify that the changes between your current install and the upgrade are expected.
 
 # diff command
-helm diff upgrade <release-name> -n <namespace> -f <path>/kots-exporter/output/helm-values.yaml --show-secrets --context 5 oci://cciserver.azurecr.io/circleci-server --version 4.0.3
+helm diff upgrade <release-name> -n <namespace> -f <path>/kots-exporter/output/helm-values.yaml --show-secrets --context 5 oci://cciserver.azurecr.io/circleci-server --version 4.0.4
 -------------------------------------------------------------------------
 ## Helm Upgrade CircleCI Server
 helm upgrade <release-name> -n <namespace> -f <path>/kots-exporter/output/helm-values.yaml oci://cciserver.azurecr.io/circleci-server --version <version-to-upgrade-to> --force
@@ -144,7 +144,7 @@ Next, execute the helm-diff command and review the output.
 ----
 helm registry login cciserver.azurecr.io -u <image-registry-username>
 
-helm diff upgrade <release-name> -n <namespace> -f <path>/kots-exporter/output/helm-values.yaml --show-secrets --context 5 oci://cciserver.azurecr.io/circleci-server --version 4.0.3
+helm diff upgrade <release-name> -n <namespace> -f <path>/kots-exporter/output/helm-values.yaml --show-secrets --context 5 oci://cciserver.azurecr.io/circleci-server --version 4.0.4
 ----
 
 Review the output generated from the `helm-diff` command using the following to help:
@@ -178,7 +178,7 @@ Once your helm-value file is verified, run the following commands to upgrade the
 Our helm registry is stored in an azure private registry. You will be provided a username and token to access the registry.
 [source,shell]
 ----
-helm upgrade circleci-server -n <namespace> -f <path>/kots-exporter/output/helm-values.yaml oci://cciserver.azurecr.io/circleci-server --version 4.0.3 --force
+helm upgrade circleci-server -n <namespace> -f <path>/kots-exporter/output/helm-values.yaml oci://cciserver.azurecr.io/circleci-server --version 4.0.4 --force
 ----
 
 [#check-upgrade-status]


### PR DESCRIPTION
# Description
The most recent version of server 4.0 is currently 4.0.4. This is an update to our migration doc which currently references server 4.0.3.

# Reasons
We have had a few customers ask if they should specifically use 4.0.3 since our docs page refers to that version. This update will bring our [migration docs page](https://circleci.com/docs/server/installation/migrate-from-server-3-to-server-4/) in line with our [latest server 4.0](https://circleci.com/server/changelog/#release-4-0-4) version as of May 3rd, 2023.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
