### PR TITLE
[DOCSS-1205] Force `sectionTags` to always be `null` in FrontMatter

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -144,6 +144,7 @@ defaults:
       sitemap: true # Enable sitemap by default
       readtime: true # Enable Read Time by default
       contentTags: null
+      sectionTags: null
 
 t:
   translation_in_progress:


### PR DESCRIPTION
# Description
- Add `sectionTags: null: null` in jekyll config.yml

# Reasons
Similar to what we did with `contentTags`, we want to ensure that there is always a `sectionTags: null` set for all the FrontMatter generated.

# Content Checklist
N/A - Not a content PR
