### PR TITLE
Add necessary import to ssh_rerun snippet

### DIFF
--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -346,6 +346,7 @@ The following is an example of a policy that blocks SSH reruns on configs where 
 package org
 
 import future.keywords
+import data.circleci.utils
 
 policy_name["ssh_rerun"]
 


### PR DESCRIPTION
Adds an import that was previously missing, which was causing the snippet to be invalid.

# Description
The SSH rerun snippet was previously missing the `import data.circleci.utils` line, which is necessary for the `    count(utils.to_set(job.context) & sensitive_contexts) > 0` line further down in the snippet.
This was previously invalid, and would not compile.

# Reasons
This means the code snippet can be copied and will work without the need to make changes, which is particularly useful as  `data.circleci.utils` does not appear elsewhere in this doc.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
