### PR TITLE
Remove broken link from workflows.md header

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -8,8 +8,6 @@ contentTags:
   - Server v4.x
   - Server v3.x
 suggested:
-  - title: Manual job approval and scheduled workflow runs
-    link: https://circleci.com/blog/manual-job-approval-and-scheduled-workflow-runs/
   - title: Filter workflows by branch
     link: https://support.circleci.com/hc/en-us/articles/115015953868?input_string=how+can+i+share+the+data+between+all+the+jobs+in+a+workflow
   - title: How to trigger a workflow


### PR DESCRIPTION
# Description
Removes a link to a blog post that no longer exists on the CircleCI site.

# Reasons
The link to a blog article no longer works, and even worse, redirects to this page.

The content is available on web.archive.org if there's a desire to re-publish it in the blog instead of removing this link.

http://web.archive.org/web/20201111192633/https://circleci.com/blog/manual-job-approval-and-scheduled-workflow-runs/

# Content Checklist
NA