### PR TITLE
Deprecate machine:true

### DIFF
--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -793,6 +793,9 @@ jobs:
 #### **`machine`**
 {: #machine }
 
+**CircleCI Cloud** The use of `machine: true` is deprecated. You must specify an image to use.
+{: class="alert alert-caution"}
+
 The machine executor is configured using the `machine` key, which takes a map:
 
 Key | Required | Type | Description
@@ -804,17 +807,24 @@ docker_layer_caching | N | Boolean | Set this to `true` to enable [Docker Layer 
 
 Example:
 
-```yaml
-version: 2.1
+{:.tab.machine.Cloud}
+```yml
 jobs:
-  build:
-    machine:
-      image: ubuntu-2004:202010-01
+  build: # name of your job
+    machine: # executor type
+      image: ubuntu-2004:202010-01 # # recommended linux image - includes Ubuntu 20.04, docker 19.03.13, docker-compose 1.27.4
+
     steps:
-      - checkout
-      - run:
-          name: "Testing"
-          command: echo "Hi"
+        # Commands run in a Linux virtual machine environment
+```
+
+{:.tab.machine.Server}
+```yml
+jobs:
+  build: # name of your job
+    machine: true # executor type
+    steps:
+      # Commands run in a Linux virtual machine environment
 ```
 
 ---

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -812,7 +812,7 @@ Example:
 jobs:
   build: # name of your job
     machine: # executor type
-      image: ubuntu-2004:202010-01 # # recommended linux image - includes Ubuntu 20.04, docker 19.03.13, docker-compose 1.27.4
+      image: ubuntu-2004:current # recommended linux image - includes Ubuntu 20.04, docker 19.03.13, docker-compose 1.27.4
 
     steps:
         # Commands run in a Linux virtual machine environment

--- a/jekyll/_cci2/executor-intro.md
+++ b/jekyll/_cci2/executor-intro.md
@@ -44,6 +44,9 @@ Find out more about the Docker execution environment on the [Using Docker](/docs
 ## Linux VM
 {: #linux-vm }
 
+**CircleCI Cloud** The use of `machine: true` is deprecated. You must specify an image to use.
+{: class="alert alert-caution"}
+
 To access the Linux VM execution environment, use the `machine` executor and specify a Linux image. For a full list of `machine` images, see the [CircleCI Developer Hub](https://circleci.com/developer/images?imageType=machine)
 
 {:.tab.machine.Cloud}

--- a/jekyll/_cci2/using-linuxvm.md
+++ b/jekyll/_cci2/using-linuxvm.md
@@ -15,6 +15,9 @@ Using the machine executor gives your application full access to OS resources an
 
 To use the machine executor, use the [`machine` key]({{site.baseurl}}/configuration-reference/#machine) in your job configuration and specify an image:
 
+**CircleCI Cloud** The use of `machine: true` is deprecated. You must specify an image to use.
+{: class="alert alert-caution"}
+
 {:.tab.machineblock.Cloud}
 ```yaml
 version: 2.1


### PR DESCRIPTION
# Description
Add note to relevant sections that `machine: true` is deprecated

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
