### PR TITLE
Add deprecation notice for affected Xcode images

### DIFF
--- a/jekyll/_includes/snippets/xcode-intel-vm.md
+++ b/jekyll/_includes/snippets/xcode-intel-vm.md
@@ -5,13 +5,16 @@
  `14.1.0` | Xcode 14.1 (14B47b) | 12.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v9002/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-14-1-rc-2-released/45890)
  `14.0.1` | Xcode 14.0.1 (14A400) | 12.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v8824/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-14-0-1-rc-released/45424)
  `13.4.1` | Xcode 13.4 (13F17a) | 12.3.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v8094/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-4-1-released/44328)
- `13.3.1` | Xcode 13.3 (13E500a) | 12.3.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v7555/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-3-1-released/43675)
- `13.2.1` | Xcode 13.2.1 (13C100) | 11.6.2 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6690/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-2-1-released/42334)
- `13.1.0` | Xcode 13.1 (13A1030d) | 11.6.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6269/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-1-rc-released/41577)
- `13.0.0` | Xcode 13.0 (13A233) | 11.5.2 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6052/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-rc-released/41256)
+ `13.3.1` * | Xcode 13.3 (13E500a) | 12.3.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v7555/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-3-1-released/43675)
+ `13.2.1` * | Xcode 13.2.1 (13C100) | 11.6.2 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6690/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-2-1-released/42334)
+ `13.1.0` * | Xcode 13.1 (13A1030d) | 11.6.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6269/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-1-rc-released/41577)
+ `13.0.0` * | Xcode 13.0 (13A233) | 11.5.2 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v6052/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-13-rc-released/41256)
  `12.5.1` | Xcode 12.5.1 (12E507) | 11.4.0 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v5775/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-12-5-1-released/40490)
- `11.7.0` | Xcode 11.7 (11E801a) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3587/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-11-7-released/37312)
+ `11.7.0` * | Xcode 11.7 (11E801a) | 10.15.5 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v3587/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-11-7-released/37312)
  {: class="table table-striped"}
+
+ The `11.7.0`, `13.0.0`, `13.1.0`, `13.2.1` and `13.3.1` images are deprecated and will be removed on 7 August 2023. See our [announcement](https://discuss.circleci.com/t/xcode-image-deprecation-and-eol-notice-2023/48264) for more details.
+ {: class="alert alert-warning"}
 
  The `medium` and `large` resource classes are being deprecated on October 2, 2023. Xcode v14.2 is the latest version that will be supported by these macOS resources. See our [announcement](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891) for more details.
  {: class="alert alert-warning"}


### PR DESCRIPTION
# Description
Add deprecation notice for affected Xcode images

# Reasons
These images are now deprecated: https://discuss.circleci.com/t/xcode-image-deprecation-and-eol-notice-2023/48264/2

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
