### PR TITLE
[GitHub Apps] integration page

### DIFF
--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -92,8 +92,6 @@ You can add or delete a configuration source for your project. If you followed t
 
 Once you define a configuration source, you can set up a trigger that points to that configuration.
 
-image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-configuration.png[Configuration setup page]
-
 [#triggers]
 === Triggers
 
@@ -104,8 +102,6 @@ If you followed the steps above to connect GitHub, a trigger set with GitHub as 
 image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-triggers.png[Trigger setup page]
 
 When the CircleCI GitHub App is installed for your organization, GitHub starts to send events for the repositories you have granted access to. When a trigger is created CircleCI has enough information to use the event data to determine if a pipeline shoud be triggered.
-
-**Trigger filters** and editing triggers is not currently supported for GitHub App integrations.
 
 [#project-settings-advanced]
 === Advanced
@@ -166,17 +162,22 @@ There are a number of built-in environment variables that are not available in G
 The following sections are features of CircleCI which are not currently fully supported. These features are planned for future releases.
 
 [#manual-trigger-pipeline-option]
-== Manual trigger pipeline option
+=== Manual trigger pipeline option
 The ability to manually trigger a pipeline from the web app is not currently supported for GitHub Apps projects.
 
 [#in-app-config-editor]
-== In-app config editor
+=== In-app config editor
 The in-app config editor is currently **only** available for GitHub App accounts during project creation.
 
 [#account-integrations]
 === Account integrations
 
 There is currently no method to manage the connection with GitHub outside of the project setup, trigger, and configuration settings. CircleCI is working on enabling users to manage their users’ GitHub identity as part of their user profile's account integration settings.
+
+[#scheudled-pipelines]
+=== Scheduled pipelines
+
+The ability to xref:scheduled-pipelines#[schedule pipelines] is not currently supported for GitHub Apps projects. This feature is planned for a future release.
 
 [#auto-cancel-redundant-workflows]
 === Auto-cancel redundant workflows

--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -97,25 +97,15 @@ image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-configu
 [#triggers]
 === Triggers
 
-**The scheduled pipelines feature is not currently available for use with GitHub App integrations.** Triggers are described below, including how to use filters to trigger pipelines based on certain conditions.
+**The scheduled pipelines feature is not currently available for use with GitHub App integrations.**
 
-Add a trigger that specifies which configuration source starts a pipeline. If you followed the steps above to connect GitHub, a trigger set with GitHub as the configuration source has been automatically added for you.
+If you followed the steps above to connect GitHub, a trigger set with GitHub as the configuration source has been automatically added for you.
 
 image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-triggers.png[Trigger setup page]
 
-Triggers and trigger rules determine how CircleCI handles events from the source of change, in this case, GitHub.
+When the CircleCI GitHub App is installed for your organization, GitHub starts to send events for the repositories you have granted access to. When a trigger is created CircleCI has enough information to use the event data to determine if a pipeline shoud be triggered.
 
-When a trigger is created, CircleCI registers a webhook with GitLab. Push events from GitLab are sent to CircleCI. CircleCI then uses the event data to determine _if_ a pipeline should run, and if so, _which_ pipeline should be run.
-
-In addition to a configuration source, each trigger includes the webhook URL, and in this scenario, a CircleCI-created GitLab token. The webhook URL and GitLab token are used to securely register the webhook within GitLab in order to receive push events from your GitLab repo.
-
-image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-edit-trigger.png[Trigger details]
-
-**Trigger filters** allow you to determine when a trigger should initiate a build based on the parameters provided by Gitlab’s webhook. CircleCI provides some common options, for example, only build on merge requests, but you can also build your own rules using the custom filter option. For example, a custom filter would allow you to only build on a specific branch or user.
-
-image::{{site.baseurl}}/assets/img/docs/gl-preview/gitlab-preview-project-settings-customize-triggers.png[Trigger details]
-
-NOTE: Currently, the only fields that can be edited for existing filters are **Trigger Name** and the **Filters** radio buttons.
+**Trigger filters** and editing triggers is not currently supported for GitHub App integrations.
 
 [#project-settings-advanced]
 === Advanced
@@ -127,12 +117,12 @@ NOTE: Currently, the only fields that can be edited for existing filters are **T
 [#project-settings-ssh-keys]
 === GitHub project SSH keys
 
-When creating a project in CircleCI, you will create and add SSH keys, which are used to check out code from your repo. Each configuration you create generates a new SSH key to access the code in the repo associated with that configuration. At this time, only **Additional SSH Keys** are applicable to GitHub App integrations.
+When creating a project in CircleCI, you will create and add SSH keys. At this time, only **Additional SSH Keys** are applicable to GitHub App integrations.
 
 [#create-ssh-key]
 ==== Create an SSH key
 
-You will be guided through the SSH key generation processing in the CircleCI web app. The steps are as follows:
+You will be guided through the SSH key generation process in the CircleCI web app on the **Create Project** page. The steps are as follows:
 
 . Create an SSH key-pair by using the following command. When prompted to enter a passphrase, do **not** enter one:
 +
@@ -140,9 +130,9 @@ You will be guided through the SSH key generation processing in the CircleCI web
   ssh-keygen -t ed25519 -C "your_email@example.com"
 ```
 
-. Go to your project on link:https://gitlab.com/[GitLab] and navigate to **Settings > Repository**, and expand the **Deploy keys** section. Enter a title in the "Title" field, then copy and paste the public key you created in step 1. Check **Grant write permissions to this key** box, then click **Add key**.
+. Go to your GitHub repository menu:Settings[Security > Deploy Keys]. Copy and paste your public key here. We **do not** require write access. The title can be anything you want.
 
-. Go to your project settings in the CircleCI app, select **SSH Keys**, and **Add SSH key**. In the "Hostname" field, enter `gitlab.com` and add the private key you created in step 1. Then click **Add SSH Key**.
+. In the CircleCI web app **Create Project** page, copy and paste your private key, including `---BEGIN RSA PRIVATE KEY---` and `---END RSA PRIVATE KEY---`, into the **GitHub personal SSH key** field.
 
 When you push to your GitLab repository from a job, CircleCI will use the SSH key you added.
 
@@ -164,21 +154,6 @@ Add or remove users, and manage user roles for the organization as well as user 
 == Roles and permissions
 
 CircleCI users have different abilities depending on assigned roles in a particular organization. For a detailed list of CircleCI org and project roles and associated permissions, see the xref:roles-and-permissions-overview#[Roles and permissions] page.
-
-[#user-settings]
-== User settings
-
-[#user-account-integrations]
-=== Account integrations
-
-In the **User Settings** section of your CircleCI user profile, you have the ability to enable multiple account integrations.
-
-//image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-account-integrations.png[User account integrations page]
-
-The ability to connect to multiple account integrations on CircleCI allows you to:
-
-- Easily access all source controls on your account
-- Use all authentication methods available on CircleCI
 
 [#deprecated-system-environment-variables]
 == Deprecated system environment variables

--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -12,7 +12,7 @@ contentTags:
 
 [NOTE]
 ====
-**GitHub authentication with CircleCI is changing**. Starting 14th August 2023 when you authenticate your CircleCI account with GitHub, this will be done through our GitHub App, rather than the GitHub OAuth app. You can see which account type you have by heading to the CircleCI web app and inspecting the URL in your browser:
+**GitHub authentication with CircleCI is changing**. Starting August 2023 when you authenticate your CircleCI account with GitHub, you may find this will be done through our GitHub App, rather than the GitHub OAuth app. You can see which account type you have by heading to the CircleCI web app and inspecting the URL in your browser:
 
 * This style of URL indicates you authenticated with the **GitHub App**: `https://app.circleci.com/pipelines/circleci/UTxCZDiJ9MLGLC8hR1ZDmg`
 * This style of URL indicates you authenticated with the **GitHub OAuth app**: `https://app.circleci.com/github/<your GitHub username>`

--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -6,7 +6,7 @@ contentTags:
 = GitHub App integration overview
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn how to integrate GitLab with CircleCI to manage your GitLab CI/CD pipelines with our GitLab CI step-by-step tutorial.
+:page-description: Learn how to integrate GitHub with CircleCI to manage your GitHub CI/CD pipelines.
 :icons: font
 :experimental:
 
@@ -24,16 +24,23 @@ If your CircleCI account is authenticated through the **GitHub App**, the conten
 
 This page walks you through integrating a GitHub project with CircleCI. The sections below introduce you to concepts and ways to manage CI/CD (continuous integration and continuous delivery) pipelines for your GitHub project. CircleCI features that are in development for GitHub projects are detailed in the <<coming-soon>> section.
 
+The following limits are currently in place for GitHub App integrations:
+
+- Each user can create up to three organizations.
+- Each organization under a Free plan can have up to 10 projects.
+
+If you need more organizations or projects, consider upgrading to a xref:plan-overview#[Paid plan], or link:https://support.circleci.com/hc/en-us/requests/new[contact our Support team].
+
 [#sign-up]
 == Steps to integrate GitHub projects with CircleCI
 
-Follow the steps on the xref:first-steps#gitlab-signup[Sign up and try CircleCI] page to connect your GitLab account, which creates your CircleCI organization.
+Follow the steps on the xref:first-steps#[Sign up and try CircleCI] page to connect your GitHub account, which creates your CircleCI organization.
 
 When you create a new organization and connect your GitHub account, you will be prompted to create a new project from a repository. You will be presented with the following options to set up a CircleCI configuration for your project:
 
 * **Faster**: Commit a starter CI pipeline to a new branch.
 +
-CircleCI automatically creates a new branch and commits a basic configuration file. You may make further changes to the file afterwards in your GitLab repo.
+CircleCI automatically creates a new branch and commits a basic configuration file. You may make further changes to the file afterwards in your GitHub repo.
 
 * **Fast**: Use a `config.yml` template that you can edit and save.
 +
@@ -42,15 +49,6 @@ You can choose a sample `.circleci/config.yml` to best fit your project from a v
 Choosing **Faster** automatically triggers a pipeline once you create the project.
 
 NOTE: If you are new to CircleCI, you may wish to get started with our xref:getting-started#[Quickstart guide], our xref:hello-world#[Hello world] examples, or take a look at some of our xref:sample-config#[sample configurations] that demonstrate different types of workflows. The xref:configuration-reference#[Configuration reference] is a full reference to the keys used in a `.circleci/config.yml` file.
-
-When you connect a repo with your CircleCI project, behind the scenes, CircleCI is registering a webhook within your GitHub repository. You may verify this once you have successfully created the project by navigating to your repository's **Settings > Webhooks** page.
-
-The following limits are currently in place for GitLab integrations:
-
-- Each user can create up to three organizations.
-- Each organization under a Free plan can have up to 10 projects.
-
-If you need more organizations or projects, consider upgrading to a xref:plan-overview#[Paid plan], or link:https://support.circleci.com/hc/en-us/requests/new[contact our Support team].
 
 [#trigger-pipeline]
 == Trigger a pipeline in CircleCI
@@ -74,7 +72,7 @@ Within CircleCI, a project can have one or more **configurations**, which are pi
 
 A project can have one or more **triggers**, which are events from a source of change. _Triggers_ include, but are not limited to, a VCS. A trigger determines which configuration should be used to start a pipeline.
 
-The following settings are found by clicking the **Project Settings** button within your project. At this time, both configurations and triggers are limited to GitLab integrations.
+The following settings are found by clicking the **Project Settings** button within your project. At this time, both configurations and triggers are limited to GitLab and GitHub App integrations.
 
 [#people]
 === People
@@ -90,9 +88,7 @@ For a complete list of permissions, see the xref:roles-and-permissions-overview#
 [#configuration]
 === Configuration
 
-Currently, you can add or delete a configuration source for your project. If you followed the steps above to connect GitLab, a GitLab configuration source has been automatically added for you.
-
-For GitLab Self-managed, you are able to select any instance that you have previously added as a configuration source. If you wish to set a different feature branch or repository from a self-managed instance as a new configuration source, you will first need to add a new connection via your xref:#organization-settings-integrations[**Organization Settings**]. In either case, you will also need to enter your personal access token again to authorize this connection.
+You can add or delete a configuration source for your project. If you followed the steps above to connect GitHub, a GitHub configuration source has been automatically added for you.
 
 Once you define a configuration source, you can set up a trigger that points to that configuration.
 
@@ -101,13 +97,13 @@ image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-configu
 [#triggers]
 === Triggers
 
-**The scheduled pipelines feature is not currently available for use with GitLab.** GitLab triggers are described below, including how to use filters to trigger pipelines based on certain conditions.
+**The scheduled pipelines feature is not currently available for use with GitHub App integrations.** Triggers are described below, including how to use filters to trigger pipelines based on certain conditions.
 
-Add a trigger that specifies which configuration source starts a pipeline. If you followed the steps above to connect GitLab, a trigger set with GitLab as the configuration source has been automatically added for you.
+Add a trigger that specifies which configuration source starts a pipeline. If you followed the steps above to connect GitHub, a trigger set with GitHub as the configuration source has been automatically added for you.
 
 image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-triggers.png[Trigger setup page]
 
-Triggers and trigger rules determine how CircleCI handles events from the source of change, in this case, GitLab.
+Triggers and trigger rules determine how CircleCI handles events from the source of change, in this case, GitHub.
 
 When a trigger is created, CircleCI registers a webhook with GitLab. Push events from GitLab are sent to CircleCI. CircleCI then uses the event data to determine _if_ a pipeline should run, and if so, _which_ pipeline should be run.
 
@@ -129,14 +125,16 @@ NOTE: Currently, the only fields that can be edited for existing filters are **T
 - At this time, auto-cancel redundant workflows is not supported. Refer to the xref:skip-build#auto-cancelling[Auto cancelling] section of the `skip` or `cancel` jobs and workflows page for more details.
 
 [#project-settings-ssh-keys]
-=== GitLab project SSH keys
+=== GitHub project SSH keys
 
-When creating a project in CircleCI, you will create and add SSH keys, which are used to check out code from your repo. Each configuration you create generates a new SSH key to access the code in the repo associated with that configuration. At this time, only **Additional SSH Keys** are applicable to GitLab projects.
+When creating a project in CircleCI, you will create and add SSH keys, which are used to check out code from your repo. Each configuration you create generates a new SSH key to access the code in the repo associated with that configuration. At this time, only **Additional SSH Keys** are applicable to GitHub App integrations.
 
 [#create-ssh-key]
 ==== Create an SSH key
 
-. Create an SSH key-pair by following the link:https://docs.gitlab.com/ee/user/ssh.html[GitLab instructions]. When prompted to enter a passphrase, do **not** enter one (below is one example command to generate a key on macOS):
+You will be guided through the SSH key generation processing in the CircleCI web app. The steps are as follows:
+
+. Create an SSH key-pair by using the following command. When prompted to enter a passphrase, do **not** enter one:
 +
 ```shell
   ssh-keygen -t ed25519 -C "your_email@example.com"
@@ -151,7 +149,7 @@ When you push to your GitLab repository from a job, CircleCI will use the SSH ke
 For more information on SSH keys, please visit the xref:add-ssh-key#[Adding an SSH key to CircleCI] page.
 
 [#organization-settings]
-== Organization settings - GitLab
+== Organization settings
 
 For GitHub Apps integrations, organizations and users are managed independently from your VCS. Organizations and users are considered CircleCI organizations and users, with their own roles and permissions that do not rely on those defined in your VCS.
 
@@ -192,6 +190,14 @@ There are a number of built-in environment variables that are not available in G
 
 The following sections are features of CircleCI which are not currently fully supported. These features are planned for future releases.
 
+[#manual-trigger-pipeline-option]
+== Manual trigger pipeline option
+The ability to manually trigger a pipeline from the web app is not currently supported for GitHub Apps projects.
+
+[#in-app-config-editor]
+== In-app config editor
+The in-app config editor is currently **only** available for GitHub App accounts during project creation.
+
 [#account-integrations]
 === Account integrations
 
@@ -210,12 +216,17 @@ Passing secrets to forked pull requests is not currently supported.
 [#stop-building]
 === Stop building
 
-GitLab integrations do not currently support the **Stop Building** option that can normally be found in **Project settings**. The recommendation is to delete your webhooks in your GitLab repo if you no longer want a CircleCI pipeline to run.
+GitHub App integrations do not currently support the **Stop Building** option that can normally be found in **Project settings**.
+
+The recommendation is to either:
+
+* Suspend your installation. This would stop sending all events to CircleCI, so all builds will stop. This option is available in GitHub **Organization settings** under the **GitHub Apps** menu option.
+* Stop a single project from sending events to CircleCI. This option is available in GitHub **Organization settings** under the **GitHub Apps** menu option. Under **Repository access**, select **Only select repositories** and deselect the repository you want to stop building.
 
 [#ssh-rerun]
 === SSH rerun
 
-SSH reruns are not currently supported for GitLab projects. This feature is in development and will be available soon.
+SSH reruns are not currently supported for GitHub App projects. This feature is in development and will be available soon.
 
 [#additional-ssh-keys-only]
 === Additional SSH keys only
@@ -225,7 +236,7 @@ Deploy keys and user keys are not used by GitHub Apps integrations. All keys are
 [#free-and-open-source-setting]
 === Free and open source setting
 
-Open source plans are not currently available to GitLab customers. CircleCI will keep the open source community up to date as work continues to support this.
+Open source plans are not currently available to GitHub App customers. CircleCI will keep the open source community up to date as work continues to support this.
 
 [#test-insights]
 === Test Insights

--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -130,7 +130,7 @@ You will be guided through the SSH key generation process in the CircleCI web ap
 
 . In the CircleCI web app **Create Project** page, copy and paste your private key, including `---BEGIN RSA PRIVATE KEY---` and `---END RSA PRIVATE KEY---`, into the **GitHub personal SSH key** field.
 
-When you push to your GitLab repository from a job, CircleCI will use the SSH key you added.
+When you push to your GitHub repository from a job, CircleCI will use the SSH key you added.
 
 For more information on SSH keys, please visit the xref:add-ssh-key#[Adding an SSH key to CircleCI] page.
 
@@ -202,12 +202,12 @@ The recommendation is to either:
 [#ssh-rerun]
 === SSH rerun
 
-SSH reruns are not currently supported for GitHub App projects. This feature is in development and will be available soon.
+SSH reruns are not currently supported for GitHub App projects. This feature will be available in a future release.
 
 [#additional-ssh-keys-only]
 === Additional SSH keys only
 
-Deploy keys and user keys are not used by GitHub Apps integrations. All keys are stored in **Project Settings > Additional SSH Keys**. Use the **Create Project** option to get a project set up. You will be guided through creating SSH keys for your project.
+Deploy keys and user keys are not used by GitHub Apps integrations. All keys are stored in menu:Project Settings[ Additional SSH Keys]. Use the **Create Project** option to get a project set up. You will be guided through creating SSH keys for your project.
 
 [#free-and-open-source-setting]
 === Free and open source setting

--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -1,0 +1,244 @@
+---
+contentTags:
+  platform:
+  - Cloud
+---
+= GitHub App integration overview
+:page-layout: classic-docs
+:page-liquid:
+:page-description: Learn how to integrate GitLab with CircleCI to manage your GitLab CI/CD pipelines with our GitLab CI step-by-step tutorial.
+:icons: font
+:experimental:
+
+[NOTE]
+====
+**GitHub authentication with CircleCI is changing**. Starting 14th August 2023 when you authenticate your CircleCI account with GitHub, this will be done through our GitHub App, rather than the GitHub OAuth app. You can see which account type you have by heading to the CircleCI web app and inspecting the URL in your browser:
+
+* This style of URL indicates you authenticated with the **GitHub App**: `https://app.circleci.com/pipelines/circleci/UTxCZDiJ9MLGLC8hR1ZDmg`
+* This style of URL indicates you authenticated with the **GitHub OAuth app**: `https://app.circleci.com/github/<your GitHub username>`
+
+For more information about the differences, see the link:https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps[GitHub docs comparison page].
+====
+
+If your CircleCI account is authenticated through the **GitHub App**, the content on this page is for you.
+
+This page walks you through integrating a GitHub project with CircleCI. The sections below introduce you to concepts and ways to manage CI/CD (continuous integration and continuous delivery) pipelines for your GitHub project. CircleCI features that are in development for GitHub projects are detailed in the <<coming-soon>> section.
+
+[#sign-up]
+== Steps to integrate GitHub projects with CircleCI
+
+Follow the steps on the xref:first-steps#gitlab-signup[Sign up and try CircleCI] page to connect your GitLab account, which creates your CircleCI organization.
+
+When you create a new organization and connect your GitHub account, you will be prompted to create a new project from a repository. You will be presented with the following options to set up a CircleCI configuration for your project:
+
+* **Faster**: Commit a starter CI pipeline to a new branch.
++
+CircleCI automatically creates a new branch and commits a basic configuration file. You may make further changes to the file afterwards in your GitLab repo.
+
+* **Fast**: Use a `config.yml` template that you can edit and save.
++
+You can choose a sample `.circleci/config.yml` to best fit your project from a variety of templates (for example, Node.js, Python, iOS apps). You can make changes to the file in CircleCI before saving. The config is committed on a new branch.
+
+Choosing **Faster** automatically triggers a pipeline once you create the project.
+
+NOTE: If you are new to CircleCI, you may wish to get started with our xref:getting-started#[Quickstart guide], our xref:hello-world#[Hello world] examples, or take a look at some of our xref:sample-config#[sample configurations] that demonstrate different types of workflows. The xref:configuration-reference#[Configuration reference] is a full reference to the keys used in a `.circleci/config.yml` file.
+
+When you connect a repo with your CircleCI project, behind the scenes, CircleCI is registering a webhook within your GitHub repository. You may verify this once you have successfully created the project by navigating to your repository's **Settings > Webhooks** page.
+
+The following limits are currently in place for GitLab integrations:
+
+- Each user can create up to three organizations.
+- Each organization under a Free plan can have up to 10 projects.
+
+If you need more organizations or projects, consider upgrading to a xref:plan-overview#[Paid plan], or link:https://support.circleci.com/hc/en-us/requests/new[contact our Support team].
+
+[#trigger-pipeline]
+== Trigger a pipeline in CircleCI
+
+When you create a new project using the **Faster** (commit a starter CI pipeline) option described in the section above, a pipeline is automatically triggered. You should see the pipeline running shortly after you are taken to the CircleCI dashboard.
+
+If you use the **Fast** config setup, the pipeline is not triggered until you save the `.circleci/config.yml` by clicking the **Commit and Run** button in the web app.
+
+Each time you push changes to your GitHub repository, a new pipeline is triggered and you should see it running for the project within the CircleCI web app.
+
+image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-successful-pipeline.png[Successful pipeline run]
+
+Editing an existing CircleCI configuration within the web app is not currently available. You may make further changes to the config in your GitHub repo. Committing further changes in your repo will automatically trigger a pipeline.
+
+Manually triggering a pipeline from the CircleCI web app is not available at this time.
+
+[#project-settings]
+== Project settings
+
+Within CircleCI, a project can have one or more **configurations**, which are pipeline definitions. _Configurations_ include, but are not limited to, a `.circleci/config.yml` file in your repo.
+
+A project can have one or more **triggers**, which are events from a source of change. _Triggers_ include, but are not limited to, a VCS. A trigger determines which configuration should be used to start a pipeline.
+
+The following settings are found by clicking the **Project Settings** button within your project. At this time, both configurations and triggers are limited to GitLab integrations.
+
+[#people]
+=== People
+
+Project roles give control over which users have access to which projects within an organization. This enables teams to have limited access to only their projects, while managers and others can have broader organizational access. The access options are:
+
+* Admin: Read and write access to the project and all settings and ability to manage other users' access.
+* Contributor: Read and write access to the project and some settings.
+* Viewer: Read only access to the project and some settings.
+
+For a complete list of permissions, see the xref:roles-and-permissions-overview#[Roles and permissions overview] page.
+
+[#configuration]
+=== Configuration
+
+Currently, you can add or delete a configuration source for your project. If you followed the steps above to connect GitLab, a GitLab configuration source has been automatically added for you.
+
+For GitLab Self-managed, you are able to select any instance that you have previously added as a configuration source. If you wish to set a different feature branch or repository from a self-managed instance as a new configuration source, you will first need to add a new connection via your xref:#organization-settings-integrations[**Organization Settings**]. In either case, you will also need to enter your personal access token again to authorize this connection.
+
+Once you define a configuration source, you can set up a trigger that points to that configuration.
+
+image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-configuration.png[Configuration setup page]
+
+[#triggers]
+=== Triggers
+
+**The scheduled pipelines feature is not currently available for use with GitLab.** GitLab triggers are described below, including how to use filters to trigger pipelines based on certain conditions.
+
+Add a trigger that specifies which configuration source starts a pipeline. If you followed the steps above to connect GitLab, a trigger set with GitLab as the configuration source has been automatically added for you.
+
+image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-triggers.png[Trigger setup page]
+
+Triggers and trigger rules determine how CircleCI handles events from the source of change, in this case, GitLab.
+
+When a trigger is created, CircleCI registers a webhook with GitLab. Push events from GitLab are sent to CircleCI. CircleCI then uses the event data to determine _if_ a pipeline should run, and if so, _which_ pipeline should be run.
+
+In addition to a configuration source, each trigger includes the webhook URL, and in this scenario, a CircleCI-created GitLab token. The webhook URL and GitLab token are used to securely register the webhook within GitLab in order to receive push events from your GitLab repo.
+
+image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-project-settings-edit-trigger.png[Trigger details]
+
+**Trigger filters** allow you to determine when a trigger should initiate a build based on the parameters provided by Gitlab’s webhook. CircleCI provides some common options, for example, only build on merge requests, but you can also build your own rules using the custom filter option. For example, a custom filter would allow you to only build on a specific branch or user.
+
+image::{{site.baseurl}}/assets/img/docs/gl-preview/gitlab-preview-project-settings-customize-triggers.png[Trigger details]
+
+NOTE: Currently, the only fields that can be edited for existing filters are **Trigger Name** and the **Filters** radio buttons.
+
+[#project-settings-advanced]
+=== Advanced
+
+- You can enable dynamic configuration using setup workflows in CircleCI. To learn about dynamic configuration, read the xref:dynamic-config#[Dynamic configuration] guide.
+- At this time, the **Free and Open Source** setting is not currently supported, but there are plans to make this available in the future.
+- At this time, auto-cancel redundant workflows is not supported. Refer to the xref:skip-build#auto-cancelling[Auto cancelling] section of the `skip` or `cancel` jobs and workflows page for more details.
+
+[#project-settings-ssh-keys]
+=== GitLab project SSH keys
+
+When creating a project in CircleCI, you will create and add SSH keys, which are used to check out code from your repo. Each configuration you create generates a new SSH key to access the code in the repo associated with that configuration. At this time, only **Additional SSH Keys** are applicable to GitLab projects.
+
+[#create-ssh-key]
+==== Create an SSH key
+
+. Create an SSH key-pair by following the link:https://docs.gitlab.com/ee/user/ssh.html[GitLab instructions]. When prompted to enter a passphrase, do **not** enter one (below is one example command to generate a key on macOS):
++
+```shell
+  ssh-keygen -t ed25519 -C "your_email@example.com"
+```
+
+. Go to your project on link:https://gitlab.com/[GitLab] and navigate to **Settings > Repository**, and expand the **Deploy keys** section. Enter a title in the "Title" field, then copy and paste the public key you created in step 1. Check **Grant write permissions to this key** box, then click **Add key**.
+
+. Go to your project settings in the CircleCI app, select **SSH Keys**, and **Add SSH key**. In the "Hostname" field, enter `gitlab.com` and add the private key you created in step 1. Then click **Add SSH Key**.
+
+When you push to your GitLab repository from a job, CircleCI will use the SSH key you added.
+
+For more information on SSH keys, please visit the xref:add-ssh-key#[Adding an SSH key to CircleCI] page.
+
+[#organization-settings]
+== Organization settings - GitLab
+
+For GitHub Apps integrations, organizations and users are managed independently from your VCS. Organizations and users are considered CircleCI organizations and users, with their own roles and permissions that do not rely on those defined in your VCS.
+
+To manage settings at the organization level, click btn:[Organization Settings] in the CircleCI web app sidebar.
+
+[#organization-settings-people]
+=== People
+
+Add or remove users, and manage user roles for the organization as well as user invites. See the xref:roles-and-permissions-overview#[Roles and permissions overview] page for full details.
+
+[#roles-and-permissions]
+== Roles and permissions
+
+CircleCI users have different abilities depending on assigned roles in a particular organization. For a detailed list of CircleCI org and project roles and associated permissions, see the xref:roles-and-permissions-overview#[Roles and permissions] page.
+
+[#user-settings]
+== User settings
+
+[#user-account-integrations]
+=== Account integrations
+
+In the **User Settings** section of your CircleCI user profile, you have the ability to enable multiple account integrations.
+
+//image::{{site.baseurl}}/assets/img/docs/gl-ga/gitlab-ga-account-integrations.png[User account integrations page]
+
+The ability to connect to multiple account integrations on CircleCI allows you to:
+
+- Easily access all source controls on your account
+- Use all authentication methods available on CircleCI
+
+[#deprecated-system-environment-variables]
+== Deprecated system environment variables
+
+There are a number of built-in environment variables that are not available in GitHub-based projects for accounts authenticated through GitHub Apsps. VCS support for each environment variable is indicated in the xref:variables#built-in-environment-variables[Built-in environment variables] table on the Project values and variables page. If your pipelines need these environment variables, we recommend you use suitable replacements from the available xref:pipeline-variables#[pipeline values].
+
+[#coming-soon]
+== Coming soon
+
+The following sections are features of CircleCI which are not currently fully supported. These features are planned for future releases.
+
+[#account-integrations]
+=== Account integrations
+
+There is currently no method to manage the connection with GitHub outside of the project setup, trigger, and configuration settings. CircleCI is working on enabling users to manage their users’ GitHub identity as part of their user profile's account integration settings.
+
+[#auto-cancel-redundant-workflows]
+=== Auto-cancel redundant workflows
+
+Auto-cancel redundant workflows is not currently supported. It is often used to remove noise from the pipeline page and lower the time to feedback for a commit. Refer to the xref:skip-build#auto-cancelling[Skip or cancel jobs and workflows] page for more details.
+
+[#passing-secrets-to-forked-pull-requests]
+=== Passing secrets to forked pull requests
+
+Passing secrets to forked pull requests is not currently supported.
+
+[#stop-building]
+=== Stop building
+
+GitLab integrations do not currently support the **Stop Building** option that can normally be found in **Project settings**. The recommendation is to delete your webhooks in your GitLab repo if you no longer want a CircleCI pipeline to run.
+
+[#ssh-rerun]
+=== SSH rerun
+
+SSH reruns are not currently supported for GitLab projects. This feature is in development and will be available soon.
+
+[#additional-ssh-keys-only]
+=== Additional SSH keys only
+
+Deploy keys and user keys are not used by GitHub Apps integrations. All keys are stored in **Project Settings > Additional SSH Keys**. Use the **Create Project** option to get a project set up. You will be guided through creating SSH keys for your project.
+
+[#free-and-open-source-setting]
+=== Free and open source setting
+
+Open source plans are not currently available to GitLab customers. CircleCI will keep the open source community up to date as work continues to support this.
+
+[#test-insights]
+=== Test Insights
+
+xref:insights-tests#[Test Insights] is currently not supported.
+
+[#badges]
+=== Badges
+
+The xref:status-badges#[status badge] and xref:insights-snapshot-badge#[Insights snapshot badge] features are not currently supported.
+
+[#next-steps]
+== Next Steps
+- xref:config-intro#[Configuration tutorial]
+- xref:hello-world#[Hello world]
+

--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -154,7 +154,7 @@ CircleCI users have different abilities depending on assigned roles in a particu
 [#deprecated-system-environment-variables]
 == Deprecated system environment variables
 
-There are a number of built-in environment variables that are not available in GitHub-based projects for accounts authenticated through GitHub Apsps. VCS support for each environment variable is indicated in the xref:variables#built-in-environment-variables[Built-in environment variables] table on the Project values and variables page. If your pipelines need these environment variables, we recommend you use suitable replacements from the available xref:pipeline-variables#[pipeline values].
+There are a number of built-in environment variables that are not available in GitHub-based projects for accounts authenticated through GitHub Apps. VCS support for each environment variable is indicated in the xref:variables#built-in-environment-variables[Built-in environment variables] table on the Project values and variables page. If your pipelines need these environment variables, we recommend you use suitable replacements from the available xref:pipeline-variables#[pipeline values].
 
 [#coming-soon]
 == Coming soon

--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -12,7 +12,7 @@ contentTags:
 
 [NOTE]
 ====
-**GitHub authentication with CircleCI is changing**. Starting 14th August 2023 when you authenticate your CircleCI account with GitHub, this will be done through our GitHub App, rather than the GitHub OAuth app. You can see which account type you have by heading to the CircleCI web app and inspecting the URL in your browser:
+**GitHub authentication with CircleCI is changing**. Starting August 2023 when you authenticate your CircleCI account with GitHub, you may find this will be done through our GitHub App, rather than the GitHub OAuth app. You can see which account type you have by heading to the CircleCI web app and inspecting the URL in your browser:
 
 * This style of URL indicates you authenticated with the **GitHub App**: `https://app.circleci.com/pipelines/circleci/UTxCZDiJ9MLGLC8hR1ZDmg`
 * This style of URL indicates you authenticated with the **GitHub OAuth app**: `https://app.circleci.com/github/<your GitHub username>`

--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -3,17 +3,29 @@ contentTags:
   platform:
   - Cloud
 ---
-= GitHub integration overview
+= GitHub OAuth app integration overview
 :page-layout: classic-docs
 :page-liquid:
 :page-description: This document provides an overview of using GitHub and GitHub Enterprise with CircleCI.
 :icons: font
 :experimental:
 
-[#overview]
-== Overview
+[NOTE]
+====
+**GitHub authentication with CircleCI is changing**. Starting 14th August 2023 when you authenticate your CircleCI account with GitHub, this will be done through our GitHub App, rather than the GitHub OAuth app. You can see which account type you have by heading to the CircleCI web app and inspecting the URL in your browser:
 
-To use CircleCI with GitHub you need to connect your GitHub account. When you add a project to CircleCI, the following settings are added to the repository using the permissions you gave CircleCI when you signed up:
+* This style of URL indicates you authenticated with the **GitHub App**: `https://app.circleci.com/pipelines/circleci/UTxCZDiJ9MLGLC8hR1ZDmg`
+* This style of URL indicates you authenticated with the **GitHub OAuth app**: `https://app.circleci.com/github/<your GitHub username>`
+
+For more information about the differences, see the link:https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps[GitHub docs comparison page].
+====
+
+If your CircleCI account is authenticated through the **GitHub OAuth app**, the content on this page is for you.
+
+[#introduction]
+== Introduction
+
+When you add a project to CircleCI, the following settings are added to the repository using the permissions you gave CircleCI when you signed up:
 
 - A deploy key that is used to check out your project from GitHub.
 - A service hook (or "push hook") that is used to notify CircleCI when you push to GitHub.
@@ -27,7 +39,7 @@ There are some additional, less common cases where CircleCI uses hooks, as follo
 
 These settings can be found in each project's individual **Project Settings** section of the CircleCI web app.
 
-The ability to override the **Only build pull requests** setting is supported. Specifically, CircleCI will run validation on all commits from additional, non-default branches that are specified via regular expression (for example, `release.\*`).  Details on how to enable can be found on our link:https://discuss.circleci.com/t/product-launch-override-only-build-prs-setting/47807[community forum]. 
+The ability to override the **Only build pull requests** setting is supported. Specifically, CircleCI will run validation on all commits from additional, non-default branches that are specified via regular expression (for example, `release.\*`).  Details on how to enable can be found on our link:https://discuss.circleci.com/t/product-launch-override-only-build-prs-setting/47807[community forum].
 
 It is possible to edit the webhooks in GitHub to restrict events that trigger a build. Editing the webhook settings lets you change which hooks get sent to CircleCI, but does not change the types of hooks that trigger builds. CircleCI will always build push hooks, and build on PR hooks (depending on settings), but if you remove push hooks from the webhook settings, CircleCI will not build.
 

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -30,8 +30,10 @@ en:
             link: config-editor
       - name: VCS integration
         children:
-          - name: GitHub integration overview
+          - name: GitHub OAuth integration overview
             link: github-integration
+          - name: GitHub apps integration overview
+            link: github-apps-integration
           - name: Bitbucket integration overview
             link: bitbucket-integration
           - name: GitLab integration overview
@@ -1010,8 +1012,10 @@ ja:
       - name: VCS Integration
         i18n_name: VCSとの連携
         children:
-          - name: GitHub
+          - name: GitHub OAuth
             link: ja/github-integration
+          - name: GitHub apps
+            link: ja/github-apps-integration
           - name: Bitbucket
             link: ja/bitbucket-integration
           - name: GitLab


### PR DESCRIPTION
# Description

* Create GitHub App integration page 
* Update original GitHub integration page to specify GitHub OAuth app
* Remove signup info from GitHub OAuth app integration page

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
