### PR TITLE
Add deprecation warnings for Intel macOS resources

### DIFF
--- a/jekyll/_includes/snippets/macos-resource-table.md
+++ b/jekyll/_includes/snippets/macos-resource-table.md
@@ -1,14 +1,26 @@
 Class | vCPUs | RAM | Cloud | Server
 ---|---|---|---|---
-medium | 4 @ 2.7 GHz | 8GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
-macos.x86.medium.gen2 | 4 @ 3.2 GHz | 8GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
-large | 8 @ 2.7 GHz | 16GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
+medium* | 4 @ 2.7 GHz | 8GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
+macos.x86.medium.gen2* | 4 @ 3.2 GHz | 8GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
+large* | 8 @ 2.7 GHz | 16GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
 macos.m1.medium.gen1 | 4 @ 3.2 GHz | 6GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
 macos.m1.large.gen1 | 8 @ 3.2 GHz | 12GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
-macos.x86.metal.gen1 | 12 @ 3.2 GHz | 32GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
+macos.x86.metal.gen1* | 12 @ 3.2 GHz | 32GB | <i class="fa fa-check" aria-hidden="true"></i> | <i class="fa fa-times" aria-hidden="true"></i>
 {: class="table table-striped"}
 
- The `medium` and `large` resource classes are being deprecated on October 2, 2023. Xcode v14.2 is the latest version that will be supported by these macOS resources. See our [announcement](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891) for more details.
+<b>We are deprecating support for all Intel-based macOS resources.</b>
+<br />
+<br />
+The `medium` and `large` resource classes are being deprecated on October 2, 2023. Xcode v14.2 is the latest version that will be supported by these macOS resources.
+<br />
+<br />
+The `macos.x86.metal.gen1` resource class is being deprecated on October 2, 2023. Xcode v14.0.1 is the latest version that will be supported by these macOS resources.
+<br />
+<br />
+The `macos.x86.medium.gen2` resource class is being deprecated on January 31, 2024. Xcode v15.1 is the latest version that will be supported by this macOS resource.
+<br />
+<br />
+See our [announcement](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718) for more details.
 {: class="alert alert-warning"}
 
 The `macos.x86.metal.gen1` resource requires a minimum 24-hour lease. See the [Dedicated Host for macOS]({{ site.baseurl }}/dedicated-hosts-macos) page to learn more about this resource class.


### PR DESCRIPTION
# Description
Expand deprecation alert to include details for remaining Intel-based macOS deprecations.

# Reasons
We're deprecating all Intel macOS resources over the next 6 months.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
