### PR TITLE
[DOCSS-1130] Remove references of `OIDC` in config policy helpers

### DIFF
--- a/jekyll/_cci2/manage-contexts-with-config-policies.adoc
+++ b/jekyll/_cci2/manage-contexts-with-config-policies.adoc
@@ -331,7 +331,7 @@ image::config-policies/context-fail-2.png[Dashboard page showing fail]
 [#define-the-contexts-reserved-by-a-project]
 == Define the contexts reserved by a project
 
-You may want to reserve contexts for use by a defined list of projects, blocking the use of those contexts by any project not in the allow-list. One possible use case for this would be locking contexts related to OIDC access to only those applications (projects) that need it. Any app that does not need this OIDC access will not be able to access those contexts. Developers will receive a hard fail, and pipelines will fail to trigger.
+You may want to reserve contexts for use by a defined list of projects, blocking the use of those contexts by any project not in the allow-list. One possible use case for this would be locking contexts containing deployment keys to only those applications (projects) that need it. Any app that does not need this access will not be able to access those contexts. Developers will receive a hard fail, and pipelines will fail to trigger.
 
 Use the `contexts_reserved_by_project_ids` helper to create a policy to apply this restriction. This helper function accepts project IDs and context names. It prevents the usage of any reserved contexts for projects that are not in the allow-list.
 


### PR DESCRIPTION
# Description
Remove references of `OIDC` in config policy helpers

# Reasons
Jira: https://circleci.atlassian.net/browse/SNC-310

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
