### PR TITLE
Add section on config policies for dynamic config

### DIFF
--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -375,6 +375,20 @@ For further reading, see the link:https://circleci.com/blog/compliance-with-conf
 
 It is important to be able to deploy new policies with confidence, knowing how they will be applied, and the decisions they will generate ahead of time. To enable this process, the `circleci policy test` command is available. The `test` subcommand is inspired by the golang and opa test commands. For more information on setting up testing, see the xref:test-config-policies#[Test config policies] guide.
 
+[#dynamic-config]
+== Writing policies for projects that use dynamic configuration
+
+Config policies are evaluated at every stage, including:
+
+* Against the setup config
+against continuation configs
+against normal configs
+IF you want a rule that is only for setup configs or only for non-setup configs, you need to encode that when you enable the rule:
+enable_hard["setup_rule"] { input.setup } # only applied to configs with `setup: true`
+enable_hard["not_setup_rule"] { not input.setup } # only applied to configs that do not have `setup: true`
+enable_hard["some_rule"] # rule applied to all configs
+
+
 [#example-policy]
 == Example policy
 

--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -384,7 +384,7 @@ You can write config policies to govern projects that use dynamic configuration 
 * _Continuation_ configurations
 * Standard configurations
 
-If required for your project, you can encode rules to apply only setup configs, or only to non-setup configs, as follows:
+If required for your project, you can encode rules to apply only to setup configs, or only to non-setup configs, as follows:
 
 [source,rego]
 ----

--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -376,18 +376,32 @@ For further reading, see the link:https://circleci.com/blog/compliance-with-conf
 It is important to be able to deploy new policies with confidence, knowing how they will be applied, and the decisions they will generate ahead of time. To enable this process, the `circleci policy test` command is available. The `test` subcommand is inspired by the golang and opa test commands. For more information on setting up testing, see the xref:test-config-policies#[Test config policies] guide.
 
 [#dynamic-config]
-== Writing policies for projects that use dynamic configuration
+== Config policies and dynamic configuration
 
-Config policies are evaluated at every stage, including:
+You can write config policies to govern projects that use dynamic configuration too. Policies are evaluated against:
 
-* Against the setup config
-against continuation configs
-against normal configs
-IF you want a rule that is only for setup configs or only for non-setup configs, you need to encode that when you enable the rule:
+* _Setup_ configurations
+* _Continuation_ configurations
+* Standard configurations
+
+If required for your project, you can encode rules to apply only setup configs, or only to non-setup configs, as follows:
+
+[source,rego]
+----
 enable_hard["setup_rule"] { input.setup } # only applied to configs with `setup: true`
-enable_hard["not_setup_rule"] { not input.setup } # only applied to configs that do not have `setup: true`
-enable_hard["some_rule"] # rule applied to all configs
+----
 
+[source,rego]
+----
+enable_hard["not_setup_rule"] { not input.setup } # only applied to configs that do not have `setup: true`
+----
+
+[source,rego]
+----
+enable_hard["some_rule"] # rule applied to all configs
+----
+
+For more information about dynamic configuration, see the xref:dynamic-config#[Dynamic configuration overview]
 
 [#example-policy]
 == Example policy

--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -401,7 +401,7 @@ enable_hard["not_setup_rule"] { not input.setup } # only applied to configs that
 enable_hard["some_rule"] # rule applied to all configs
 ----
 
-For more information about dynamic configuration, see the xref:dynamic-config#[Dynamic configuration overview]
+For more information about dynamic configuration, see the xref:dynamic-config#[Dynamic configuration overview].
 
 [#example-policy]
 == Example policy


### PR DESCRIPTION
# Description
* Add a section to show that policies are evaluated against setup and continuation configs as well as normal configs.
* Also suggest ways to have policies only apply to the setup or continuation parts

# Reasons
Customer request

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
