### PR TITLE
ONPREM-328 - Machine runner package installation 

### DIFF
--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -5,7 +5,7 @@ contentTags:
   - Server v4.x
   - Server v3.x
 ---
-= Machine runner installation on Linux
+= Machine runner package installation on Linux
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Instructions on how to install CircleCI's self-hosted runner on Linux.
@@ -33,30 +33,28 @@ This page describes how to install CircleCI's machine runner on Linux.
 --
 {% include snippets/runner/install-with-web-app-steps.adoc %}
 --
+
 [.tab.machine-runner.CLI_installation]
 --
 {% include snippets/runner/install-with-cli-steps.adoc %}
-
 --
 
 
 [#install-circleci-runner]
 == 2. Install circleci-runner
-
 [.tab.machine-runner-package-installation.debian]
 --
 {% include snippets/runner/machine-runner-deb-package-install.adoc %}
 --
+
 [.tab.machine-runner-package-installation.rpm]
 --
 {% include snippets/runner/machine-runner-rpm-package-install.adoc %}
 --
-[.tab.machine-runner-package-installation.manual_installation]
---
-{% include snippets/runner/machine-runner-manual-install.adoc %}
 
---
+{% include snippets/machine-runner-example.adoc %}
 
+The job will then execute using your self-hosted runner when you push the config to your VCS provider.
 
 [#troubleshooting]
 == Troubleshooting

--- a/jekyll/_cci2/runner-installation-linux.adoc
+++ b/jekyll/_cci2/runner-installation-linux.adoc
@@ -39,215 +39,24 @@ This page describes how to install CircleCI's machine runner on Linux.
 
 --
 
-[#download-the-launch-agent-script]
-== 2. Download launch-agent script and install binary
 
-{% include snippets/runner/launch-agent-download.adoc %}
+[#install-circleci-runner]
+== 2. Install circleci-runner
 
-[#create-the-circleci-user-and-working-directory]
-== 3. Create `circleci` user and working directory
+[.tab.machine-runner-package-installation.debian]
+--
+{% include snippets/runner/machine-runner-deb-package-install.adoc %}
+--
+[.tab.machine-runner-package-installation.rpm]
+--
+{% include snippets/runner/machine-runner-rpm-package-install.adoc %}
+--
+[.tab.machine-runner-package-installation.manual_installation]
+--
+{% include snippets/runner/machine-runner-manual-install.adoc %}
 
-These will be used when executing the task-agent. These commands must be run as a user with permissions to create other users (e.g. `root`). For information about GECOS, see the https://en.wikipedia.org/wiki/Gecos_field[wiki page].
+--
 
-[#ubuntu-debian]
-=== Ubuntu/Debian
-
-```shell
-id -u circleci &>/dev/null || sudo adduser --disabled-password --gecos GECOS circleci
-```
-
-[#centos-rhel]
-=== CentOS/RHEL
-
-```shell
-id -u circleci &>/dev/null || sudo adduser -c GECOS circleci
-```
-
-[#create-the-working-directory]
-=== Create the working directory and set permissions
-
-```shell
-sudo mkdir -p /var/opt/circleci
-```
-
-```shell
-sudo chmod 0750 /var/opt/circleci
-```
-
-```shell
-sudo chown -R circleci /var/opt/circleci /opt/circleci
-```
-
-Consider running the following additional command if you would like to use certified orbs, without errors, that work on Cloud on your self-hosted runner. Note that this enables code to execute root commands on your machine, and changes to the system may persist after the job is run.
-
-```shell
-echo "circleci ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers
-```
-
-[#create-the-circleci-self-hosted-runner-configuration]
-== 4. Create self-hosted runner configuration
-
-Create a `launch-agent-config.yaml` file with a path of `/etc/opt/circleci/launch-agent-config.yaml`, owned by `circleci`, with permissions `600`. Use the following commands:
-
-```shell
-sudo mkdir -p /etc/opt/circleci && sudo touch /etc/opt/circleci/launch-agent-config.yaml
-```
-
-```shell
-sudo chown -R circleci: /etc/opt/circleci
-```
-
-```shell
-sudo chmod 600 /etc/opt/circleci/launch-agent-config.yaml
-```
-
-Copy the following to the new `/etc/opt/circleci/launch-agent-config.yaml` file:
-
-```yaml
-api:
-  auth_token: AUTH_TOKEN
-  # On server, set url to the hostname of your server installation. For example,
-  # url: https://circleci.example.com
-
-runner:
-  name: RUNNER_NAME
-  working_directory: /var/opt/circleci/workdir
-  cleanup_working_directory: true
-```
-
-- Replace `AUTH_TOKEN` with the resource class token created in the xref:runner-installation#circleci-web-app-installation.adoc[set up process].
-- Replace `RUNNER_NAME` with the name you would like for your self-hosted runner. `RUNNER_NAME` is unique to the machine that is installing the runner. `RUNNER_NAME` can be any value you would like, and it does not need to include any part of your namespace or resource class name. However, it is recommended to use the hostname of the machine so that it can be used to identify the agent when viewing statuses and job results in the CircleCI web app. The only special characters accepted in RUNNER_NAME are `. () - _`.
-
-[#configure-selinux-policy]
-=== Configure SELinux policy (RHEL 8)
-
-An SELinux policy is required for self-hosted runner to accept and launch jobs on RHEL 8 systems (earlier versions of RHEL are unsupported). Note that this policy does not add any permissions to the ones that may be required by individual jobs on this self-hosted runner install.
-
-Create directory `/etc/opt/circleci/policy` and generate the initial policy module:
-
-```shell
-sudo mkdir -p /etc/opt/circleci/policy
-```
-
-```shell
-# Install sepolicy and rpmbuild if you haven't already
-sudo yum install -y policycoreutils-devel rpm-build
-```
-
-```shell
-sudo sepolicy generate --path /etc/opt/circleci/policy --init /opt/circleci/circleci-launch-agent
-```
-
-Download the following type enforcing file https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te[`circleci_launch_agent.te`] and install the policy:
-
-```shell
-sudo curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te --output /etc/opt/circleci/policy/circleci_launch_agent.te
-```
-
-```shell
-sudo /etc/opt/circleci/policy/circleci_launch_agent.sh
-```
-
-[#start-machine-runner]
-== 5. Start machine runner
-
-You can now start machine runner as follows:
-
-```shell
-sudo /opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
-```
-
-You can also optionally run machine runner <<#enable-the-systemd-unit,as a systemd service>>.
-
-{% include snippets/machine-runner-example.adoc %}
-
-The job will then execute using your self-hosted runner when you push the config to your VCS provider.
-
-[#enable-the-systemd-unit]
-== Enable the `systemd` unit
-
-NOTE: This step is optional.
-
-You will need to have https://systemd.io/[systemd] version 235+ installed for this optional step.
-
-Create `/usr/lib/systemd/system/circleci.service` owned by `root` with permissions `755`.
-
-```shell
-sudo touch /usr/lib/systemd/system/circleci.service
-```
-
-```shell
-sudo chown root: /usr/lib/systemd/system/circleci.service
-```
-
-```shell
-sudo chmod 755 /usr/lib/systemd/system/circleci.service
-```
-
-You must ensure that `TimeoutStopSec` is greater than the total amount of time a task will run for, which defaults to 5 hours.
-
-If you want to configure the CircleCI's self-hosted runner installation to start on boot, it is important to note that machine runner will attempt to consume and start jobs as soon as it starts, so it should be configured appropriately before starting. Machine runner may be configured as a service and be managed by `systemd` with the following scripts:
-
-```
-[Unit]
-Description=CircleCI Runner
-After=network.target
-[Service]
-ExecStart=/opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
-Restart=always
-User=circleci
-NotifyAccess=exec
-TimeoutStopSec=18300
-[Install]
-WantedBy = multi-user.target
-```
-
-Unlike task-agents, which use the environment of the `circleci` user, launch-agents will need to have any required environment variables (e.g., proxy settings) explicitly defined in the unit configuration file. These can be set by `Environment=` or `EnvironmentFile=`. Please visit the `systemd` https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment[documentation] for more information.
-
-You can now enable the service:
-
-```shell
-sudo systemctl enable circleci.service
-```
-
-[#start-the-service]
-=== Start the service
-
-When the CircleCI's self-hosted runner service starts, it will immediately attempt to start running jobs, so it should be fully configured before the first start of the service.
-
-```shell
-sudo systemctl start circleci.service
-```
-
-[#verify-the-service-is-running]
-=== Verify the service is running
-
-The system reports a very basic health status through the `status` field in `systemctl`. This will report **Healthy** or **Unhealthy** based on connectivity to the CircleCI APIs.
-
-You can see the status of the agent by running:
-
-```shell
-systemctl status circleci.service --no-pager
-```
-
-Which should produce output similar to:
-
-```
-circleci.service - CircleCI Runner
-   Loaded: loaded (/var/opt/circleci/circleci.service; enabled; vendor preset: enabled)
-   Active: active (running) since Fri 2020-05-29 14:33:31 UTC; 18min ago
- Main PID: 5592 (circleci-launch)
-   Status: "Healthy"
-    Tasks: 8 (limit: 2287)
-   CGroup: /system.slice/circleci.service
-           └─5592 /opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
-```
-
-You can also see the logs for the system by running:
-
-```shell
-journalctl -u circleci
-```
 
 [#troubleshooting]
 == Troubleshooting

--- a/jekyll/_cci2/runner-manual-installation-linux.adoc
+++ b/jekyll/_cci2/runner-manual-installation-linux.adoc
@@ -1,7 +1,30 @@
-//[#machine-runner-debian-manual-installation]
-//== Machine runner debian manual installation
+---
+contentTags:
+  platform:
+  - Cloud
+  - Server v4.x
+  - Server v3.x
+---
+= Machine runner manual installation on Linux
+:page-layout: classic-docs
+:page-liquid:
+:page-description: Instructions on how to install CircleCI's self-hosted runner on Linux.
+:icons: font
+:experimental:
+:machine:
+:linux:
 
-To install machine runner manually, follow these steps.
+This page describes how to install CircleCI's machine runner on Linux.
+
+[#prerequisites]
+== Prerequisites
+
+{% include snippets/runner/machine-runner-prereq.adoc %}
+
+[#self-hosted-runner-terms-agreement]
+== Self-hosted runner terms agreement
+
+{% include snippets/runner/terms.adoc %}
 
 [#create-namespace-and-resource-class]
 == 1. Create namespace and resource class
@@ -10,76 +33,81 @@ To install machine runner manually, follow these steps.
 --
 {% include snippets/runner/install-with-web-app-steps.adoc %}
 --
+
 [.tab.machine-runner.CLI_installation]
 --
 {% include snippets/runner/install-with-cli-steps.adoc %}
-
 --
 
+
+[#install-circleci-runner]
+== 2. Install circleci-runner
+
 [#download-the-launch-agent-script]
-== 2. Download launch-agent script and install binary
+=== a. Download launch-agent script and install binary
 
 {% include snippets/runner/launch-agent-download.adoc %}
 
 [#create-the-circleci-user-and-working-directory]
-== 3. Create `circleci` user and working directory
+=== b. Create `circleci` user and working directory
 
 These will be used when executing the task-agent. These commands must be run as a user with permissions to create other users (e.g. `root`). For information about GECOS, see the https://en.wikipedia.org/wiki/Gecos_field[wiki page].
 
-[#ubuntu-debian]
-=== Ubuntu/Debian
-
+. Choose your operating system:
++
+[.tab.create-user.Ubuntu/Debian]
+--
 ```shell
 id -u circleci &>/dev/null || sudo adduser --disabled-password --gecos GECOS circleci
 ```
-
-[#centos-rhel]
-=== CentOS/RHEL
-
+--
++
+[.tab.create-user.CentOS/RHEL]
+--
 ```shell
 id -u circleci &>/dev/null || sudo adduser -c GECOS circleci
 ```
+--
 
-[#create-the-working-directory]
-=== Create the working directory and set permissions
-
+. Create the working directory and set permissions:
++
 ```shell
 sudo mkdir -p /var/opt/circleci
 ```
-
++
 ```shell
 sudo chmod 0750 /var/opt/circleci
 ```
-
++
 ```shell
 sudo chown -R circleci /var/opt/circleci /opt/circleci
 ```
 
-Consider running the following additional command if you would like to use certified orbs, without errors, that work on Cloud on your self-hosted runner. Note that this enables code to execute root commands on your machine, and changes to the system may persist after the job is run.
-
+. Consider running the following additional command if you would like to use certified orbs, without errors, that work on Cloud on your self-hosted runner. Note that this enables code to execute root commands on your machine, and changes to the system may persist after the job is run.
++
 ```shell
 echo "circleci ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers
 ```
 
 [#create-the-circleci-self-hosted-runner-configuration]
-== 4. Create self-hosted runner configuration
+=== c. Create self-hosted runner configuration
 
-Create a `launch-agent-config.yaml` file with a path of `/etc/opt/circleci/launch-agent-config.yaml`, owned by `circleci`, with permissions `600`. Use the following commands:
-
+. Create a `launch-agent-config.yaml` file with a path of `/etc/opt/circleci/launch-agent-config.yaml`, owned by `circleci`, with permissions `600`. Use the following commands:
++
 ```shell
 sudo mkdir -p /etc/opt/circleci && sudo touch /etc/opt/circleci/launch-agent-config.yaml
 ```
-
++
 ```shell
 sudo chown -R circleci: /etc/opt/circleci
 ```
-
++
 ```shell
 sudo chmod 600 /etc/opt/circleci/launch-agent-config.yaml
 ```
 
-Copy the following to the new `/etc/opt/circleci/launch-agent-config.yaml` file:
-
+. Copy the following to the new `/etc/opt/circleci/launch-agent-config.yaml` file:
++
 ```yaml
 api:
   auth_token: AUTH_TOKEN
@@ -91,12 +119,11 @@ runner:
   working_directory: /var/opt/circleci/workdir
   cleanup_working_directory: true
 ```
-
-- Replace `AUTH_TOKEN` with the resource class token created in the xref:runner-installation#circleci-web-app-installation.adoc[set up process].
-- Replace `RUNNER_NAME` with the name you would like for your self-hosted runner. `RUNNER_NAME` is unique to the machine that is installing the runner. `RUNNER_NAME` can be any value you would like, and it does not need to include any part of your namespace or resource class name. However, it is recommended to use the hostname of the machine so that it can be used to identify the agent when viewing statuses and job results in the CircleCI web app. The only special characters accepted in RUNNER_NAME are `. () - _`.
+** Replace `AUTH_TOKEN` with the resource class token created in the xref:runner-installation#circleci-web-app-installation.adoc[set up process].
+** Replace `RUNNER_NAME` with the name you would like for your self-hosted runner. `RUNNER_NAME` is unique to the machine that is installing the runner. `RUNNER_NAME` can be any value you would like, and it does not need to include any part of your namespace or resource class name. However, it is recommended to use the hostname of the machine so that it can be used to identify the agent when viewing statuses and job results in the CircleCI web app. The only special characters accepted in `RUNNER_NAME` are `. () - _`.
 
 [#configure-selinux-policy]
-=== Configure SELinux policy (RHEL 8)
+=== d. Configure SELinux policy (RHEL 8)
 
 An SELinux policy is required for self-hosted runner to accept and launch jobs on RHEL 8 systems (earlier versions of RHEL are unsupported). Note that this policy does not add any permissions to the ones that may be required by individual jobs on this self-hosted runner install.
 
@@ -115,7 +142,7 @@ sudo yum install -y policycoreutils-devel rpm-build
 sudo sepolicy generate --path /etc/opt/circleci/policy --init /opt/circleci/circleci-launch-agent
 ```
 
-Download the following type enforcing file https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te[`circleci_launch_agent.te`] and install the policy:
+Download the link:https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te[type enforcement file]  and install the policy:
 
 ```shell
 sudo curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te --output /etc/opt/circleci/policy/circleci_launch_agent.te
@@ -126,7 +153,7 @@ sudo /etc/opt/circleci/policy/circleci_launch_agent.sh
 ```
 
 [#start-machine-runner]
-== 5. Start machine runner
+=== e. Start machine runner
 
 You can now start machine runner as follows:
 
@@ -225,3 +252,8 @@ You can also see the logs for the system by running:
 ```shell
 journalctl -u circleci
 ```
+
+[#troubleshooting]
+== Troubleshooting
+
+Refer to the <<troubleshoot-self-hosted-runner#troubleshoot-machine-runner,Troubleshoot Machine Runner section>> of the Troubleshoot Self-hosted Runner guide if you encounter issues installing or running machine runner on Linux.

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -230,8 +230,10 @@ en:
             link: container-runner
       - name: Machine runner
         children:
-          - name: Linux installation
+          - name: Linux package installation
             link: runner-installation-linux
+          - name: Linux manual installation
+            link: runner-manual-installation-linux
           - name: Windows installation
             link: runner-installation-windows
           - name: macOS installation

--- a/jekyll/_includes/snippets/runner/machine-runner-deb-package-install.adoc
+++ b/jekyll/_includes/snippets/runner/machine-runner-deb-package-install.adoc
@@ -4,29 +4,29 @@
 The easiest way to install runner on a debian or ubuntu system is to use CircleCI's pre-built packages.
 
 
-On the target machine, install the CircleCI registry. This script will automatically run `apt-get update`.
-
+. On the target machine, install the CircleCI registry. This script will automatically run `apt-get update`.
++
 ```shell
 curl -s https://packagecloud.io/install/repositories/circleci/runner/script.deb.sh?any=true | sudo bash
 
 ```
 
-Next, install the `circleci-runner` package.
-
+. Next, install the `circleci-runner` package.
++
 ```shell
 sudo apt-get install -y circleci-runner
 
 ```
 
-Open the runner config YAML file and replace `<< AUTH_TOKEN >>` with your token, using the text editor of your choice.
-
+. Open the runner config YAML file and replace `<< AUTH_TOKEN >>` with your token, using the text editor of your choice.
++
 ```shell
 sudo vim /etc/circleci-runner/circleci-runner-config.yaml
 
 ```
 
-Start the `circleci-runner service`, and check that it is currently running.
-
+. Start the `circleci-runner service`, and check that it is currently running.
++
 ```shell
 sudo systemctl start circleci-runner
 

--- a/jekyll/_includes/snippets/runner/machine-runner-deb-package-install.adoc
+++ b/jekyll/_includes/snippets/runner/machine-runner-deb-package-install.adoc
@@ -1,0 +1,36 @@
+//[#machine-runner-debian-package-installation]
+//== Machine runner debian package installation
+
+The easiest way to install runner on a debian or ubuntu system is to use CircleCI's pre-built packages.
+
+
+On the target machine, install the CircleCI registry. This script will automatically run `apt-get update`.
+
+```shell
+curl -s https://packagecloud.io/install/repositories/circleci/runner/script.deb.sh?any=true | sudo bash
+
+```
+
+Next, install the `circleci-runner` package.
+
+```shell
+sudo apt-get install -y circleci-runner
+
+```
+
+Open the runner config YAML file and replace `<< AUTH_TOKEN >>` with your token, using the text editor of your choice.
+
+```shell
+sudo vim /etc/circleci-runner/circleci-runner-config.yaml
+
+```
+
+Start the `circleci-runner service`, and check that it is currently running.
+
+```shell
+sudo systemctl start circleci-runner
+
+# Check status
+sudo systemctl status circleci-runner
+
+```

--- a/jekyll/_includes/snippets/runner/machine-runner-manual-install.adoc
+++ b/jekyll/_includes/snippets/runner/machine-runner-manual-install.adoc
@@ -1,0 +1,227 @@
+//[#machine-runner-debian-manual-installation]
+//== Machine runner debian manual installation
+
+To install machine runner manually, follow these steps.
+
+[#create-namespace-and-resource-class]
+== 1. Create namespace and resource class
+
+[.tab.machine-runner.Web_app_installation]
+--
+{% include snippets/runner/install-with-web-app-steps.adoc %}
+--
+[.tab.machine-runner.CLI_installation]
+--
+{% include snippets/runner/install-with-cli-steps.adoc %}
+
+--
+
+[#download-the-launch-agent-script]
+== 2. Download launch-agent script and install binary
+
+{% include snippets/runner/launch-agent-download.adoc %}
+
+[#create-the-circleci-user-and-working-directory]
+== 3. Create `circleci` user and working directory
+
+These will be used when executing the task-agent. These commands must be run as a user with permissions to create other users (e.g. `root`). For information about GECOS, see the https://en.wikipedia.org/wiki/Gecos_field[wiki page].
+
+[#ubuntu-debian]
+=== Ubuntu/Debian
+
+```shell
+id -u circleci &>/dev/null || sudo adduser --disabled-password --gecos GECOS circleci
+```
+
+[#centos-rhel]
+=== CentOS/RHEL
+
+```shell
+id -u circleci &>/dev/null || sudo adduser -c GECOS circleci
+```
+
+[#create-the-working-directory]
+=== Create the working directory and set permissions
+
+```shell
+sudo mkdir -p /var/opt/circleci
+```
+
+```shell
+sudo chmod 0750 /var/opt/circleci
+```
+
+```shell
+sudo chown -R circleci /var/opt/circleci /opt/circleci
+```
+
+Consider running the following additional command if you would like to use certified orbs, without errors, that work on Cloud on your self-hosted runner. Note that this enables code to execute root commands on your machine, and changes to the system may persist after the job is run.
+
+```shell
+echo "circleci ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers
+```
+
+[#create-the-circleci-self-hosted-runner-configuration]
+== 4. Create self-hosted runner configuration
+
+Create a `launch-agent-config.yaml` file with a path of `/etc/opt/circleci/launch-agent-config.yaml`, owned by `circleci`, with permissions `600`. Use the following commands:
+
+```shell
+sudo mkdir -p /etc/opt/circleci && sudo touch /etc/opt/circleci/launch-agent-config.yaml
+```
+
+```shell
+sudo chown -R circleci: /etc/opt/circleci
+```
+
+```shell
+sudo chmod 600 /etc/opt/circleci/launch-agent-config.yaml
+```
+
+Copy the following to the new `/etc/opt/circleci/launch-agent-config.yaml` file:
+
+```yaml
+api:
+  auth_token: AUTH_TOKEN
+  # On server, set url to the hostname of your server installation. For example,
+  # url: https://circleci.example.com
+
+runner:
+  name: RUNNER_NAME
+  working_directory: /var/opt/circleci/workdir
+  cleanup_working_directory: true
+```
+
+- Replace `AUTH_TOKEN` with the resource class token created in the xref:runner-installation#circleci-web-app-installation.adoc[set up process].
+- Replace `RUNNER_NAME` with the name you would like for your self-hosted runner. `RUNNER_NAME` is unique to the machine that is installing the runner. `RUNNER_NAME` can be any value you would like, and it does not need to include any part of your namespace or resource class name. However, it is recommended to use the hostname of the machine so that it can be used to identify the agent when viewing statuses and job results in the CircleCI web app. The only special characters accepted in RUNNER_NAME are `. () - _`.
+
+[#configure-selinux-policy]
+=== Configure SELinux policy (RHEL 8)
+
+An SELinux policy is required for self-hosted runner to accept and launch jobs on RHEL 8 systems (earlier versions of RHEL are unsupported). Note that this policy does not add any permissions to the ones that may be required by individual jobs on this self-hosted runner install.
+
+Create directory `/etc/opt/circleci/policy` and generate the initial policy module:
+
+```shell
+sudo mkdir -p /etc/opt/circleci/policy
+```
+
+```shell
+# Install sepolicy and rpmbuild if you haven't already
+sudo yum install -y policycoreutils-devel rpm-build
+```
+
+```shell
+sudo sepolicy generate --path /etc/opt/circleci/policy --init /opt/circleci/circleci-launch-agent
+```
+
+Download the following type enforcing file https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te[`circleci_launch_agent.te`] and install the policy:
+
+```shell
+sudo curl https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/rhel8-install/circleci_launch_agent.te --output /etc/opt/circleci/policy/circleci_launch_agent.te
+```
+
+```shell
+sudo /etc/opt/circleci/policy/circleci_launch_agent.sh
+```
+
+[#start-machine-runner]
+== 5. Start machine runner
+
+You can now start machine runner as follows:
+
+```shell
+sudo /opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
+```
+
+You can also optionally run machine runner <<#enable-the-systemd-unit,as a systemd service>>.
+
+{% include snippets/machine-runner-example.adoc %}
+
+The job will then execute using your self-hosted runner when you push the config to your VCS provider.
+
+[#enable-the-systemd-unit]
+== Enable the `systemd` unit
+
+NOTE: This step is optional.
+
+You will need to have https://systemd.io/[systemd] version 235+ installed for this optional step.
+
+Create `/usr/lib/systemd/system/circleci.service` owned by `root` with permissions `755`.
+
+```shell
+sudo touch /usr/lib/systemd/system/circleci.service
+```
+
+```shell
+sudo chown root: /usr/lib/systemd/system/circleci.service
+```
+
+```shell
+sudo chmod 755 /usr/lib/systemd/system/circleci.service
+```
+
+You must ensure that `TimeoutStopSec` is greater than the total amount of time a task will run for, which defaults to 5 hours.
+
+If you want to configure the CircleCI's self-hosted runner installation to start on boot, it is important to note that machine runner will attempt to consume and start jobs as soon as it starts, so it should be configured appropriately before starting. Machine runner may be configured as a service and be managed by `systemd` with the following scripts:
+
+```
+[Unit]
+Description=CircleCI Runner
+After=network.target
+[Service]
+ExecStart=/opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
+Restart=always
+User=circleci
+NotifyAccess=exec
+TimeoutStopSec=18300
+[Install]
+WantedBy = multi-user.target
+```
+
+Unlike task-agents, which use the environment of the `circleci` user, launch-agents will need to have any required environment variables (e.g., proxy settings) explicitly defined in the unit configuration file. These can be set by `Environment=` or `EnvironmentFile=`. Please visit the `systemd` https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment[documentation] for more information.
+
+You can now enable the service:
+
+```shell
+sudo systemctl enable circleci.service
+```
+
+[#start-the-service]
+=== Start the service
+
+When the CircleCI's self-hosted runner service starts, it will immediately attempt to start running jobs, so it should be fully configured before the first start of the service.
+
+```shell
+sudo systemctl start circleci.service
+```
+
+[#verify-the-service-is-running]
+=== Verify the service is running
+
+The system reports a very basic health status through the `status` field in `systemctl`. This will report **Healthy** or **Unhealthy** based on connectivity to the CircleCI APIs.
+
+You can see the status of the agent by running:
+
+```shell
+systemctl status circleci.service --no-pager
+```
+
+Which should produce output similar to:
+
+```
+circleci.service - CircleCI Runner
+   Loaded: loaded (/var/opt/circleci/circleci.service; enabled; vendor preset: enabled)
+   Active: active (running) since Fri 2020-05-29 14:33:31 UTC; 18min ago
+ Main PID: 5592 (circleci-launch)
+   Status: "Healthy"
+    Tasks: 8 (limit: 2287)
+   CGroup: /system.slice/circleci.service
+           └─5592 /opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
+```
+
+You can also see the logs for the system by running:
+
+```shell
+journalctl -u circleci
+```

--- a/jekyll/_includes/snippets/runner/machine-runner-rpm-package-install.adoc
+++ b/jekyll/_includes/snippets/runner/machine-runner-rpm-package-install.adoc
@@ -3,29 +3,29 @@
 
 The easiest way to install runner on a Red Hat, CentOS, or Fedora system is to use CircleCI's pre-built packages.
 
-On the target machine, install the CircleCI registry.
-
+. On the target machine, install the CircleCI registry.
++
 ```shell
 curl -s https://packagecloud.io/install/repositories/circleci/runner/script.rpm.sh?any=true | sudo bash
 
 ```
 
-Next, install the `circleci-runner` package.
-
+. Next, install the `circleci-runner` package.
++
 ```shell
 sudo yum install circleci-runner -y
 
 ```
 
-Open the runner config YAML file and replace `<< AUTH_TOKEN >>` with your token, using the text editor of your choice.
-
+. Open the runner config YAML file and replace `<< AUTH_TOKEN >>` with your token, using the text editor of your choice.
++
 ```shell
 sudo vim /etc/circleci-runner/circleci-runner-config.yaml
 
 ```
 
-Enable and start the `circleci-runner service`, and check that it is currently running.
-
+. Enable and start the `circleci-runner service`, and check that it is currently running.
++
 ```shell
 sudo systemctl enable circleci-runner
 sudo systemctl start circleci-runner

--- a/jekyll/_includes/snippets/runner/machine-runner-rpm-package-install.adoc
+++ b/jekyll/_includes/snippets/runner/machine-runner-rpm-package-install.adoc
@@ -1,0 +1,36 @@
+//[#machine-runner-rpm-package-installation]
+//== Machine runner rpm package installation
+
+The easiest way to install runner on a Red Hat, CentOS, or Fedora system is to use CircleCI's pre-built packages.
+
+On the target machine, install the CircleCI registry.
+
+```shell
+curl -s https://packagecloud.io/install/repositories/circleci/runner/script.rpm.sh?any=true | sudo bash
+
+```
+
+Next, install the `circleci-runner` package.
+
+```shell
+sudo yum install circleci-runner -y
+
+```
+
+Open the runner config YAML file and replace `<< AUTH_TOKEN >>` with your token, using the text editor of your choice.
+
+```shell
+sudo vim /etc/circleci-runner/circleci-runner-config.yaml
+
+```
+
+Enable and start the `circleci-runner service`, and check that it is currently running.
+
+```shell
+sudo systemctl enable circleci-runner
+sudo systemctl start circleci-runner
+
+# Check status
+sudo systemctl status circleci-runner
+
+```


### PR DESCRIPTION
# Description
Makes machine-runner installation by package the default installation method, instead of manual installation. 

# Reasons
[ONPREM-328]

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.


[ONPREM-328]: https://circleci.atlassian.net/browse/ONPREM-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ