### PR TITLE
Update line numberings for code block descriptions

### DIFF
--- a/jekyll/_cci2/config-intro.adoc
+++ b/jekyll/_cci2/config-intro.adoc
@@ -64,13 +64,13 @@ The following commentary describes what occurs in each line of the sample code:
 * *Line 3:* `build` is the first child in the `jobs` collection. In this example, `build` is also the only job.
 * *Line 4:* This specifies that you are using a Docker image for the container where your job's commands are run.
 * *Line 5:* This is the Docker image. The example shows `alpine:3.15`, a minimal image based on Alpine Linux.
-* *Lines 6-8:* Supply your Docker registry credentials. This section is optional. For further information see the link:/docs/private-images[Using Docker Authenticated Pulls] page.
-* *Line 9:* The `steps` collection is a list of `run` directives.
-* *Line 10:* Each `run` directive is executed in the order in which it is declared.
-* *Line 11:* The `name` attribute provides useful information when returning warnings, errors, and output. The `name` should be meaningful to you as an action within your build process.
-* *Line 12:* The `command` attribute is a list of shell commands that you want to execute. The initial pipe, `|`, indicates there will be multiple lines of shell commands.
-* *Line 13:* Prints `Hello World!` in your build shell.
-* *Line 14:* Prints `This is the delivery pipeline`.
+* *Lines 6-8:* Supply your Docker registry credentials. This section is optional and is omitted here. For further information see the link:/docs/private-images[Using Docker Authenticated Pulls] page.
+* *Line 6:* The `steps` collection is a list of `run` directives.
+* *Line 7:* Each `run` directive is executed in the order in which it is declared.
+* *Line 8:* The `name` attribute provides useful information when returning warnings, errors, and output. The `name` should be meaningful to you as an action within your build process.
+* *Line 9:* The `command` attribute is a list of shell commands that you want to execute. The initial pipe, `|`, indicates there will be multiple lines of shell commands.
+* *Line 10:* Prints `Hello World!` in your build shell.
+* *Line 11:* Prints `This is the delivery pipeline`.
 +
 . Commit your `config.yml` file (and push, if you are working remotely).
 . On the Projects page in CircleCI, find your project and click the blue *Set Up Project* button next to it.
@@ -132,8 +132,8 @@ jobs:
 These two small changes have significantly increased the functionality of your config file:
 
 * *Line 5:* This line now specifies a Docker image that supports git. `cimg/base:2021.04` is a small Ubuntu-based image for running basic jobs.
-* *Line 10:* The `checkout` command fetches the code from your git repo.
-* *Lines 16-20:* This second step in the `build` job is listing (using `ls -al`) the contents of the repo that has been checked out. You can now perform further actions on this repo.
+* *Line 7:* The `checkout` command fetches the code from your git repo.
+* *Lines 13-17:* This second step in the `build` job is listing (using `ls -al`) the contents of the repo that has been checked out. You can now perform further actions on this repo.
 
 As before, commit and push your updated `config.yml` file.
 
@@ -206,17 +206,17 @@ This example is more complicated than the others, but it introduces several impo
 The following commentary describes what occurs in each line of the sample code:
 
 * *Line 3:* You can add comments to your config.yml file by preceding them with the # (hash) sign.
-* *Lines 4-15:* The first job is _Hello-World_. As in Part 1, it runs two commands in a basic image.
-* *Line 17:* The second job is _Fetch-Code_. It is indented to align with the _Hello-World_ job.
-* *Lines 18-19:* The _Fetch-Code_ job uses a basic git-compatible image.
-* *Lines 23-29:* This code is repeated from Part 2, but now it is a separate job.
-* *Line 31:* The third job is _Using-Node_.
-* *Lines 32-33:* This _Using-Node_ job uses a Docker image called `cimg/node:17.2`. This image contains version 17.2 of Node, along with a browser and other useful tools.
-* *Lines 37-41:* As in the previous jobs, there is a _run_ step. This time, the command `node -v` prints the version of Node running in the container.
-* *Lines 42-43:* This line creates a Workflow called _Example-Workflow_. Workflows define a list of jobs and their run order.
-* *Lines 44-45:* These lines specify the first job, _Hello-World_.
-* *Lines 46-48:* The syntax for the _Fetch-Code_ job is slightly different. The job name is followed by a `requires:`, then a _requires_ statement. This line specifies that the _Hello-World_ job must run successfully before the _Fetch-Code_ job is executed.
-* *Lines 49-51:* The final job is _Using-Node_. As before, this job requires the successful completion of the previous job, _Fetch-Code_.
+* *Lines 4-12:* The first job is _Hello-World_. As in Part 1, it runs two commands in a basic image.
+* *Line 14:* The second job is _Fetch-Code_. It is indented to align with the _Hello-World_ job.
+* *Lines 15-16:* The _Fetch-Code_ job uses a basic git-compatible image.
+* *Lines 27-23:* This code is repeated from Part 2, but now it is a separate job.
+* *Line 25:* The third job is _Using-Node_.
+* *Lines 26-27:* This _Using-Node_ job uses a Docker image called `cimg/node:17.2`. This image contains version 17.2 of Node, along with a browser and other useful tools.
+* *Lines 28-32:* As in the previous jobs, there is a _run_ step. This time, the command `node -v` prints the version of Node running in the container.
+* *Lines 33-34:* This line creates a Workflow called _Example-Workflow_. Workflows define a list of jobs and their run order.
+* *Lines 35-36:* These lines specify the first job, _Hello-World_.
+* *Lines 37-39:* The syntax for the _Fetch-Code_ job is slightly different. The job name is followed by a `requires:`, then a _requires_ statement. This line specifies that the _Hello-World_ job must run successfully before the _Fetch-Code_ job is executed.
+* *Lines 40-42:* The final job is _Using-Node_. As before, this job requires the successful completion of the previous job, _Fetch-Code_.
 
 As before, commit and push your updated `config.yml` file.
 
@@ -313,8 +313,8 @@ workflows:
 
 Most of this code will look familiar to you. There are a couple of important additions:
 
-* *Lines  64-68*: This creates a new job called _Hold-for-Approval_. The `type` specifies this is an _approval_, so you are required to manually approve this job in CircleCI. This is useful if you want to see whether the previous jobs have been executed as expected. For example, you can check that a website looks correct on a test server before making it live. Or you might want a human to perform checks before you execute any expensive jobs.
-* *Lines 69-71*: This final job - _Now-Complete_ - `requires` the successful completion of _Hold-for-Approval_, so will execute only once you have approved that previous job in CircleCI.
+* *Lines  52-56*: This creates a new job called _Hold-for-Approval_. The `type` specifies this is an _approval_, so you are required to manually approve this job in CircleCI. This is useful if you want to see whether the previous jobs have been executed as expected. For example, you can check that a website looks correct on a test server before making it live. Or you might want a human to perform checks before you execute any expensive jobs.
+* *Lines 57-59*: This final job - _Now-Complete_ - `requires` the successful completion of _Hold-for-Approval_, so will execute only once you have approved that previous job in CircleCI.
 
 As before, commit and push your updated `config.yml` file.
 


### PR DESCRIPTION
# Description
It seems like you had an earlier version of this tutorial that included lines for supplying Docker registry credentials and although these lines were taken out, the line numbers in the explanations that followed were not corrected. 

I have attempted to correct them, and added in a small statement that notes the Docker credentials are omitted for your examples.

# Reasons
Simple corrections to match seemingly new docs.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
