### PR TITLE
GitHub App updates to webhooks reference page

### DIFF
--- a/jekyll/_cci2/webhooks-reference.adoc
+++ b/jekyll/_cci2/webhooks-reference.adoc
@@ -227,7 +227,7 @@ The following data about the trigger associated with the webhook event is provid
 [#trigger-parameters]
 === Trigger parameters
 
-Data associated to the pipeline. Present for pipelines associated with GitLab. See <<#vcs>> below for GitHub and Bitbucket.
+NOTE: Data associated to the pipeline. Present for pipelines associated with GitLab or GitHub Apps. For parameters available for for GitHub OAuth app and Bitbucket integrations, see <<#vcs>> below. To find out which GitHub integration you have, see the xref:github-apps-integration#[GitHub Apps integration] page.
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]
@@ -246,7 +246,7 @@ Data associated to the pipeline. Present for pipelines associated with GitLab. S
 
 | gitlab
 | no
-| A map present when the pipeline is associated with a GitLab trigger
+| A map present when the pipeline is associated with a GitLab or GitHub App trigger
 |===
 
 [#circleci]
@@ -279,7 +279,8 @@ Data associated to the pipeline. Present for pipelines associated with GitLab. S
 [#vcs]
 === VCS
 
-NOTE: The VCS map and its contents are always present for GitHub and Bitbucket projects, but not for GitLab projects. See <<#trigger-parameters,trigger parameters>> above for GitLab parameters.
+NOTE: The VCS map and its contents are always present for GitHub OAuth app and Bitbucket projects, but not for GitLab or GitHub App projects. See <<#trigger-parameters,trigger parameters>> above for GitLab and GitHub App parameters.  To find out which GitHub integration you have, see the xref:github-apps-integration#[GitHub Apps integration] page.
+
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]
@@ -344,8 +345,10 @@ NOTE: The VCS map and its contents are always present for GitHub and Bitbucket p
 [#sample-webhook-payloads]
 == Sample webhook payloads
 
+NOTE: To find out which GitHub integration you have, see the xref:github-apps-integration#[GitHub Apps integration] page.
+
 [#workflow-completed-for-github-and-bitbucket]
-=== workflow-completed for GitHub and Bitbucket
+=== workflow-completed for GitHub OAuth and Bitbucket
 
 ```json
 {
@@ -406,7 +409,7 @@ NOTE: The VCS map and its contents are always present for GitHub and Bitbucket p
 ```
 
 [#job-completed-for-github-and-bitbucket]
-=== job-completed for GitHub and Bitbucket
+=== job-completed for GitHub OAuth and Bitbucket
 
 ```json
 {
@@ -474,7 +477,7 @@ NOTE: The VCS map and its contents are always present for GitHub and Bitbucket p
 ```
 
 [#workflow-completed-gitlab]
-=== workflow-completed for GitLab
+=== workflow-completed for GitLab and GitHub App
 
 ```json
 {
@@ -550,7 +553,7 @@ NOTE: The VCS map and its contents are always present for GitHub and Bitbucket p
 ```
 
 [#job-completed-gitlab]
-=== job-completed for GitLab
+=== job-completed for GitLab and GitHub App
 
 ```json
 {

--- a/jekyll/_cci2/webhooks-reference.adoc
+++ b/jekyll/_cci2/webhooks-reference.adoc
@@ -227,7 +227,7 @@ The following data about the trigger associated with the webhook event is provid
 [#trigger-parameters]
 === Trigger parameters
 
-NOTE: Data associated to the pipeline. Present for pipelines associated with GitLab or GitHub Apps. For parameters available for for GitHub OAuth app and Bitbucket integrations, see <<#vcs>> below. To find out which GitHub integration you have, see the xref:github-apps-integration#[GitHub Apps integration] page.
+NOTE: Data associated to the pipeline. Present for pipelines associated with GitLab or GitHub Apps. For parameters available for GitHub OAuth app and Bitbucket integrations, see <<#vcs>> below. To find out which GitHub integration you have, see the xref:github-apps-integration#[GitHub Apps integration] page.
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]


### PR DESCRIPTION
# Description
Update standalone project info on webhooks reference page to include GitHub Apps as well as GitLab, and point people to the integration page to help them work out which integration type they have.

# Reasons
Standalone support across docs

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
