### PR TITLE
add runner resource class token access information

### DIFF
--- a/jekyll/_includes/snippets/faq/self-hosted-runner-faq-snip.adoc
+++ b/jekyll/_includes/snippets/faq/self-hosted-runner-faq-snip.adoc
@@ -10,7 +10,7 @@ A resource class is a label to match your CircleCI job with a type of runner (or
 
 Resource classes help you identify a pool of self-hosted runners, which allow you to set up your configuration to send jobs to specific resources. For example, if you have multiple machines running macOS, and multiple machines running Linux, you could create resource classes for each of these, `orgname/macOS` and `orgname/linux`, respectively. At the job level in your `.circleci/config.yml`, you can associate which self-hosted runner resources to send a job to based on the resource class.
 
-Every time you create a resource class, a *resource class token* is generated that is associated with the given resource class. This token is the method by which CircleCI authenticates that the resource class is valid.
+Every time you create a resource class, a *resource class token* is generated that is associated with the given resource class. This token is the method by which CircleCI authenticates that the resource class is valid. The resource class token only has access to claim tasks.
 
 [#what-is-the-security-model-for-the-circleci-self-hosted-runner]
 === What is the security model for CircleCI's self-hosted runners?


### PR DESCRIPTION
# Description
Add a mention of what the runner resource class token has access to.

# Reasons
Customer requested official documentation that the runner resource class token can only be used to claim tasks
