### PR TITLE
GitLab users need GH or BB account to SSH

### DIFF
--- a/jekyll/_cci2/browser-testing.md
+++ b/jekyll/_cci2/browser-testing.md
@@ -242,6 +242,9 @@ $ ssh -p PORT ubuntu@IP_ADDRESS -L 5900:localhost:5900
 ## X11 forwarding over SSH
 {: #x11-forwarding-over-ssh }
 
+**Using GitLab?** SSH reruns will only work for GitLab-based projects if your CircleCI user account also has an associated GitHub or Bitbucket integration in addition to GitLab. Your user account's Bitbucket or GitHub SSH keys can be used for SSH reruns with GitLab. CircleCI will add functionality to allow you to manage SSH keys for your GitLab account to enable SSH rerun functionality without a GitHub or Bitbucket account.
+{: class="alert alert-info" }
+
 CircleCI also supports X11 forwarding over SSH. X11 forwarding is similar to VNC &mdash; you can interact with the browser running on CircleCI from your local machine.
 
 1. Install an X Window System on your computer. If you're using macOS, consider [XQuartz](http://xquartz.macosforge.org/landing/).

--- a/jekyll/_cci2/gitlab-integration.adoc
+++ b/jekyll/_cci2/gitlab-integration.adoc
@@ -768,7 +768,9 @@ GitLab integrations do not currently support the **Stop Building** option that c
 [#ssh-rerun]
 === SSH rerun
 
-Support for SSH rerun will only work if your user account has a Bitbucket or GitHub integration in addition to GitLab. Your user account's Bitbucket or GitHub SSH keys can be used for SSH reruns with GitLab. CircleCI will be adding functionality to allow users to manage SSH keys so SSH reruns are possible. SSH reruns do not get passed context secrets. CircleCI is working on providing administrators with greater control over the use of secrets and SSH reruns.
+SSH reruns will only work for GitLab-based projects if your CircleCI user account also has an associated GitHub or Bitbucket integration in addition to GitLab. Your user account's Bitbucket or GitHub SSH keys can be used for SSH reruns with GitLab. CircleCI will add functionality to allow you to manage SSH keys for your GitLab account to enable SSH rerun functionality without a GitHub or Bitbucket account.
+
+SSH reruns do not get passed secrets stored in contexts. CircleCI is working on providing administrators with greater control over the use of secrets and SSH reruns.
 
 [#additional-ssh-keys-only]
 === Additional SSH keys only

--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -9,10 +9,15 @@ contentTags:
   - Server v3.x
 ---
 
-## Overview
-{: #overview }
+Troubleshoot problems in a job using **Rerun job with SSH**. Using this feature you can inspect log files, running processes, and directory paths.
 
-Often the best way to troubleshoot problems is to SSH into a job and inspect log files, running processes, and directory paths. CircleCI gives you the option to access all jobs via SSH. Read our [blog post](https://circleci.com/blog/debugging-ci-cd-pipelines-with-ssh-access/) on debugging CI/CD pipelines with SSH.
+## Introduction
+{: #introduction }
+
+**Using GitLab?** SSH reruns will only work for GitLab-based projects if your CircleCI user account also has an associated GitHub or Bitbucket integration in addition to GitLab. Your user account's Bitbucket or GitHub SSH keys can be used for SSH reruns with GitLab. CircleCI will add functionality to allow you to manage SSH keys for your GitLab account to enable SSH rerun functionality without a GitHub or Bitbucket account.
+{: class="alert alert-info" }
+
+CircleCI gives you the option to access all jobs via SSH. Read our [blog post](https://circleci.com/blog/debugging-ci-cd-pipelines-with-ssh-access/) on debugging CI/CD pipelines with SSH.
 
 When you log in with SSH, you are running an **interactive** login shell. You may be running the command on top of the directory where the command failed the first time, or you may be running the command from the directory one level up from where the command failed (e.g. `~/project/` or `~/`). Either way, you will not be initiating a clean run. You may wish to execute `pwd` or `ls` to ensure that you are in the correct directory.
 

--- a/jekyll/_cci2/using-windows.md
+++ b/jekyll/_cci2/using-windows.md
@@ -307,6 +307,9 @@ jobs:
 ## SSH into your Windows build
 {: #ssh-into-your-windows-build }
 
+**Using GitLab?** SSH reruns will only work for GitLab-based projects if your CircleCI user account also has an associated GitHub or Bitbucket integration in addition to GitLab. Your user account's Bitbucket or GitHub SSH keys can be used for SSH reruns with GitLab. CircleCI will add functionality to allow you to manage SSH keys for your GitLab account to enable SSH rerun functionality without a GitHub or Bitbucket account.
+{: class="alert alert-info" }
+
 It is possible to SSH into a Windows build container. This is useful for troubleshooting problems in your pipeline. Follow these steps to SSH into a Windows container:
 
 ### Steps
@@ -315,9 +318,9 @@ It is possible to SSH into a Windows build container. This is useful for trouble
 
 1. Ensure that you have added an SSH key to your [GitHub](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/) or [Bitbucket](https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html) account.
 
-2. To start a job with SSH enabled, select the 'Rerun job with SSH' option from the 'Rerun Workflow' dropdown menu.
+2. To start a job with SSH enabled, select the **Rerun job with SSH** option from the "Rerun Workflow" dropdown menu.
 
-3. To see the connection details, expand the 'Enable SSH' section in the job output where you will see the SSH command needed to connect:
+3. To see the connection details, expand the "Enable SSH" section in the job output where you will see the SSH command needed to connect:
 ![SSH connection details]({{ site.baseurl }}/assets/img/docs/ssh-windows-obf.png)
 
 Ensure that you are passing the name of the shell you want to run when you SSH


### PR DESCRIPTION
# Description
Adds banner to relevant pages.
I chose not to add the banner to the vs code extension page because I think the whole pipelines manager feature is unsupported to GitLab so that will cover SSH too.

# Reasons
Ensuring GitLab users find relevant info on every page

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
