### PR TITLE
docs: fix typo in filename

### DIFF
--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -148,7 +148,7 @@ sudo curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-
 ```
 
 ```shell
-sudo /etc/opt/circleci/policy/circleci_launch_agent.sh
+sudo /etc/opt/circleci/policy/circleci_launch_agent.te
 ```
 
 [#start-machine-runner]

--- a/jekyll/_cci2_ja/runner-installation-linux.adoc
+++ b/jekyll/_cci2_ja/runner-installation-linux.adoc
@@ -155,7 +155,7 @@ sudo curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-
 ```
 
 ```shell
-sudo /etc/opt/circleci/policy/circleci_launch_agent.sh
+sudo /etc/opt/circleci/policy/circleci_launch_agent.te
 ```
 
 [#start-machine-runner]


### PR DESCRIPTION
# Description

I was installing the SELinux policy on my Machine Runner, and noted this typo in the filename (extension).
Verified that fixing the filename worked and my Runner instance ran fine.

# Reasons


# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
