### PR TITLE
Fixed the JA faq adoc

### DIFF
--- a/jekyll/_cci2_ja/faq.adoc
+++ b/jekyll/_cci2_ja/faq.adoc
@@ -13,40 +13,40 @@ contentTags:
 :page-layout: classic-docs
 :short-title: よくあるご質問
 
-This page answers frequently asked questions about the following CircleCI topics:
+このページでは、以下の CircleCI に関してよく寄せられるご質問にお答えします：
 
 [.table]
 [cols=2*]
 |===
-|<<#general,General>>
-|<<#self-hosted-runner,Self-hosted runner>>
+|<<#general,一般>>
+|<<#self-hosted-runner,セルフホストランナー>>
 
-|<<#migration,Migration>>
-|<<#pipelines,Pipelines>>
+|<<#migration,移行>>
+|<<#pipelines,パイプライン>>
 
 |<<#host-circleci,Host CircleCI>>
-|<<#scheduled-pipelines,Scheduled pipelines>>
+|<<#scheduled-pipelines,パイプラインのスケジューリング>>
 
-|<<#architecture,Architecture>>
-|<<#workflows,Workflows>>
+|<<#architecture,アーキテクチャ>>
+|<<#workflows,ワークフロー機能>>
 
-|<<#dedicated-hosts-macos,Dedicated hosts for macOS>>
-|<<#dynamic-configuration,Dynamic configuration>>
+|<<#dedicated-hosts-macos,macOS の専有ホスト>>
+|<<#dynamic-configuration,ダイナミックコンフィグ>>
 
-|<<#orbs,Orbs>>
-|<<#billing,Billing>>
+|<<#orbs,Orb>>
+|<<#billing,料金・支払い>>
 
 |<<#author-orbs,Author orbs>>
-|<<#cancel-performance-plan,Cancel Performance plan>>
+|<<#cancel-performance-plan,Performance プランのキャンセル>>
 |===
 
 [#general]
-== 概要
+== 一般
 
 include::../_includes/snippets/faq/ja/general-faq-snip.adoc[]
 
 [#migration]
-== Nomad Metrics
+== 移行
 
 include::../_includes/snippets/faq/ja/migration-faq-snip.adoc[]
 
@@ -103,11 +103,11 @@ include::../_includes/snippets/faq/ja/dynamic-configuration-faq-snip.adoc[]
 [#billing]
 == 料金・支払い
 
-Visit our link:https://circleci.com/pricing/[Pricing page] to find details about CircleCI's plans.
+CircleCI のご利用プランの詳細については、link:https://circleci.com/pricing/[料金ページ]をご覧ください。
 
 include::../_includes/snippets/faq/ja/billing-faq-snip.adoc[]
 
 [#cancel-performance-plan]
-== Cancel Performance plan
+== Performance プランのキャンセル
 
 include::../_includes/snippets/faq/ja/cancel-subscription-faq-snip.adoc[]


### PR DESCRIPTION
# Description
Turns out Crowdin never reflected the changes to this page this whole time. Hence, the live page was all in English despite available translated strings for all snippets. 

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
