### PR TITLE
add details to CLI local jobs executor limitations

### DIFF
--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -270,9 +270,9 @@ The commands above will run the entire `build` job (only jobs, not workflows, ca
 
 Although running jobs locally with `circleci` is very helpful, there are some limitations.
 
-**Machine executor**
+**Executors**
 
-You cannot use the machine executor in local jobs. This is because the machine executor requires an extra VM to run its jobs.
+The CLI does not support running jobs that use a <</executor-intro#linux-vm,Machine>> (`machine`) or <</executor-intro#macos,macOS>> (`macos`) executor locally. This is because these executors require running an additional Virtual Machine. Only jobs that use a <</executor-intro#docker,Docker>> (`docker`) executor can be run locally.
 
 **Add SSH keys**
 

--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -272,7 +272,7 @@ Although running jobs locally with `circleci` is very helpful, there are some li
 
 **Executors**
 
-The CLI does not support running jobs that use a <</executor-intro#linux-vm,Machine>> (`machine`) or <</executor-intro#macos,macOS>> (`macos`) executor locally. This is because these executors require running an additional Virtual Machine. Only jobs that use a <</executor-intro#docker,Docker>> (`docker`) executor can be run locally.
+The CLI does not support running jobs that use a <<executor-intro#linux-vm,machine>> (`machine`) or <<executor-intro#macos,macOS>> (`macos`) executor locally. This is because these executors require running an additional virtual machine. Only jobs that use a <<executor-intro#docker,Docker>> (`docker`) executor can be run locally.
 
 **Add SSH keys**
 


### PR DESCRIPTION
# Description

In the "How to use the CircleCI local CLI" page, adds details to limitations as pertains to Machine and macOS "executors".

# Reasons

* [Jira](https://circleci.atlassian.net/browse/DEVEX-1189)
* [GitHub](https://github.com/CircleCI-Public/circleci-cli/issues/963)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
