### PR TITLE
update to current container runner image tag

### DIFF
--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -225,7 +225,7 @@ The following is for **Kubernetes object settings**. All settings prefixed with 
 
 | agent.image.tag
 | Agent image tag
-| edge
+| kubernetes-3
 
 | agent.pullSecrets
 | link:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/[Secret objects] container private registry credentials for the container runner pod itself, not the ephemeral pods that execute tasks


### PR DESCRIPTION
# Description
The docs currently refer to `edge` as the default image tag for the container runner agent. This tag is not considered stable and only used for testing and triaging. This PR updates the default tag to match what is in the default helm chart values for the latest stable release of the container runner agent. 

# Reasons
We were providing inaccurate and possibly breaking information about the the version of agent to use for container runners. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
