### PR TITLE
Consistent use of parallel and concurrent

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -15,6 +15,8 @@ Use parallelism and test splitting to:
 * Specify a number of [executors](/docs/executor-intro/) across which to split your tests.
 * Split your test suite using one of the options provided by the CircleCI CLI: by name, size or by using timing data.
 
+If you are interested to read about concurrent job runs, see the [Concurrency overview](/docs/concurrency) page.
+
 ## Introduction
 {: #introduction }
 

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -58,6 +58,9 @@ _For a full specification of the_ `workflows` _key, see the [Workflows](/docs/co
 
 To run a set of concurrent jobs, add a new `workflows:` section to the end of your existing `.circleci/config.yml` file with the version and a unique name for the workflow.
 
+### Concurrent job execution
+{: concurrent-job-execution }
+
 The following sample `.circleci/config.yml` file shows the default workflow orchestration with two concurrent jobs. It is defined by using the `workflows` key named `build_and_test`, and by nesting the `jobs` key with a list of job names. The jobs have no dependencies defined, so they will run concurrently.
 
 ```yaml
@@ -86,7 +89,7 @@ workflows:
       - build
       - test
 ```
-See the [Sample Parallel Workflow config](https://github.com/CircleCI-Public/circleci-demo-workflows/blob/parallel-jobs/.circleci/config.yml) for a full example.
+See the [Sample concurrent workflow config](https://github.com/CircleCI-Public/circleci-demo-workflows/blob/parallel-jobs/.circleci/config.yml) for a full example.
 
 When using workflows, try to do the following:
 
@@ -95,8 +98,8 @@ When using workflows, try to do the following:
 
 Consider reading the [Optimization overview](/docs/optimizations/) for more tips related to improving your configuration.
 
-### Sequential job execution example
-{: #sequential-job-execution-example }
+### Sequential job execution
+{: #sequential-job-execution }
 
 The following example shows a workflow with four sequential jobs. The jobs run according to configured requirements, each job waiting to start until the required job finishes successfully as illustrated in the diagram.
 
@@ -124,8 +127,8 @@ The dependencies are defined by setting the `requires` key as shown. The `deploy
 
 See the [Sample Sequential Workflow config](https://github.com/CircleCI-Public/circleci-demo-workflows/blob/sequential-branch-filter/.circleci/config.yml) for a full example.
 
-### Fan-out/fan-in workflow example
-{: #fan-outfan-in-workflow-example }
+### Fan-out/fan-in workflow
+{: #fan-outfan-in-workflow }
 
 The illustrated example workflow runs a common build job, then fans-out to run a set of acceptance test jobs concurrently, and finally fans-in to run a common deploy job.
 

--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -59,7 +59,7 @@ _For a full specification of the_ `workflows` _key, see the [Workflows](/docs/co
 To run a set of concurrent jobs, add a new `workflows:` section to the end of your existing `.circleci/config.yml` file with the version and a unique name for the workflow.
 
 ### Concurrent job execution
-{: concurrent-job-execution }
+{: #concurrent-job-execution }
 
 The following sample `.circleci/config.yml` file shows the default workflow orchestration with two concurrent jobs. It is defined by using the `workflows` key named `build_and_test`, and by nesting the `jobs` key with a list of job names. The jobs have no dependencies defined, so they will run concurrently.
 


### PR DESCRIPTION
# Description
* Add link to Concurrency overview from Parallelism overview to catch people who have searched "parallel" when they want concurrent jobs in workflows etc
* Use correct terminology on Workflows overview page

# Reasons
Clear confusion from reader feedback

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
