### PR TITLE
JA rerun failed 

### DIFF
--- a/jekyll/_cci2_ja/rerun-failed-tests.adoc
+++ b/jekyll/_cci2_ja/rerun-failed-tests.adoc
@@ -9,22 +9,21 @@ contentTags:
 :page-liquid:
 :page-description: このドキュメントでは、ジョブで失敗したテストのみを再実行し、クレジットの使用量を最適化する方法についてわかりやすく解説します。
 :icons: font
-:toc: macro
+:experimental:
 
-:toc-title:
 
-WARNING: この機能は**プレビュー段階**です。お客様ご自身の責任においてご利用ください。 本機能は一般公開されない可能性があります。 ご質問がある場合や問題が発生した際には、link:https://discuss.circleci.com/t/product-launch-re-run-failed-tests-only/47775/[コミュニティフォーラム]にコメントをお寄せください。
+失敗したテストの再実行機能を使用すると、一過性のテスト失敗が発生したときに、テスト・スイート全体を再実行する代わりに、テストのサブセットだけを再実行することができます。
 
-[#motivation-and-introduction]
-== 背景および概要
+[#introduction]
+== 概要
 
-CircleCI では、この度、**失敗したテストのみを再実行できる機能**をプレビュー公開しました。 このオプションを選択すると (下図参照)、テストが一時的に失敗した際に、テストスイート全体ではなく一部のテストのみを再実行できます。
+失敗したテストの再実行を選択すると (下図参照)、テストが一時的に失敗した際に、テストスイート全体ではなく一部のテストのみを再実行できます。
 
 これまで、ワークフロー内のテストジョブのテスト結果が不安定である場合にワークフローの実行を完了するには、link:https://support.circleci.com/hc/en-us/articles/360050303671-How-To-Rerun-a-Workflow[失敗状態からワークフローを再実行]するしかありませんでした。 この方法では、成功したものも含めてテストジョブの*すべてのテスト*を再実行するため、フィードバックの獲得が遅れ、不要なクレジットを使うことにもなります。
 
 "Re-run failed tests only (失敗したテストのみの再実行)" オプションでは、新しいコミットではなく__同じ__コミットで失敗したテストを再実行できます。
 
-image::{{site.baseurl}}/assets/img/docs/rerun-failed-tests-option.png[Option to rerun failed tests from Rerun menu]
+image::{{site.baseurl}}/assets/img/docs/rerun-failed-tests-option.png[再実行メニューから失敗したテストを再実行するオプション]
 
 [#prerequisites]
 == 前提条件
@@ -239,11 +238,31 @@ CircleCIのテストセットアップが   `circleci tests run`  コマンド�
 [#known-limitations]
 == 既知の制限
 
-* 失敗したテストのみを再実行する場合、再実行後のジョブの実行時にタイミングに基づくテスト分割の効率が想定より低くなることがあります。これは、テストのうち、失敗して再実行されたものの結果だけが保存されるためです。
+* テストジョブが並列処理とテスト分割を使用している場合、ジョブは `parallelism` キーで指定された数のコンテナ/仮想マシン (VM) をスピンアップします。しかし、これらの並列コンテナ/VM のそれぞれに対してテストを実行するステップでは、並列コンテナ/VM の総数に対してテストを分割した後に、テストのサブセットを実行するか、テストを実行しないようにします。
++
+たとえば、並列度を 8 に設定した場合、テスト分割が発生した後に、最初の並列コンテナ/VM を「満たす(fill)」だけのテストしか実行されない可能性があります。残りの 7 個のコンテナ/VM は起動しますが、テスト実行ステップに到達してもテストは実行されません。
++
+クレジットの節約を最大化したい場合は、並列コンテナ/VMがジョブの最初のステップとしてテストを実行するかどうかを即座にチェックし、実行するテストがない場合はジョブの実行を終了します。例えば:
++
+```yml
+steps:
+  - checkout
+  - run: |
+    mkdir -p ./tmp && \
+    >./tmp/tests.txt && \
+    circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command ">./tmp/tests.txt xargs echo" --split-by=timings #Get the list of filenames for this container/VM
+
+    [ -s tmp/tests.txt ] || circleci-agent step halt #if there are no filenames, terminate execution
+
+  - node/install
+  # Proceed with the rest of the job
+```
+
 * 現時点では、テストを実行する Orb とこの新機能を組み合わせることはできません。
 * シェルスクリプトを呼び出してテストを実行する場合、`circleci tests run` は `circleci/config.yml` ではなく**シェルスクリプト内**に記載してください。
 * "Re-run failed tests only (失敗したテストのみを再実行)" 機能では、組織のワークスペースのxref:persist-data#custom-storage-usage[保持期間]を超えたジョブを再実行することはできません。
 * ジョブでコードカバレッジレポートのアップロードを行う場合、link:https://discuss.circleci.com/t/product-launch-re-run-failed-tests-only-circleci-tests-run/47775/3?u=sebastian-lerner[再実行中に問題が発生することがあります]。
+
 
 [#troubleshooting]
 == トラブルシューティング
@@ -251,10 +270,35 @@ CircleCIのテストセットアップが   `circleci tests run`  コマンド�
 `circleci tests run` を設定した後、"Rerun failed tests only "をクリックすると、*すべてのテスト* が再実行されます：
 
 1. `circleci tests run` を起動するときに `--verbose` 設定が有効になっていることを確認します。 これは、`circleci tests run` が  "re-run " 時にどのような "テスト "を受けているかを表示します。
-1. テスト結果を含むJUnit XMLをCircleCIにアップロードするには、xref:configuration-reference#storeartifacts[`store_artifacts`]を使用します。  これは `store_test_results` で CircleCI にアップロードされるファイルと同じものです。
-1. 新しくアップロードされた JUnit XML を [**Artifacts**] タブで手動で検査し、`file=` 属性または `classname` 属性があることを確認します。  どちらも存在しない場合、再実行（re-run）しようとすると予期しない動作が発生します。  このページの指示に従って、使用しているテストランナーが JUnit XML のテスト結果を `file`（推奨）または `classname` 属性で出力していることを確認してください。  それでも問題が解決しない場合は、link:https://discuss.circleci.com/t/product-launch-re-run-failed-tests-only-circleci-tests-run/47775/48[コミュニティフォーラム]にコメントしてください。
+2. テスト結果を含むJUnit XMLをCircleCIにアップロードするには、xref:configuration-reference#storeartifacts[`store_artifacts`]を使用します。  これは `store_test_results` で CircleCI にアップロードされるファイルと同じものです。
+3. 新しくアップロードされた JUnit XML を [**Artifacts**] タブで手動で検査し、`file=` 属性または `classname` 属性があることを確認します。  どちらも存在しない場合、再実行（re-run）しようとすると予期しない動作が発生します。  このページの指示に従って、使用しているテストランナーが JUnit XML のテスト結果を `file`（推奨）または `classname` 属性で出力していることを確認してください。  それでも問題が解決しない場合は、link:https://discuss.circleci.com/t/product-launch-re-run-failed-tests-only-circleci-tests-run/47775/48[コミュニティフォーラム]にコメントしてください。
 
-[#FAQs]
+---
+
+`circleci tests run` は入力がスペースまたは改行で区切られていることを期待します。 テストファイル名にスペースが含まれている場合、特に `pytest` を使用している場合は問題が発生する可能性があります。 回避策としては、link:https://docs.pytest.org/en/7.1.x/example/parametrize.html#set-marks-or-test-id-for-individual-parametrized-test[公式 Pytest ドキュメント] の説明に従って、名前に空白を含むテストに特定の ID を使用する方法があります。
+
+ジョブを並列実行してファイルをワークスペースに永続化する場合、再実行時に `persist_to_workspace` ステップが指定されたディレクトリにコンテンツを見つけられなかったために並列実行が失敗することがあります。 これは、すべての並列実行に分散させるのに十分なテストがない場合、再実行で並列実行が常にテストを実行するとは限らないために起こる可能性があります。
+
+このような失敗を避けるには、テストを実行する前に `mkdir` コマンドを追加して、最終的にワークスペースに永続化されるディレクトリを設定します。
+
+```yaml
+steps:
+      - checkout
+      - run: mkdir no_files_here
+      - run: #test command with circleci tests run that populates no_files_here if tests are run
+      - store_test_results:
+          path: ./test-results
+      - store_artifacts:
+          path: ./test-results
+      - persist_to_workspace:
+          root: .
+          paths:
+            - no_files_here
+```
+
+再実行時に、並列実行がテストを実行している場合は `no_files_here` が入力されます。 テストを実行していない場合は、`persist_to_workspace` ディレクトリが存在するので、`no_files_here` ステップは失敗しません。
+
+[#FAQs] 
 == FAQ
 
 **質問:** 不明点や問題がある場合の問い合わせ先はどこですか？


### PR DESCRIPTION
# Description
The same changes were applied except for the side nav. 
The sidenav structure from the backend for the JA isn't the same as the EN for some reason. 

https://github.com/circleci/circleci-docs/pull/8173

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
