### PR TITLE
add optimization overview to sidebar and refresh

### DIFF
--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: "Optimizations Overview"
+title: "Optimization reference"
 description: "Learn about ways to optimize your CircleCI pipelines"
 contentTags:
   platform:

--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -1,8 +1,7 @@
 ---
 layout: classic-docs
 title: "Optimizations Overview"
-short-title: "Optimizations Overview"
-description: "CircleCI build optimizations"
+description: "Learn about ways to optimize your CircleCI pipelines"
 contentTags:
   platform:
   - Cloud
@@ -10,50 +9,19 @@ contentTags:
   - Server v3.x
 ---
 
-This document provides an overview of ways to optimize your CircleCI configuration. Each optimization method will be described briefly, and present possible use cases for speeding up your jobs.
+This page provides an overview of the various ways you can optimize your CircleCI configuration. Each optimization method is described briefly, along with possible use cases.
 
-* TOC
-{:toc}
+## Optimize your data usage
+{: #data}
 
-## Custom storage controls
+### Custom storage controls
 {: #custom-storage-controls }
 
-The [CircleCI web app](https://app.circleci.com/) provides controls to customize the storage retention period of workspaces, caches, and artifacts. You can find these settings by navigating to **Plan > Usage Controls**. By default, the storage period is 30 days for artifacts, and 15 days for caches and workspaces. These are also the maximum retention periods for storage. The maximum storage period is 30 days for artifacts, and 15 days for caches and workspaces.
+The [CircleCI web app](https://app.circleci.com/) provides controls to customize the storage retention period for workspaces, caches, and artifacts. You can find these settings by navigating to **Plan > Usage Controls**. By default, the storage periods are set to the maximum: 30 days for artifacts, and 15 days for caches and workspaces.
 
 See the [Persisting Data]({{site.baseurl}}/persist-data/#custom-storage-usage) page for more information on custom storage settings.
 
-## Docker image choice
-{: #docker-image-choice }
-
-Choosing the right docker image for your project can have huge impact on build time. For example, choosing a basic language image means dependencies and tools need to be downloaded each time your pipeline is run, whereas, if you choose or build an image that has these dependencies and tools already installed, this time will be saved for each build run. When configuring your projects and specifying images, consider the following options:
-
-* CircleCI provides a range of [convenience images]({{site.baseurl}}/circleci-images/#section=configuration), typically based on official Docker images, but with a range of useful language tools pre-installed.
-* You can create [custom images]({{site.baseurl}}/custom-images/#section=configuration), maximizing specificity for your projects. To help with this we provide [guidance for building images manually]({{site.baseurl}}/custom-images/#creating-a-custom-image-manually).
-
-## Docker layer caching
-{: #docker-layer-caching }
-
-Docker layer caching is a feature that can help to reduce the _build time_ of a Docker image in your build. DLC is useful if you find yourself frequently building Docker images as a regular part of your CI/CD process.
-
-DLC is similar to _caching dependencies_, in that it _saves_ the image layers that you build within your job, making them available on subsequent builds.
-
-* Read more on the [Docker Layer Caching]({{site.baseurl}}/docker-layer-caching) page.
-
-## Caching dependencies
-{: #caching-dependencies }
-
-Caching should be one of the first things you consider when trying to optimize your jobs. If a job fetches data at any point, it is likely that you can make use of caching. A common example is the use of a package/dependency manager. If your project uses Yarn, Bundler, or Pip, for example, the dependencies downloaded during a job can be cached for later use rather than being re-downloaded on every build.
-
-* Read more on the [Caching Dependencies]({{site.baseurl}}/caching) page.
-
-## Workflows
-{: #workflows }
-
-Workflows provide a means to define a collection of jobs and their run order. If at any point in your configuration you see a step where two jobs could happily run independent of one another, workflows may be helpful. Workflows also provide several other features to augment and improve your CI/CD configuration. Read more about workflows on the [Workflow]({{site.baseurl}}/workflows/) page.
-
-* You can view examples of workflows in the [CircleCI demo workflows repo](https://github.com/CircleCI-Public/circleci-demo-workflows/).
-
-## Workspaces
+### Workspaces
 {: #workspaces }
 
 Workspaces are used to pass along data that is _unique to a run_ and is needed for _downstream jobs_. So, if you are using workflows, a job run earlier in your build might fetch data and then make it _available later_ for jobs that run later in a build.
@@ -62,23 +30,84 @@ To persist data from a job and make it available to downstream jobs via the [`at
 
 * Read more on the [Workspaces]({{site.baseurl}}/workspaces/) page.
 
-## Parallelism
+## Speed up pipelines
+{: #speed}
+
+### Docker image choice
+{: #docker-image-choice }
+
+Choosing the right docker image for your project can have huge impact on build time. For example, choosing a basic language image means dependencies and tools need to be downloaded each time your pipeline is run, whereas, if you choose or build an image that has these dependencies and tools already installed, this time will be saved for each build run. When configuring your projects and specifying images, consider the following options:
+
+* CircleCI provides a range of [convenience images](/docs/circleci-images/#section=configuration), typically based on official Docker images, but with a range of useful language tools pre-installed.
+* You can create [custom images](/docs/custom-images/#section=configuration), maximizing specificity for your projects. To help with this we provide [guidance for building images manually](/docs/custom-images/#creating-a-custom-image-manually).
+
+### Docker layer caching
+{: #docker-layer-caching }
+
+Docker layer caching is a feature that can help to reduce the _build time_ of a Docker image in your build. DLC is useful if you find yourself frequently building Docker images as a regular part of your CI/CD process.
+
+DLC is similar to _caching dependencies_, in that it _saves_ the image layers that you build within your job, making them available on subsequent builds.
+
+* Read more on the [Docker Layer Caching]({{site.baseurl}}/docker-layer-caching) page.
+
+### Caching dependencies
+{: #caching-dependencies }
+
+Caching should be one of the first things you consider when trying to optimize your jobs. If a job fetches data at any point, it is likely that you can make use of caching. A common example is the use of a package/dependency manager. If your project uses Yarn, Bundler, or Pip, for example, the dependencies downloaded during a job can be cached for later use rather than being re-downloaded on every build.
+
+* Read more on the [Caching Dependencies]({{site.baseurl}}/caching) page.
+
+### Workflows
+{: #workflows }
+
+Workflows provide a means to define a collection of jobs and their run order. If at any point in your configuration you see a step where two jobs could happily run independent of one another, workflows may be helpful. Workflows also provide several other features to augment and improve your CI/CD configuration. Read more about workflows on the [Workflow]({{site.baseurl}}/workflows/) page.
+
+* You can view examples of workflows in the [CircleCI demo workflows repo](https://github.com/CircleCI-Public/circleci-demo-workflows/).
+
+### Parallelism
 {: #parallelism }
 
 If your project has a large test suite, you can configure your build to use [`parallelism`]({{site.baseurl}}/configuration-reference#parallelism) together with either [CircleCI's test splitting functionality]({{site.baseurl}}/parallelism-faster-jobs/#using-the-circleci-cli-to-split-tests), or a [third party application or library]({{site.baseurl}}/parallelism-faster-jobs/#other-ways-to-split-tests) to split your tests across multiple machines. CircleCI supports automatic test allocation across machines on a file-basis, however, you can also manually customize how tests are allocated.
 
 * Read more about splitting tests on the [Parallelism]({{site.baseurl}}/parallelism-faster-jobs/) page.
 
-## Resource class
+### Resource class
 {: #resource-class }
 
 Using `resource_class`, it is possible to specify CPU and RAM resources for each job. For a full list of available resource class options for CircleCI cloud see the [configuration reference](/docs/configuration-reference/#resourceclass). For an equivalent list for CircleCI server installations, contact your system administrator.
 
 * Read more about resource classes on the [resource class overview](/docs/resource-class-overview/) page.
 
+## Optimize your configuration files
+{: #configuraiton }
+
+### Dynamic configuration
+{: dynamic-configuration}
+
+Use dynamic configuration to generate CircleCI config files dynamically, depending on specific Pipeline values or file paths. Dynamic config allows your to:
+
+* Execute conditional workflows/commands.
+
+* Pass pipeline parameter values and/or generate additional configuration.
+
+* Trigger separate config.yml configurations, which exist outside the default parent .circleci/ directory.
+
+Read more about dynamic configuration on the [Dynamic configuration](/docs/dynamic-config/) overview page.
+
+### Orbs
+{: #orbs }
+
+Orbs are reusable packages of parameterizable configuration that can be used in any project. Use orbs to:
+
+* Simplify configuration (`.circleci/_config.yml`)
+* Automate repeated processes
+* Accelerate project setup
+* Simplify integration with third-party tools
+
+Read more about orbs on the [Orbs overview](/docs/orb-intro/) page.
+
 ## See also
 {: #see-also }
-{:.no_toc}
 
 - [Persisting Data]({{site.baseurl}}/persist-data)
 - For a complete list of customizations, view the [Configuration Reference]({{site.baseurl}}/configuration-reference/) page.

--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -38,8 +38,8 @@ To persist data from a job and make it available to downstream jobs via the [`at
 
 Choosing the right docker image for your project can have huge impact on build time. For example, choosing a basic language image means dependencies and tools need to be downloaded each time your pipeline is run, whereas, if you choose or build an image that has these dependencies and tools already installed, this time will be saved for each build run. When configuring your projects and specifying images, consider the following options:
 
-* CircleCI provides a range of [convenience images](/docs/circleci-images/#section=configuration), typically based on official Docker images, but with a range of useful language tools pre-installed.
-* You can create [custom images](/docs/custom-images/#section=configuration), maximizing specificity for your projects. To help with this we provide [guidance for building images manually](/docs/custom-images/#creating-a-custom-image-manually).
+* CircleCI provides a range of [convenience images](/docs/circleci-images/), typically based on official Docker images, but with a range of useful language tools pre-installed.
+* You can create [custom images](/docs/custom-images/), maximizing specificity for your projects. To help with this we provide [guidance for building images manually](/docs/custom-images/#creating-a-custom-image-manually).
 
 ### Docker layer caching
 {: #docker-layer-caching }

--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -82,7 +82,7 @@ Using `resource_class`, it is possible to specify CPU and RAM resources for each
 {: #configuraiton }
 
 ### Dynamic configuration
-{: dynamic-configuration}
+{: #dynamic-configuration}
 
 Use dynamic configuration to generate CircleCI config files dynamically, depending on specific pipeline values or file paths. Dynamic config allows you to:
 

--- a/jekyll/_cci2/optimizations.md
+++ b/jekyll/_cci2/optimizations.md
@@ -84,7 +84,7 @@ Using `resource_class`, it is possible to specify CPU and RAM resources for each
 ### Dynamic configuration
 {: dynamic-configuration}
 
-Use dynamic configuration to generate CircleCI config files dynamically, depending on specific Pipeline values or file paths. Dynamic config allows your to:
+Use dynamic configuration to generate CircleCI config files dynamically, depending on specific pipeline values or file paths. Dynamic config allows you to:
 
 * Execute conditional workflows/commands.
 

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -280,6 +280,8 @@ en:
         children:
           - name: Reusable configuration reference
             link: reusing-config
+          - name: Optimizations reference
+            link: optimizations
 
   - name: Project Insights
     icon: icons/sidebar/insights-new.svg


### PR DESCRIPTION
# Description

I thought this would make a good reference page. The original ask in the ticket was to split this page up and make overview sections for the three optimization sections we have. I felt this wasn't the right thing to do at this time as we've been talking about making landing pages instead, so thought a reference page would work instead to find a place for the page in the sidebar.

# Reasons
Optimizations overview was not on the sidebar.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
