### PR TITLE
fix video with passthrough block

### DIFF
--- a/jekyll/_cci2/scheduled-pipelines.adoc
+++ b/jekyll/_cci2/scheduled-pipelines.adoc
@@ -98,9 +98,11 @@ The video offers a short tutorial for the following scenarios:
 - Set a schedule with the API
 - Migrate from scheduled workflows to scheduled pipelines
 
+++++
 <div class="video-wrapper">
   <iframe width="560" height="315" src="https://www.youtube.com/embed/x3ruGpx6SEI" title="Scheduled pipelines tutorial" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
+++++
 
 For the documentation for these scenarios, visit the following pages:
 - xref:set-a-nightly-scheduled-pipeline#[Set a nightly scheduled pipeline]


### PR DESCRIPTION
# Description

fixes #8050 

Video was not displayed, just the html. Fixed by enclosing the html in a pass through block

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
