### PR TITLE
Replace reference to image ARN to image URI in "Pull an image from AWS ECR with OIDC" doc

### DIFF
--- a/jekyll/_cci2/pull-an-image-from-aws-ecr-with-oidc.adoc
+++ b/jekyll/_cci2/pull-an-image-from-aws-ecr-with-oidc.adoc
@@ -84,12 +84,12 @@ If you followed the xref:openid-connect-tokens#set-up-aws[Set up AWS instruction
 jobs:
   job_name:
     docker:
-      - image: <your-image-arn>
+      - image: <your-image-uri>
         aws_auth:
           oidc_role_arn: <your-iam-role-arn>
 ----
 
-. Replace `<your-image-arn>` with the Amazon Resource Name (ARN) of the ECR image you want to pull. This ARN typically follows the format `aws_account_id.dkr.ecr.region.amazonaws.com/repository:tag`.
+. Replace `<your-image-uri>` with the URI of the ECR image you want to pull. This URI typically follows the format `aws_account_id.dkr.ecr.region.amazonaws.com/repository:tag`.
 
 . Replace `<your-iam-role-arn>` with the ARN of the IAM role you want to assume. This is the role you created in the last section.
 


### PR DESCRIPTION
# Description
Changing reference from image ARN to image URI to use when pulling an image from AWS ECR with OIDC.

# Reasons
After following the documentation I noticed that the process is not working with the ARN but with the image URI instead.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
