### PR TITLE
[MAC-1719] remove mke-1a IP ranges

### DIFF
--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -156,12 +156,6 @@ CircleCI *does not recommend* configuring an IP-based firewall based on the AWS 
 
 In addition to AWS and GCP (see above), CircleCI's macOS Cloud hosts jobs executed by machines. The following IP address ranges are used by CircleCI macOS Cloud:
 
-- 162.252.208.0/24
-- 162.252.209.0/24
-- 192.206.63.0/24
-- 162.221.90.0/24
-- 38.39.177.0/24
-- 38.39.178.0/24
 - 38.39.188.0/24
 - 38.39.189.0/24
 - 38.39.186.0/24


### PR DESCRIPTION
# Description
The macos team will be decommissioning the network (`mke-1a`) in which these IPs are living. Therefore, we are retired these IP ranges from use

# Reasons
Therefore, we are retired these IP ranges from use. Here is a linked [JIRA Ticket](https://circleci.atlassian.net/browse/MAC-1719)

# Content Checklist
None of the below were necessary since only lines were being deleted from existing page.

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
