### PR TITLE
suggest link to reference guide

### DIFF
--- a/jekyll/_cci2/examples-and-guides-overview.adoc
+++ b/jekyll/_cci2/examples-and-guides-overview.adoc
@@ -50,4 +50,4 @@ Use the tutorial associated with your platform to learn about the customization 
 [#next-steps]
 == Next steps
 - Read the <<sample-config#,Sample config.yml Files>> document for examples of using concurrent workflows, sequential workflows, fan-in/fan-out workflows, and building Linux and iOS in one configuration file.
-- Refer to the reference guide https://circleci.com/docs/configuration-reference/ for detailed syntax.
+- Refer to the xref:configuration-reference#[Configuration reference page] for detailed syntax.

--- a/jekyll/_cci2/examples-and-guides-overview.adoc
+++ b/jekyll/_cci2/examples-and-guides-overview.adoc
@@ -49,5 +49,5 @@ Use the tutorial associated with your platform to learn about the customization 
 
 [#next-steps]
 == Next steps
-
 - Read the <<sample-config#,Sample config.yml Files>> document for examples of using concurrent workflows, sequential workflows, fan-in/fan-out workflows, and building Linux and iOS in one configuration file.
+- Refer to the reference guide https://circleci.com/docs/configuration-reference/ for detailed syntax.


### PR DESCRIPTION
Suggesting a link to the reference guide from "Examples and Guides Overview" page as it is hard to find the reference guide
