### PR TITLE
Update Xcode 14.3.1 to release version

### DIFF
--- a/jekyll/_includes/snippets/xcode-intel-vm.md
+++ b/jekyll/_includes/snippets/xcode-intel-vm.md
@@ -1,7 +1,7 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
  `15.0.0` | Xcode 15.0 Beta 1 (15A5160n) | 13.3.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12394/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-beta-1-released/48298)
-`14.3.1` | Xcode 14.3.1 (14E300b) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12131/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
+`14.3.1` | Xcode 14.3.1 (14E300c) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12298/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
  `14.2.0` | Xcode 14.2 (14C18) | 12.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v10821/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-2-rc-released-breaking-changes/46303)
  `14.1.0` | Xcode 14.1 (14B47b) | 12.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v9002/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-14-1-rc-2-released/45890)
  `14.0.1` | Xcode 14.0.1 (14A400) | 12.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v8824/index.html) | [Release Notes](https://discuss.circleci.com/t/xcode-14-0-1-rc-released/45424)

--- a/jekyll/_includes/snippets/xcode-silicon-vm.md
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.md
@@ -1,6 +1,6 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
- `14.3.1` | Xcode 14.3.1 (14E300b) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12128/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
+ `14.3.1` | Xcode 14.3.1 (14E300c) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12297/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
  `14.2.0` | Xcode 14.2 (14C18) | 12.6.3 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11441/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/announcing-apple-silicon-m1-support-now-available/46908)
  `14.1.0` | Xcode 14.1 (14B47b) | 12.6.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11763/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/announcing-m1-large-now-available-on-performance-plans/47797/22)
  `14.0.1` | Xcode 14.0.1 (14A400) | 12.6.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11770/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/announcing-m1-large-now-available-on-performance-plans/47797/22)


### PR DESCRIPTION
# Description
Update Xcode 14.3.1 to release version

# Reasons
Update Xcode 14.3.1 release version replaces the RC release
