### PR TITLE
remove no_toc

### DIFF
--- a/jekyll/_cci2/contexts.md
+++ b/jekyll/_cci2/contexts.md
@@ -342,7 +342,7 @@ To rotate an environment variable from the API, call the [Update environment var
 
 ## See also
 {: #see-also }
-{:.no_toc}
+
 
 * [CircleCI environment variable descriptions]({{site.baseurl}}/env-vars/)
 * [Workflows]({{site.baseurl}}/workflows/)

--- a/jekyll/_cci2/custom-images.md
+++ b/jekyll/_cci2/custom-images.md
@@ -47,7 +47,7 @@ The following sections provide a walkthrough of how to create a custom image man
 
 ### Prerequisite
 {: #prerequisite }
-{:.no_toc}
+
 
 - A working [Docker installation](https://docs.docker.com/install/).
 For more details,
@@ -55,7 +55,7 @@ see Docker's [Getting Started documentation](https://docs.docker.com/get-started
 
 ### Creating a `Dockerfile`
 {: #creating-a-dockerfile }
-{:.no_toc}
+
 
 To create a custom image,
 you must [create a `Dockerfile`](https://docs.docker.com/get-started/part2/#define-a-container-with-dockerfile).
@@ -67,7 +67,7 @@ as shown in [this Docker demo project](https://github.com/CircleCI-Public/circle
 
 ### Choosing and setting a base image
 {: #choosing-and-setting-a-base-image }
-{:.no_toc}
+
 
 Before you create a custom image,
 you must choose another image from which to extend the custom image.
@@ -91,7 +91,7 @@ FROM golang:1.8.0
 
 ### Installing additional tools
 {: #installing-additional-tools }
-{:.no_toc}
+
 
 To install any additional tools
 or execute other commands,
@@ -104,7 +104,7 @@ RUN go get github.com/jstemmer/go-junit-report
 
 #### Required tools for primary containers
 {: #required-tools-for-primary-containers }
-{:.no_toc}
+
 
 In order to be used as a primary container on CircleCI,
 a custom Docker image must have the following tools installed:
@@ -125,7 +125,7 @@ you must use the `ADD` instruction instead of `RUN` (see below).
 
 ### Adding other files and directories
 {: #adding-other-files-and-directories }
-{:.no_toc}
+
 
 To add files and directories
 that are not present in package managers,
@@ -138,7 +138,7 @@ ADD ./db/migrations /migrations
 
 ### Adding an entrypoint
 {: #adding-an-entrypoint }
-{:.no_toc}
+
 
 To run the container as an executable,
 use the [`ENTRYPOINT` instruction](https://docs.docker.com/engine/reference/builder/#entrypoint).
@@ -163,7 +163,7 @@ consider using a background step instead of an entrypoint.
 
 ### Building the image
 {: #building-the-image }
-{:.no_toc}
+
 
 After all of the required tools are specified in the `Dockerfile` it is possible to build the image.
 
@@ -184,7 +184,7 @@ Congratulations, you've just built your first image! Now we need to store it som
 
 ### Storing images in a Docker registry
 {: #storing-images-in-a-docker-registry }
-{:.no_toc}
+
 
 In order to allow CircleCI to use your custom image, store it in a public [Docker Registry](https://docs.docker.com/registry/introduction/). The easiest mechanism is to create an account on [Docker Hub](https://hub.docker.com/) because Docker Hub allows you to store unlimited public images for free. If your organization is already using Docker Hub you can use your existing account.
 
@@ -194,7 +194,7 @@ The example uses Docker Hub, but it is possible to use different registries if y
 
 ### Preparing the image for the registry
 {: #preparing-the-image-for-the-registry }
-{:.no_toc}
+
 
 Log in to Docker Hub with your account and create a new repository on the [add repository](https://hub.docker.com/add/repository/) page. It is best practice to use a pattern similar to `<project-name>-<container-name>` for a repository name (for example, `cci-demo-docker-primary`).
 
@@ -212,7 +212,7 @@ The `-t` key specifies the name and tag of the new image:
 
 ### Pushing the image to the registry
 {: #pushing-the-image-to-the-registry }
-{:.no_toc}
+
 
 Push the image to Docker Hub:
 
@@ -225,7 +225,7 @@ $ docker push circleci/cci-demo-docker-primary:0.0.1
 
 ### Using your image on CircleCI
 {: #using-your-image-on-circleci }
-{:.no_toc}
+
 
 After the image is successfully pushed it is available for use it in your `.circleci/config.yml`:
 

--- a/jekyll/_cci2/databases.md
+++ b/jekyll/_cci2/databases.md
@@ -16,7 +16,7 @@ This document describes how to use the official CircleCI pre-built Docker contai
 
 ## Overview
 {: #overview }
-{:.no_toc}
+
 
 CircleCI provides pre-built images for languages and services like databases with a lot of conveniences added into the images on [CircleCI Developer Hub](https://circleci.com/developer/images).
 
@@ -91,7 +91,7 @@ This section describes additional optional configuration for further customizing
 
 ### Using binaries
 {: #using-binaries }
-{:.no_toc}
+
 
 To use `pg_dump`, `pg_restore` and similar utilities requires some extra configuration to ensure that `pg_dump` invocations will also use the correct version. Add the following to your `config.yml` file to enable `pg_*` or equivalent database utilities:
 
@@ -103,7 +103,7 @@ To use `pg_dump`, `pg_restore` and similar utilities requires some extra configu
 
 ### Using Dockerize to wait for dependencies
 {: #using-dockerize-to-wait-for-dependencies }
-{:.no_toc}
+
 
 Using multiple Docker containers for your jobs may cause race conditions if the service in a container does not start  before the job tries to use it. For example, your PostgreSQL container might be running, but might not be ready to accept connections. Work around this problem by using `dockerize` to wait for dependencies.
 Following is an example of how to do this in your CircleCI `config.yml` file:
@@ -151,7 +151,7 @@ Redis also has a CLI available:
 
 ## See also
 {: #see-also }
-{:.no_toc}
+
 
 Refer to the [Database Configuration Examples]({{ site.baseurl }}/postgres-config/) document for additional configuration file examples.
 

--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -105,6 +105,6 @@ See [our support article for more information](https://support.circleci.com/hc/e
 
 ## See also
 {: #see-also }
-{:.no_toc}
+
 
 See the [Mounting Folders section of the Running Docker Commands]({{ site.baseurl }}/building-docker-images/#mounting-folders) for examples and details.

--- a/jekyll/_cci2/docker-to-machine.md
+++ b/jekyll/_cci2/docker-to-machine.md
@@ -17,7 +17,7 @@ make when moving from the Docker executor to machine, or vice versa.
 
 ## Overview
 {: #overview }
-{:.no_toc}
+
 
 Occasionally, the Docker executor isn't quite the right fit for your
 builds. This can include a lack of memory or requiring more dedicated

--- a/jekyll/_cci2/ios-codesigning.md
+++ b/jekyll/_cci2/ios-codesigning.md
@@ -56,7 +56,7 @@ certificates and profiles.
 
 ### Preparing your Xcode project for use with Fastlane Match
 {: #preparing-your-xcode-project-for-use-with-fastlane-match }
-{:.no_toc}
+
 
 Before setting up Match you must ensure that the code signing
 settings in your Xcode project are configured as follows:
@@ -66,7 +66,7 @@ settings in your Xcode project are configured as follows:
 
 ### Adding Match to the Fastlane lane
 {: #adding-match-to-the-fastlane-lane }
-{:.no_toc}
+
 
 On CircleCI, Fastlane Match will need to be run every time you build and sign your app. The easiest way to do this is to add the `match` action to the lane which builds your app.
 
@@ -97,7 +97,7 @@ end
 
 ### Adding a user key to the CircleCI project
 {: #adding-a-user-key-to-the-circleci-project }
-{:.no_toc}
+
 
 To enable Fastlane Match to download the certificates and the keys
 from GitHub, it is necessary to add a user key with access to both the
@@ -130,7 +130,7 @@ project repo and the Fastlane Match repo from GitHub.
 
 ### Adding the Match passphrase to the project
 {: #adding-the-match-passphrase-to-the-project }
-{:.no_toc}
+
 
 To enable Fastlane Match to decrypt the certificates and profiles stored in
 the GitHub repo, it is necessary to add the encryption passphrase that
@@ -142,7 +142,7 @@ encrypted at rest.
 
 ### Building and code-signing the app on CircleCI
 {: #invoking-the-fastlane-test-lane-on-circleci }
-{:.no_toc}
+
 
 After you have configured Match and added its invocation into the appropriate
 lane, you can run that lane on CircleCI. The following `config.yml` will

--- a/jekyll/_cci2/local-cli.md
+++ b/jekyll/_cci2/local-cli.md
@@ -128,7 +128,7 @@ For **macOS** installations with Homebrew, you will need to run the following co
 
 ### Updating the legacy CLI
 {: #updating-the-legacy-cli }
-{:.no_toc}
+
 
 The newest version of the CLI is a [CircleCI-Public open source project](https://github.com/CircleCI-Public/circleci-cli). If you have the [old CLI installed](https://github.com/circleci/local-cli), run the following commands to update and switch to the new CLI:
 

--- a/jekyll/_cci2/orb-author.md
+++ b/jekyll/_cci2/orb-author.md
@@ -101,7 +101,7 @@ Each directory within `src` corresponds with a [reusable configuration]({{site.b
 
 ##### @orb.yml
 {: #orbyml }
-{:.no_toc}
+
 
 @orb.yml acts as the "root" to your orb project and contains the config version, the orb description, the display key, and imports any additional orbs if needed.
 
@@ -120,7 +120,7 @@ display:
 
 ##### Commands
 {: #commands }
-{:.no_toc}
+
 
 Author and add [Reusable Commands]({{site.baseurl}}/reusing-config/#authoring-reusable-commands) to the `src/commands` directory. Each _YAML_ file within this directory will be treated as an orb command, with a name which matches its filename.
 
@@ -145,7 +145,7 @@ steps:
 
 ##### Examples
 {: #examples }
-{:.no_toc}
+
 
 Author and add [Usage Examples]({{site.baseurl}}/orb-concepts/#usage-examples) to the `src/examples` directory. Usage Examples are not for use directly by end users in their project configs, but they provide a way for you, the orb developer, to share use-case specific examples on the [Orb Registry](https://circleci.com/developer/orbs) for users to reference.
 
@@ -155,7 +155,7 @@ View a full example from the [Orb Template](https://github.com/CircleCI-Public/O
 
 ##### Executors
 {: #executors }
-{:.no_toc}
+
 
 Author and add [Parameterized Executors]({{site.baseurl}}/reusing-config/#authoring-reusable-executors) to the `src/executors` directory.
 
@@ -165,7 +165,7 @@ View a full example from the [Orb Template](https://github.com/CircleCI-Public/O
 
 ##### Jobs
 {: #jobs }
-{:.no_toc}
+
 
 Author and add [Parameterized Jobs]({{site.baseurl}}/reusing-config/#authoring-parameterized-jobs) to the `src/jobs` directory.
 
@@ -229,7 +229,7 @@ steps:
 
 ##### Why include scripts?
 {: #why-include-scripts }
-{:.no_toc}
+
 
 CircleCI configuration is written in `YAML`. Logical code such as `bash` can be encapsulated and executed on CircleCI through `YAML`, but, for developers, it is not convenient to write and test programmatic code within a non-executable format. Also, parameters can become cumbersome in more complex scripts as the `<<parameter>>` syntax is a CircleCI native YAML enhancement, and not something that can be interpreted and executed locally.
 
@@ -237,7 +237,7 @@ Using the orb development kit and the `<<include(file)>>` syntax, you can import
 
 ##### Using parameters with scripts
 {: #using-parameters-with-scripts }
-{:.no_toc}
+
 
 To keep your scripts portable and locally executable, it is best practice to expect a set of environment variables within your scripts and set them at the config level. The `greet.sh` file, which was included with the special `<<include(file)>>` syntax above in our `greet.yml` command file, looks like this:
 

--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -64,7 +64,7 @@ Executors defined within orbs can be used to run jobs within your project config
 
 #### Executor definition example
 {: #executor-definition-example }
-{:.no_toc}
+
 
 {:.tab.executor.Node-Docker}
 ```yaml
@@ -197,7 +197,7 @@ To avoid negatively impacting a user's CI process, orb authors should strictly a
 
 ### Production orbs
 {: #production-orbs }
-{:.no_toc}
+
 
 Production orbs are immutable and can be found on the [Orb Registry](https://circleci.com/developer/orbs).
 
@@ -210,7 +210,7 @@ Production orbs are immutable and can be found on the [Orb Registry](https://cir
 
 ### Development orbs
 {: #development-orbs }
-{:.no_toc}
+
 
 Development orbs are temporary overwrite-able orb tag versions, useful for rapid development and testing prior to deploying a semver deployed production change.
 
@@ -223,7 +223,7 @@ Development orbs are temporary overwrite-able orb tag versions, useful for rapid
 
 ### Inline orbs
 {: #inline-orbs }
-{:.no_toc}
+
 
 Inline orbs are defined directly within the user's config, are completely local and scoped to the individual project.
 
@@ -375,7 +375,7 @@ jobs:
 
 ## See also
 {: #see-also }
-{:.no_toc}
+
 
 - Refer to [Orb Introduction]({{site.baseurl}}/orb-intro/) for a high-level overview of CircleCI orbs.
 - Refer to [Orbs Reference]({{site.baseurl}}/reusing-config/) for detailed reference information about Orbs, including descriptions of commands, jobs and executors.

--- a/jekyll/_cci2/postgres-config.md
+++ b/jekyll/_cci2/postgres-config.md
@@ -86,7 +86,7 @@ registry of your choosing.
 
 ### Example environment setup
 {: #example-environment-setup }
-{:.no_toc}
+
 
 You must declare your database configuration explicitly because multiple pre-built or custom images may be in use. For example, Rails will try to use a database URL in the following order:
 

--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -621,7 +621,7 @@ jobs:
 
 ### Invoking reusable executors
 {: #invoking-reusable-executors }
-{:.no_toc}
+
 
 The following example passes `my-executor` as the value of a `name` key under `executor` -- this method is primarily employed when passing parameters to executor invocations:
 

--- a/jekyll/_cci2/security-supply-chain.md
+++ b/jekyll/_cci2/security-supply-chain.md
@@ -60,6 +60,6 @@ Using dependency pinning with hashes like this prevents malicious binaries or pa
 
 ## See also
 {: #see-also }
-{:.no_toc}
+
 
 - [Security recommendations]({{site.baseurl}}/security-recommendations)

--- a/jekyll/_cci2/using-windows.md
+++ b/jekyll/_cci2/using-windows.md
@@ -306,7 +306,7 @@ It is possible to SSH into a Windows build container. This is useful for trouble
 
 ### Steps
 {: #steps }
-{:.no_toc}
+
 
 1. Ensure that you have added an SSH key to your [GitHub](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/) or [Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html) account.
 


### PR DESCRIPTION
# Description
Remove all instances of no_toc across docs

# Reasons
Previously we would manage the TOC to prevent it getting too long, this was back when the TOC appeared at the top of a page. With the right hand page TOC this is no longer necessary and actually can be confusing to the reader.


# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
