### PR TITLE
Intro to web app - banners to notify that some features not available for standalone

### DIFF
--- a/jekyll/_cci2/introduction-to-the-circleci-web-app.adoc
+++ b/jekyll/_cci2/introduction-to-the-circleci-web-app.adoc
@@ -68,12 +68,14 @@ If you do not see your project and it is not currently building on CircleCI, che
 
 Projects associated with your organization will appear on the **Projects** page. You have the option to:
 
-* _Set Up_ any project that you are the owner of in your VCS.
+* xref:create-project#[_Set Up_ or _Create_ any project] that you are the owner of in your VCS.
 * _Follow_ any project in your organization to gain access to its pipelines and to subscribe to xref:notifications#[email notifications] for the project's status.
 
 Following or setting up a project adds it to your dashboard. Unfollowing a project removes it from your dashboard.
 
 Clicking the three dots (meatball menu) in the project row will allow you to open an individual project's configuration file, Insights, and settings. If you are following a project, you will also see an option to unfollow the project from this menu. There is also a **Project Settings** button found on individual project pages, which you can view by clicking on a project's name in the main **Projects** dashboard.
+
+NOTE: Some settings and functionality described in this section, including the in-app configuration editor, are currently not available in xref:github-apps-integration#[GitHub App] or xref:gitlab-integration#[GitLab] projects. Refer to the Coming soon section in each integration overview page for more details on CircleCI features that are not fully supported.    
 
 image::web_ui_projects.png[Projects page]
 
@@ -111,6 +113,8 @@ image::web_ui_text_editor.png[Text editor in the web app]
 [#insights]
 == Insights
 
+NOTE: Some settings and functionality described in this section, including the in-app configuration editor, are currently not available in xref:github-apps-integration#[GitHub App] or xref:gitlab-integration#[GitLab] projects. Refer to the Coming soon section in each integration overview page for more details on CircleCI features that are not fully supported.  
+
 The Insights page shows you specific numbers related to workflow run, workflow duration, credits consumed, and the overall success rate for all projects in your organization over a selected time range. At this time, the ranges you can choose are 24 hours, seven, 30, 60, and 90 days.
 
 image::web_ui_insights_overview.png[Insights page]
@@ -120,7 +124,7 @@ While the main Insights page gives you an overview of all projects, you can also
 image::web_ui_insights_runs.png[Details of insights]
 
 [#self-hosted-runners]
-== Self-Hosted Runners
+== Self-Hosted runners
 
 The self-hosted runners page shows the inventory of resource classes and associated self-hosted runners. You may also create a new resource class from this page. Before this ability is available to you, you will need to accept the terms of use for self-hosted runners, which is found in the <<#organization-settings,organization settings>>.
 
@@ -176,6 +180,8 @@ image::web_ui_plan_controls.png[Usage controls]
 
 [#user-settings]
 == User settings
+
+NOTE: Some settings and functionality described in this section, including the in-app configuration editor, are currently not available in xref:github-apps-integration#[GitHub App] or xref:gitlab-integration#[GitLab] projects. Refer to the Coming soon section in each integration overview page for more details on CircleCI features that are not fully supported.  
 
 User settings can be found by scrolling to the bottom of the side navigation and clicking on your user icon.
 


### PR DESCRIPTION
# Description
Add banners on [Intro to the web app](https://circleci.com/docs/introduction-to-the-circleci-web-app/) to notify readers that some features and web app settings are not available for GitLab / GH App projects/orgs.

# Reasons
GH App authorization starting this week

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
