### PR TITLE
Post-brownout banner for runner 1.0 deprecation

### DIFF
--- a/jekyll/_cci2/runner-api.adoc
+++ b/jekyll/_cci2/runner-api.adoc
@@ -13,7 +13,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 This document contains all the external facing endpoints for the CircleCI's self-hosted runner API. This API is separate from the main CircleCI v2 API and is used for the management and execution of self-hosted runner jobs. It is hosted at `runner.circleci.com`
 

--- a/jekyll/_cci2/runner-concepts.adoc
+++ b/jekyll/_cci2/runner-concepts.adoc
@@ -13,7 +13,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 [#namespaces-and-resource-classes]
 == Namespaces and resource classes

--- a/jekyll/_cci2/runner-config-reference.adoc
+++ b/jekyll/_cci2/runner-config-reference.adoc
@@ -12,7 +12,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 [#self-hosted-runner-configuration-reference]
 == Machine runner configuration reference

--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -13,7 +13,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 This page answers frequently asked questions for CircleCI's self-hosted container and machine runners.
 

--- a/jekyll/_cci2/runner-installation-docker.adoc
+++ b/jekyll/_cci2/runner-installation-docker.adoc
@@ -14,7 +14,7 @@ contentTags:
 :toc-title:
 :machine:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 This page describes how to install CircleCI's machine runner with the Docker executor. If you are looking to set up self-hosted runners in a private Kubernetes cluster, please visit the <<container-runner#,Container runner>> page.
 

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -15,7 +15,7 @@ contentTags:
 :machine:
 :linux:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 This page describes how to install CircleCI's machine runner on Linux.
 

--- a/jekyll/_cci2/runner-installation-mac.adoc
+++ b/jekyll/_cci2/runner-installation-mac.adoc
@@ -15,7 +15,7 @@ contentTags:
 :machine:
 :macos:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 This page describes how to install CircleCI's machine runner on macOS.
 

--- a/jekyll/_cci2/runner-installation-windows.adoc
+++ b/jekyll/_cci2/runner-installation-windows.adoc
@@ -15,7 +15,7 @@ contentTags:
 :machine:
 :windows:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 This page describes how to install CircleCI's machine runner on Windows. This has been tested for Windows Server 2019 and Windows Server 2016, both in Datacenter Edition. Other Server SKUs with Desktop Experience and Remote Desktop Services should also work.
 

--- a/jekyll/_cci2/runner-on-kubernetes.adoc
+++ b/jekyll/_cci2/runner-on-kubernetes.adoc
@@ -13,7 +13,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 [#strongly-recommended-method]
 == Strongly recommended method

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -13,7 +13,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/runner-scaling.adoc
+++ b/jekyll/_cci2/runner-scaling.adoc
@@ -14,7 +14,7 @@ contentTags:
 :toc-title:
 toc::[]
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
+++ b/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
@@ -11,7 +11,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-{% include snippets/runner-1.0-deprecation-brownout.adoc %}
+{% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 This page describes errors and troubleshooting methods for container and machine runners.
 

--- a/jekyll/_cci2/upgrading-circleci-machine-runner-on-cloud.adoc
+++ b/jekyll/_cci2/upgrading-circleci-machine-runner-on-cloud.adoc
@@ -11,7 +11,7 @@ contentTags:
 :toc: macro:
 :toc-tittle:
 
-CAUTION: **Self-hosted runner version 1.0 is temporarily unavailable today starting from 12:00PM EST.** Version 1.0 will permanently sunset on July 27, 2023. **Update to 1.1.**
+CAUTION: **Self-hosted runner version 1.0 will sunset on July 27, 2023. Update to 1.1 now.**
 
 This page describes how to update the CircleCI **machine runner** on CircleCI cloud.
 

--- a/jekyll/_includes/snippets/runner-1.0-deprecation-post-brownout.adoc
+++ b/jekyll/_includes/snippets/runner-1.0-deprecation-post-brownout.adoc
@@ -1,0 +1,1 @@
+CAUTION: Self-hosted runner version 1.0 will sunset on July 27, 2023. xref:upgrading-circleci-machine-runner-on-cloud#[Update to 1.1 now.]


### PR DESCRIPTION
# Description
Replace brownout banner with new post-brownout banner urging runner 1.0 users to update to 1.1.

circleci.com/docs/upgrading-circleci-machine-runner-on-cloud/ has the banner hardcoded as it is the page being linked to in the snippet.

# Reasons
Runner 1.0 will sunset July 27, 2023.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
