### PR TITLE
remove unused toc attributes and add experimental

### DIFF
--- a/jekyll/_cci2/about-circleci.adoc
+++ b/jekyll/_cci2/about-circleci.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: An overview of CircleCI, continuous integration and continuous delivery
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/add-ssh-key.adoc
+++ b/jekyll/_cci2/add-ssh-key.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: How to add additional SSH keys to CircleCI
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 If deploying to your servers requires SSH access, you will need to add SSH keys to CircleCI.
 

--- a/jekyll/_cci2/android-machine-image.adoc
+++ b/jekyll/_cci2/android-machine-image.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Using the Android image on the machine executor
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview]
 == Overview

--- a/jekyll/_cci2/audit-logs.adoc
+++ b/jekyll/_cci2/audit-logs.adoc
@@ -9,14 +9,13 @@ version:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview]
 == Overview
-CircleCI logs important events in the system for audit and forensic analysis purposes. Audit logs are separate from system logs that track performance and network metrics. 
+CircleCI logs important events in the system for audit and forensic analysis purposes. Audit logs are separate from system logs that track performance and network metrics.
 
-If you have administrator permissions for your organization, you can access the audit log feature from the UI in the link:https://app.circleci.com/[web app]: 
+If you have administrator permissions for your organization, you can access the audit log feature from the UI in the link:https://app.circleci.com/[web app]:
 
 . Select **Organization Settings** in the web app sidebar.
 . Select **Security** from the menu.
@@ -25,7 +24,7 @@ If you have administrator permissions for your organization, you can access the 
 
 NOTE: In some situations, the internal machinery may generate duplicate events in the audit logs. The `id` field of the downloaded logs is unique per event and can be used to identify duplicate entries.
 
-Per link:https://circleci.com/privacy/#information[our data retention policy], audit logs can be retrieved for up to 12 months. 
+Per link:https://circleci.com/privacy/#information[our data retention policy], audit logs can be retrieved for up to 12 months.
 
 [#audit-log-events]
 == Audit log events

--- a/jekyll/_cci2/benefits-of-circleci.adoc
+++ b/jekyll/_cci2/benefits-of-circleci.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Benefits of choosing CircleCI for CI/CD
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 
 [#benefits-of-circleci]

--- a/jekyll/_cci2/bitbucket-integration.adoc
+++ b/jekyll/_cci2/bitbucket-integration.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: This document provides an overview of using Bitbucket with CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview]
 == Overview

--- a/jekyll/_cci2/circleci-config-sdk.adoc
+++ b/jekyll/_cci2/circleci-config-sdk.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
 ---
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: The CircleCI Config SDK is a JavaScript package library for generating CircleCI config YAML.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview]
 == Overview

--- a/jekyll/_cci2/concurrency.adoc
+++ b/jekyll/_cci2/concurrency.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: This page summarizes concurrency, and suggests ways to use concurrency to your advantage.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This page summarizes concurrency, and suggests ways to use concurrency to your advantage.
 

--- a/jekyll/_cci2/config-intro.adoc
+++ b/jekyll/_cci2/config-intro.adoc
@@ -10,12 +10,11 @@ contentTags:
 :page-liquid:
 :page-description: "Learn how to get started with the CircleCI config.yml file."
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This guide gets you started with the CircleCI `config.yml` file.
 
-toc::[]
+
 
 [#getting-started-with-circleci-config]
 == Getting started with CircleCI config

--- a/jekyll/_cci2/config-policies-for-self-hosted-runner.adoc
+++ b/jekyll/_cci2/config-policies-for-self-hosted-runner.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 
@@ -36,7 +35,7 @@ Example output:
 {
   "enabled": true
 }
----- 
+----
 +
 {% include snippets/find-organization-id.adoc %}
 
@@ -76,7 +75,7 @@ In the following steps you will replace `namespace/resource_class` and `project_
 .. Replace `namespace/resource_class` in the `runner.rego` file with the name of the resource class that you would like to restrict.
 
 . Replace `project_UUIDs` with a project ID:
-.. In the CircleCI web app, navigate to your projects dashboard by selecting **Projects** in the sidebar. Find the project you want to allow to build on your self-hosted runner, and then click the ellipsis (`...`) next to that project and select **Project Settings**. 
+.. In the CircleCI web app, navigate to your projects dashboard by selecting **Projects** in the sidebar. Find the project you want to allow to build on your self-hosted runner, and then click the ellipsis (`...`) next to that project and select **Project Settings**.
 .. Copy the Project ID from the overview page and replace `project_UUIDs` with this project ID.
 
 [#push-up-your-policy-bundle]
@@ -117,7 +116,7 @@ policy_name["runner_policies"]
 
 enable_hard["resource_class_check"]
 
-resource_class_check = config.resource_class_by_project({ 
+resource_class_check = config.resource_class_by_project({
   "my-namespace/runner-test1": {
     "a20ae1c6-d723-4c03-9bb6-01d5b3594e02",
     "2accadd0-c832-489e-b837-4de03def0d35"

--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 

--- a/jekyll/_cci2/config-policy-reference.adoc
+++ b/jekyll/_cci2/config-policy-reference.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 

--- a/jekyll/_cci2/container-runner-installation.adoc
+++ b/jekyll/_cci2/container-runner-installation.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
 ---
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Instructions on how to install CircleCI's container runner.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 :container:
 
 This page describes how to install CircleCI's container runner.
@@ -27,7 +26,7 @@ This page describes how to install CircleCI's container runner.
 {% include snippets/runner/terms.adoc %}
 
 [#create-namespace-and-resource-class]
-== 1. Create namespace and resource class 
+== 1. Create namespace and resource class
 
 [.tab.container-runner.Web_app_installation]
 --

--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -1,6 +1,6 @@
 ---
 description: Details of CircleCI's container runner
-contentTags: 
+contentTags:
   platform:
   - Cloud
 ---
@@ -8,8 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document is a comprehensive guide to operating and configuring jobs with the CircleCI container runner.
 
@@ -49,7 +48,7 @@ Each resource class supports the following parameters:
 - `token`: The runner resource class token used to claim tasks (**required**).
 - Custom Kubernetes pod configuration for pods used to run CircleCI jobs.
 
-The pod configuration takes all fields that a normal link:https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#debugging[Kubernetes pod does]. If service containers are used in a CircleCI job, the first `container` spec is used for all containers within the task pod. There is currently no way to provide a different container configuration between service containers and the main task container. 
+The pod configuration takes all fields that a normal link:https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#debugging[Kubernetes pod does]. If service containers are used in a CircleCI job, the first `container` spec is used for all containers within the task pod. There is currently no way to provide a different container configuration between service containers and the main task container.
 
 The following fields will be overwritten by container runner to ensure correct task function, and expected CircleCI configuration behavior:
 
@@ -66,7 +65,7 @@ Below is a full configuration example, containing two resource classes:
 
 ```yaml
 agent:
-  resourceClasses:  
+  resourceClasses:
     circleci-runner/resourceClass:
       token: TOKEN1
       metadata:
@@ -87,10 +86,10 @@ agent:
         volumes:
           - name: xyz
             emptyDir: {}
-    
+
     circleci-runner/resourceClass2:
       token: TOKEN2
-      spec: 
+      spec:
         imagePullSecrets:
           - name: "other"
 ```
@@ -104,12 +103,12 @@ The secret should contain a field for each resource class, using the resource cl
 
 ```yaml
 agent:
-  resourceClasses:  
+  resourceClasses:
     circleci-runner/resourceClass:
       metadata:
         annotations:
           custom.io: <my-annotation>
-    
+
     circleci-runner/resourceClass2:
   customSecret: <name_of_secret>
 ```
@@ -129,7 +128,7 @@ Additional instructions can be found in our link:https://support.circleci.com/hc
 
 [#parameters]
 === Helm Chart Parameters
- 
+
 The following are **CircleCI specific settings**:
 
 [.table.table-striped]
@@ -167,12 +166,12 @@ The following are **CircleCI specific settings**:
 | Maximum number of tasks claimed/run concurrently
 | 20
 
-| agent.kubeGCEnabled 
-| Option to enabled/disable garbage collection 
+| agent.kubeGCEnabled
+| Option to enabled/disable garbage collection
 | true
 
-| agent.kubeGCThreshold  
-| Length of time pods can run before deleted by GC 
+| agent.kubeGCThreshold
+| Length of time pods can run before deleted by GC
 | 5h5m
 
 | agent.constraintChecker.enable
@@ -253,7 +252,7 @@ The following is for **Kubernetes object settings**. All settings prefixed with 
 | {}
 
 | agent.nodeSelector
-| Node selector for agent pods 
+| Node selector for agent pods
 | {}
 
 | agent.tolerations
@@ -361,7 +360,7 @@ limits:
 [#constraint-validation]
 == Constraint Validation
 
-Container runner allows you to configure task pods with the full range of Kubernetes settings. This means pods can potentially be configured in a way which cannot be scheduled due to their constraints. To help with this, container runner has a constraint checker which periodically validates each resource class configuration against the current state of the cluster, to ensure pods can be scheduled. This prevents container runner claiming jobs which it cannot schedule which would then fail. 
+Container runner allows you to configure task pods with the full range of Kubernetes settings. This means pods can potentially be configured in a way which cannot be scheduled due to their constraints. To help with this, container runner has a constraint checker which periodically validates each resource class configuration against the current state of the cluster, to ensure pods can be scheduled. This prevents container runner claiming jobs which it cannot schedule which would then fail.
 
 If the constraint checker fails too many checks, it will disable claiming for that resource class until the checks start to pass again.
 
@@ -375,13 +374,13 @@ As an example of how this works, consider the following resource class configura
 
 ```yaml
 agent:
-  resourceClasses:  
+  resourceClasses:
     circleci-runner/resourceClass:
       token: TOKEN1
       spec:
         nodeSelector:
           disktype: ssd
-    
+
     circleci-runner/resourceClass2:
       token: TOKEN2
 ```
@@ -435,7 +434,7 @@ You can confirm that this has been configured correctly by running `kubectl get 
 Once this device has been added, update the container-agent <<#resource-class-configuration-custom-pod,resource class configuration>>:
 
 ```yaml
-resourceClasses: 
+resourceClasses:
  <namespace>/<resourceClass>:
   token: <token>
    spec:

--- a/jekyll/_cci2/convenience-images-support-policy.adoc
+++ b/jekyll/_cci2/convenience-images-support-policy.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: CircleCI Convenience Images release, update, and deprecation policy
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview]
 == Overview
@@ -23,7 +22,7 @@ This policy applies to all CircleCI convenience images we publish to the `cimg` 
 [#base-images]
 == Base images
 
-Our Docker convenience images are all built upon our base image, `cimg/base`. This image is in turn built upon the official Ubuntu docker image. 
+Our Docker convenience images are all built upon our base image, `cimg/base`. This image is in turn built upon the official Ubuntu docker image.
 
 We aim to build variants of this image for all LTS versions of Ubuntu that are being maintained in “Standard Support” status. We will stop building variants of `cimg/base` with Ubuntu LTS versions that drop out of support.
 
@@ -56,7 +55,7 @@ We do not provide a `latest`, or `current`, tag for any convenience images, othe
 [#critical-cve-patches]
 == Critical CVE patches
 
-When critical CVEs are disclosed that affect the versions of the operating system or software stack in our convenience images, we will investigate the impact that this has on our images being used within CircleCI execution environments. 
+When critical CVEs are disclosed that affect the versions of the operating system or software stack in our convenience images, we will investigate the impact that this has on our images being used within CircleCI execution environments.
 
 In most cases, due to the ephemeral and isolated nature of the containers in the environment, it is not necessary to patch these images. We will always communicate our stance on these disclosures on our link:https://discuss.circleci.com/[Discuss Forum].
 

--- a/jekyll/_cci2/create-an-orb.adoc
+++ b/jekyll/_cci2/create-an-orb.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Tutorial showing how to create an orb using the orb development kit.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This tutorial guides you through creating a new orb using the orb development kit. The starting point is creating a new repository on link:https://github.com[GitHub.com].
 

--- a/jekyll/_cci2/create-and-manage-config-policies.adoc
+++ b/jekyll/_cci2/create-and-manage-config-policies.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 

--- a/jekyll/_cci2/create-project.adoc
+++ b/jekyll/_cci2/create-project.adoc
@@ -10,12 +10,11 @@ contentTags:
 :page-liquid:
 :page-description: "Learn how to create a project in CircleCI."
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This guide gets you started with creating a project in CircleCI.
 
-toc::[]
+
 
 [#step-one-link-your-vcs-with-circleci]
 == Step One: Link your VCS with CircleCI

--- a/jekyll/_cci2/credits.adoc
+++ b/jekyll/_cci2/credits.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about CircleCI's dedicated host resource class offering for macOS users.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document describes how to find the available resources regarding credits with CircleCI.
 

--- a/jekyll/_cci2/dedicated-hosts-macos.adoc
+++ b/jekyll/_cci2/dedicated-hosts-macos.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about CircleCI's dedicated host resource class offering for macOS users.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 The dedicated host resource class is available for those developing, building, testing, and signing iOS, iPadOS, macOS, WatchOS, and tvOS applications using the Xcode IDE. These dedicated resources provide an isolated environment for increased security.
 

--- a/jekyll/_cci2/deploy-android-applications.adoc
+++ b/jekyll/_cci2/deploy-android-applications.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn to deploy Android apps through CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to automatically deploy your Android app through CircleCI with link:https://fastlane.tools/[Fastlane].
 

--- a/jekyll/_cci2/deploy-over-ssh.adoc
+++ b/jekyll/_cci2/deploy-over-ssh.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to configure CircleCI to deploy your application over SSH.
 

--- a/jekyll/_cci2/deploy-service-update-to-aws-ecs.adoc
+++ b/jekyll/_cci2/deploy-service-update-to-aws-ecs.adoc
@@ -12,8 +12,7 @@ document-type:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to to configure CircleCI to deploy to AWS ECS using CircleCI orbs.
 

--- a/jekyll/_cci2/deploy-to-aws.adoc
+++ b/jekyll/_cci2/deploy-to-aws.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to configure CircleCI to deploy to Amazon Web Services.
 

--- a/jekyll/_cci2/deploy-to-azure-container-registry.adoc
+++ b/jekyll/_cci2/deploy-to-azure-container-registry.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to to configure CircleCI to deploy to Azure Container Registry.
 

--- a/jekyll/_cci2/deploy-to-capistrano.adoc
+++ b/jekyll/_cci2/deploy-to-capistrano.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will be provided with an example CircleCI configuration to deploy to Capistrano.
 

--- a/jekyll/_cci2/deploy-to-cloud-foundry.adoc
+++ b/jekyll/_cci2/deploy-to-cloud-foundry.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to configure CircleCI to deploy to Cloud Foundry.
 

--- a/jekyll/_cci2/deploy-to-firebase.adoc
+++ b/jekyll/_cci2/deploy-to-firebase.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to configure CircleCI to deploy to Firebase.
 

--- a/jekyll/_cci2/deploy-to-google-cloud-platform.adoc
+++ b/jekyll/_cci2/deploy-to-google-cloud-platform.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to configure CircleCI to deploy to Google Cloud Platform.
 

--- a/jekyll/_cci2/deploy-to-heroku.adoc
+++ b/jekyll/_cci2/deploy-to-heroku.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to configure CircleCI to deploy to Heroku.
 

--- a/jekyll/_cci2/deploy-to-npm-registry.adoc
+++ b/jekyll/_cci2/deploy-to-npm-registry.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 In this how-to guide, you will learn how to configure CircleCI to publish to the NPM registry.
 

--- a/jekyll/_cci2/deployment-overview.adoc
+++ b/jekyll/_cci2/deployment-overview.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn the basics of CircleCI deployment.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/dynamic-config.adoc
+++ b/jekyll/_cci2/dynamic-config.adoc
@@ -11,8 +11,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Instead of manually creating an individual CircleCI configuration per project, you might prefer in some cases to generate these configurations dynamically, depending on specific xref:pipeline-variables#[Pipeline values] or file paths.
 

--- a/jekyll/_cci2/examples-and-guides-overview.adoc
+++ b/jekyll/_cci2/examples-and-guides-overview.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Resources for learning CircleCI using examples.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This page provides a collection of examples to help you learn how to build, test, and deploy applications written in the most common programming languages, frameworks, and platforms on CircleCI.
 

--- a/jekyll/_cci2/fail-fast.adoc
+++ b/jekyll/_cci2/fail-fast.adoc
@@ -8,7 +8,6 @@ version:
 :page-liquid:
 :page-description: A new way to tighten your feedback loop when running tests on CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 WARNING: This preview feature will not be moved to general availability and is deprecated. For questions and/or issues, please comment on our link:https://discuss.circleci.com/t/product-launch-preview-fail-tests-faster/46785[Community forum].

--- a/jekyll/_cci2/first-steps.adoc
+++ b/jekyll/_cci2/first-steps.adoc
@@ -1,22 +1,21 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
 ---
 = Sign up and try CircleCI
 :page-layout: classic-docs
 :page-liquid:
-:page-description: First step for using CircleCI. 
+:page-description: First step for using CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 To run your very first build on CircleCI, go to the link:https://circleci.com/signup/[Sign Up] page. Sign up with your GitHub, Bitbucket or GitLab account, or your email address for the option to connect to your code later in the process.
 
 [#vcs-signup]
 == Sign up with GitHub or Bitbucket
 
-. Click on either link:https://circleci.com/auth/vcs-connect?connection=Github[**Sign Up with GitHub**] or link:https://circleci.com/auth/vcs-connect?connection=Bitbucket[**Sign Up with Bitbucket**] to start the authentication process and allow CircleCI to access your code.   
+. Click on either link:https://circleci.com/auth/vcs-connect?connection=Github[**Sign Up with GitHub**] or link:https://circleci.com/auth/vcs-connect?connection=Bitbucket[**Sign Up with Bitbucket**] to start the authentication process and allow CircleCI to access your code.
 +
 NOTE: If you are using GitHub, you have the option to limit CircleCI, preventing access to your private repositories. To do this, use the drop down menu at the side of the Sign Up button, and select **Public Repos Only** from the list.
 
@@ -64,9 +63,9 @@ NOTE: The full set of documentation for integrating GitLab with CircleCI can be 
 
 . Explore some example projects within the CircleCI app if you do not want to connect to your code at this time. You can take a look at a popular open source project building on CircleCI (link:https://app.circleci.com/pipelines/github/facebook/react[React by Facebook]), or one of our own sample projects: a link:https://app.circleci.com/pipelines/github/CircleCI-Public/sample-javascript-cfd/[sample JavaScript app], and a link:https://app.circleci.com/pipelines/github/CircleCI-Public/sample-python-cfd/[sample Python app].
 
-You will be able to start exploring features such as link:/docs/pipelines[pipelines] and link:/docs/workflows[workflows]. The **Dashboard**, **Projects**, **Organization Settings**, and **Plan** pages are not available until you connect your code.  
+You will be able to start exploring features such as link:/docs/pipelines[pipelines] and link:/docs/workflows[workflows]. The **Dashboard**, **Projects**, **Organization Settings**, and **Plan** pages are not available until you connect your code.
 
-When you are ready, you can connect to your GitHub, BitBucket, or GitLab accounts from the CircleCI web app.  
+When you are ready, you can connect to your GitHub, BitBucket, or GitLab accounts from the CircleCI web app.
 
 [#terms]
 == Terms

--- a/jekyll/_cci2/get-started-with-the-vs-code-extension.adoc
+++ b/jekyll/_cci2/get-started-with-the-vs-code-extension.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
 ---
@@ -8,10 +8,9 @@ contentTags:
 :page-liquid:
 :page-description: A quickstart tutorial for the CircleCI VS Code extension.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
-This tutorial is a quickstart guide to setting up and using the official CircleCI VS Code extension. You can read more about the extension's capabilities in the xref:vs-code-extension-overview#[overview]. 
+This tutorial is a quickstart guide to setting up and using the official CircleCI VS Code extension. You can read more about the extension's capabilities in the xref:vs-code-extension-overview#[overview].
 
 [#prerequisites]
 == Prerequisites
@@ -102,9 +101,9 @@ The extension integrates a Language Server specific to CircleCI configuration fi
 
 . To verify that language support is working, open a `.yml` file in a `.circleci` directory.
 +
-Even without taking any further action, you should see: 
+Even without taking any further action, you should see:
 
-* Syntax coloration is applied. 
+* Syntax coloration is applied.
 * Red warnings appear if you introduce syntax errors.
 * You are able to use go-to-definition commands on the file.
 +

--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: This document provides an overview of using GitHub and GitHub Enterprise with CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview]
 == Overview

--- a/jekyll/_cci2/gitlab-integration.adoc
+++ b/jekyll/_cci2/gitlab-integration.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn how to integrate GitLab with CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview]
 == Overview

--- a/jekyll/_cci2/glossary.adoc
+++ b/jekyll/_cci2/glossary.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: A glossary of terms used for the CircleCI product.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#circleci-administrator]
 == CircleCI administrator

--- a/jekyll/_cci2/inject-environment-variables-with-api.adoc
+++ b/jekyll/_cci2/inject-environment-variables-with-api.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server 3.x
@@ -8,10 +8,9 @@ contentTags:
 = Inject environment variables with the CircleCI API
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to inject env var values using the API. 
+:page-description: How to inject env var values using the API.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#api-v2]
 == API v2
@@ -22,7 +21,7 @@ A pipeline can be triggered with specific parameter values using the API v2
 endpoint to link:https://circleci.com/docs/api/v2/index.html#operation/getPipelineConfigById[trigger a pipeline].
 This can be done by passing a `parameters` key in the JSON packet of the `POST` body.
 
-The example below triggers a pipeline with parameter values for `workingdir` and `image-tag`. 
+The example below triggers a pipeline with parameter values for `workingdir` and `image-tag`.
 
 NOTE: In order to pass a parameter when triggering a pipeline via the API, the parameter must be xref:reusing-config#using-the-parameters-declaration[declared in the configuration file].
 
@@ -42,7 +41,7 @@ Read more about pipeline parameters on the xref:pipeline-variables#[Pipeline val
 [#api-v1]
 == API v1
 
-You can inject environment variables with the `build_parameters` key to enable your functional tests to build against different targets on each run (for example, a run with a deploy step to a staging environment that requires functional testing against different hosts). 
+You can inject environment variables with the `build_parameters` key to enable your functional tests to build against different targets on each run (for example, a run with a deploy step to a staging environment that requires functional testing against different hosts).
 
 It is possible to include `build_parameters` by sending a JSON body with `Content-type: application/json` as in the following example that uses `bash` and `curl`. You may also use an HTTP library in your language of choice.
 
@@ -84,7 +83,7 @@ Build parameters are environment variables, therefore their names have to meet t
 - They must not begin with a number.
 - They must contain at least one character.
 
-Aside from the usual constraints for environment variables, there are no restrictions on the values themselves and are treated as simple strings. 
+Aside from the usual constraints for environment variables, there are no restrictions on the values themselves and are treated as simple strings.
 
 Build parameters are exported as environment variables inside each job's containers and can be used by scripts/programs and commands in `.circleci/config.yml`. The injected environment variables may be used to influence the steps that are run during the job. It is important to note that injected environment variables will not override values defined in `.circleci/config.yml` nor in the project settings.
 

--- a/jekyll/_cci2/insights-snapshot-badge.adoc
+++ b/jekyll/_cci2/insights-snapshot-badge.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Generate a badge that displays Insights metrics for a project.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CAUTION: Insights snapshot badges are not currently supported for GitLab projects.
 

--- a/jekyll/_cci2/introduction-to-the-circleci-web-app.adoc
+++ b/jekyll/_cci2/introduction-to-the-circleci-web-app.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: This document describes the basic features and settings of the CircleCI web app.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 The CircleCI web application is a graphic user interface for many of the same features that are available in the CircleCI command line interface. The application can be found at link:https://app.circleci.com[https://app.circleci.com].
 

--- a/jekyll/_cci2/introduction-to-yaml-configurations.adoc
+++ b/jekyll/_cci2/introduction-to-yaml-configurations.adoc
@@ -11,8 +11,7 @@ contentTags:
 :page-liquid:
 :page-description: "Overview of CircleCI configuration written in YAML"
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 The crux of connecting CircleCI to your project is a `config.yml`, which is held in a `.circleci` directory. CircleCI configuration files are written in https://yaml.org/[YAML], a more human-friendly data serialization format for programming languages. YAML is a strict superset of JSON, so anything you can do in JSON, you can also do in YAML. CircleCI YAML configurations will largely consist of key-value pairs, and nested key-value pairs.
 

--- a/jekyll/_cci2/manage-contexts-with-config-policies.adoc
+++ b/jekyll/_cci2/manage-contexts-with-config-policies.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn how to manage the use of contexts with config policies.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 

--- a/jekyll/_cci2/migrate-from-deploy-to-run.adoc
+++ b/jekyll/_cci2/migrate-from-deploy-to-run.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: A how-to guide on how to migrage from the deprecated deploy step to run.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/migrate-scheduled-workflows-to-scheduled-pipelines.adoc
+++ b/jekyll/_cci2/migrate-scheduled-workflows-to-scheduled-pipelines.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
 ---
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Migrate scheduled workflows to scheduled pipelines
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 NOTE: **The deprecation of the scheduled workflows feature has been postponed**. Since the deprecation announcement went live, your feedback and feature requests have been monitored and it is clear there is more work to do in order to improve the existing scheduled pipelines experience, and also make migration easier for all. Updates on a new deprecation timeline will be announced here and on link:https://discuss.circleci.com/[CircleCI Discuss].
 

--- a/jekyll/_cci2/migrating-from-aws.adoc
+++ b/jekyll/_cci2/migrating-from-aws.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This overview provides instructions for installing CircleCI Server on Amazon Web Services (AWS) with Terraform.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document provides an overview of how to migrate from AWS CodeCommit to CircleCI.
 

--- a/jekyll/_cci2/migrating-from-azuredevops.adoc
+++ b/jekyll/_cci2/migrating-from-azuredevops.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: An overview of how to migrate from Azure DevOps to CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document provides an overview of how to migrate from Azure DevOps to CircleCI.
 

--- a/jekyll/_cci2/migrating-from-buildkite.adoc
+++ b/jekyll/_cci2/migrating-from-buildkite.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: An overview of how to migrate from Buildkite to CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document provides an overview of how to migrate from Buildkite to CircleCI.
 

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: An overview of how to migrate from GitHub Actions to CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document provides an overview of how to migrate from GitHub Actions to CircleCI.
 

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: An overview of how to migrate from GitLab to CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document provides an overview of how to migrate from GitLab to CircleCI.
 

--- a/jekyll/_cci2/migrating-from-teamcity.adoc
+++ b/jekyll/_cci2/migrating-from-teamcity.adoc
@@ -10,8 +10,7 @@ contentTags:
 :description: An overview of how to migrate from TeamCity to CircleCI.
 :source-highlighter: pygments.rb
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document provides an overview of how to migrate from TeamCity to CircleCI.
 

--- a/jekyll/_cci2/migration-intro.adoc
+++ b/jekyll/_cci2/migration-intro.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This document provides an overview of the stages required to migrate your CI/CD pipelines to CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#why-migrate-to-circleci]
 == Why migrate to CircleCI?

--- a/jekyll/_cci2/notify-a-slack-channel-of-a-paused-workflow.adoc
+++ b/jekyll/_cci2/notify-a-slack-channel-of-a-paused-workflow.adoc
@@ -1,6 +1,6 @@
 ---
 description: "A how to guide for using the Slack orb to notify a Slack channel of a paused workflow."
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -12,12 +12,11 @@ document-type:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Slack is a real-time collaboration application where team members can work together to perform routine tasks and projects through custom channels and workspaces. When using the CircleCI platform, you may find it useful to enable custom notifications with the Slack app based on specific team needs and requirements.
 
-The https://circleci.com/developer/orbs/orb/circleci/slack[CircleCI Slack orb] enables you to create different notifications and messages that can be delivered to your desired recipients. 
+The https://circleci.com/developer/orbs/orb/circleci/slack[CircleCI Slack orb] enables you to create different notifications and messages that can be delivered to your desired recipients.
 
 This page shows how to use a built-in job from the Slack orb to notify a Slack channel when there is a paused workflow awaiting approval. For more information on approval see the <<workflows#holding-a-workflow-for-a-manual-approval,Using Workflows to Orchestrate Jobs>> page.
 

--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn how to use OpenID Connect ID tokens for access to compatible cloud services.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI provides OpenID Connect ID (OIDC) tokens in environment variables. A job can be configured to use these tokens to access compatible cloud services without long-lived credentials being stored in CircleCI.
 

--- a/jekyll/_cci2/orb-author-faq.adoc
+++ b/jekyll/_cci2/orb-author-faq.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :page-description: This page answers the most frequently asked questions by orb authors.
-:toc: macro
-:toc-title:
+:experimental:
 
 This document describes various questions and technical issues that you may find helpful when authoring orbs.
 

--- a/jekyll/_cci2/orbs-faq.adoc
+++ b/jekyll/_cci2/orbs-faq.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: This page answers the most frequently asked questions about orbs.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document describes various questions and technical issues that you may find helpful when working with orbs.
 

--- a/jekyll/_cci2/pipeline-variables.adoc
+++ b/jekyll/_cci2/pipeline-variables.adoc
@@ -12,8 +12,7 @@ contentTags:
 :page-liquid:
 :page-description: This document describes the Free plan available to developers on CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/plan-free.adoc
+++ b/jekyll/_cci2/plan-free.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: This document describes the Free plan available to developers on CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 :orbs:
 
 This document describes the Free plan available to developers.

--- a/jekyll/_cci2/plan-overview.adoc
+++ b/jekyll/_cci2/plan-overview.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: This document is an introduction to the plans CircleCI offers to developers.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document is an introduction to the plans CircleCI offers to developers.
 

--- a/jekyll/_cci2/plan-performance.adoc
+++ b/jekyll/_cci2/plan-performance.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: This document describes the Performance plan available to developers on CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 :orbs:
 
 This document describes the Performance plan available to developers.

--- a/jekyll/_cci2/plan-scale.adoc
+++ b/jekyll/_cci2/plan-scale.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: This document describes the Scale plan available to developers on CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document describes the Scale plan available to developers.
 

--- a/jekyll/_cci2/plan-server.adoc
+++ b/jekyll/_cci2/plan-server.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This document describes the Server plan available to developers on CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 :concurrency:
 :orbs:
 

--- a/jekyll/_cci2/private-images.adoc
+++ b/jekyll/_cci2/private-images.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: This document describes how to authenticate with your Docker registry provider to pull images.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document describes how to authenticate with your Docker registry provider to pull images.
 

--- a/jekyll/_cci2/pull-an-image-from-aws-ecr-with-oidc.adoc
+++ b/jekyll/_cci2/pull-an-image-from-aws-ecr-with-oidc.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn how to pull an image from AWS ECR using OIDC authentication
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Follow this how-to guide to configure a `docker` job to pull an image from AWS ECR using OIDC authentication.
 

--- a/jekyll/_cci2/rename-organizations-and-repositories.adoc
+++ b/jekyll/_cci2/rename-organizations-and-repositories.adoc
@@ -8,8 +8,7 @@ version:
 :page-liquid:
 :page-description: This how-to guide goes over changing the names of organizations and repositories.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 If you need to rename an organization or repository that you have previously connected to CircleCI, best practice is to follow the steps listed below. If you do not follow this process, it is possible you may lose access to your organization or repository settings, including **environment variables** and **contexts**.
 

--- a/jekyll/_cci2/rerun-failed-tests-only.adoc
+++ b/jekyll/_cci2/rerun-failed-tests-only.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: How to re-run only failed tests in a job and optimize credit usage.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#motivation-and-introduction]
 == Motivation and introduction
@@ -41,19 +40,19 @@ NOTE: If your current job is using xref:test-splitting-tutorial#[intelligent tes
     name: Run tests
     command: |
       mkdir test-results
-      TEST_FILES=$(circleci tests glob "**/test_*.py" | circleci tests split --split-by=timings) 
+      TEST_FILES=$(circleci tests glob "**/test_*.py" | circleci tests split --split-by=timings)
       pytest -o junit_family=legacy --junitxml=test-results/junit.xml $TEST_FILES
-      
+
 - store_test_results:
     path: test-results
 ```
 
 This example snippet is from a CircleCI configuration file that:
 
-. Executes Python test files that end in `.py`, 
-. Splits tests by previous timing results (you can follow xref:test-splitting-tutorial#[this tutorial] on intelligent test splitting), 
-. Stores the test results in a new directory called `test-results`, and 
-. Uploads those test results to CircleCI.  
+. Executes Python test files that end in `.py`,
+. Splits tests by previous timing results (you can follow xref:test-splitting-tutorial#[this tutorial] on intelligent test splitting),
+. Stores the test results in a new directory called `test-results`, and
+. Uploads those test results to CircleCI.
 
 **Note:** `-o junit_family=legacy` is present to ensure that the test results being generated contain the `file` attribute. Not included in this snippet is the key to set parallelism (read the xref:parallelism-faster-jobs#[Test splitting and parallelism] page for more information).
 
@@ -77,7 +76,7 @@ In the snippet below, the example has been updated to use the `circleci tests ru
 * `TEST_FILES=$(circleci tests glob "**/test_*.py")`
 +
 Use CircleCI's xref:troubleshoot-test-splitting#video-troubleshooting-globbing[glob command] to put together a list of test files. In this case, we are looking for any test file that starts with `test_` and ends with `.py`. Ensure that the glob string is enclosed in quotes.
-  
+
 * `echo "$TEST_FILES" |`
 +
 Pass the list of test files to the `circleci tests run` command as standard input (link:https://www.computerhope.com/jargon/s/stdin.htm[`stdin`]).
@@ -86,13 +85,13 @@ Pass the list of test files to the `circleci tests run` command as standard inpu
   ** Invoke `circleci tests run` and specify the original command (`pytest`) used to run tests as part of the `--command=` parameter. **This is required**. `xargs` must be present as well.
   ** `--verbose` is an optional parameter for `circleci tests run` which enables more verbose debugging messages.
   ** *Optional*: `--split-by=timings` enables intelligent test splitting by timing for `circleci tests run`. Note that this is not required in order to use `circleci tests run`. If your testing job is not using CircleCI's test splitting, omit this parameter.
-  
+
 NOTE: You can specify the timing type similar to `circleci tests split --split-by=timings --timings-type=` using a `--timings-type=` flag.  You can pass `file`, `classname`, or `name` (`name` splits by test name) to `--timings-type=` as a flag to `circleci tests run`.
-  
+
 [#verify-the-configuration]
 ==== Verify the configuration
 
-After updating your configuration, run the job that runs tests again and make sure that the same number of tests are being executed as before the config.yml change.  
+After updating your configuration, run the job that runs tests again and make sure that the same number of tests are being executed as before the config.yml change.
 
 Then, the next time you encounter a test failure on that job, click the "Re-run failed tests only" button.  If the `--verbose` setting is enabled, you should see output similar to the following the next time you click "Rerun failed tests only" with this job on CircleCI:
 
@@ -100,14 +99,14 @@ Then, the next time you encounter a test failure on that job, click the "Re-run 
 Installing circleci-tests-plugin-cli plugin.
 circleci-tests-plugin-cli plugin Installed. Version: 1.0.5976-439c1fc
 DEBUG[2023-05-18T22:09:08Z] Attempting to read from stdin. This will hang if no input is provided.
-INFO[2023-06-14T23:52:50Z] received failed tests from workflow ***** 
+INFO[2023-06-14T23:52:50Z] received failed tests from workflow *****
 DEBUG[2023-05-18T22:09:08Z] 2 test(s) failed out of 56 total test(s). Rerunning 1 test file(s)
 DEBUG[2023-06-14T23:52:50Z] if all tests are being run instead of only failed tests, ensure your JUnit XML has a file or classname attribute.
-INFO[2023-05-18T22:09:08Z] starting execution                           
+INFO[2023-05-18T22:09:08Z] starting execution
 DEBUG[2023-05-18T22:09:08Z] Received: ****
 ```
 
-If you see `rerunning failed tests` present in the step's output, the functionality is configured properly.  You'll also see output that shows the total number of failed tests from the original job run, the total number of 
+If you see `rerunning failed tests` present in the step's output, the functionality is configured properly.  You'll also see output that shows the total number of failed tests from the original job run, the total number of
 
 The job should only re-run tests that are from a `classname` of `file` that had at least one test failure when the "Re-run failed tests only" button is clicked. If you are seeing different behavior, comment on this https://discuss.circleci.com/t/product-launch-re-run-failed-tests-only/47775/[Discuss post] for support.
 
@@ -166,13 +165,13 @@ gem 'rspec_junit_formatter'
 ```yaml
      -run:
         name: run tests
-        command: | 
+        command: |
           mkdir test_results
-          cd ./cypress 
-          npm ci 
+          cd ./cypress
+          npm ci
           npm run start &
-          circleci tests glob "cypress/**/*.cy.js" | circleci tests run --command="xargs npx cypress run --reporter cypress-circleci-reporter --spec" --verbose --split-by=timings #--split-by=timings is optional, only use if you are using CircleCI's test splitting 
-     
+          circleci tests glob "cypress/**/*.cy.js" | circleci tests run --command="xargs npx cypress run --reporter cypress-circleci-reporter --spec" --verbose --split-by=timings #--split-by=timings is optional, only use if you are using CircleCI's test splitting
+
      - store_test_results
         path: test_results
 ```
@@ -191,7 +190,7 @@ Remember to modify the `glob` command for your specific use case.  **If your cur
       command: yarn add --dev jest-junit
 ```
 +
-You can also add it to your `jest.config.js` file by following these link:https://www.npmjs.com/package/jest-junit[usage instructions].  
+You can also add it to your `jest.config.js` file by following these link:https://www.npmjs.com/package/jest-junit[usage instructions].
 
 . Modify your test command to look something similar to:
 +
@@ -200,7 +199,7 @@ You can also add it to your `jest.config.js` file by following these link:https:
     command: |
       npx jest --listTests | circleci tests run --command=“JEST_JUNIT_ADD_FILE_ATTRIBUTE=true xargs npx jest --config jest.config.js --runInBand --” --verbose --split-by=timings
     environment:
-      JEST_JUNIT_OUTPUT_DIR: ./reports/     
+      JEST_JUNIT_OUTPUT_DIR: ./reports/
   - store_test_results:
       path: ./reports/
 ```
@@ -223,14 +222,14 @@ You can also add it to your `jest.config.js` file by following these link:https:
       echo "$TESTFILES" | circleci tests run --command="xargs pnpm playwright test --config=playwright.config.ci.ts --reporter=junit" --verbose --split-by=timings
 ```
 
-. Update the `glob` command to match your use case. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.**. If you are not using test splitting, `--split-by=timings` can be omitted. Note: you may also use link:https://playwright.dev/docs/test-reporters#junit-reporter[Playwright's built-in flag] (`PLAYWRIGHT_JUNIT_OUTPUT_NAME`) to specify the JUnit XML output directory.  
+. Update the `glob` command to match your use case. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.**. If you are not using test splitting, `--split-by=timings` can be omitted. Note: you may also use link:https://playwright.dev/docs/test-reporters#junit-reporter[Playwright's built-in flag] (`PLAYWRIGHT_JUNIT_OUTPUT_NAME`) to specify the JUnit XML output directory.
 +
 NOTE: Ensure that you are using version 1.34.2 or later of Playwright. Earlier versions of Playwright may not output JUnit XML in a format that is compatible with this feature.
 
 [#output-test-files-only]
 === Output test files only
 
-If your testing set-up on CircleCI is not compatible with invoking your test runner in the `circleci tests run` command, you can opt to use `circleci tests run` to receive the file names, output the file names, and save the file names to a temporary location.  You can then subsequently invoke your test runner using the outputted file names.  
+If your testing set-up on CircleCI is not compatible with invoking your test runner in the `circleci tests run` command, you can opt to use `circleci tests run` to receive the file names, output the file names, and save the file names to a temporary location.  You can then subsequently invoke your test runner using the outputted file names.
 
 Example:
 
@@ -245,7 +244,7 @@ The snippet above will write the list of test file names to `files.txt`.  On a n
 [#known-limitations]
 == Known limitations
 
-* If your testing job is using parallelism and test splitting, the job will spin up the number of containers/virtual machines (VMs) that are specified with the `parallelism` key. However, the step that runs tests for each of those parallel containers/VMs will only run a subset of tests, or no tests, after the tests are split across the total number of parallel containers/VMs. For example, if parallelism is set to eight, there may only be enough tests after the test splitting occurs to "fill" the first parallel container/VM. The remaining seven containers/VMs will still start up, but they will not run any tests when they get to the test execution step.  **The vast majority of customers still observe substantial time and credit savings** despite spinning up containers/VMs that do not run tests.  
+* If your testing job is using parallelism and test splitting, the job will spin up the number of containers/virtual machines (VMs) that are specified with the `parallelism` key. However, the step that runs tests for each of those parallel containers/VMs will only run a subset of tests, or no tests, after the tests are split across the total number of parallel containers/VMs. For example, if parallelism is set to eight, there may only be enough tests after the test splitting occurs to "fill" the first parallel container/VM. The remaining seven containers/VMs will still start up, but they will not run any tests when they get to the test execution step.  **The vast majority of customers still observe substantial time and credit savings** despite spinning up containers/VMs that do not run tests.
 * Orbs that run tests may not work with this new functionality at this time.
 * If a shell script is invoked to run tests, `circleci tests run` should be placed **in the shell script** itself, and not `.circleci/config.yml`.
 * Jobs that are older than the xref:persist-data#custom-storage-usage[retention period] for workspaces for the organization cannot be re-run with "Re-run failed tests".
@@ -278,7 +277,7 @@ After configuring `circleci tests run`, if you see *all tests* are re-run after 
 
 **Question:** What happens if I try to use the functionality but `circleci tests run` is not used in the `.circleci/config.yml` file?
 
-**Answer:** All tests will be executed when the workflow runs again, including failed tests. This is equivalent to selecting "Rerun workflow from failed".  
+**Answer:** All tests will be executed when the workflow runs again, including failed tests. This is equivalent to selecting "Rerun workflow from failed".
 
 ---
 
@@ -296,9 +295,9 @@ After configuring `circleci tests run`, if you see *all tests* are re-run after 
 
 **Question:** I don't see my test framework on this page, can I still use the functionality?
 
-**Answer:** Yes, as long as your job meets the xref:#prerequisites[prerequisites] outlined above. The re-run failed tests functionality is test runner and test framework-agnostic. You can use the methods described in the xref:collect-test-data#[Collect test data] document to ensure that the job is uploading test results. Note that `classname` and `file` is not always present by default, so your job may require additional configuration.  
+**Answer:** Yes, as long as your job meets the xref:#prerequisites[prerequisites] outlined above. The re-run failed tests functionality is test runner and test framework-agnostic. You can use the methods described in the xref:collect-test-data#[Collect test data] document to ensure that the job is uploading test results. Note that `classname` and `file` is not always present by default, so your job may require additional configuration.
 
-From there, follow the xref:#quickstart[Quickstart] section to modify your test command to use `circleci tests run`. 
+From there, follow the xref:#quickstart[Quickstart] section to modify your test command to use `circleci tests run`.
 
 If you run into issues, comment on the https://discuss.circleci.com/t/product-launch-re-run-failed-tests-only/47775/[Discuss post].
 
@@ -312,7 +311,7 @@ If you run into issues, comment on the https://discuss.circleci.com/t/product-la
 
 **Question:** My maven surefire tests are failing when I try to set this feature up?
 
-**Answer:** You may need to add the `-DfailIfNoTests=false` flag to ensure the testing framework ignores skipped tests instead of reporting a failure when it sees a skipped test on a dependent module. 
+**Answer:** You may need to add the `-DfailIfNoTests=false` flag to ensure the testing framework ignores skipped tests instead of reporting a failure when it sees a skipped test on a dependent module.
 
 ---
 
@@ -324,13 +323,13 @@ If you run into issues, comment on the https://discuss.circleci.com/t/product-la
 
 **Question:** Why does the re-run appear to be running all tests instead of only failed tests?
 
-**Answer:** The most common case where this occurs is when the JUnit XML is not outputting a "file" attribute.  If you upload your test results XML to an artifact, you can inspect whether or not it has the "file" attribute.  
+**Answer:** The most common case where this occurs is when the JUnit XML is not outputting a "file" attribute.  If you upload your test results XML to an artifact, you can inspect whether or not it has the "file" attribute.
 
 ---
 
 **Question:** Are tests that were reported by my test runner as "Skipped" or "Ignored" re-run when I click "Rerun failed tests only"?
 
-**Answer:** No, only test files that have at least one test case reported as "Failed" will be re-run.  
+**Answer:** No, only test files that have at least one test case reported as "Failed" will be re-run.
 
 ---
 

--- a/jekyll/_cci2/resource-class-overview.adoc
+++ b/jekyll/_cci2/resource-class-overview.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: An overview of resource classes in CircleCI
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Use resource classes to:
 

--- a/jekyll/_cci2/rotate-project-ssh-keys.adoc
+++ b/jekyll/_cci2/rotate-project-ssh-keys.adoc
@@ -29,8 +29,7 @@ sectionTags:
 :page-liquid:
 :page-description: How to guide detailing how to rotate your project SSH keys.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 :experimental:
 
 To revoke usage of a project SSH key, rotate the key pairs by following the steps outlined below. There are separate instructions for each supported version control system (VCS).

--- a/jekyll/_cci2/run-a-job-in-a-container.adoc
+++ b/jekyll/_cci2/run-a-job-in-a-container.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn how to run a job in a container on your machine with Docker.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 The link:https://circleci-public.github.io/circleci-cli/[CLI] enables you to run individual jobs on your local machine with Docker. This can be useful to run tests before pushing configuration changes, or debugging your build process without impacting your build queue.
 

--- a/jekyll/_cci2/runner-api.adoc
+++ b/jekyll/_cci2/runner-api.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: This document contains all the external facing endpoints for the CircleCI's self-hosted runner API.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 {% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 

--- a/jekyll/_cci2/runner-concepts.adoc
+++ b/jekyll/_cci2/runner-concepts.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Conceptual Overview for CircleCI's self-hosted runner.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 {% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 

--- a/jekyll/_cci2/runner-config-reference.adoc
+++ b/jekyll/_cci2/runner-config-reference.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -9,8 +9,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 {% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
@@ -128,7 +127,7 @@ runner:
 === runner.cleanup_working_directory
 `$LAUNCH_AGENT_RUNNER_CLEANUP_WORK_DIR`
 
-CircleCI recommends using a knowable directory, however it is possbile to specify `%s` in the path. This value will be replaced with a different value for each job. This is a substitution that is only knowable at job runtime, under the environment variable `$CIRCLE_WORKING_DIRECTORY`. 
+CircleCI recommends using a knowable directory, however it is possbile to specify `%s` in the path. This value will be replaced with a different value for each job. This is a substitution that is only knowable at job runtime, under the environment variable `$CIRCLE_WORKING_DIRECTORY`.
 
 Example:
 

--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: This page answers the most frequently asked questions for the CircleCI's self-hosted runner product.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 {% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 

--- a/jekyll/_cci2/runner-installation-docker.adoc
+++ b/jekyll/_cci2/runner-installation-docker.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Instructions on how to install CircleCI's self-hosted runner on Docker.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 :machine:
 
 {% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
@@ -46,7 +45,7 @@ The host needs to have Docker installed. Once the `runner` container is started,
 The number of containers running in parallel on the host is constrained by the host's available resources and your jobs' performance requirements.
 
 [#create-namespace-and-resource-class]
-=== 1. Create namespace and resource class 
+=== 1. Create namespace and resource class
 
 [.tab.machine-runner.Web_app_installation]
 --

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Instructions on how to install CircleCI's self-hosted runner on Linux.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 :machine:
 :linux:
 
@@ -30,7 +29,7 @@ This page describes how to install CircleCI's machine runner on Linux.
 {% include snippets/runner/terms.adoc %}
 
 [#create-namespace-and-resource-class]
-== 1. Create namespace and resource class 
+== 1. Create namespace and resource class
 
 [.tab.machine-runner.Web_app_installation]
 --

--- a/jekyll/_cci2/runner-installation-mac.adoc
+++ b/jekyll/_cci2/runner-installation-mac.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Instructions on how to install CircleCI's self-hosted runner on macOS.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 :machine:
 :macos:
 
@@ -30,7 +29,7 @@ This page describes how to install CircleCI's machine runner on macOS.
 {% include snippets/runner/terms.adoc %}
 
 [#create-namespace-and-resource-class]
-== 1. Create namespace and resource class 
+== 1. Create namespace and resource class
 
 [.tab.machine-runner.Web_app_installation]
 --

--- a/jekyll/_cci2/runner-installation-windows.adoc
+++ b/jekyll/_cci2/runner-installation-windows.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Instructions on how to install CircleCI's self-hosted runner on Windows.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 :machine:
 :windows:
 
@@ -37,7 +36,7 @@ Since this setup creates a new local administrator user that runs CircleCI jobs,
 {% include snippets/runner/terms.adoc %}
 
 [#create-namespace-and-resource-class]
-== 1. Create namespace and resource class 
+== 1. Create namespace and resource class
 
 [.tab.machine-runner.Web_app_installation]
 --

--- a/jekyll/_cci2/runner-on-kubernetes.adoc
+++ b/jekyll/_cci2/runner-on-kubernetes.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Use this installation guide to set up CircleCI's self-hosted runners on your Kubernetes cluster.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 {% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -10,15 +10,14 @@ contentTags:
 :page-liquid:
 :page-description: Learn how CircleCI's self-hosted runners enable you to use your own infrastructure for running jobs.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 {% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
 [#introduction]
 == Introduction
 
-CircleCI's self-hosted runner enables you to use your own infrastructure for running jobs. This means you will be able to build and test on a wider variety of architectures, as well as have additional control over the environment. 
+CircleCI's self-hosted runner enables you to use your own infrastructure for running jobs. This means you will be able to build and test on a wider variety of architectures, as well as have additional control over the environment.
 
 You have the option of installing your self-hosted runner in a Kubernetes cluster using a container runner, or within a machine execution environment using a machine runner. The diagrams below illustrate how CircleCI's container runner and machine runner extend our existing systems.
 
@@ -37,7 +36,7 @@ image::runner-overview-diagram.png[CircleCI's machine runner architecture]
 [#circleci-self-hosted-runner-operation]
 == CircleCI's self-hosted runner operation
 
-Once a CircleCI's self-hosted runner is installed, the self-hosted runner polls `circleci.com` for work, runs jobs, and returns status, logs, and artifacts to CircleCI. 
+Once a CircleCI's self-hosted runner is installed, the self-hosted runner polls `circleci.com` for work, runs jobs, and returns status, logs, and artifacts to CircleCI.
 
 [#circleci-runner-use-cases]
 == CircleCI runner use cases
@@ -63,7 +62,7 @@ CircleCI offers two types of self-hosted runners: container and machine.
 CircleCI's self-hosted runner has historically executed each job using a one-to-one mapping between the CI job and a <<configuration-reference#machine,machine>> environment (virtual or physical) that has the self-hosted runner binary installed on it. Exclusively running jobs in this manner sacrifices several benefits of a container-based solution that are afforded on CircleCI’s cloud platform when using the <<using-docker#,Docker executor>>:
 
 * The ability to seamlessly use custom Docker images during job execution
-* Access to a consistent, clean containerized build environment with every job 
+* Access to a consistent, clean containerized build environment with every job
 
 Container runner is installed in a Kubernetes (k8s) cluster which enables you to run containerized jobs on self-hosted compute, similar to how jobs use the native Docker executor to run on CircleCI’s cloud platform. This solution allows you to run hundreds of jobs at once, scaling pods effectively to meet compute demands.
 

--- a/jekyll/_cci2/runner-scaling.adoc
+++ b/jekyll/_cci2/runner-scaling.adoc
@@ -1,6 +1,6 @@
 ---
 description: Learn how to scale CircleCI's self-hosted runners.
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -10,9 +10,8 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
-toc::[]
+:experimental:
+
 
 {% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 
@@ -37,7 +36,7 @@ There are several API endpoints to help you set up a solution to scale machine r
 * <<runner-api#get-apiv2runnertasksrunning,Running Tasks>>
 * <<runner-api#get-apiv2runner,List Resource Classes>>
 
-A scaling solution can use the above endpoints to calculate the total number of waiting tasks which can be run. The task data endpoints are scoped to a single resource class, so it's important to query every available resource class to get the total number of running tasks. 
+A scaling solution can use the above endpoints to calculate the total number of waiting tasks which can be run. The task data endpoints are scoped to a single resource class, so it's important to query every available resource class to get the total number of running tasks.
 
 If you're using machine runners, you can devise a scaling solution to add more machine runners to the resource class that has more pending work.
 

--- a/jekyll/_cci2/runner-upgrading-on-server.adoc
+++ b/jekyll/_cci2/runner-upgrading-on-server.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Server v4.x
   - Server v3.x
@@ -8,13 +8,12 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 
 This page describes how to update the CircleCI's **machine runner** on CircleCI server installations.
 
-toc::[]
+
 
 [#self-hosted-runner-for-server-compatibility]
 == Machine runner on server compatibility

--- a/jekyll/_cci2/schedule-pipelines-with-multiple-workflows.adoc
+++ b/jekyll/_cci2/schedule-pipelines-with-multiple-workflows.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
 ---
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: "Learn how to set conditionals for scheduled pipelines in multiple workflows."
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#introduction]
 == Introduction
@@ -55,7 +54,7 @@ You may also add filtering for workflows that should *not* run when a schedule i
 version: 2.1
 ...
 daily-run-workflow:
-# run workflow only when the daily_build pipeline is triggered 
+# run workflow only when the daily_build pipeline is triggered
   when:
     and:
       - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
@@ -120,23 +119,23 @@ The example below demonstrates three workflows scheduled with pipeline values. T
 version: 2.1
 ...
 workflows:
-# run workflow only when the daily_build pipeline is triggered 
+# run workflow only when the daily_build pipeline is triggered
   daily-run-workflow:
-    when: 
+    when:
       equal: [ daily_build, << pipeline.schedule.name >> ]
     jobs:
       - job-one
 
   nightly-run-workflow:
   # run workflow only when the daily_build pipeline is triggered
-    when: 
+    when:
       equal: [ daily_build, << pipeline.schedule.name >> ]
     jobs:
       - job-two
 
   weekly-run-workflow:
   # run workflow only when the weekly_build pipeline is triggered
-    when: 
+    when:
       equal: [ weekly_build, << pipeline.schedule.name >> ]
     jobs:
       - job-three

--- a/jekyll/_cci2/scheduled-pipelines.adoc
+++ b/jekyll/_cci2/scheduled-pipelines.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about scheduled pipelines for your CircleCI projects.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 **Scheduled pipelines are currently available for GitHub and Bitbucket VCS users.** Scheduled pipelines allow you to trigger pipelines periodically based on a schedule. Scheduled pipelines retain all the features of pipelines:
 

--- a/jekyll/_cci2/security-overview.adoc
+++ b/jekyll/_cci2/security-overview.adoc
@@ -10,8 +10,7 @@ version:
 :page-liquid:
 :page-description: This document provides an introduction to security features at CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document outlines recommended best practices to ensure the security of data and secrets when using CircleCI. If you are getting started with CircleCI, there are some security best practices to consider as a CircleCI user.
 

--- a/jekyll/_cci2/security-server.adoc
+++ b/jekyll/_cci2/security-server.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: This document outlines security features built into CircleCI and related integrations.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document outlines security features built into CircleCI and related integrations.
 

--- a/jekyll/_cci2/selecting-a-workflow-to-run-using-pipeline-parameters.adoc
+++ b/jekyll/_cci2/selecting-a-workflow-to-run-using-pipeline-parameters.adoc
@@ -1,6 +1,6 @@
 ---
 description: "A how-to guide for selecting a workflow to run using pipeline parameters."
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -12,8 +12,7 @@ document-type:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 You might find that you want to manually trigger a specific workflow to run using the API but still run a workflow on every push to your project. To achieve this, use <<pipeline-variables#pipeline-parameters-in-configuration,pipeline parameters>> to decide which workflow(s) to run.
 
@@ -62,7 +61,7 @@ workflows:
 [#supply-parameter-with-api]
 == Supply parameter with API
 
-The `action` parameter will default to `build` on pushes to the project. Below is an example of supplying a different value to `action` using the API v2 link:https://circleci.com/docs/api/v2/#operation/triggerPipeline[Trigger a New Pipeline] endpoint to select a different workflow to run. 
+The `action` parameter will default to `build` on pushes to the project. Below is an example of supplying a different value to `action` using the API v2 link:https://circleci.com/docs/api/v2/#operation/triggerPipeline[Trigger a New Pipeline] endpoint to select a different workflow to run.
 
 In this example, the workflow named `report` would run. Remember to substitute <<api-developers-guide#getting-started-with-the-api,`project-slug`>> with your values.
 

--- a/jekyll/_cci2/server/installation/hardening-your-cluster.adoc
+++ b/jekyll/_cci2/server/installation/hardening-your-cluster.adoc
@@ -9,12 +9,11 @@ contentTags:
 :page-liquid:
 :page-description: This section provides supplemental information on hardening your Kubernetes cluster.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This section provides supplemental information on hardening your Kubernetes cluster.
 
-toc::[]
+
 
 [#network-topology]
 == Network topology

--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -7,8 +7,7 @@ contentTags:
 = Installation reference
 :page-layout: classic-docs
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#example-manifests]
 == Example Manifests

--- a/jekyll/_cci2/server/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/installation/installation-reference.adoc
@@ -1,11 +1,12 @@
 ---
 contentTags:
   platform:
-    - Server v4.x
+    - Server v4.0
     - Server Admin
 ---
 = Installation reference
 :page-layout: classic-docs
+:page-description: Reference page for all values options available for installations of CircleCI server v4
 :icons: font
 :experimental:
 

--- a/jekyll/_cci2/server/installation/installing-server-behind-a-proxy.adoc
+++ b/jekyll/_cci2/server/installation/installing-server-behind-a-proxy.adoc
@@ -9,14 +9,13 @@ contentTags:
 :page-description: Learn how to install CircleCI server v4.x behind a proxy.
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Depending on your security requirements, you might want to install CircleCI server behind a proxy. Installing behind a proxy gives you the power to monitor and control access between your installation and the broader Internet.
 
 Configuring a proxy happens during link:/docs/server/installation/phase-2-core-services#l-installing-behind-a-proxy[Phase 2 - Core services].
 
-toc::[]
+
 
 [#known-limitations]
 == Known limitations

--- a/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
+++ b/jekyll/_cci2/server/installation/migrate-from-server-2-to-server-4.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn now to migrate from CircleCI server 2.19.x to 4.0.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Migrating from v2.19.x to v4.0 requires you to back up your v2.19 instance data (including Mongo, Postgres, and Vault), and then restore that data in a waiting server v4.0 instance. If you experience problems, you can fall back to your v2.19 instance. Migration requires an operational server v4.0 installation.
 

--- a/jekyll/_cci2/server/installation/migrate-from-server-3-to-server-4.adoc
+++ b/jekyll/_cci2/server/installation/migrate-from-server-3-to-server-4.adoc
@@ -9,14 +9,13 @@ contentTags:
 :page-liquid:
 :page-description: Learn now to migrate from CircleCI server v3.x to v4.x.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Migrating from server v3.x to v4.0.x is an _in-place_ migration. You will generate a helm-value file, which will be used in a helm command to upgrade CircleCI server from v3.x to v4.0.x.
 
 We recommend using a staging environment before completing this process in a production environment. This will allow you to gain a better understanding of the migration process, and give you an idea of how long the migration will take to complete.
 
-toc::[]
+
 
 [#prerequisites]
 == Prerequisites

--- a/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/installation/phase-1-prerequisites.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server application.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 

--- a/jekyll/_cci2/server/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/installation/phase-2-core-services.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Find the steps and prerequisites for the server v4.x installation.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 
@@ -18,7 +17,7 @@ Before you begin with the CircleCI server v4.x core services installation phase,
 
 NOTE: In the following sections, replace any sections indicated by `< >` with your details.
 
-toc::[]
+
 
 [#create-a-namespace]
 == 1. Create a namespace

--- a/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/installation/phase-3-execution-environments.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 
@@ -17,7 +16,7 @@ Before you begin with the CircleCI server v4.x execution environment installatio
 
 NOTE: In the following sections, replace any sections indicated by `< >` with your details.
 
-toc::[]
+
 
 [#nomad-clients]
 == 1. Nomad clients

--- a/jekyll/_cci2/server/installation/phase-4-post-installation.adoc
+++ b/jekyll/_cci2/server/installation/phase-4-post-installation.adoc
@@ -7,8 +7,7 @@ contentTags:
 = Phase 4 - Post installation
 :page-layout: classic-docs
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 
@@ -16,7 +15,7 @@ Before you begin with the CircleCI server v4.x post installation phase, ensure y
 
 NOTE: In the following sections, replace any sections indicated by `< >` with your details.
 
-toc::[]
+
 
 [#backup-and-restore]
 == Backup and restore

--- a/jekyll/_cci2/server/installation/upgrade-server-4.adoc
+++ b/jekyll/_cci2/server/installation/upgrade-server-4.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: "This document lists the steps required to upgrade a CircleCI server v4.x installation."
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This page describes the steps needed to upgrade you CircleCI server v4.x installation.
 

--- a/jekyll/_cci2/server/operator/application-lifecycle.adoc
+++ b/jekyll/_cci2/server/operator/application-lifecycle.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about CircleCI server v4.x semantic versioning and release schedules.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI is committed to supporting four minor versions of the software. This means a minor version will receive patches for up to 12 months. We use semantic versioning to help identify releases and their impact on your installation.
 

--- a/jekyll/_cci2/server/operator/backup-and-restore.adoc
+++ b/jekyll/_cci2/server/operator/backup-and-restore.adoc
@@ -9,10 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This document outlines recommendations for how to back up and restore your CircleCI server instance data and state.
 :icons: font
-:toc: macro
-:toc-title:
-
-toc::[]
+:experimental:
 
 [#overview-backup]
 == Overview

--- a/jekyll/_cci2/server/operator/circleci-server-security-features.adoc
+++ b/jekyll/_cci2/server/operator/circleci-server-security-features.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This document outlines security features built into CircleCI and related integrations.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document outlines security features built into CircleCI and related integrations.
 

--- a/jekyll/_cci2/server/operator/configuring-external-services.adoc
+++ b/jekyll/_cci2/server/operator/configuring-external-services.adoc
@@ -9,12 +9,9 @@ contentTags:
 :page-liquid:
 :page-description: This document describes how to configure the following external services for use with a CircleCI server 4.x installation
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This page describes how to configure external services for use with either a new CircleCI server v4.x installation or migrating internal Postgres and MongoDB data from existing CircleCI server v4.x installation to your externalized datastores.
-
-toc::[]
 
 [#postgresql]
 == PostgreSQL

--- a/jekyll/_cci2/server/operator/expanding-internal-database-volumes.adoc
+++ b/jekyll/_cci2/server/operator/expanding-internal-database-volumes.adoc
@@ -9,10 +9,7 @@ contentTags:
 :imagesdir: ../assets/img/docs/
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
-
-toc::[]
+:experimental:
 
 [#overview]
 == Overview

--- a/jekyll/_cci2/server/operator/faq.adoc
+++ b/jekyll/_cci2/server/operator/faq.adoc
@@ -9,10 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Find answers about the CircleCI server v4.x data retention policy, what control is granted over Nomad certificates
 :icons: font
-:toc: macro
-:toc-title:
-
-toc::[]
+:experimental:
 
 ## Does Server 4.0 have a data retention policy?
 We do not currently support a defined data retention policy. Data is stored indefinitely on server.

--- a/jekyll/_cci2/server/operator/introduction-to-nomad-cluster-operation.adoc
+++ b/jekyll/_cci2/server/operator/introduction-to-nomad-cluster-operation.adoc
@@ -9,12 +9,8 @@ contentTags:
 :page-liquid:
 :page-description: Learn how to operate the Nomad Cluster in your CircleCI 2.0 installation.
 :icons: font
-:toc: macro
-:toc-title:
 
 CircleCI uses https://www.nomadproject.io/[Nomad] as the primary job scheduler. This section provides a basic introduction to Nomad for understanding how to operate the Nomad Cluster in your CircleCI installation.
-
-toc::[]
 
 [#basic-terminology-and-architecture]
 == Basic terminology and architecture

--- a/jekyll/_cci2/server/operator/manage-virtual-machines-with-vm-service.adoc
+++ b/jekyll/_cci2/server/operator/manage-virtual-machines-with-vm-service.adoc
@@ -9,14 +9,10 @@ contentTags:
 :page-liquid: CircleCI Server’s VM service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
 :page-description:
 :icons: font
-:toc: macro
-:toc-title:
 
 VM service controls how https://circleci.com/docs/configuration-reference/#machine[`machine`] executor and https://circleci.com/docs/building-docker-images[Remote Docker] jobs are run.
 
 This section describes the available configuration options for VM service. Refer to the default `values.yaml` file for details on how to pre-scale virtual machines.
-
-toc::[]
 
 CAUTION: We recommend that you leave these options at their defaults until you have successfully configured and verified the core and build services of your server installation. Steps to set up VM service are provided in the installation guide for link:/docs/server/installation/phase-3-execution-environments/#aws-vm-service[AWS] and link:/docs/server/installation/phase-3-execution-environments/#gcp-authentication[GCP].
 

--- a/jekyll/_cci2/server/operator/managing-build-artifacts.adoc
+++ b/jekyll/_cci2/server/operator/managing-build-artifacts.adoc
@@ -9,12 +9,9 @@ contentTags:
 :page-liquid:
 :page-description: Learn how build artifacts persist data after a job is completed and how they can be used for longer-term storage of your build process outputs.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Build artifacts persist data after a job is completed. They can be used for longer-term storage of your build process outputs. For example, when a Java build/test process finishes, the output of the process is saved as a `.jar` file. CircleCI can store this file as an artifact, keeping it available long after the process has finished.
-
-toc::[]
 
 [#safe-and-unsafe-content-types]
 == Safe and unsafe content types

--- a/jekyll/_cci2/server/operator/managing-load-balancers.adoc
+++ b/jekyll/_cci2/server/operator/managing-load-balancers.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Use this guide to make the frontend load balancer private.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI server uses a load balancer to manage network traffic entering and leaving the Kubernetes cluster.
 

--- a/jekyll/_cci2/server/operator/managing-orbs.adoc
+++ b/jekyll/_cci2/server/operator/managing-orbs.adoc
@@ -9,16 +9,12 @@ contentTags:
 :page-liquid:
 :page-description: Use this page to learn about orbs and how to manage them within CircleCI server v4.x.
 :icons: font
-:toc: macro
-:toc-title:
 
 This section describes how to manage orbs for an installation of server v4.x. Server installations include their own local orb registry. All orbs referenced in configs refer to the orbs in the server orb registry. You are responsible for maintaining orbs. This includes copying orbs from the public registry, updating orbs that may have been previously copied, and registering your company's private orbs, if they exist.
 
 For information on orbs and related use cases, see the link:/docs/orb-intro/[orbs docs].
 
 If you are looking for information on creating an orb, see the https://circleci.com/docs/orb-author-intro/[Introduction to Authoring Orbs].
-
-toc::[]
 
 Orbs are accessed via the https://circleci.com/docs/local-cli/[CircleCI CLI]. Orbs require your CircleCI user to be an admin. They also require a https://circleci.com/docs/managing-api-tokens/[personal API token].
 

--- a/jekyll/_cci2/server/operator/managing-user-accounts.adoc
+++ b/jekyll/_cci2/server/operator/managing-user-accounts.adoc
@@ -9,12 +9,9 @@ contentTags:
 :page-liquid:
 :page-description: This section provides information to help CircleCI server v4.x  operators manage user accounts.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This section provides information to help operators manage user accounts. For an overview of user accounts, see the Admin settings overview from the CircleCI app by clicking on your profile in the top right corner and selecting *Admin*.
-
-toc::[]
 
 [#suspending-accounts]
 == Suspending accounts

--- a/jekyll/_cci2/server/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/operator/operator-overview.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This guide contains information for CircleCI server operators, or those responsible for ensuring CircleCI server is running properly through maintenance and monitoring. Before reading this operator guide, ensure you have read the https://circleci.com/docs/server/overview/circleci-server-v4-overview[CircleCI Server v4.x Overview].
 
@@ -22,8 +21,6 @@ CircleCI server can run Docker jobs on the Nomad clients, and also in dedicated 
 Job artifacts and outputs are sent directly from jobs in Nomad to object storage (S3, GCS, or other supported options).
 
 Audit logs and other items from the application are also stored in object storage, so both the Kubernetes cluster and the Nomad clients need access to object storage.
-
-toc::[]
 
 [#execution-environment]
 == Execution environment

--- a/jekyll/_cci2/server/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/operator/troubleshooting-and-support.adoc
@@ -9,12 +9,9 @@ contentTags:
 :page-liquid:
 :page-description: Use this document to find troubleshooting steps if you are having problems with your CircleCI server v4.x installation.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document describes an initial set of troubleshooting steps to take if you are experiencing problems with your CircleCI server v4.x installation. If your issue is not addressed below, you can generate a support bundle or contact your CircleCI account team.
-
-toc::[]
 
 [#generate-support-bundle]
 == Generate support bundle

--- a/jekyll/_cci2/server/operator/usage-data-collection.adoc
+++ b/jekyll/_cci2/server/operator/usage-data-collection.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about CircleCI usage data collection for the purpose of improving our product and services.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI typically collects usage data, such as logs and other aggregated data, for the purpose of improving our products and services. We never collect personally identifiable information or information that is specific to your projects or accounts.
 

--- a/jekyll/_cci2/server/operator/user-authentication.adoc
+++ b/jekyll/_cci2/server/operator/user-authentication.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: CircleCI server currently supports OAuth through GitHub or GitHub Enterprise.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI server currently supports OAuth through GitHub or GitHub Enterprise.
 

--- a/jekyll/_cci2/server/overview/circleci-server-v4-overview.adoc
+++ b/jekyll/_cci2/server/overview/circleci-server-v4-overview.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: CircleCI server v4.x is a continuous integration and continuous delivery (CI/CD) platform that you can install on your GCP or AWS Kubernetes cluster.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/server/overview/release-notes.adoc
+++ b/jekyll/_cci2/server/overview/release-notes.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Details of the new features included in each CircleCI server 4.x release.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Server v4.0 offers the following:
 

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/additional-considerations.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/additional-considerations.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This page presents some items that should be considered when starting an air-gapped installation of CircleCI server
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#non-tls-docker-registry-installations]
 == Non-TLS Docker Registry Installations

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/example-values.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/example-values.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This page presents an example values.yaml file to help with setting up an air-gapped installation of CircleCI server
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 The following snippet shows an example `values.yaml` file for a Helm installation of CircleCI server in an air-gapped environment.
 

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-1-prerequisites.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: A guide to installing CircleCI server in an air-gapped environment. Requirements, images and Helm charts.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 The guides in this section walk you through the steps required to install CircleCI server in an air-gapped environment.
 

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: How to configure object storage through MinIO to run CircleCI server in an air-gapped environment.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#create-buckets-in-minio]
 == 1. Create buckets in MinIO

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-3-install-circleci-server.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-3-install-circleci-server.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: How to install the CircleCI server Helm deployment to an air-gapped environment.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 With prerequisites installed, and object storage configured, you can now copy over and install the CircleCI Helm deployment to the Kubernetes cluster in your air-gapped environment.
 

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-4-configure-nomad-clients.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-4-configure-nomad-clients.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: How to configure Nomad clients to run with CircleCI server in an air-gapped environment.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI server uses Nomad clients to perform container-based build actions. These machines will need to exist within the air-gapped environment to communicate with the CircleCI server Helm deployment.
 

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-5-test-your-installation.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-5-test-your-installation.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: How to test your CircleCI server installation in an air-gapped environment.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Test your air-gapped installation using CircleCI's Reality Check project.
 

--- a/jekyll/_cci2/server/v4.1/installation/hardening-your-cluster.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/hardening-your-cluster.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This section provides supplemental information on hardening your Kubernetes cluster.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This section provides supplemental information on hardening your Kubernetes cluster.
 

--- a/jekyll/_cci2/server/v4.1/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/installation-reference.adoc
@@ -1,12 +1,11 @@
 ---
 contentTags:
   platform:
-  - Server v4.1
-  - Server Admin
+    - Server v4.1
+    - Server Admin
 ---
 = Installation reference
 :page-layout: classic-docs
-:page-liquid:
 :page-description: Reference page for all values options available for installations of CircleCI server v4
 :icons: font
 :experimental:
@@ -267,7 +266,7 @@ a|
 | `github.clientId`
 | string
 | `""`
-a| Client ID for OAuth Login via Github:
+a| Client ID for OAuth Login via GitHub:
 
 **Option 1:** Set the value here and CircleCI will create the Kubernetes Secret automatically.
 

--- a/jekyll/_cci2/server/v4.1/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/installation-reference.adoc
@@ -6,9 +6,10 @@ contentTags:
 ---
 = Installation reference
 :page-layout: classic-docs
+:page-liquid:
+:page-description: Raference page from all values.yaml options available for installations of CircleCI server v4.1.x
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#example-manifests]
 == Example Manifests

--- a/jekyll/_cci2/server/v4.1/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/installation-reference.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Installation reference
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Raference page from all values.yaml options available for installations of CircleCI server v4.1.x
+:page-description: Reference page for all values options available for installations of CircleCI server v4
 :icons: font
 :experimental:
 

--- a/jekyll/_cci2/server/v4.1/installation/installing-server-behind-a-proxy.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/installing-server-behind-a-proxy.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-description: Learn how to install CircleCI server v4.x behind a proxy.
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Depending on your security requirements, you might want to install CircleCI server behind a proxy. Installing behind a proxy gives you the power to monitor and control access between your installation and the broader Internet.
 

--- a/jekyll/_cci2/server/v4.1/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/phase-1-prerequisites.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server application.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 

--- a/jekyll/_cci2/server/v4.1/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/phase-2-core-services.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Find the steps and prerequisites for the server v4.x installation.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 

--- a/jekyll/_cci2/server/v4.1/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/phase-3-execution-environments.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 

--- a/jekyll/_cci2/server/v4.1/installation/phase-4-post-installation.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/phase-4-post-installation.adoc
@@ -7,8 +7,7 @@ contentTags:
 = Phase 4 - Post installation
 :page-layout: classic-docs
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 // This doc uses ifdef and ifndef directives to display or hide content specific to Google Cloud Storage (env-gcp) and AWS (env-aws). Currently, this affects only the generated PDFs. To ensure compatability with the Jekyll version, the directives test for logical opposites. For example, if the attribute is NOT env-aws, display this content. For more information, see https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/.
 

--- a/jekyll/_cci2/server/v4.1/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/upgrade-server.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: "This document lists the steps required to upgrade a CircleCI server v4.x installation."
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This page describes the steps needed to upgrade you CircleCI server v4.x installation.
 

--- a/jekyll/_cci2/server/v4.1/operator/application-lifecycle.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/application-lifecycle.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about CircleCI server v4.x semantic versioning and release schedules.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI is committed to supporting four minor versions of the software. This means a minor version will receive patches for up to 12 months. We use semantic versioning to help identify releases and their impact on your installation.
 

--- a/jekyll/_cci2/server/v4.1/operator/backup-and-restore.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/backup-and-restore.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This document outlines recommendations for how to back up and restore your CircleCI server instance data and state.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview-backup]
 == Overview

--- a/jekyll/_cci2/server/v4.1/operator/circleci-server-security-features.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/circleci-server-security-features.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: This document outlines security features built into CircleCI and related integrations.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document outlines security features built into CircleCI and related integrations.
 

--- a/jekyll/_cci2/server/v4.1/operator/configuring-external-services.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/configuring-external-services.adoc
@@ -9,12 +9,9 @@ contentTags:
 :page-liquid:
 :page-description: This document describes how to configure the following external services for use with a CircleCI server 4.x installation
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This page describes how to configure external services for use with either a new CircleCI server v4.x installation or migrating internal Postgres and MongoDB data from existing CircleCI server v4.x installation to your externalized datastores.
-
-toc::[]
 
 [#postgresql]
 == PostgreSQL

--- a/jekyll/_cci2/server/v4.1/operator/expanding-internal-database-volumes.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/expanding-internal-database-volumes.adoc
@@ -9,8 +9,7 @@ contentTags:
 :imagesdir: ../assets/img/docs/
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview]
 == Overview

--- a/jekyll/_cci2/server/v4.1/operator/faq.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/faq.adoc
@@ -9,10 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Find answers about the CircleCI server v4.x data retention policy, what control is granted over Nomad certificates
 :icons: font
-:toc: macro
-:toc-title:
-
-toc::[]
+:experimental:
 
 ## Does server 4.x have a data retention policy?
 We do not currently support a defined data retention policy. Data is stored indefinitely on server.

--- a/jekyll/_cci2/server/v4.1/operator/introduction-to-nomad-cluster-operation.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/introduction-to-nomad-cluster-operation.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn how to operate the Nomad Cluster in your CircleCI 2.0 installation.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI uses link:https://www.nomadproject.io/[Nomad] as the primary job scheduler. This section provides a basic introduction to Nomad for understanding how to operate the Nomad Cluster in your CircleCI installation.
 

--- a/jekyll/_cci2/server/v4.1/operator/manage-virtual-machines-with-vm-service.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/manage-virtual-machines-with-vm-service.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: CircleCI server’s VM service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 VM service controls how xref:../../../configuration-reference/#machine[`machine`] executor and xref:../../../building-docker-images[Remote Docker] jobs are run.
 

--- a/jekyll/_cci2/server/v4.1/operator/managing-build-artifacts.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/managing-build-artifacts.adoc
@@ -9,12 +9,9 @@ contentTags:
 :page-liquid:
 :page-description: Learn how build artifacts persist data after a job is completed and how they can be used for longer-term storage of your build process outputs.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Build artifacts persist data after a job is completed. They can be used for longer-term storage of your build process outputs. For example, when a Java build/test process finishes, the output of the process is saved as a `.jar` file. CircleCI can store this file as an artifact, keeping it available long after the process has finished.
-
-toc::[]
 
 [#safe-and-unsafe-content-types]
 == Safe and unsafe content types

--- a/jekyll/_cci2/server/v4.1/operator/managing-load-balancers.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/managing-load-balancers.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Use this guide to make the frontend load balancer private.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI server uses a load balancer to manage network traffic entering and leaving the Kubernetes cluster.
 

--- a/jekyll/_cci2/server/v4.1/operator/managing-orbs.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/managing-orbs.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Use this page to learn about orbs and how to manage them within CircleCI server v4.x.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This section describes how to manage orbs for an installation of server v4.x. Server installations include their own local orb registry. All orbs referenced in configs refer to the orbs in the server orb registry. You are responsible for maintaining orbs. This includes copying orbs from the public registry, updating orbs that may have been previously copied, and registering your company's private orbs, if they exist.
 

--- a/jekyll/_cci2/server/v4.1/operator/managing-user-accounts.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/managing-user-accounts.adoc
@@ -9,12 +9,11 @@ contentTags:
 :page-liquid:
 :page-description: This section provides information to help CircleCI server v4.x  operators manage user accounts.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This section provides information to help operators manage user accounts. For an overview of user accounts, see the Admin settings overview from the CircleCI app by clicking on your profile in the top right corner and selecting *Admin*.
 
-toc::[]
+
 
 [#suspending-accounts]
 == Suspending accounts

--- a/jekyll/_cci2/server/v4.1/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/operator-overview.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This guide contains information for CircleCI server operators, or those responsible for ensuring CircleCI server is running properly through maintenance and monitoring. Before reading this operator guide, ensure you have read the xref:../overview/circleci-server-overview#[CircleCI server v4.1 overview].
 

--- a/jekyll/_cci2/server/v4.1/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/troubleshooting-and-support.adoc
@@ -9,12 +9,9 @@ contentTags:
 :page-liquid:
 :page-description: Use this document to find troubleshooting steps if you are having problems with your CircleCI server v4.x installation.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document describes an initial set of troubleshooting steps to take if you are experiencing problems with your CircleCI server v4.x installation. If your issue is not addressed below, you can generate a support bundle or contact your CircleCI account team.
-
-toc::[]
 
 [#generate-support-bundle]
 == Generate support bundle

--- a/jekyll/_cci2/server/v4.1/operator/upgrade-mongo.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/upgrade-mongo.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn how to upgrade MongoDB up to v4.4.15 in an installation of CircleCI server.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 MongoDB is a database service used by CircleCI server. This page describes how to upgrade MongoDB to version `4.4.15`.
 

--- a/jekyll/_cci2/server/v4.1/operator/usage-data-collection.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/usage-data-collection.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about CircleCI usage data collection for the purpose of improving our product and services.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI typically collects usage data, such as logs and other aggregated data, for the purpose of improving our products and services. We never collect personally identifiable information or information that is specific to your projects or accounts.
 

--- a/jekyll/_cci2/server/v4.1/operator/user-authentication.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/user-authentication.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: CircleCI server currently supports OAuth through GitHub or GitHub Enterprise.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI server currently supports OAuth through GitHub or GitHub Enterprise.
 

--- a/jekyll/_cci2/server/v4.1/overview/circleci-server-overview.adoc
+++ b/jekyll/_cci2/server/v4.1/overview/circleci-server-overview.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: CircleCI server v4.x is a continuous integration and continuous delivery (CI/CD) platform that you can install on your GCP or AWS Kubernetes cluster.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/server/v4.1/overview/release-notes.adoc
+++ b/jekyll/_cci2/server/v4.1/overview/release-notes.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-liquid:
 :page-description: Details of the new features included in each CircleCI server 4.x release.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#overview]
 == Overview

--- a/jekyll/_cci2/set-a-nightly-scheduled-pipeline.adoc
+++ b/jekyll/_cci2/set-a-nightly-scheduled-pipeline.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: "Learn how to create scheduled pipelines on a specific timetable."
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/set-environment-variable.adoc
+++ b/jekyll/_cci2/set-environment-variable.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: How to set environment variables for use in your CircleCI pipelines.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 There are several ways to use environment variables in CircleCI to provide variety in scope and authorization level.
 

--- a/jekyll/_cci2/slack-orb-tutorial.adoc
+++ b/jekyll/_cci2/slack-orb-tutorial.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: "Learn how to get started with the CircleCI Slack orb"
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This guide gets you started with the CircleCI Slack orb.
 

--- a/jekyll/_cci2/ssh-server.adoc
+++ b/jekyll/_cci2/ssh-server.adoc
@@ -9,8 +9,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This section describes how SSH reruns work within installations of CircleCI server. This information is designed to help system administrators have an overview to help with considerations when customizations are made to an installation. This guide is also here to help with debugging in the event of a problem with SSH reruns in an installation.
 

--- a/jekyll/_cci2/stop-building-a-project-on-circleci.adoc
+++ b/jekyll/_cci2/stop-building-a-project-on-circleci.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn how to remove a project from your CircleCI account
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#introduction]
 == Introduction

--- a/jekyll/_cci2/style/formatting.adoc
+++ b/jekyll/_cci2/style/formatting.adoc
@@ -1,8 +1,7 @@
 = Formatting
 :page-layout: classic-docs
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#styling-text]
 == Styling text
@@ -20,12 +19,12 @@
 [#using-notes-tips-cautions-warnings]
 == Using notes, tips, cautions, and warnings
 
-When writing in asciidoc the following _admonitions_ are available: note, tip, important, caution, warning. 
+When writing in asciidoc the following _admonitions_ are available: note, tip, important, caution, warning.
 
 [#when-to-use-each-type]
 === When to use each type
 
-* `note`: Use to add some supplementary information to a section or point that could benefit from some highlighting to draw the reader's attention. 
+* `note`: Use to add some supplementary information to a section or point that could benefit from some highlighting to draw the reader's attention.
 * `tip`: Use to add some guidance on how to carry out a step or how to act on some advice contained within the section.
 * `important`: This admonition type is not used often in CircleCI docs. Consider whether one of the ofther options is a better fit before using.
 * `caution`: Use to make the reader aware they need to be careful when acting on some advice.
@@ -74,8 +73,8 @@ You can also make a longer admonition block for any of the types listed above:
 
 [source,adoc]
 ----
-[CAUTION] 
-==== 
+[CAUTION]
+====
 This is a longer admonition with an ordered list:
 
 . Step 1
@@ -84,8 +83,8 @@ This is a longer admonition with an ordered list:
 ====
 ----
 
-[CAUTION] 
-====  
+[CAUTION]
+====
 This is a longer admonition with an ordered list:
 
 . Step 1

--- a/jekyll/_cci2/style/style-and-voice.adoc
+++ b/jekyll/_cci2/style/style-and-voice.adoc
@@ -1,8 +1,7 @@
 = Style and voice
 :page-layout: classic-docs
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 == Talk confidently and directly
 Use an active voice, talk directly to the reader using simple, direct, clear and confident language. Using active voice helps us to keep instructions as short as possible, and is, in most cases, the quickest way to convey meaning to the reader
@@ -57,7 +56,7 @@ Assume technical competence but explain concepts clearly and simply. Some concep
 * Avoid semicolons and dashes (en or em) to split sentences. Instead, add a new sentence, or use commas and periods.
 * Do not use ampersands (&) as a substitute for the word "and". The ampersand is used in logical notation for the binary operator AND.
 * Do not put a period at the end of a sentence if the sentence ends with a URL, code sample or command. People are likely to copy and paste and could end up copying the period too.
-* We use the oxford comma. For example: “Please bring me a pencil, eraser, and notebook.” The comma after “eraser” is the oxford comma. 
+* We use the oxford comma. For example: “Please bring me a pencil, eraser, and notebook.” The comma after “eraser” is the oxford comma.
 
 == Numbers
 * Write out numbers one through nine, 10 and above use numerals. Some exceptions:
@@ -65,7 +64,7 @@ Assume technical competence but explain concepts clearly and simply. Some concep
 ** Ages, even for inanimate objects: Beth, a 12-year-old turtle; the 2-year-old testing framework
 ** Dollars and cents: $5; 5 cents
 ** Measurements (such as dimensions and speed): 6 feet tall, 9-by-12 workspace; 7 miles per hour
-** Millions, billions: 3 million users 
+** Millions, billions: 3 million users
 
 == Grammar
 * "Login" and "Setup" are not verbs, they are nouns. Use as follows:

--- a/jekyll/_cci2/style/using-images.adoc
+++ b/jekyll/_cci2/style/using-images.adoc
@@ -1,8 +1,7 @@
 = Using images
 :page-layout: classic-docs
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 == Guidelines for all images
 * Ensure all images have descriptive alternative text. For example, in asciidoc:
@@ -17,7 +16,7 @@ image::name-of-image.png[Alternative text to describe the image, including, if p
 
 == Remove or change information in images
 
-All personally identifiable information should be removed from images included in CircleCI's documentation. 
+All personally identifiable information should be removed from images included in CircleCI's documentation.
 
 There are a few places in the web app where personal information appears. Most personally identifiable information can be updated by opening the developer console in the browser and inspecting the web app (`command + option + I` on Mac, `control + shift + J` on Windows). Inside the console you can edit the text elements in the HTML of the web app. Once all elements have been inspected and updated, a screenshot can be taken.
 

--- a/jekyll/_cci2/test-config-policies.adoc
+++ b/jekyll/_cci2/test-config-policies.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 

--- a/jekyll/_cci2/test-splitting-tutorial.adoc
+++ b/jekyll/_cci2/test-splitting-tutorial.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn to split and run tests in parallel in CircleCI.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This guide walks you through a basic example of test splitting in CircleCI. Test splitting helps speed up your pipelines.
 

--- a/jekyll/_cci2/testing-ios.adoc
+++ b/jekyll/_cci2/testing-ios.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-description: Testing iOS applications on macOS.
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This document describes how to set up and customize testing for an iOS application with CircleCI.
 

--- a/jekyll/_cci2/triggers-overview.adoc
+++ b/jekyll/_cci2/triggers-overview.adoc
@@ -1,6 +1,6 @@
 ---
 description: "A guide to the various ways to manage pipeline triggering in CircleCI"
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
@@ -12,8 +12,7 @@ document-type:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Pipelines are triggered in response to actions or scheduled to run at specific times and frequencies. Each method of triggering a pipeline is described below.
 
@@ -45,7 +44,7 @@ image::trigger-pipeline-popup.png[screenshot showing the popup you will see when
 [#run-a-pipeline-using-the-api]
 == Trigger a pipeline using the API
 
-You can trigger a pipeline for a project using the https://circleci.com/docs/api/v2/index.html#operation/triggerPipeline[Trigger a New Pipeline] endpoint. 
+You can trigger a pipeline for a project using the https://circleci.com/docs/api/v2/index.html#operation/triggerPipeline[Trigger a New Pipeline] endpoint.
 
 . If you have not already, get set up to use API v2 by following the steps in the  <<api-developers-guide#authentication-and-authorization,API Developers Guide>>.
 

--- a/jekyll/_cci2/troubleshoot-pipelines.adoc
+++ b/jekyll/_cci2/troubleshoot-pipelines.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Troubleshooting guide for pipelines and scheduled pipelines.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This page describes errors and troubleshooting methods for pipelines and scheduled pipelines.
 

--- a/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
+++ b/jekyll/_cci2/troubleshoot-self-hosted-runner.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Errors and troubleshooting methods for container and machine runners.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 {% include snippets/runner-1.0-deprecation-post-brownout.adoc %}
 

--- a/jekyll/_cci2/troubleshoot-test-splitting.adoc
+++ b/jekyll/_cci2/troubleshoot-test-splitting.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Tips and common errors to help troubleshoot your CircleCI test splitting implementation.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#using-test-splitting-with-python-django-tests]
 ## Using test splitting with Python Django tests

--- a/jekyll/_cci2/troubleshoot.adoc
+++ b/jekyll/_cci2/troubleshoot.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: Troubleshoot CircleCI and various setups and integrations.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This page offers troubleshooting suggestions for the following aspects of CircleCI:
 

--- a/jekyll/_cci2/use-the-circleci-cli-to-split-tests.adoc
+++ b/jekyll/_cci2/use-the-circleci-cli-to-split-tests.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 CircleCI supports automatic test allocation across parallel compute environments. When the `parallelism` key in your CircleCI configuration is set to a value greater than `1`, CircleCI spins up identical execution environments in which your job is run.
 

--- a/jekyll/_cci2/use-the-cli-for-config-and-policy-development.adoc
+++ b/jekyll/_cci2/use-the-cli-for-config-and-policy-development.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 NOTE: The config policies feature is available on the **Scale** plan and is currently in **open preview**.
 

--- a/jekyll/_cci2/using-branch-filters.adoc
+++ b/jekyll/_cci2/using-branch-filters.adoc
@@ -12,8 +12,7 @@ document-type:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#branch-filtering-for-job-steps]
 == Branch-filtering to control when job steps will run

--- a/jekyll/_cci2/using-dynamic-configuration.adoc
+++ b/jekyll/_cci2/using-dynamic-configuration.adoc
@@ -12,8 +12,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This section assumes you have already read the xref:dynamic-config#[Dynamic Configuration] page and
 have followed the steps outlined in the xref:dynamic-config#getting-started-with-dynamic-config-in-circleci[Getting Started with Dynamic Configuration] section.

--- a/jekyll/_cci2/using-macos.adoc
+++ b/jekyll/_cci2/using-macos.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-description: "Learn how to configure a your jobs to run in the macOS execution environment."
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 The macOS execution environment is used for iOS and macOS development, allowing you to test, build, and deploy macOS and iOS applications on CircleCI. The macOS executor runs jobs in a macOS environment and provides access to iPhone, iPad, Apple Watch, and Apple TV simulators.
 

--- a/jekyll/_cci2/using-matrix-jobs.adoc
+++ b/jekyll/_cci2/using-matrix-jobs.adoc
@@ -12,8 +12,7 @@ document-type:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 Matrix jobs provide a way to run a job multiple times with arguments. Arguments are supplied using parameters. There are many uses for this feature, including testing on multiple operating systems and against different language or library versions.
 

--- a/jekyll/_cci2/variables.adoc
+++ b/jekyll/_cci2/variables.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 This page is a reference for all built-in values available for use in your CircleCI projects.
 

--- a/jekyll/_cci2/vs-code-extension-overview.adoc
+++ b/jekyll/_cci2/vs-code-extension-overview.adoc
@@ -8,8 +8,7 @@ contentTags:
 :page-liquid:
 :page-description: Learn about how the CircleCI VS Code extension can help you manage your pipelines, workflows and jobs.
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 The CircleCI Visual Studio Code extension enables you to manage your CircleCI pipelines directly from VS Code.
 

--- a/jekyll/_cci2/webhooks-reference.adoc
+++ b/jekyll/_cci2/webhooks-reference.adoc
@@ -10,8 +10,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:toc: macro
-:toc-title:
+:experimental:
 
 [#common-top-level-keys]
 == Common top level keys of webhooks


### PR DESCRIPTION
# Description
Removes asciidoc attributes that allow page TOC to be placed in a location, and add the title Contents (this is the deafult) to the main toc. This was previously used for PDF generation, which we have now stopped. I've left these in for server 3 doc in case we at some stage create a PDF for server 3 at the point it is deprecated.

Added the :experimental: attribute to all .adoc files. This allows us to use the menu and button macros: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#keyboard-button-and-menu-macros

# Reasons
Use menu and button macros so that we can make mass changes to the styling if required, and for improved style

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
