### PR TITLE
[CPE-1884] chore: Update relevant GPU docs

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -845,12 +845,8 @@ If you are using CircleCI server, contact your system administrator for details 
 
 When using the Linux [GPU executor]({{ site.baseurl }}/using-gpu), the available images are:
 
-* `ubuntu-2004-cuda-11.4:202110-01` - CUDA v11.4.2, Docker v20.10.7, nvidia-container-toolkit v1.5.1-1
-* `ubuntu-2004-cuda-11.2:202103-01` - CUDA v11.2.1, Docker v20.10.5, nvidia-container-toolkit v1.4.2-1
-* `ubuntu-1604-cuda-11.1:202012-01` - CUDA v11.1, Docker v19.03.13, nvidia-container-toolkit v1.4.0-1
-* `ubuntu-1604-cuda-10.2:202012-01` - CUDA v10.2, Docker v19.03.13, nvidia-container-toolkit v1.3.0-1
-* `ubuntu-1604-cuda-10.1:201909-23` - CUDA v10.1, Docker v19.03.0-ce, nvidia-docker v2.2.2
-* `ubuntu-1604-cuda-9.2:201909-23` - CUDA v9.2, Docker v19.03.0-ce, nvidia-docker v2.2.2
+* `linux-cuda-11:default` v11.4, v11.6, v11.8 (default), Docker v20.10.24
+* `linux-cuda-12:default` v12.0, v12.1 (default), Docker v20.10.24
 
 ---
 
@@ -1123,8 +1119,8 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-1604-cuda-10.1:201909-23
-    resource_class: gpu.nvidia.small
+      image: linux-cuda-12:default
+      resource_class: gpu.nvidia.medium
     steps:
       - run: nvidia-smi
       - run: docker run --gpus all nvidia/cuda:9.0-base nvidia-smi
@@ -2622,4 +2618,3 @@ workflows:
               only: main
 ```
 {% endraw %}
-

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -158,10 +158,9 @@ version: 2.1
 
 jobs:
   build:
-    resource_class: gpu.nvidia.small
     machine:
-      image: ubuntu-2004-cuda-11.4:202110-01
-    resource_class: gpu.nvidia.small
+      image: linux-cuda-12:default
+    resource_class: gpu.nvidia.medium
     steps:
       - run: nvidia-smi
 ```

--- a/jekyll/_cci2/hello-world.adoc
+++ b/jekyll/_cci2/hello-world.adoc
@@ -146,7 +146,8 @@ version: 2.1
 jobs:
   hello-job:
     machine:
-      image: ubuntu-2004-cuda-11.4:202110-01
+      image: linux-cuda-12:default
+      resource_class: gpu.nvidia.medium
     steps:
       - checkout # check out the code in the project directory
       - run: echo "hello world" # run the `echo` command

--- a/jekyll/_cci2/optimizations.adoc
+++ b/jekyll/_cci2/optimizations.adoc
@@ -159,8 +159,8 @@ jobs:
 jobs:
   build:
     machine:
-      image: ubuntu-2004-cuda-11.4:202110-01
-    resource_class: gpu.nvidia.small
+      image: linux-cuda-12:default
+    resource_class: gpu.nvidia.medium
     steps:
     #  ...  other config
 ----

--- a/jekyll/_cci2/using-gpu.md
+++ b/jekyll/_cci2/using-gpu.md
@@ -21,7 +21,8 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004-cuda-11.4:202110-01
+      image: linux-cuda-12:default
+      resource_class: gpu.nvidia.medium
     steps:
       - run: nvidia-smi
 ```
@@ -68,8 +69,8 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004-cuda-11.4:202110-01
-    resource_class: gpu.nvidia.small
+      image: linux-cuda-12:default
+    resource_class: gpu.nvidia.medium
     steps:
       - run: nvidia-smi
 ```

--- a/jekyll/_includes/snippets/gpu-linux-resource-table.md
+++ b/jekyll/_includes/snippets/gpu-linux-resource-table.md
@@ -1,7 +1,8 @@
 Class | vCPUs | RAM | GPUs | GPU model | GPU Memory (GiB) | Disk Size (GiB) | Cloud | Server
 ---|---|---|---|---|---|---|---|---
-gpu.nvidia.small |   4   | 15  | 1 | Nvidia Tesla P4 | 8 | 300 | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
+gpu.nvidia.small.multi |   4   | 15  | 2 | Nvidia Tesla P4 | 8 | 300 | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
 gpu.nvidia.medium |   8   | 30  | 1 | Nvidia Tesla T4 | 16 | 300 | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
+gpu.nvidia.medium.multi |   8   | 30  | 4 | Nvidia Tesla T4 | 16 | 300 | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
 gpu.nvidia.large |   8   | 30  | 1 | Nvidia Tesla V100 | 16 | 300 | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
 {: class="table table-striped"}
 

--- a/jekyll/archived/_cci2/executor-types.md
+++ b/jekyll/archived/_cci2/executor-types.md
@@ -388,8 +388,8 @@ version: 2.1
 jobs:
   build:
     machine:
-      resource_class: gpu.nvidia.small
-      image: ubuntu-1604-cuda-10.1:201909-23
+      image: linux-cuda-12:default
+      resource_class: gpu.nvidia.medium
     steps:
       - run: nvidia-smi
 ```


### PR DESCRIPTION
# Description
A brief description of the changes.
Mainly went through references to GPU images that were outdated and/or were using a resource class that is not compatible. for reference, [these are the resource classes that are compatible](https://github.com/circleci/machine-provisioner/blob/main/deploy/conf/machine-provisioner-config.yml#L1190)

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
[CPE-1884](https://circleci.atlassian.net/browse/CPE-1884)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [N/A] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [N/A] Include relevant backlinks to other CircleCI docs/pages.


[CPE-1884]: https://circleci.atlassian.net/browse/CPE-1884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ