### PR TITLE
Container runner reference

### DIFF
--- a/jekyll/_cci2/container-runner-installation.adoc
+++ b/jekyll/_cci2/container-runner-installation.adoc
@@ -45,7 +45,7 @@ Once you have installed the container runner within your cluster, create and tri
 * `image:`
 * `resource_class: <namespace>/<resource-class>`
 
-Simple example of how you could set up a job (`cimg/base:2021.11` is a commonly used CirlceCI Docker image):
+Simple example of how you could set up a job (`cimg/base:2021.11` is a commonly used CircleCI Docker image):
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -4,7 +4,7 @@ contentTags:
   platform:
   - Cloud
 ---
-= Container runner reference guide
+= Container runner reference
 :page-layout: classic-docs
 :page-liquid:
 :icons: font

--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -11,29 +11,33 @@ contentTags:
 :toc: macro
 :toc-title:
 
-[#introduction-and-motivation]
-== Introduction and motivation
-
-CircleCI’s <<runner-overview#,self-hosted runner>> has historically executed each job using a one to one mapping between the CI job and a <<configuration-reference#machine,machine>> environment (virtual or physical) that has the self-hosted runner binary installed on it. By exclusively running jobs in this manner, users sacrifice several benefits of a container-based solution that are afforded on CircleCI’s cloud platform when using the <<using-docker#,Docker executor>>:
-
-* The ability to seamlessly use custom Docker images during job execution.
-* Access to a consistent, clean containerized build environment with every job 
-
-Container runner is a type of self-hosted runner a user can install in a Kubernetes (k8s) cluster which enables them to run containerized CI jobs on self-hosted compute, similar to how jobs that use the native Docker executor run on CircleCI’s cloud platform.
-
-Container runner is a complement to the machine runner, not a replacement.
-
-After installation of the container-agent, the container runner will claim your containerized jobs, schedule them within an ephemeral pod, and execute the work within a container-based execution environment.
-
-.Container-agent model - Many container-agent : task-agents
-image::container-runner-model.png[Container-agent model]
-
-View the xref:runner-faqs#sample-configuration-container-agent[Runner FAQ page] for a full sample configuration of container runner.
+This document is a comprehensive guide to operating and configuring jobs with the CircleCI container runner.
 
 [#running-your-first-job]
 == Running your first job with container runner
 
 Follow the instructions outlined on the <<runner-installation#,self-hosted runner installation>> page to download the container runner and run your first job. You can also use the link:https://app.circleci.com/[CircleCI web app] to get started with self-hosted runners.
+
+[#sample-configuration-container-agent]
+== Container runner sample configuration
+
+```yaml
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:2021.11
+    resource_class: <namespace>/<resource-class>
+    steps:
+      - checkout
+      - ...
+
+workflows:
+  build-workflow:
+    jobs:
+      - build
+```
 
 [#resource-class-configuration-custom-pod]
 == Resource class configuration and custom task pod configuration

--- a/jekyll/_cci2/runner-api.adoc
+++ b/jekyll/_cci2/runner-api.adoc
@@ -71,7 +71,7 @@ This token is generated when creating a new resource class. This token is only d
 
 Lists the available self-hosted runners based on the specified parameters. It is mandatory to use one parameter to filter results.
 
-[#authentication-methods]
+[#get-api-v2-runner-authentication-methods]
 ==== Authentication methods
 
 * Circle-Token (personal authentication)
@@ -79,7 +79,7 @@ Lists the available self-hosted runners based on the specified parameters. It is
 ** This allows the endpoint to be accessible on circleci.com/api/v2/runner for users that have already logged into circleci.com
 * Resource class token (generated when creating a resource class)
 
-[#request]
+[#get-api-v2-runner-request]
 ===== Request
 
 [.table.table-striped]
@@ -104,7 +104,7 @@ Lists the available self-hosted runners based on the specified parameters. It is
 | filters the list of self-hosted runners by namespace.
 |===
 
-[#examples]
+[#get-api-v2-runner-examples]
 ==== Examples
 
 ```shell
@@ -117,7 +117,7 @@ curl -X GET https://runner.circleci.com/api/v2/runner?namespace=test-namespace \
     -H "Circle-Token: secret-token"
 ```
 
-[#response]
+[#get-api-v2-runner-response]
 ==== Response
 
 [.table.table-striped]
@@ -132,7 +132,7 @@ curl -X GET https://runner.circleci.com/api/v2/runner?namespace=test-namespace \
 |JSON
 |===
 
-[#response-schema]
+[#get-api-v2-runner-response-schema]
 ==== Response schema
 
 [.table.table-striped]
@@ -184,7 +184,7 @@ curl -X GET https://runner.circleci.com/api/v2/runner?namespace=test-namespace \
 |version of the machine runner launch-agent running
 |===
 
-[#example]
+[#get-api-v2-runner-example]
 ==== Example
 
 ```json
@@ -208,14 +208,14 @@ curl -X GET https://runner.circleci.com/api/v2/runner?namespace=test-namespace \
 
 Get the number of unclaimed tasks for a given resource class.
 
-[#authentication-methods]
+[#get-api-v2-tasks-authentication-methods]
 ==== Authentication methods
 
 * Circle-Token (personal authentication)
 * Browser session authentication
 ** This allows the endpoint to be accessible on circleci.com/api/v2/runner for users that have already logged into circleci.com
 
-[#request]
+[#get-api-v2-tasks-request]
 ==== Request
 
 [.table.table-striped]
@@ -234,7 +234,7 @@ Get the number of unclaimed tasks for a given resource class.
 | filters tasks by specific resource class.
 |===
 
-[#examples]
+[#get-api-v2-tasks-examples]
 ==== Examples
 
 ```shell
@@ -242,7 +242,7 @@ curl -X GET https://runner.circleci.com/api/v2/tasks?resource-class=test-namespa
     -H "Circle-Token: secret-token"
 ```
 
-[#response]
+[#get-api-v2-tasks-response]
 ==== Response
 
 [.table.table-striped]
@@ -257,7 +257,7 @@ curl -X GET https://runner.circleci.com/api/v2/tasks?resource-class=test-namespa
 |JSON
 |===
 
-[#response-schema]
+[#get-api-v2-tasks-response-schema]
 ==== Response schema
 
 [.table.table-striped]
@@ -274,7 +274,7 @@ curl -X GET https://runner.circleci.com/api/v2/tasks?resource-class=test-namespa
 |number of unclaimed tasks
 |===
 
-[#example]
+[#get-api-v2-tasks-example]
 ==== Example
 
 ```json
@@ -288,14 +288,14 @@ curl -X GET https://runner.circleci.com/api/v2/tasks?resource-class=test-namespa
 
 Get the number of running tasks for a given resource class.
 
-[#authentication-methods]
+[#get-api-v2-tasks-running-authentication-methods]
 ==== Authentication methods
 
 * Circle-Token (personal authentication)
 * Browser Session Authentication
 ** This allows the endpoint to be accessible on circleci.com/api/v2/runner for users that have already logged into circleci.com.
 
-[#request]
+[#get-api-v2-tasks-running-request]
 ==== Request
 
 [.table.table-striped]
@@ -314,7 +314,7 @@ Get the number of running tasks for a given resource class.
 | filters tasks by specific resource class.
 |===
 
-[#examples]
+[#get-api-v2-tasks-running-examples]
 ==== Examples
 
 ```shell
@@ -322,7 +322,7 @@ curl -X GET https://runner.circleci.com/api/v2/tasks/running?resource-class=test
     -H "Circle-Token: secret-token"
 ```
 
-[#response]
+[#get-api-v2-tasks-running-response]
 ==== Response
 
 [.table.table-striped]
@@ -337,7 +337,7 @@ curl -X GET https://runner.circleci.com/api/v2/tasks/running?resource-class=test
 |JSON
 |===
 
-[#response-schema]
+[#get-api-v2-tasks-running-response-schema]
 ==== Response schema
 
 [.table.table-striped]
@@ -354,7 +354,7 @@ curl -X GET https://runner.circleci.com/api/v2/tasks/running?resource-class=test
 |number of running tasks
 |===
 
-[#example]
+[#get-api-v2-tasks-running-example]
 ==== Example
 
 ```json

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -50,14 +50,23 @@ There are two key use cases CircleCI aims to meet with self-hosted runners:
 [#choosing-a-runner-execution-environment]
 == Choosing a runner execution environment
 
-CircleCI offers multiple execution environments for self-hosted runners: container and machine.
+CircleCI offers two types of self-hosted runners: container and machine.
 
 [#container-runner-use-case]
 === Container runner
 
+CircleCI's self-hosted runner has historically executed each job using a one-to-one mapping between the CI job and a <<configuration-reference#machine,machine>> environment (virtual or physical) that has the self-hosted runner binary installed on it. By exclusively running jobs in this manner, users sacrifice several benefits of a container-based solution that are afforded on CircleCI’s cloud platform when using the <<using-docker#,Docker executor>>:
+
+* The ability to seamlessly use custom Docker images during job execution.
+* Access to a consistent, clean containerized build environment with every job 
+
 Container runner is installed in a Kubernetes (k8s) cluster which enables you to run containerized jobs on self-hosted compute, similar to how jobs use the native Docker executor to run on CircleCI’s cloud platform. This solution allows you to run hundreds of jobs at once, scaling pods effectively to meet compute demands.
 
+After installation of the container-agent, the container runner will claim your containerized jobs, schedule them within an ephemeral pod, and execute the work within a container-based execution environment.
+
 Container runner allows you to use CircleCI's <<circleci-images#,convenience images>> as well as custom Docker images.
+
+Container runner is a complement to the machine runner, not a replacement.
 
 [#machine-runner-use-case]
 === Machine runner

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -55,9 +55,9 @@ CircleCI offers two types of self-hosted runners: container and machine.
 [#container-runner-use-case]
 === Container runner
 
-CircleCI's self-hosted runner has historically executed each job using a one-to-one mapping between the CI job and a <<configuration-reference#machine,machine>> environment (virtual or physical) that has the self-hosted runner binary installed on it. By exclusively running jobs in this manner, users sacrifice several benefits of a container-based solution that are afforded on CircleCI’s cloud platform when using the <<using-docker#,Docker executor>>:
+CircleCI's self-hosted runner has historically executed each job using a one-to-one mapping between the CI job and a <<configuration-reference#machine,machine>> environment (virtual or physical) that has the self-hosted runner binary installed on it. Exclusively running jobs in this manner sacrifices several benefits of a container-based solution that are afforded on CircleCI’s cloud platform when using the <<using-docker#,Docker executor>>:
 
-* The ability to seamlessly use custom Docker images during job execution.
+* The ability to seamlessly use custom Docker images during job execution
 * Access to a consistent, clean containerized build environment with every job 
 
 Container runner is installed in a Kubernetes (k8s) cluster which enables you to run containerized jobs on self-hosted compute, similar to how jobs use the native Docker executor to run on CircleCI’s cloud platform. This solution allows you to run hundreds of jobs at once, scaling pods effectively to meet compute demands.

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -210,7 +210,7 @@ en:
         children:
           - name: Container runner installation
             link: container-runner-installation
-          - name: Container runner reference guide
+          - name: Container runner reference
             link: container-runner
       - name: Machine runner
         children:

--- a/jekyll/_includes/snippets/faq/self-hosted-runner-faq-snip.adoc
+++ b/jekyll/_includes/snippets/faq/self-hosted-runner-faq-snip.adoc
@@ -257,30 +257,6 @@ Just like a machine runner, a container runner allows users to run arbitrary cod
 
 An IAM role can be associated with the service account used for the container runner by following the link:https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[AWS documentation]. If an image in a job configuration specifies AWS credentials, those credentials will be used instead of the IAM role attached to the container runner service account. See the xref:container-runner#[Container runner] documentation for more details about the container runner service account.
 
-[#sample-configuration-container-agent]
-==== What does a full sample configuration look like that uses container runner?
-
-```yaml
-version: 2.1
-
-jobs:
-  build:
-    docker:
-      - image: cimg/base:2021.11
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-    resource_class: <namespace>/<resource-class>
-    steps:
-      - checkout
-      - ...
-
-workflows:
-  build-workflow:
-    jobs:
-      - build
-```
-
 ==== What if I want to run my CI job within a container, but do not want to use Kubernetes?
 
 If you would like to run your CI job within a container, but do not want to use Kubernetes, you can use a xref:runner-installation-docker#[machine runner] with Docker installed.


### PR DESCRIPTION
# Description
* Remove conceptual content from container runner reference so that it is more purely a reference guide, and transfer that content to the self-hosted runner overview
* Update titles for consistency
* Also includes fixes for runner API reference section headers

# Reasons
Continuation of runner content reorg

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
