### PR TITLE
Go links updates

### DIFF
--- a/jekyll/_cci2/language-go.md
+++ b/jekyll/_cci2/language-go.md
@@ -201,7 +201,6 @@ workflows:
 ## See also
 {: #see-also-new }
 
-- [Use test splitting with Python Django tests]({{site.support_base_url}}/hc/en-us/articles/360048786831-Use-test-splitting-with-Python-Django-tests)
-- [Testing Flask framework with Pytest]({{site.blog_base_url}}/testing-flask-framework-with-pytest/)
-- [How do I use Django on CircleCI?]({{site.support_base_url}}/hc/en-us/articles/115012795327-How-do-I-use-Django-on-CircleCI-)
+- [Test splitting and rerun failed tests for Go](/docs/rerun-failed-tests/#configure-a-job-running-go-tests)
+- [Continuous integration for Go applications](https://circleci.com/blog/continuous-integration-for-go-applications/)
 - Tutorial: [Test splitting to speed up your pipelines](/docs/test-splitting-tutorial)


### PR DESCRIPTION
# Description
Add Go links to last section of Go Quickstart

# Reasons
Python links were left in there by mistake

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
