### PR TITLE
Include executor parameter type in sidebar

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -213,7 +213,6 @@ commands:
 
 #### Executor
 {: #executor }
-{:.no_toc}
 
 Use an `executor` parameter type to allow the invoker of a job to decide what executor it will run on.
 


### PR DESCRIPTION
# Description

Removes `{:.no_toc}` for the `executor` parameter type.

# Reasons

It's confusing that it wasn't in the sidebar when the other types are.

cc @kbatuigas as the other parameter types had `{:.no_toc}` removed in 9af117cb438caa6cd569ddcb9969ec5041891c75

# Content Checklist

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
