### PR TITLE
V1 reference refresh: config version

### DIFF
--- a/src-api/source/includes/_builds_and_jobs.md
+++ b/src-api/source/includes/_builds_and_jobs.md
@@ -271,20 +271,14 @@ https://circleci.com/api/v1.1/project/:vcs-type/:username/:project
 }
 ```
 
-### See Also
-
-[Triggering Jobs with the API](https://circleci.com/docs/2.0/api-job-trigger/#section=jobs)
-
 **`POST` Request:** Triggers a new build and then returns a summary of the build.
 
 **Parameter** | **Description**
 ------- | -------------
 revision | The specific revision to build. Default is null and the head of the branch is used. Cannot be used with tag parameter.
 tag | The tag to build. Default is null. Cannot be used with revision parameter.
-parallel | The number of containers to use to run the build. Default is null and the project default is used. This parameter is ignored for builds running on our 2.0 infrastructure.
 build_parameters | Additional environment variables to inject into the build environment. A map of names to values.
 
-**Note** Triggering a new job is not currently supported with configurations that specify `version: 2.1`.
 
 ## Trigger a new Job with a Branch
 
@@ -376,13 +370,12 @@ https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/tree/:branch
 **`POST` Request:** Triggers a new build and then returns a summary of the build.
 
 <aside class="notice">
-For more about build parameters, see 2.0 build parameters <a href="https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-api-v1">for environment variables</a>. The response for “failed” should be a boolean `true` or `null`.
+For more about build parameters, refer to the guide for <a href="https://circleci.com/docs/inject-environment-variables-with-api/#api-v1">injecting environment variables with API v1</a>. The response for “failed” should be a boolean `true` or `null`.
 </aside>
 
 **Parameter** | **Description**
 ------- | -------------
 revision | The specific revision to build. Default is null and the head of the branch is used. Cannot be used with tag parameter.
-parallel | The number of containers to use to run the build. Default is null and the project default is used. This parameter is ignored for builds running on our 2.0 infrastructure.
 build_parameters | Additional environment variables to inject into the build environment. A map of names to values.
 
 **Note** Triggering a new job with a branch is not currently supported with configurations that specify `version: 2.1`.
@@ -447,5 +440,5 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_n
 **`GET` Request** Provides test metadata for a build.
 
 <aside class="notice">
-Learn how to set up your 2.0 builds to <a href="https://circleci.com/docs/2.0/collect-test-data/">Collect Test Metadata</a>.
+Learn how to set up your jobs to <a href="https://circleci.com/docs/collect-test-data//">collect test metadata</a>.
 </aside>

--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -15,30 +15,6 @@ Although RESTful APIs include these 4 HTTP verbs, the CircleCI API does not curr
 Access to billing functions is only available from the CircleCI application.
 </aside>
 
-## Rate Limiting
-
-The CircleCI API is protected by a number of rate limiting measures to ensure the stability of the system. We reserve the right to throttle the requests made by an individual user, or the requests made to individual resources in order to ensure a fair level of service to all of our users.
-
-As the author of an API integration with CircleCI, your integration should expect to be throttled, and should be able to gracefully handle failure.
-There are different protections and limits in place for different parts of the API. In particular, we protect our API against **sudden large bursts of traffic**, and we protect against **sustained high volumes** of requests, for example, frequent polling.
-
-For HTTP APIs, when a request is throttled, you will receive [HTTP status code 429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429). If your integration requires that a throttled request is completed, then you should retry these requests after a delay, using an exponential backoff.
-In most cases, the HTTP 429 response code will be accompanied by the [Retry-After HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After). When this header is present, your integration should wait for the period of time specified by the header value before retrying a request.
-
-## API Syntax
-
-When making an API request, make sure you follow standard REST API syntax and formatting. Adhering to proper REST API syntax ensures that the API server can properly process your request and return a JSON response. To make a request to the CircleCI API, use the format shown in the pane to the right:
-
-```sh
-"https://circleci.com/api/v1.1"
-```
-
-Where:
-
-* https://circleci.com - the resource URL for the API being called.
-* api - the class being called.
-* v1.1 - the API version.
-
 ## Authentication
 
 The CircleCI API utilizes token-based authentication to manage access to the API server and validate that a user has permission to make API requests. Before you can make an API request, you must first add an API token and then verify that you are authenticated by the API server to make requests. The process to add an API token and have the API server authenticate you is described in the sections below.
@@ -100,7 +76,59 @@ the colon ":" tells curl that there's no password.
 
 DEPRECATED (this option will be removed in the future): The API token can be added to the `circle-token` query param:
 
-## Version Control Systems (:vcs-type)
+
+## Summary of API Endpoints
+
+All CircleCI API endpoints begin with `https://circleci.com/api/v1.1/`
+
+### GET Requests
+
+**API** | **Description**
+------- | -------------
+/me | Provides information about the signed in user.
+/projects | Lists all projects you are following on CircleCI, with build information organized by branch.
+ /project/:vcs-type/:username/:project | Returns a build summary for each of the last 30 builds for a single git repo.
+/recent-builds | Returns a build summary for each of the last 30 recent builds, ordered by build\_num.
+/project/:vcs-type/:username/:project/:build_num | Returns full details for a single build. The response includes all of the fields from the build summary. This is also the payload for the [notification webhooks](https://circleci.com/docs/configuration-reference/#notify), in which case this object is the value to a key named ‘payload’.
+/project/:vcs-type/:username/:project/:build_num/artifacts | Lists the artifacts produced by a given build.
+/project/:vcs-type/:username/:project/checkout-key/:fingerprint | Retrieves a checkout key.
+
+### POST Requests
+
+**API** | **Description**
+------- | -------------
+/project/:vcs-type/:username/:project/follow | Follow a new project on CircleCI.
+/project/:vcs-type/:org_name/:project/:build\_num/retry | Retries the build, returns a summary of the new build.
+/project/:vcs-type/:username/:project/:build\_num/cancel | Cancels the build, returns a summary of the build.
+/project/:vcs-type/:username/:project/:build_num/ssh-users | Adds a user to the build's SSH permissions.
+/project/:vcs-type/:username/:project/tree/:branch | Triggers a new build, returns a summary of the build. Optional [build parameters](https://circleci.com/docs/inject-environment-variables-with-api/#api-v1) can be set.
+/project/:vcs-type/:username/:project/ssh-key | Creates an ssh key used to access external systems that require SSH key-based authentication.
+/project/:vcs-type/:username/:project/checkout-key | Creates a new checkout key.
+
+### DELETE Requests
+
+**API** | **Description**
+------- | -------------
+/project/:vcs-type/:username/:project/checkout-key/:fingerprint | Deletes a checkout key.
+/project/:vcs-type/:username/:project/ssh-key | Delete the SSH key from a project.
+
+## Getting Started
+
+### API Syntax
+
+When making an API request, make sure you follow standard REST API syntax and formatting. Adhering to proper REST API syntax ensures that the API server can properly process your request and return a JSON response. To make a request to the CircleCI API, use the format shown in the pane to the right:
+
+```sh
+"https://circleci.com/api/v1.1"
+```
+
+Where:
+
+* https://circleci.com - the resource URL for the API being called.
+* api - the class being called.
+* v1.1 - the API version.
+
+## Version Control Systems
 
 ```sh
 curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/tree/:branch
@@ -108,10 +136,15 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/tree/:br
 
 New with v1.1 of the API, for endpoints under /project you will now need to tell CircleCI what version control system type your project uses. You may currently select either ‘github’ or ‘bitbucket’. The command for recent builds for a project would be formatted like the example shown in the right pane.
 
-## F/OSS
+## Rate Limiting
 
-If you have a [Free / Open Source Software (F/OSS) project] (https://www.gnu.org/philosophy/free-sw.html), and have the setting turned on in Advanced Settings in your project dashboard, some read-only /project endpoints will return the requested data without the need for a token. People will also be able to view the build results dashboard for the project as well.
+The CircleCI API is protected by a number of rate limiting measures to ensure the stability of the system. We reserve the right to throttle the requests made by an individual user, or the requests made to individual resources in order to ensure a fair level of service to all of our users.
 
+As the author of an API integration with CircleCI, your integration should expect to be throttled, and should be able to gracefully handle failure.
+There are different protections and limits in place for different parts of the API. In particular, we protect our API against **sudden large bursts of traffic**, and we protect against **sustained high volumes** of requests, for example, frequent polling.
+
+For HTTP APIs, when a request is throttled, you will receive [HTTP status code 429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429). If your integration requires that a throttled request is completed, then you should retry these requests after a delay, using an exponential backoff.
+In most cases, the HTTP 429 response code will be accompanied by the [Retry-After HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After). When this header is present, your integration should wait for the period of time specified by the header value before retrying a request.
 
 ## List Ordering
 
@@ -139,48 +172,6 @@ If no accept header is specified (or it is empty), CircleCI will return the data
 
 Some CircleCI APIs may emit a `Cache-Control` header to indicate that the response may be cached for a period of time. This feature can be used to avoid unnecessary re-fetching of data that will not change. If you plan to make a large volume of API requests you are strongly encouraged to make use of this header in order to improve your performance and lower your risk of being rate limited.
 
-## Getting Started
+## F/OSS
 
-CircleCI 1.0 and 2.0 are supported by API version 1.1 as documented in the following sections:
-
-* Summary of API Endpoints
-* User
-* Projects
-* Test Metadata
-* SSH Keys
-* Heroku Keys
-
-## Summary of API Endpoints
-
-All CircleCI API endpoints begin with `https://circleci.com/api/v1.1/`
-
-### GET Requests
-
-**API** | **Description**
-------- | -------------
-/me | Provides information about the signed in user.
-/projects | Lists all projects you are following on CircleCI, with build information organized by branch.
- /project/:vcs-type/:username/:project | Returns a build summary for each of the last 30 builds for a single git repo.
-/recent-builds | Returns a build summary for each of the last 30 recent builds, ordered by build\_num.
-/project/:vcs-type/:username/:project/:build_num | Returns full details for a single build. The response includes all of the fields from the build summary. This is also the payload for the [notification webhooks](https://circleci.com/docs/2.0/configuration-reference/#notify), in which case this object is the value to a key named ‘payload’.
-/project/:vcs-type/:username/:project/:build_num/artifacts | Lists the artifacts produced by a given build.
-/project/:vcs-type/:username/:project/checkout-key/:fingerprint | Retrieves a checkout key.
-
-### POST Requests
-
-**API** | **Description**
-------- | -------------
-/project/:vcs-type/:username/:project/follow | Follow a new project on CircleCI.
-/project/:vcs-type/:org_name/:project/:build\_num/retry | Retries the build, returns a summary of the new build.
-/project/:vcs-type/:username/:project/:build\_num/cancel | Cancels the build, returns a summary of the build.
-/project/:vcs-type/:username/:project/:build_num/ssh-users | Adds a user to the build's SSH permissions.
-/project/:vcs-type/:username/:project/tree/:branch | Triggers a new build, returns a summary of the build. Optional [build parameters](https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-api-v1) can be set.
-/project/:vcs-type/:username/:project/ssh-key | Creates an ssh key used to access external systems that require SSH key-based authentication.
-/project/:vcs-type/:username/:project/checkout-key | Creates a new checkout key.
-
-### DELETE Requests
-
-**API** | **Description**
-------- | -------------
-/project/:vcs-type/:username/:project/checkout-key/:fingerprint | Deletes a checkout key.
-/project/:vcs-type/:username/:project/ssh-key | Delete the SSH key from a project.
+If you have a [Free / Open Source Software (F/OSS) project] (https://www.gnu.org/philosophy/free-sw.html), and have the setting turned on in Advanced Settings in your project dashboard, some read-only /project endpoints will return the requested data without the need for a token. People will also be able to view the build results dashboard for the project as well.

--- a/src-api/source/includes/_overview.md
+++ b/src-api/source/includes/_overview.md
@@ -128,13 +128,13 @@ Where:
 * api - the class being called.
 * v1.1 - the API version.
 
-## Version Control Systems
+### Version Control Systems
 
 ```sh
 curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/tree/:branch
 ```
 
-New with v1.1 of the API, for endpoints under /project you will now need to tell CircleCI what version control system type your project uses. You may currently select either ‘github’ or ‘bitbucket’. The command for recent builds for a project would be formatted like the example shown in the right pane.
+New with v1.1 of the API, for endpoints under `/project`` you will now need to tell CircleCI what version control system type your project uses. You may currently select either ‘github’ or ‘bitbucket’. The command for recent builds for a project would be formatted like the example shown in the right pane.
 
 ## Rate Limiting
 


### PR DESCRIPTION
# Description
* Remove the `parallel` param from the Trigger a new job and Trigger a new job with branch calls, which make references to 2.0 architecture
* Edits to Overview
    * The existing 'Getting Started' section doesn't appear to serve any function so I've replaced that content with the 'API syntax' section for now
    * Rearranged subsections to reflect this general flow: Authentication -> Get started (API syntax) -> Additional details about requests -> Additional details about responses

# Reasons
References to "CircleCI 1.0/2.0" is no longer relevant to most users

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
