### PR TITLE
The disable_concurrency flag needs to be true for it to work

### DIFF
--- a/jekyll/_cci2/server/v4.1/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/troubleshooting-and-support.adoc
@@ -139,5 +139,5 @@ If your org is hitting the hard-coded concurrency limits, you can disable these 
 ----
 distributor_dispatcher:
   ...
-  disable_concurrency: false
+  disable_concurrency: true
 ----


### PR DESCRIPTION
# Description
Our docs suggest that the `disable_concurrency` flag needs to be set to `false` in order to disable concurrency. However, when the value is set to `false`, the feature still remains disabled. 

This value needs to be set to `true` for the `distributor_dispatcher` to completely override concurrency and start all jobs for server.

# Reasons


A customer ran into an issue ([CIRCLE-40328](https://circleci.atlassian.net/browse/CIRCLE-40328)) where two GitHub orgs alone were blocked and setting the value to true fixed the issue.

```
distributor_dispatcher:
  ...
  disable_concurrency: false
```

This update would ensure that other customers are not blocked as well. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.


[CIRCLE-40328]: https://circleci.atlassian.net/browse/CIRCLE-40328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ