### PR TITLE
[PIPE-4019] Add org.workflows.deleted audit event

### DIFF
--- a/jekyll/_cci2/audit-logs.adoc
+++ b/jekyll/_cci2/audit-logs.adoc
@@ -46,6 +46,7 @@ The following are the system events that are logged. See `action` in the Field s
 - workflow.job.finish
 - workflow.job.scheduled
 - workflow.job.start
+- org.workflows.deleted
 
 [#audit-log-fields]
 == Audit log fields


### PR DESCRIPTION
# Description
This event is published by workflows-conductor (WFC) after processing user deletion requests from data-deletion-service. After WFC deletes all workflow data associated with the org, we need to publish an audit log.

# Reasons
https://circleci.atlassian.net/browse/PIPE-4019

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
