### PR TITLE
add missing colon to cypress example Re-run failed tests

### DIFF
--- a/jekyll/_cci2/rerun-failed-tests.adoc
+++ b/jekyll/_cci2/rerun-failed-tests.adoc
@@ -175,7 +175,7 @@ gem 'rspec_junit_formatter'
           npm run start &
           circleci tests glob "cypress/**/*.cy.js" | circleci tests run --command="xargs npx cypress run --reporter cypress-circleci-reporter --spec" --verbose --split-by=timings #--split-by=timings is optional, only use if you are using CircleCI's test splitting
 
-     - store_test_results
+     - store_test_results:
         path: test_results
 ```
 +

--- a/jekyll/_cci2_ja/rerun-failed-tests.adoc
+++ b/jekyll/_cci2_ja/rerun-failed-tests.adoc
@@ -170,7 +170,7 @@ gem 'rspec_junit_formatter'
           npm run start &
           circleci tests glob "cypress/**/*.cy.js" | circleci tests run --command="xargs npx cypress run --reporter cypress-circleci-reporter --spec" --verbose --split-by=timings #--split-by=timings is optional, only use if you are using CircleCI's test splitting
 
-     - store_test_results
+     - store_test_results:
         path: test_results
 ```
 +


### PR DESCRIPTION
# Description
add missing colon to cypress example Re-run failed tests

# Reasons
The yml was invalid, it was missing the colon. Other examples using `store_test_results` have the colon

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
