### PR TITLE
Add AWS deploy page to sidebar

### DIFF
--- a/jekyll/_cci2/deploy-to-aws.adoc
+++ b/jekyll/_cci2/deploy-to-aws.adoc
@@ -87,8 +87,8 @@ jobs: # Define the build and deploy jobs
             --cache-control "max-age=86400"
 ```
 
-[#deploy-to-aws-s3-with-2-configuration]
-== Deploy to S3 with 2.0 configuration
+[#deploy-to-aws-s3-without orbs]
+== Deploy to S3 without orbs
 
 [#create-iam-user-2]
 === 1. Create IAM user

--- a/jekyll/_cci2/ecs-ecr.md
+++ b/jekyll/_cci2/ecs-ecr.md
@@ -1,6 +1,6 @@
 ---
 layout: classic-docs
-title: Deploy to AWS ECR/ECS
+title: Push image to ECR and deploy to ECS
 description: How to use CircleCI to deploy to AWS ECS from ECR
 contentTags:
   platform:

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -544,8 +544,8 @@ en:
             link: deploy-to-artifactory
           - name: Deploy to AWS
             link: deploy-to-aws
-          - name: Deploy service update to AWS ECS
-            link: deploy-service-update-to-aws-ecs
+          - name: Push image to ECR and deploy to ECS
+            link: ecr-ecs
           - name: Deploy to Azure Container Registry
             link: deploy-to-azure-container-registry
           - name: Deploy to Capistrano


### PR DESCRIPTION
# Description
* Added page to sidebar
* Removed deploy-service-update-to-aws-ecs from deploy section because it's also int he orbs section
* Also I found a reference to 2.0 config in another AWS deploy how-to so fixed
* Made page title better reflect what's on the page

Just to note, we have 3 pages that cover AWS deployment use cases, one is marked at outdated but looks like the content is still useful. I'll make a separate ticket to review all this content.

# Reasons
All pages should be available in the navigation

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
