### PR TITLE
VSCode Extension - Clarify what qualifies a project to be selectable …

### DIFF
--- a/jekyll/_cci2/get-started-with-the-vs-code-extension.adoc
+++ b/jekyll/_cci2/get-started-with-the-vs-code-extension.adoc
@@ -52,7 +52,7 @@ NOTE: **Using GitLab?** The pipelines manager does not yet support GitLab projec
 
 If your VS Code workspace contains one or more CircleCI projects, the extension will detect them automatically, and the pipelines panel will be populated with your most recent pipelines.
 
-If no project is detected, open the extension's settings page (either through the VS Code command `CircleCI: Open Settings`, or by clicking on the settings icon (icon:cog[]) at the top of the pipelines panel), and select your projects manually.
+If no project is detected, open the extension's settings page (either through the VS Code command `CircleCI: Open Settings`, or by clicking on the settings icon (icon:cog[]) at the top of the pipelines panel), and select your projects manually. Only projects you follow are listed for selection.
 
 image::{{site.baseurl}}/assets/img/docs/vs_code_extension_pipelines_panel_zoomed.png[The pipelines panel displays pipelines you follow.]
 


### PR DESCRIPTION
…in setup

People who are less familiar with CircleCI and just want to see build statuses in their IDE can be confused as to why none of their projects show in the settings page, especially if none are autodetected.

Reiterating the prerequsite of "A project you follow that is building on CircleCI" within the "Set up your project" section can drastically help remove cognitive overhead in trying to figure out what qualifies a project to show in this Project selection list. The point is very easy to miss otherwise.