### PR TITLE
Add Insights badge templates and options

### DIFF
--- a/jekyll/_cci2/insights-snapshot-badge.adoc
+++ b/jekyll/_cci2/insights-snapshot-badge.adoc
@@ -65,7 +65,7 @@ In the templates below, replace `< >` items with your own details. Some options 
 --
 [source,asciidoc]
 ----
-image:https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>["CircleCI", link="https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true"]
+image:https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT_NAME>/<BRANCH>/<WORKFLOW_NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR_API_TOKEN_WITH_STATUS_SCOPE>["CircleCI", link="https://app.circleci.com/insights/<VCS_FULL>/<ORG_NAME>/<PROJECT_NAME>/workflows/<WORKFLOW_NAME>/overview?branch=<BRANCH>&reporting-window=<TIME_WINDOW_VERBOSE>&insights-snapshot=true"]
 ----
 --
 
@@ -73,7 +73,7 @@ image:https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/
 --
 [source,markdown]
 ----
-[![CircleCI](https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>)](https://app.circleci.com/insights/github/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true)
+[![CircleCI](https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT_NAME>/<BRANCH>/<WORKFLOW_NAME>/badge.svg?window=<TIME_WINDOW>&circle-token=<YOUR_API_TOKEN_WITH_STATUS_SCOPE>)](https://app.circleci.com/insights/github/<VCS_FULL>/<ORG_NAME>/<PROJECT_NAME>/workflows/<WORKFLOW_NAME>/overview?branch=<BRANCH>&reporting-window=<TIME_WINDOW_VERBOSE>&insights-snapshot=true)
 ----
 --
 
@@ -81,7 +81,7 @@ image:https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/
 --
 [source,pod]
 ----
-=for HTML <a href="https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true"><img src="https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>"></a>
+=for HTML <a href="https://app.circleci.com/insights/<VCS_FULL>/<ORG_NAME>/<PROJECT_NAME>/workflows/<WORKFLOW_NAME>/overview?branch=<BRANCH>&reporting-window=<TIME_WINDOW_VERBOSE>&insights-snapshot=true"><img src="https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT_NAME>/<BRANCH>/<WORKFLOW_NAME>/badge.svg?window=<TIME_WINDOW>&circle-token=<YOUR_API_TOKEN_WITH_STATUS_SCOPE>"></a>
 ----
 --
 
@@ -89,7 +89,7 @@ image:https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/
 --
 [source,rdoc]
 ----
-{<img src="https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>" alt="CircleCI" />}[https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true]
+{<img src="https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT_NAME>/<BRANCH>/<WORKFLOW_NAME>/badge.svg?window=<TIME_WINDOW>&circle-token=<YOUR_API_TOKEN_WITH_STATUS_SCOPE>" alt="CircleCI" />}[https://app.circleci.com/insights/<VCS_FULL>/<ORG_NAME>/<PROJECT_NAME>/workflows/<WORKFLOW_NAME>/overview?branch=<BRANCH>&reporting-window=<TIME_WINDOW_VERBOSE>&insights-snapshot=true]
 ----
 --
 
@@ -97,8 +97,8 @@ image:https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/
 --
 [source,reStructuredText]
 ----
-.. image:: https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>
-        :target: https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true
+.. image:: https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT_NAME>/<BRANCH>/<WORKFLOW_NAME>/badge.svg?window=<TIME_WINDOW>&circle-token=<YOUR_API_TOKEN_WITH_STATUS_SCOPE>
+        :target: https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT_NAME>/workflows/<WORKFLOW_NAME>/overview?branch=<BRANCH>&reporting-window=<TIME_WINDOW_VERBOSE>&insights-snapshot=true
 ----
 --
 

--- a/jekyll/_cci2/insights-snapshot-badge.adoc
+++ b/jekyll/_cci2/insights-snapshot-badge.adoc
@@ -1,12 +1,12 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
 ---
 = Insights Snapshot Badge
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Generate a badge that displays Insights metrics for a project. 
+:page-description: Generate a badge that displays Insights metrics for a project.
 :icons: font
 :toc: macro
 :toc-title:
@@ -14,7 +14,7 @@ contentTags:
 [#overview]
 == Overview
 
-The Insights snapshot badge, similar to a xref:status-badges#[status badge] that is commonly embedded in project READMEs, provides a quick view of your project's health and usage metrics.   
+The Insights snapshot badge, similar to a xref:status-badges#[status badge] that is commonly embedded in project READMEs, provides a quick view of your project's health and usage metrics.
 
 image::insights-snapshot-badge-example.png[Insights snapshot badge embedded on README]
 
@@ -28,9 +28,9 @@ While commonly placed in a project README, Insights snapshot badges can be embed
 * *Success Rate* - The percentage of successful builds for the selected workflow, over the specified time window.
 
 [#generating-an-insights-snapshot-badge]
-== Generating an Insights snapshot badge
+== Generate an Insights snapshot badge
 
-To generate an insights snapshot badge code snippet for a public repository, go to the link:https://app.circleci.com/[CircleCI web app], and select a specific project. Then, open *Project Settings* and navigate to the *Insights Snapshot Badge* page. 
+To generate an insights snapshot badge code snippet for a public repository, go to the link:https://app.circleci.com/[CircleCI web app], and select a specific project. Then, open *Project Settings* and navigate to the *Insights Snapshot Badge* page.
 
 On the Insights Snapshot Badge page, you can select the branch, workflow, and time window for which you want to display project metrics for, as well as the desired format for the code snippet.
 
@@ -51,11 +51,83 @@ The following is an example of a Insights snapshot badge generated for our Circl
 ```
 
 [#creating-badges-for-private-repositories]
-== Creating badges for private repositories
+== Create badges for private repositories
 
 To create an Insights snapshot badge for a private project, you will need to create an API token with a scope of “Status” and include that token in the image source URL. If you already have a status badge generated for the same project, you may reuse the same API token for the Insights snapshot badge.
 
 You can add an API token directly from the Insights Snapshot Badge page by clicking on the *Add API Token* button. This creates an API token with a scope of "Status" and the label "insights-snapshot". (You will also see the new token in your project's *API Permissions* settings page.) Your code snippet is displayed after the API token is created.
+
+If you would like to reuse an API token with the scope of "Status", which you have already created for your project status badge, you can use one of the following templates as an alternative to the badge generator in the CircleCI web app described above.
+
+In the templates below, replace `< >` items with your own details. Some options are shown in the table below.
+
+[.tab.badge.Asciidoc]
+--
+[source,asciidoc]
+----
+image:https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>["CircleCI", link="https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true"]
+----
+--
+
+[.tab.badge.Markdown]
+--
+[source,markdown]
+----
+[![CircleCI](https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>)](https://app.circleci.com/insights/github/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true)
+----
+--
+
+[.tab.badge.Pod]
+--
+[source,pod]
+----
+=for HTML <a href="https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true"><img src="https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>"></a>
+----
+--
+
+[.tab.badge.Rdoc]
+--
+[source,rdoc]
+----
+{<img src="https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>" alt="CircleCI" />}[https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true]
+----
+--
+
+[.tab.badge.reStructuredText]
+--
+[source,reStructuredText]
+----
+.. image:: https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>
+        :target: https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true
+----
+--
+
+[.tab.badge.Textile]
+--
+[source,textile]
+----
+!https://dl.circleci.com/insights-snapshot/<VCS>/<ORG_NAME>/<PROJECT-NAME>/<BRANCH>/<WORKFLOW-NAME>/badge.svg?window=<TIME-WINDOW>&circle-token=<YOUR-API-TOKEN-WITH-STATUS-SCOPE>!:https://app.circleci.com/insights/<VCS-FULL>/<ORG_NAME>/<PROJECT-NAME>/workflows/<WORKFLOW-NAME>/overview?branch=<BRANCH>&reporting-window=<TIME-WINDOW-VERBOSE>&insights-snapshot=true
+----
+--
+
+[.table.table-striped]
+[cols=2*, options="header", stripes=even]
+|===
+| Item
+| Options
+
+| `TIME-WINDOW`
+| `24h`, `7d`, `30d`, `60d`, `90d`
+
+| `TIME-WINDOW-VERBOSE`
+| `last-24-hours`, `last-7-days`, `last-30-days`, `last-60-days`, `last-90-days`
+
+| `VCS`
+| `gh`, `bb`
+
+| `VCS-FULL`
+| `github`, `bitbucket`
+|===
 
 [#see-also]
 == See also


### PR DESCRIPTION
# Description
Fixes #7531 

Include templates from Insights snapshot badges so people with private repos can reuse API tokens from status badges rather than creating a new one.

# Reasons
In docs we mentioned it is possible to reuse the token from a status badge for an Insights snapshot badge, but without the templates this is not possible because the process of generating the badge in the web app includes creating a new token.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
