### PR TITLE
batched updates to rerun failed tests page

### DIFF
--- a/jekyll/_cci2/rerun-failed-tests.adoc
+++ b/jekyll/_cci2/rerun-failed-tests.adoc
@@ -268,7 +268,7 @@ NOTE: Ensure that you are using version 1.34.2 or later of Playwright. Earlier v
     ./gradlew test $GRADLE_ARGS
 
 - store_test_results:
-    ...
+    path: build/test-results/test
 ```
 
 . Update the `glob` command to match your use case. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.**. If you are not using test splitting, `--split-by=timings` can be omitted.
@@ -332,7 +332,7 @@ Django takes as input test filenames with a format that uses dots ("."), however
       pipenv run coverage run manage.py test --parallel=8 --verbosity=2 $TESTFILES
 
 - store_test_results:
-    ...
+    path: test-results
 ```
 
 [#known-limitations]

--- a/jekyll/_cci2/rerun-failed-tests.adoc
+++ b/jekyll/_cci2/rerun-failed-tests.adoc
@@ -311,7 +311,7 @@ Example:
     path: test-results
 ```
 
-The snippet above will write the list of test file names to `files.txt`.  On a non-rerun, this list will be all of the test file names.  On a "rerun", the list will be a subset of file names (the test file names that had at least 1 test failure in the previous run).  You can pass the list of test file names from `files.txt` into, for example, your custom `makefile`.  If using parallelism, CircleCI spins up the same number of containers/VMs as the parallelism level that is set in config.yml, however, not all parallel containers/VMs will execute tests.  For the parallel containers/VMs that will not run tests, files.txt may not be created.  The `halt` command ensures that in the case where a parallel run is not executing tests, the parallel run is stopped immediately.
+The snippet above will write the list of test file names to `files.txt`.  On a non-rerun, this list will be all of the test file names.  On a "rerun", the list will be a subset of file names (the test file names that had at least 1 test failure in the previous run).  You can pass the list of test file names from `files.txt` into, for example, your custom `makefile`.  If using parallelism, CircleCI spins up the same number of containers/VMs as the parallelism level that is set in `.circleci/config.yml`. However, not all parallel containers/VMs will execute tests.  For the parallel containers/VMs that will not run tests, `files.txt` may not be created.  The `halt` command ensures that in the case where a parallel run is not executing tests, the parallel run is stopped immediately.
 
 [#configure-a-job-running-playwright-tests]
 === Configure a job running Django tests

--- a/jekyll/_cci2/rerun-failed-tests.adoc
+++ b/jekyll/_cci2/rerun-failed-tests.adoc
@@ -287,9 +287,19 @@ Example:
  - run:
     command: |
       circleci tests glob "src/**/*js" | circleci tests run --command=">files.txt xargs echo" --verbose --split-by=timings #split-by=timings is optional
+      [ -s tmp/files.txt ] || circleci-agent step halt #if a re-run and there are no tests to re-run for this parallel run, stop execution
+
+ - run:
+    name: Run tests
+    command: |
+      mkdir test-results
+      ... #pass files.txt into your test command
+
+ - store_test_results:
+    path: test-results
 ```
 
-The snippet above will write the list of test file names to `files.txt`.  On a non-rerun, this list will be all of the test file names.  On a "rerun", the list will be a subset of file names (the test file names that had at least 1 test failure in the previous run).  You can pass the list of test file names from `files.txt` into, for example, your custom `makefile`.
+The snippet above will write the list of test file names to `files.txt`.  On a non-rerun, this list will be all of the test file names.  On a "rerun", the list will be a subset of file names (the test file names that had at least 1 test failure in the previous run).  You can pass the list of test file names from `files.txt` into, for example, your custom `makefile`.  If using parallelism, CircleCI spins up the same number of containers/VMs as the parallelism level that is set in config.yml, however, not all parallel containers/VMs will execute tests.  For the parallel containers/VMs that will not run tests, files.txt may not be created.  The `halt` command ensures that in the case where a parallel run is not executing tests, the parallel run is stopped immediately.
 
 [#configure-a-job-running-playwright-tests]
 === Configure a job running Django tests
@@ -317,7 +327,7 @@ For example, if parallelism is set to eight, there may only be enough tests afte
 +
 **In most cases, you can still observe substantial time and credit savings** despite spinning up containers/VMs that do not run tests.
 +
-If you would like to maximize credit savings, you can immediately check for whether the parallel container/VM will execute tests as the first step in a job, and if there are no tests to run, terminate job execution. For example:
+If you would like to maximize credit savings, you can immediately check for whether the parallel container/VM will execute tests as the first step in a job, and if there are no tests to run, terminate job execution.  With this approach, ensure that the logic to run tests happens in a subsequent step. For example:
 +
 ```yml
 steps:
@@ -325,13 +335,21 @@ steps:
   - run: |
     mkdir -p ./tmp && \
     >./tmp/tests.txt && \
-    circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command=">./tmp/tests.txt xargs echo" --split-by=timings #Get the list of filenames for this container/VM
+    circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command=">./tmp/tests.txt xargs echo" --split-by=timings #Get the list of tests for this container/VM
 
-    [ -s tmp/tests.txt ] || circleci-agent step halt #if there are no filenames, terminate execution after this step
+    [ -s tmp/tests.txt ] || circleci-agent step halt #if there are no tests, terminate execution after this step
 
-  - node/install
-  # Proceed with the rest of the job
+ - run:
+    name: Run tests
+    command: |
+      mkdir test-results
+      ...
+
+ - store_test_results:
+    path: test-results
 ```
+
+
 +
 See <<parallel-rerun-failure>> for a workaround to avoid failures if you are also using `persist_to_workspace`.
 +
@@ -459,6 +477,13 @@ On a rerun, if the parallel run is running tests, `no_files_here` will be popula
 === Approval jobs
 
 If your workflow has an approval job, and a failed job containing failed tests that you wish to rerun, you will not be able to click btn:[Rerun failed tests] until the workflow has terminated.  This means that you must cancel the approval job before you can click btn:[Rerun failed tests].
+
+[#Error-can-not-rerun-failed-tests-no-failed-tests-could-be-found]
+=== Error: can not rerun failed tests: no failed tests could be found
+
+If your job that has failed uploads test results but there are no failed tests and `circleci tests run` was used, the "rerun failed tests" button will be clickable.  However, upon clicking, the new workflow will fail with the following message: `Error: can not rerun failed tests: no failed tests could be found"`.
+
+To resolve this error, use "Rerun workflow from failed" to rerun all tests.  "Rerun failed tests" will only work if there are failed tests being reported in the "Tests" tab.
 
 [#FAQs]
 == FAQs

--- a/jekyll/_cci2/rerun-failed-tests.adoc
+++ b/jekyll/_cci2/rerun-failed-tests.adoc
@@ -498,7 +498,7 @@ If your workflow has an approval job, and a failed job containing failed tests t
 [#Error-can-not-rerun-failed-tests-no-failed-tests-could-be-found]
 === Error: can not rerun failed tests: no failed tests could be found
 
-If your job that has failed uploads test results but there are no failed tests and `circleci tests run` was used, the "rerun failed tests" button will be clickable.  However, upon clicking, the new workflow will fail with the following message: `Error: can not rerun failed tests: no failed tests could be found"`.
+If your job that has failed uploads test results but there are no failed tests and `circleci tests run` was used, the "rerun failed tests" button will be clickable.  However, upon clicking, the new workflow will fail with the following message: `Error: can not rerun failed tests: no failed tests could be found`.
 
 To resolve this error, use "Rerun workflow from failed" to rerun all tests.  "Rerun failed tests" will only work if there are failed tests being reported in the "Tests" tab.
 

--- a/jekyll/_cci2/rerun-failed-tests.adoc
+++ b/jekyll/_cci2/rerun-failed-tests.adoc
@@ -134,7 +134,7 @@ gem 'rspec_junit_formatter'
       circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml" --verbose --split-by=timings
 
  - store_test_results:
-    ...
+    path: ~/rspec
 ```
 
 . Update the `glob` command to match your use case. See the RSpec section in the xref:collect-test-data#rspec[Collect Test Data] document for details on how to output test results in an acceptable format for `rspec`. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.** If you are not using test splitting, `--split-by=timings` can be omitted.
@@ -151,7 +151,7 @@ gem 'rspec_junit_formatter'
     circleci tests glob "features/**/*.feature" | circleci tests run --command="xargs bundle exec cucumber --format junit,fileattribute=true --out ~/cucumber/junit.xml" --verbose --split-by=timings
 
 - store_test_results:
-    ...
+    ~/cucumber
 ```
 
 . Update the `glob` command to match your use case. See the Cucumber section in the xref:collect-test-data#cucumber[Collect Test Data] document for details on how to output test results in an acceptable format for `Cucumber`. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.** If you are not using test splitting, `--split-by=timings` can be omitted.
@@ -232,7 +232,7 @@ You can also add it to your `jest.config.js` file by following these link:https:
       echo "$TESTFILES" | circleci tests run --command="xargs pnpm playwright test --config=playwright.config.ci.ts --reporter=junit" --verbose --split-by=timings
 
  - store_test_results:
-    ...
+    path: results.xml
 ```
 
 . Update the `glob` command to match your use case. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.**. If you are not using test splitting, `--split-by=timings` can be omitted. Note: you may also use link:https://playwright.dev/docs/test-reporters#junit-reporter[Playwright's built-in flag] (`PLAYWRIGHT_JUNIT_OUTPUT_NAME`) to specify the JUnit XML output directory.

--- a/jekyll/_cci2/rerun-failed-tests.adoc
+++ b/jekyll/_cci2/rerun-failed-tests.adoc
@@ -132,6 +132,9 @@ gem 'rspec_junit_formatter'
  - run:
     command: |
       circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml" --verbose --split-by=timings
+
+ - store_test_results:
+    ...
 ```
 
 . Update the `glob` command to match your use case. See the RSpec section in the xref:collect-test-data#rspec[Collect Test Data] document for details on how to output test results in an acceptable format for `rspec`. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.** If you are not using test splitting, `--split-by=timings` can be omitted.
@@ -146,6 +149,9 @@ gem 'rspec_junit_formatter'
 - run:
     command: |
     circleci tests glob "features/**/*.feature" | circleci tests run --command="xargs bundle exec cucumber --format junit,fileattribute=true --out ~/cucumber/junit.xml" --verbose --split-by=timings
+
+- store_test_results:
+    ...
 ```
 
 . Update the `glob` command to match your use case. See the Cucumber section in the xref:collect-test-data#cucumber[Collect Test Data] document for details on how to output test results in an acceptable format for `Cucumber`. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.** If you are not using test splitting, `--split-by=timings` can be omitted.
@@ -204,8 +210,8 @@ You can also add it to your `jest.config.js` file by following these link:https:
       npx jest --listTests | circleci tests run --command=“JEST_JUNIT_ADD_FILE_ATTRIBUTE=true xargs npx jest --config jest.config.js --runInBand --” --verbose --split-by=timings
     environment:
       JEST_JUNIT_OUTPUT_DIR: ./reports/
-  - store_test_results:
-      path: ./reports/
+- store_test_results:
+    path: ./reports/
 ```
 
 . Update the `npx jest --listTests` command to match your use case. See the Jest section in the xref:collect-test-data#jest[Collect Test Data] document for details on how to output test results in an acceptable format for `jest`. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.** If you are not using test splitting, `--split-by=timings` can be omitted.
@@ -224,6 +230,9 @@ You can also add it to your `jest.config.js` file by following these link:https:
       pnpm run serve &
       TESTFILES = $(circleci tests glob "specs/e2e/**/*.spec.ts")
       echo "$TESTFILES" | circleci tests run --command="xargs pnpm playwright test --config=playwright.config.ci.ts --reporter=junit" --verbose --split-by=timings
+
+ - store_test_results:
+    ...
 ```
 
 . Update the `glob` command to match your use case. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.**. If you are not using test splitting, `--split-by=timings` can be omitted. Note: you may also use link:https://playwright.dev/docs/test-reporters#junit-reporter[Playwright's built-in flag] (`PLAYWRIGHT_JUNIT_OUTPUT_NAME`) to specify the JUnit XML output directory.
@@ -257,6 +266,9 @@ NOTE: Ensure that you are using version 1.34.2 or later of Playwright. Earlier v
     echo "Prepared arguments for Gradle: $GRADLE_ARGS"
 
     ./gradlew test $GRADLE_ARGS
+
+- store_test_results:
+    ...
 ```
 
 . Update the `glob` command to match your use case. **If your current job is using xref:test-splitting-tutorial#[CircleCI's intelligent test splitting], you must change the `circleci tests split` command to `circleci tests run` with the `--split-by=timings` parameter.**. If you are not using test splitting, `--split-by=timings` can be omitted.
@@ -306,17 +318,22 @@ The snippet above will write the list of test file names to `files.txt`.  On a n
 
 Django takes as input test filenames with a format that uses dots ("."), however, it outputs JUnit XML in a format that uses slashes "/".  To account for this, get the list of test filenames first, change the filenames to be separated by dots "." instead of slashes "/", and pass the filenames into the test command.
 
-[source,yaml]
-----
-# Get the test file names, write them to files.txt, and split them by historical timing data
-circleci tests glob "**/test*.py" | circleci tests run --command=">files.txt xargs echo" --verbose --split-by=timings #split-by-timings is optional
-# Change filepaths into format Django accepts (replace slashes with dots).  Save the filenames in a TESTFILES variable
-cat files.txt | tr "/" "." | sed "s/\.py//g" | sed "s/tests\.//g" > circleci_test_files.txt
-cat circleci_test_files.txt
-TESTFILES=$(cat circleci_test_files.txt)
-# Run the tests (TESTFILES) with the reformatted test file names
-pipenv run coverage run manage.py test --parallel=8 --verbosity=2 $TESTFILES
-----
+```
+- run:
+    name: Run tests
+    command: |
+      # Get the test file names, write them to files.txt, and split them by historical timing data
+      circleci tests glob "**/test*.py" | circleci tests run --command=">files.txt xargs echo" --verbose --split-by=timings #split-by-timings is optional
+      # Change filepaths into format Django accepts (replace slashes with dots).  Save the filenames in a TESTFILES variable
+      cat files.txt | tr "/" "." | sed "s/\.py//g" | sed "s/tests\.//g" > circleci_test_files.txt
+      cat circleci_test_files.txt
+      TESTFILES=$(cat circleci_test_files.txt)
+      # Run the tests (TESTFILES) with the reformatted test file names
+      pipenv run coverage run manage.py test --parallel=8 --verbosity=2 $TESTFILES
+
+- store_test_results:
+    ...
+```
 
 [#known-limitations]
 == Known limitations


### PR DESCRIPTION
1. added in something that some customers are missing when it comes to using the halt command
2. added to output file names section that the halt command is probably needed to avoid a failure if using parallelism
3. added to troubleshooting section an error for an edge case that 3 ppl reported last week
4. add store_test_results to all examples since i've talked to a few customers who forgot to add that because they just copied from the docs and didn't read the prereqs