### PR TITLE
Server v4: Service account clarifications

### DIFF
--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -178,7 +178,9 @@ gcloud config set compute/region <REGION>
 ----
 . Create your cluster
 +
-TIP: CircleCI recommends using https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identity] to allow workloads/pods in your GKE clusters to impersonate Identity and Access Management (IAM) service accounts to access Google Cloud services. Use the following command to provision a simple cluster:
+TIP: CircleCI recommends using https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identity] to allow workloads/pods in your GKE clusters to impersonate Identity and Access Management (IAM) service accounts to access Google Cloud services.
++
+Use the following command to provision a simple cluster:
 +
 [source,shell]
 ----
@@ -188,9 +190,7 @@ gcloud container clusters create circleci-server \
   --workload-pool=<PROJECT_ID>.svc.id.goog
 ----
 +
-NOTE: Your kube-context should get updated with the new cluster credentials automatically.
-+
-If you need to update your kube-context manually, you can by running the following:
+Your kube-context should get updated with the new cluster credentials automatically. If you need to update your kube-context manually, you can by running the following:
 +
 [source,shell]
 ----
@@ -208,14 +208,14 @@ gcloud components install gke-gcloud-auth-plugin
 ----
 kubectl cluster-info
 ----
-. Create a service account:
+. Create a service account to be used for authentication with Workload Identity:
 +
 [source,shell]
 ----
 gcloud iam service-accounts create <SERVICE_ACCOUNT_ID> --description="<DESCRIPTION>" \
   --display-name="<DISPLAY_NAME>"
 ----
-. Retrieve credentials for the service account:
+. Create a private key for your service account:
 +
 [source,shell]
 ----
@@ -235,13 +235,26 @@ Follow these steps if you already have a GKE cluster and need to enable Workload
   gcloud container clusters update "<CLUSTER_NAME>" \
     --workload-pool="<PROJECT_ID>.svc.id.goog"
 ----
+. Create a service account to be used for authentication with Workload Identity:
++
+[source,shell]
+----
+gcloud iam service-accounts create <SERVICE_ACCOUNT_ID> --description="<DESCRIPTION>" \
+  --display-name="<DISPLAY_NAME>"
+----
+. Create a private key for your service account:
++
+[source,shell]
+----
+gcloud iam service-accounts keys create <KEY_FILE> \
+  --iam-account <SERVICE_ACCOUNT_ID>@<PROJECT_ID>.iam.gserviceaccount.com
+----
 . Get node pools of existing GKE cluster:
 +
 [source,shell]
 ----
   gcloud container node-pools list --cluster "<CLUSTER_NAME>"
 ----
-
 . Update existing node pools:
 +
 [source,shell]

--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -176,7 +176,7 @@ gcloud config set project <PROJECT_ID>
 gcloud config set compute/zone <ZONE>
 gcloud config set compute/region <REGION>
 ----
-. Create your cluster
+. Create your cluster.
 +
 TIP: CircleCI recommends using https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identity] to allow workloads/pods in your GKE clusters to impersonate Identity and Access Management (IAM) service accounts to access Google Cloud services.
 +

--- a/jekyll/_cci2/server/v4.1/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/phase-1-prerequisites.adoc
@@ -178,7 +178,9 @@ gcloud config set compute/region <REGION>
 ----
 . Create your cluster
 +
-TIP: CircleCI recommends using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identity] to allow workloads/pods in your GKE clusters to impersonate Identity and Access Management (IAM) service accounts to access Google Cloud services. Use the following command to provision a simple cluster:
+TIP: CircleCI recommends using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identity] to allow workloads/pods in your GKE clusters to impersonate Identity and Access Management (IAM) service accounts to access Google Cloud services.
++
+Use the following command to provision a simple cluster:
 +
 [source,shell]
 ----
@@ -188,9 +190,7 @@ gcloud container clusters create circleci-server \
   --workload-pool=<PROJECT_ID>.svc.id.goog
 ----
 +
-NOTE: Your kube-context should get updated with the new cluster credentials automatically.
-+
-If you need to update your kube-context manually, you can by running the following:
+Your kube-context should get updated with the new cluster credentials automatically. If you need to update your kube-context manually, you can by running the following:
 +
 [source,shell]
 ----
@@ -208,14 +208,14 @@ gcloud components install gke-gcloud-auth-plugin
 ----
 kubectl cluster-info
 ----
-. Create a service account:
+. Create a service account to be used for authentication with Workload Identity:
 +
 [source,shell]
 ----
 gcloud iam service-accounts create <SERVICE_ACCOUNT_ID> --description="<DESCRIPTION>" \
   --display-name="<DISPLAY_NAME>"
 ----
-. Retrieve credentials for the service account:
+. Create a private key for your service account:
 +
 [source,shell]
 ----
@@ -234,6 +234,20 @@ Follow these steps if you already have a GKE cluster and need to enable Workload
 ----
   gcloud container clusters update "<CLUSTER_NAME>" \
     --workload-pool="<PROJECT_ID>.svc.id.goog"
+----
+. Create a service account to be used for authentication with Workload Identity:
++
+[source,shell]
+----
+gcloud iam service-accounts create <SERVICE_ACCOUNT_ID> --description="<DESCRIPTION>" \
+  --display-name="<DISPLAY_NAME>"
+----
+. Create a private key for your service account:
++
+[source,shell]
+----
+gcloud iam service-accounts keys create <KEY_FILE> \
+  --iam-account <SERVICE_ACCOUNT_ID>@<PROJECT_ID>.iam.gserviceaccount.com
 ----
 . Get node pools of existing GKE cluster:
 +

--- a/jekyll/_cci2/server/v4.1/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/phase-1-prerequisites.adoc
@@ -176,7 +176,7 @@ gcloud config set project <PROJECT_ID>
 gcloud config set compute/zone <ZONE>
 gcloud config set compute/region <REGION>
 ----
-. Create your cluster
+. Create your cluster.
 +
 TIP: CircleCI recommends using link:https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[Workload Identity] to allow workloads/pods in your GKE clusters to impersonate Identity and Access Management (IAM) service accounts to access Google Cloud services.
 +


### PR DESCRIPTION
# Description
fixes #7774  

* Clarify why a service account is created when creating a new cluster for a server v4 installation
* Add the service account steps to the optional section for those who have an existing cluster and want to switch to use Workload Identity. Previously there was no indication that the steps in the previous section needed to be followed.

# Reasons
Reports that this section was confusing because readers were asked to create a service account with no explanation why.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
