### PR TITLE
Update return type for built-in environment variable CIRCLE_PULL_REQUESTS

### DIFF
--- a/jekyll/_includes/snippets/built-in-env-vars.adoc
+++ b/jekyll/_includes/snippets/built-in-env-vars.adoc
@@ -94,8 +94,7 @@
 | `CIRCLE_PULL_REQUESTS`
 | GitHub, Bitbucket
 | List or String
-| Comma-separated list of URLs of the current build's associated pull requests. If there is only one associated pull request, returns the URL of 
-| the associated pull request as a string.
+| Comma-separated list of URLs of the current build's associated pull requests. If there is only one associated pull request, returns the URL of the associated pull request as a string.
 
 | `CIRCLE_REPOSITORY_URL`
 | GitHub, Bitbucket

--- a/jekyll/_includes/snippets/built-in-env-vars.adoc
+++ b/jekyll/_includes/snippets/built-in-env-vars.adoc
@@ -93,8 +93,9 @@
 
 | `CIRCLE_PULL_REQUESTS`
 | GitHub, Bitbucket
-| List
-| Comma-separated list of URLs of the current build's associated pull requests.
+| List or String
+| Comma-separated list of URLs of the current build's associated pull requests. If there is only one associated pull request, returns the URL of 
+| the associated pull request as a string.
 
 | `CIRCLE_REPOSITORY_URL`
 | GitHub, Bitbucket


### PR DESCRIPTION
# Description
Return type of built-in environment variable CIRCLE_PULL_REQUESTS is a string when only one pull request is associated with the build.

# Reasons
Wasn't sure if this was a bug, if so, thought I'd update the docs until it's fixed.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
