### PR TITLE
Update set-a-nightly-scheduled-pipeline.adoc

### DIFF
--- a/jekyll/_cci2/set-a-nightly-scheduled-pipeline.adoc
+++ b/jekyll/_cci2/set-a-nightly-scheduled-pipeline.adoc
@@ -2,7 +2,6 @@
 contentTags:
   platform:
   - Cloud
-  - Server v4.x
   - Server v3.x
 ---
 = Set a nightly scheduled pipeline

--- a/jekyll/_cci2/set-a-nightly-scheduled-pipeline.adoc
+++ b/jekyll/_cci2/set-a-nightly-scheduled-pipeline.adoc
@@ -2,7 +2,6 @@
 contentTags:
   platform:
   - Cloud
-  - Server v3.x
 ---
 = Set a nightly scheduled pipeline
 :page-layout: classic-docs


### PR DESCRIPTION
remove reference to server as the feature is not available for that version

# Description
Removing server 3/4 references as the feature is not available.

# Reasons
Listing server 3/server 4 on this page confuses users as the feature is not available.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
