### PR TITLE
Add shell script doc to side nav

### DIFF
--- a/jekyll/_cci2/using-shell-scripts.md
+++ b/jekyll/_cci2/using-shell-scripts.md
@@ -12,7 +12,7 @@ contentTags:
 ## Overview
 {: #overview }
 
-Configuring CircleCI often requires writing shell scripts. While shell scripting can give you finer control over your build, it is possible you will come across a few errors. You can avoid many of these errors by reviewing the best practices explained below.
+Configuring CircleCI often requires writing shell scripts. While shell scripting can give you finer control over your pipelines, it is possible you will come across a few errors. You can avoid many of these errors by reviewing the best practices explained below.
 
 ## Shell script best practices
 {: #shell-script-best-practices }
@@ -22,7 +22,7 @@ Configuring CircleCI often requires writing shell scripts. While shell scripting
 
 [ShellCheck](https://github.com/koalaman/shellcheck) is a shell script static analysis tool that gives warnings and suggestions for bash/sh shell scripts.
 
-Use the [Shellcheck orb](https://circleci.com/developer/orbs/orb/circleci/shellcheck) for the simplest way to add shellcheck to your `version: 2.1` configuration (remember to replace `x.y.z` with a valid version):
+Use the [ShellCheck orb](https://circleci.com/developer/orbs/orb/circleci/shellcheck) for the simplest way to add ShellCheck to your configuration (remember to replace `x.y.z` with a valid version):
 
 ```yaml
 version: 2.1
@@ -46,7 +46,7 @@ jobs:
     ...
 ```
 
-Alternatively, shell check can be configured without using the orb if you are using version 2 configuration:
+Alternatively, ShellCheck can be configured without using the orb:
 
 ```yaml
 version: 2.1
@@ -79,7 +79,7 @@ workflows:
               only: main # only run build-job on main branch
 ```
 
-Take caution when using `set -o xtrace` / `set -x` with ShellCheck. When the shell expands secret environment variables, they will be exposed in a not-so-secret way, as in the example below.
+Take caution when using `set -o xtrace` / `set -x` with ShellCheck. When the shell expands secret environment variables, they can be exposed, as in the example below.
 {: class="alert alert-info" }
 
 As cautioned above, observe how the `tmp.sh` script file reveals too much.
@@ -103,7 +103,7 @@ You must set SECRET_ENV_VAR!
 + '[' -z 's3cr3t!' ']'
 ```
 
-### Set Error Flags
+### Set error flags
 {: #set-error-flags }
 
 There are several error flags you can set to automatically exit scripts when unfavorable conditions occur. As a best practice, add the following flags at the beginning of each script to protect yourself from tricky errors.
@@ -130,10 +130,11 @@ In your terminal, navigate to the folder/location of the script you want to run.
 sh <name-of-file>.sh
 ```
 
-Occassionally, a script might not be executable by default, and you will be required to make the file executable before you run it. This process differs per platform, and you will need to search how to do this for your specific platform. For example, you can try to right-click on the script file and see if there is an option to make it executable. If you are on macOS or Linux, you can also look up how to use `chmod` commands to make a script file executable with different permissions.
+Occassionally, a script might not be executable by default, and you will be required to make the file executable before you run it. This process differs per platform, and you will need to search how to do this for your specific platform. 
+
+For example, you can try to right-click on the script file and see if there is an option to make it executable. If you are on macOS or Linux, you can also look up how to use `chmod` commands to make a script file executable with different permissions.
 
 ## Additional resources
 {: #additional-resources }
-{:.no_toc}
 
 For more detailed explanations and additional techniques, see this [Writing Robust Bash Shell Scripts](https://www.davidpashley.com/articles/writing-robust-shell-scripts) blog post on writing robust shell scripts.

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -122,6 +122,8 @@ en:
             link: databases
           - name: Migrate from deploy to run
             link: migrate-from-deploy-to-run
+          - name: Using shell scripts
+            link: using-shell-scripts
       - name: Reference
         children:
           - name: Project values and variables
@@ -1050,6 +1052,9 @@ ja:
           - name: Migrate from deploy to run
             link: ja/migrate-from-deploy-to-run
             i18n_name: deployからrunへの移行
+          - name: Using shell scripts
+            link: ja/using-shell-scripts
+            i18n_name: シェルスクリプトの使用
       - name: Reference
         i18n_name: リファレンス
         children:
@@ -1384,9 +1389,6 @@ ja:
           - name: Secure secrets handling
             link: ja/security-recommendations
             i18n_name: シークレットの安全な取り扱い
-          - name: Using shell scripts
-            link: ja/using-shell-scripts
-            i18n_name: シェルスクリプトの使用
       - name: Config policy management
         i18n_name: 設定ファイルのポリシー管理
         children:


### PR DESCRIPTION
# Description
* Add https://circleci.com/docs/using-shell-scripts/ to side navigation 
* Minor text edits
* Move to different section in JA side nav

# Reasons
The EN doc was not in the side nav. This PR adds the doc to the Orchestrate & Trigger side nav section in order to surface it to readers who are learning about configuring and managing their pipelines and configs

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
