### PR TITLE
Improve CLI docs structure for findability

### DIFF
--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -11,6 +11,26 @@ contentTags:
 
 This page describes how to use some features of the CircleCI CLI.
 
+== Prerequisites
+
+To follow the guides on this page you will need the following:
+
+* A CircleCI account (you can link:https://circleci.com/signup/[sign up for free])
+* Local installation of the CircleCI CLI. Steps and options are available on the xref:local-cli#[Installing the local CLI] page.
+* xref:local-cli#configure-the-cli[Set up and configure] the CircleCI CLI.
+
+[#validate-a-circleci-config]
+== Validate a CircleCI config
+
+You can avoid pushing additional commits to test your `.circleci/config.yml` by using the CLI to validate your configuration locally.
+
+To validate your configuration, navigate to a directory with a `.circleci/config.yml` file and run:
+
+```shell
+circleci config validate
+# Config file at .circleci/config.yml is valid
+```
+
 [#orb-development-kit]
 == Orb development kit
 

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: Installing the CircleCI local CLI
+title: Install and configure the CircleCI local CLI
 description: How to install the CircleCI local CLI
 categories: [troubleshooting]
 contentTags:
@@ -24,16 +24,14 @@ The [CircleCI command line interface (CLI)](https://circleci-public.github.io/ci
 
 Some of the things you can do with the CLI include:
 
-- Debug and validate your CI config
-- Run jobs locally
+- [Debug and validate your CircleCI configuration](/docs/how-to-use-the-circleci-local-cli/#validate-a-circleci-config)
+- [Run jobs locally](/docs/how-to-use-the-circleci-local-cli/#run-a-job-in-a-container-on-your-machine)
 - Query CircleCI's API
-- Create, publish, view, and manage orbs
-- Manage contexts
+- [Create, publish, view, and manage orbs](/docs/how-to-use-the-circleci-local-cli/#orb-development-kit)
+- [Manage contexts](/docs/how-to-use-the-circleci-local-cli/#context-management)
+- [Split your tests](/docs/how-to-use-the-circleci-local-cli/#test-splitting) to run across [parallel environments](/docs/parallelism-faster-jobs/) to reduce pipeline duration
 
 This page covers the installation and usage of the CircleCI CLI. The expectation is you have basic knowledge of CI/CD, [CircleCI's concepts]({{site.baseurl}}/concepts). You should already have a CircleCI account, an account with a supported VCS, and have your terminal open and ready to go.
-
-* TOC
-{:toc}
 
 ## Installation
 {: #installation }
@@ -141,8 +139,8 @@ circleci switch
 
 This command may prompt you for `sudo` if your user does not have write permissions to the install directory, `/usr/local/bin`.
 
-## Configuring the CLI
-{: #configuring-the-cli }
+## Configure the CLI
+{: #configure-the-cli }
 
 Before using the CLI, you need to generate a CircleCI API token from the [Personal API Token tab](https://app.circleci.com/settings/user/tokens). After you get your token, configure the CLI by running:
 
@@ -151,18 +149,6 @@ circleci setup
 ```
 
 The set up process will prompt you for configuration settings. If you are using the CLI with CircleCI cloud, use the default CircleCI host. If you are using CircleCI server, change the value to your installation address (for example, circleci.your-org.com).
-
-## Validate a CircleCI config
-{: #validate-a-circleci-config }
-
-You can avoid pushing additional commits to test your `.circleci/config.yml` by using the CLI to validate your configuration locally.
-
-To validate your configuration, navigate to a directory with a `.circleci/config.yml` file and run:
-
-```shell
-circleci config validate
-# Config file at .circleci/config.yml is valid
-```
 
 ## Uninstallation
 {: #uninstallation }
@@ -189,8 +175,6 @@ choco uninstall circleci-cli -y --remove dependencies
 If you wish to suggest ways we could improve the CLI please [share your suggestion on the GitHub repo](https://github.com/CircleCI-Public/circleci-cli)
 
 - [How to check private repositories with local jobs using the CircleCI CLI?](https://support.circleci.com/hc/en-us/articles/360033753374-Checkout-private-repositories-with-local-jobs-run-through-circleci-cli)
-
-- [How to validate your CircleCI configuration with the CLI?](https://support.circleci.com/hc/en-us/articles/360006735753-How-to-validate-your-CircleCI-configuration)
 
 - [How to know if your project is using deprecated Machine images with the CLI?](https://support.circleci.com/hc/en-us/articles/4421154407195-Deprecating-Ubuntu-14-04-and-16-04-images-EOL-5-31-22)
 

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -169,7 +169,18 @@ choco uninstall circleci-cli -y --remove dependencies
 ```
 **Alternative curl uninstall**: Remove the `circleci` executable from `usr/local/bin`
 
-## Useful links
+## Next steps
+{: #next-steps }
+
+- [How to validate your CircleCI configuration](/docs/how-to-use-the-circleci-local-cli/#validate-a-circleci-config)
+- [How to run a job in a container on your local machine](/docs/how-to-use-the-circleci-local-cli/#run-a-job-in-a-container-on-your-machine)
+- [How to create, publish, view, and manage orbs](/docs/how-to-use-the-circleci-local-cli/#orb-development-kit)
+- [How to manage contexts](/docs/how-to-use-the-circleci-local-cli/#context-management)
+- [How to split your tests](/docs/how-to-use-the-circleci-local-cli/#test-splitting) to run across [parallel environments](/docs/parallelism-faster-jobs/) to reduce pipeline duration
+
+---
+
+## CLI articles in the support centre
 {: #useful-links }
 
 If you wish to suggest ways we could improve the CLI please [share your suggestion on the GitHub repo](https://github.com/CircleCI-Public/circleci-cli)
@@ -199,7 +210,7 @@ If you wish to suggest ways we could improve the CLI please [share your suggesti
 - [How to use realitycheck to validate your CircleCI Server installation for GitHub Enterprise via the CLI?](https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation)
 
 
-## Troubleshooting
+### Troubleshooting
 {: #troubleshooting }
 
 - [What if the CLI context commands error with "Must have admin permission"?](https://support.circleci.com/hc/en-us/articles/360047644153-CircleCI-CLI-Context-Command-errors-with-Must-have-admin-permission-)
@@ -209,8 +220,3 @@ If you wish to suggest ways we could improve the CLI please [share your suggesti
 - [What if the CLI command “circleci local execute” fails with "--storage-opt is supported only for overlay over xfs with 'pquota' mount option"?](https://support.circleci.com/hc/en-us/articles/7060937560859-How-to-resolve-error-storage-opt-is-supported-only-for-overlay-over-xfs-with-pquota-mount-option-when-running-jobs-locally-with-the-cli)
 
 - [What if the CLI command “circleci local execute” fails with “not implemented for cgroup v2 unified hierarchy“?](https://support.circleci.com/hc/en-us/articles/4413013337371-CircleCI-CLI-Running-circleci-local-execute-Results-in-not-implemented-for-cgroup-v2-unified-hierarchy-Error)
-
-## Next steps
-{: #next-steps }
-
-- [Introduction to execution environments]({{site.baseurl}}/executor-intro)

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -456,8 +456,10 @@ en:
     children:
       - name: CLI
         children:
-          - name: Installing the CircleCI local CLI
+          - name: Install and configure the CircleCI local CLI
             link: local-cli
+          - name: How to use the CircleCI local CLI
+            link: how-to-use-the-circleci-local-cli
       - name: APIs
         children:
           - name: API v2 introduction
@@ -466,6 +468,10 @@ en:
             link: api-developers-guide
           - name: Managing API tokens
             link: managing-api-tokens
+          - name: API v2 reference
+            link: https://circleci.com/docs/api/v2
+          - name: API v1 reference
+            link: https://circleci.com/docs/api/v1
       - name: IDE TOOLS
         children:
           - name: VS Code extension overview
@@ -486,16 +492,6 @@ en:
             link: sample-config
           - name: Database examples
             link: postgres-config
-      - name: How-to guides
-        children:
-          - name: How to use the CircleCI local CLI
-            link: how-to-use-the-circleci-local-cli
-      - name: Reference
-        children:
-          - name: API v2 reference
-            link: https://circleci.com/docs/api/v2
-          - name: API v1 reference
-            link: https://circleci.com/docs/api/v1
 
   - name: Test
     icon: icons/sidebar/passed.svg


### PR DESCRIPTION
# Description
* Link to how to guides from CLI installation page, both into and next steps section
* Move validate config how to to the How to page
* Remove how to and reference sections from dev toolkit section until we have better sidebar UX
* Move all links to support portal on the CLI page to "separate" section at the end of the page

# Reasons
There was no linking between the installation and how-to pages

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
