### PR TITLE
Fix phpunit-finder link typo and bash command formatting

### DIFF
--- a/jekyll/_cci2/troubleshoot-test-splitting.adoc
+++ b/jekyll/_cci2/troubleshoot-test-splitting.adoc
@@ -134,13 +134,14 @@ Some third party applications and libraries might help you to split your test su
   dynamically across parallel CI nodes, allowing your test suite execution to run
   faster. See link:https://docs.knapsackpro.com/2018/improve-circleci-parallelisation-for-rspec-minitest-cypress[CI build time graph examples].
 
-* **link:https://github.com/previousnext/phpunit-finder)[phpunit-finder]** - This is
+* **link:https://github.com/previousnext/phpunit-finder[phpunit-finder]** - This is
   a helper CLI tool that queries `phpunit.xml` files to get a list of test
   filenames and print them. This is useful if you want to split tests to run
   them in parallel based on timings on CI tools.
+
 * **link:https://golang.org/cmd/go/#hdr-List_packages_or_modules[go list]** - Use the built-in Go command `go list ./...` to glob Golang packages. This allows splitting package tests across multiple containers.
-+
-[souce,shell]
+
+[source,shell]
 ----
 go test -v $(go list ./... | circleci tests split)
 ----


### PR DESCRIPTION
# Description
ref: [Troubleshoot test splitting](https://circleci.com/docs/troubleshoot-test-splitting/)

<img width="830" alt="image" src="https://github.com/circleci/circleci-docs/assets/74545886/9ee776ac-501e-493d-a407-ec117a76f2d0">

- Fixed link typo containing a parenthesis
- Fixed a tag typo for a shell command

# Reasons

- Link did not open correctly
- Bash command was wrongly formatted

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
