### PR TITLE
remove reference to --total flag

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -109,27 +109,20 @@ The first time the tests are run there will be no timing data for the command to
 ## Manual allocation
 {: #manual-allocation }
 
-The CLI looks up the number of available execution environments, along with the current container index (`$CIRCLE_NODE_INDEX`). Then, it uses deterministic splitting algorithms to split the test files across all available containers.
-
-By default, the number of containers is specified by the `parallelism` key in the project configuration file. You can also manually set the number by using the `--total` flag.
-
-```shell
-circleci tests split --total=4 test_filenames.txt
-```
-
-Similarly, the current container index is automatically picked up from the `$CIRCLE_NODE_INDEX` environment variable, but can be manually set by using the `--index` flag.
-
-```shell
-circleci tests split --index=0 test_filenames.txt
-```
-
-## Use environment variables to split tests
-{: #using-environment-variables-to-split-tests }
-
 For full control over how tests are split across parallel executors, CircleCI provides two environment variables that you can use in place of the CLI to configure each container individually.
 
 * `$CIRCLE_NODE_TOTAL` is the total number of parallel containers being used to run your job.
 * `$CIRCLE_NODE_INDEX` is the index of the specific container that is currently running.
+
+The CLI looks up the number of available execution environments (`$CIRCLE_NODE_TOTAL`), along with the current container index (`$CIRCLE_NODE_INDEX`). Then, it uses deterministic splitting algorithms to split the test files across all available containers.
+
+The number of containers is specified by the [`parallelism` key](/docs/configuration-reference/#parallelism) in the project configuration file.
+
+The current container index is automatically picked up from the `$CIRCLE_NODE_INDEX` environment variable, but can be manually set by using the `--index` flag.
+
+```shell
+circleci tests split --index=0 test_filenames.txt
+```
 
 Refer to the [Project values and variables](/docs/variables#built-in-environment-variables) page for more details.
 


### PR DESCRIPTION
# Description

fixes #7833 

Remove reference to --total flag, as this was confusing, and the way it was presented as an alternative to the parallelism key was incorrect.

# Reasons
Incorrect content

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
