### PR TITLE
add JEST_JUNIT_ADD_FILE_ATTRIBUTE to collect-test-data

### DIFF
--- a/jekyll/_cci2/collect-test-data.md
+++ b/jekyll/_cci2/collect-test-data.md
@@ -166,6 +166,7 @@ steps:
       command: jest --ci --runInBand --reporters=default --reporters=jest-junit
       environment:
         JEST_JUNIT_OUTPUT_DIR: ./reports/
+        JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
   - store_test_results:
       path: ./reports/
 ```


### PR DESCRIPTION
this is needed for split by timings, and rerun failed test as jest-junit doesn't include the `file` attribute by default.

# Description
add JEST_JUNIT_ADD_FILE_ATTRIBUTE to jest section

# Reasons
this is needed for split by timings, and rerun failed test to work as jest-junit doesn't include the `file` attribute by default.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
