### PR TITLE
[GITHUB APPS] config editor banner

### DIFF
--- a/jekyll/_cci2/config-editor.md
+++ b/jekyll/_cci2/config-editor.md
@@ -2,12 +2,15 @@
 layout: classic-docs
 title: "Using the CircleCI In-app Configuration Editor"
 description: "Docs page on In-app configuration editor use and features"
-contentTags: 
+contentTags:
   platform:
   - Cloud
   - Server v4.x
   - Server v3.x
 ---
+
+The in-app config editor is not currently available to [GitLab](/docs/gitlab-integration/) or [GitHub Apps](/docs/github-apps-integration) integrations.
+{: class="alert alert-warning"}
 
 With the CircleCI configuration editor, you can modify your configuration files without the use of the [CircleCI CLI]({{site.baseurl}}/local-cli/) or a text editor. Using the CircleCI configuration editor gives you the ability to modify your CI/CD processes quickly, and in a unified fashion.
 

--- a/jekyll/_cci2/config-editor.md
+++ b/jekyll/_cci2/config-editor.md
@@ -9,7 +9,7 @@ contentTags:
   - Server v3.x
 ---
 
-The in-app config editor is not currently available to [GitLab](/docs/gitlab-integration/) or [GitHub Apps](/docs/github-apps-integration) integrations.
+The in-app config editor is not currently available outside the project creation process to [GitLab](/docs/gitlab-integration/) or [GitHub Apps](/docs/github-apps-integration) integrations.
 {: class="alert alert-warning"}
 
 With the CircleCI configuration editor, you can modify your configuration files without the use of the [CircleCI CLI]({{site.baseurl}}/local-cli/) or a text editor. Using the CircleCI configuration editor gives you the ability to modify your CI/CD processes quickly, and in a unified fashion.

--- a/jekyll/_cci2/config-editor.md
+++ b/jekyll/_cci2/config-editor.md
@@ -9,7 +9,7 @@ contentTags:
   - Server v3.x
 ---
 
-The in-app config editor is not currently available outside the project creation process to [GitLab](/docs/gitlab-integration/) or [GitHub Apps](/docs/github-apps-integration) integrations.
+The in-app config editor is not currently available outside the project creation process for [GitLab](/docs/gitlab-integration/) or [GitHub Apps](/docs/github-apps-integration) integrations.
 {: class="alert alert-warning"}
 
 With the CircleCI configuration editor, you can modify your configuration files without the use of the [CircleCI CLI]({{site.baseurl}}/local-cli/) or a text editor. Using the CircleCI configuration editor gives you the ability to modify your CI/CD processes quickly, and in a unified fashion.


### PR DESCRIPTION
# Description
Add banner to config editor page to state it's not available for GL or GH Apps. Apart from when creating a project (GL Cloud only).

# Reasons
Standalone support across docs

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
