### PR TITLE
Onprem 326/machine runner preview migration

### DIFF
--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
@@ -45,7 +45,7 @@ mv /etc/opt/circleci/launch-agent-config.yaml /etc/circleci-runner/circleci-runn
 Alternatively, you can let the machine agent install process create a config file template and copy the existing config into the newly created file (CROSSLINK)
 
 [#uninstalling-launch-agent-linux-se]
-==== RHEL/Rocky Linux
+=== RHEL/Rocky Linux
 
 In addition to the steps listed above, the SELinux policy should be uninstalled using the following command:
 

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
@@ -42,7 +42,7 @@ sudo rm /usr/lib/systemd/system/circleci.service
 mv /etc/opt/circleci/launch-agent-config.yaml /etc/circleci-runner/circleci-runner-config.yaml
 ```
 +
-Alternatively, you can let the machine agent install process create a config file template and copy the existing config into the newly created file (CROSSLINK)
+Alternatively, you can let the machine agent install process create a config file template and copy the xref:runner-installation-linux#create-the-circleci-self-hosted-runner-configuration[existing config] into the newly created file.
 
 [#uninstalling-launch-agent-linux-se]
 === RHEL/Rocky Linux

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
@@ -54,33 +54,35 @@ sudo semodule -r circleci_launch_agent
 ```
 
 [#install-machine-agent]
-== 2. Installing the Machine Agent
+== 2. Install the machine agent
 
 Packaged versions of the machine runner 3.0 are available for Linux for a streamlined installation experience.
 
-. At present deb and rpm packages are available for linux. Use the following commands to install them
+. Deb and rpm packages are available for Linux. Choose your package, and install using the following commands. The packages install the latest version of the agent. They also create a CircleCI user as well as required directories for operation of the agent.
 +
+[tab.package.Deb]
+--
 ```shell
 # DEB Commands
 # This script installs the package repository to the package manager
 curl -s https://packagecloud.io/install/repositories/circleci/runner/script.deb.sh | sudo bash
 sudo apt install circleci-runner
 ```
+--
 +
+[tab.package.Rpm]
+--
 ```shell
 # RPM Commands
 # This script installs the package repository to the package manager
 curl -s https://packagecloud.io/install/repositories/circleci/runner/script.rpm.sh | sudo bash
 sudo yum install circleci-runner
 ```
+--
+
+. The packages create template configuration files at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, you will need to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading.
 +
-The packages install the latest version of the agent. They also create a circleci user as well as required directories for operation of the agent.
-
-. The packages create a template configuration file at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, you will need to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading.
-
-+
-Once the config file has been populated, the following command will restart the agent so it can begin claiming:
-
+Once the configuration file has been populated, the following command will restart the agent so it can begin claiming:
 +
 ```shell
 sudo systemctl enable circlci-runner

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
@@ -1,5 +1,5 @@
 ---
-contentTags: 
+contentTags:
   platform:
   - Cloud
 ---
@@ -14,9 +14,9 @@ contentTags:
 :experimental:
 :linux:
 
-This page describes how to migrate an existing launch agent installation to machine runner 3.0 preview. The machine runner 3.0 is a new way to run machine jobs for self-hosted runners, with improved network resiliency and simpler installation management strategy utilizing operating system packages.
+This page describes how to migrate an existing launch agent installation to machine runner 3.0. The machine runner 3.0 is a new way to run machine jobs for self-hosted runners, with improved network resiliency and simpler installation management strategy utilizing operating system packages.
 
-NOTE: Machine runner 3.0 is currently in **open preview**, and is currently available on **Linux** only.
+NOTE: Machine runner 3.0 is currently in **open preview**, and is currently available on **Linux** only
 
 Migrating from launch agent to machine runner 3.0 is a straightforward process. The prerequisites remain the same. First, uninstall and remove launch agent, then, install the machine runner 3.0 agent. The configuration file is 1:1 compatible between the agents so no modifications are needed during the migration
 
@@ -76,7 +76,7 @@ sudo yum install circleci-runner
 +
 The packages install the latest version of the agent. They also create a circleci user as well as required directories for operation of the agent.
 
-. The packages create a template configuration file at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, you will need to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading. 
+. The packages create a template configuration file at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, you will need to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading.
 
 +
 Once the config file has been populated, the following command will restart the agent so it can begin claiming:

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3.adoc
@@ -14,7 +14,7 @@ contentTags:
 :experimental:
 :linux:
 
-This page describes how to migrate an existing launch agent installation to machine runner 3.0. The machine runner 3.0 is a new way to run machine jobs for self-hosted runners, with improved network resiliency and simpler installation management strategy utilizing operating system packages.
+This page describes how to migrate an existing launch agent installation to machine runner 3.0. Machine runner 3.0 includes improved network resiliency, and a simpler installation management strategy, utilizing operating system packages.
 
 NOTE: Machine runner 3.0 is currently in **open preview**, and is currently available on **Linux** only
 

--- a/jekyll/_cci2/migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview.adoc
+++ b/jekyll/_cci2/migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview.adoc
@@ -16,17 +16,16 @@ contentTags:
 
 This page describes how to migrate an existing launch agent installation to machine runner 3.0 preview. The machine runner 3.0 is a new way to run machine jobs for self-hosted runners, with improved network resiliency and simpler installation management strategy utilizing operating system packages.
 
-NOTE: Machine runner 3.0 is currently in open preview
-NOTE: Machine runner 3.0 is currently only available on Linux
+NOTE: Machine runner 3.0 is currently in **open preview**, and is currently available on **Linux** only.
 
-Migrating from launch agent to the machine runner 3.0 preview is a straightforward process. The prerequisites remain the same. First uninstall and remove launch agent, then, install the machine runner 3.0 agent. The configuration file is 1:1 compatible between the agents so no modifications are needed during the migration
+Migrating from launch agent to machine runner 3.0 is a straightforward process. The prerequisites remain the same. First, uninstall and remove launch agent, then, install the machine runner 3.0 agent. The configuration file is 1:1 compatible between the agents so no modifications are needed during the migration
 
 [#uninstall-launch-agent]
 == 1. Uninstall launch agent
 
 The first step is to uninstall launch agent. The exact process depends on the platform, as described in the following sections.
 
-If the agent has been installed as a `systemd` service, run the following commands to stop and uninstall the service unit, and delete the service file (the new agent will install a new service unit):
+. If the agent has been installed as a `systemd` service, run the following commands to stop and uninstall the service unit, and delete the service file (the new agent will install a new service unit):
 +
 ```shell
 sudo systemctl stop circleci.service
@@ -57,7 +56,7 @@ sudo semodule -r circleci_launch_agent
 [#install-machine-agent]
 == 2. Installing the Machine Agent
 
-Packaged versions of the machine runner 3.0 preview are available for Linux for a streamlined installation experience.
+Packaged versions of the machine runner 3.0 are available for Linux for a streamlined installation experience.
 
 . At present deb and rpm packages are available for linux. Use the following commands to install them
 +
@@ -75,9 +74,9 @@ curl -s https://packagecloud.io/install/repositories/circleci/runner/script.rpm.
 sudo yum install circleci-runner
 ```
 +
-The packages installs the latest version of the agent. They also create a circleci user as well as required directories for operation of the agent.
+The packages install the latest version of the agent. They also create a circleci user as well as required directories for operation of the agent.
 
-. The packages creates a template configuration file at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, you will need to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading. 
+. The packages create a template configuration file at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, you will need to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading. 
 
 +
 Once the config file has been populated, the following command will restart the agent so it can begin claiming:

--- a/jekyll/_cci2/migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview.adoc
+++ b/jekyll/_cci2/migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview.adoc
@@ -3,7 +3,7 @@ contentTags:
   platform:
   - Cloud
 ---
- = Migrating from launch agent to the machine runner 3.0 preview
+= Migrate from launch agent to machine runner 3.0 - Open preview
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Steps to migrate from using launch agent to the machine runner 3.0 preview

--- a/jekyll/_cci2/migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview.adoc
+++ b/jekyll/_cci2/migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview.adoc
@@ -3,11 +3,10 @@ contentTags:
   platform:
   - Cloud
 ---
-
- = Migrating from Launch Agent to the Machine Runner 3.0 Preview
+ = Migrating from launch agent to the machine runner 3.0 preview
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Instructions on how to migrate from Launch agent to the machine runner 3.0 preview
+:page-description: Steps to migrate from using launch agent to the machine runner 3.0 preview
 :icons: font
 :toc: macro
 :toc-title:
@@ -20,15 +19,14 @@ This page describes how to migrate an existing launch agent installation to mach
 NOTE: Machine runner 3.0 is currently in open preview
 NOTE: Machine runner 3.0 is currently only available on Linux
 
-Migrating from Launch Agent to the Machine Runner 3.0 preview is a fairly straightforward process. The prerequisites are the same as for Launch Agent. First Launch Agent is uninstalled and removed and then Machine Runner 3.0 agent is installed. The configuration file is 1:1 compatible between the agents so should not need modifying during the migration
+Migrating from launch agent to the machine runner 3.0 preview is a straightforward process. The prerequisites remain the same. First uninstall and remove launch agent, then, install the machine runner 3.0 agent. The configuration file is 1:1 compatible between the agents so no modifications are needed during the migration
 
 [#uninstall-launch-agent]
-== 1. Uninstalling Launch Agent
+== 1. Uninstall launch agent
 
 The first step is to uninstall launch agent. The exact process depends on the platform, as described in the following sections.
 
-If the agent has been installed as a `systemd` service, run the following commands the stop and uninstall the service unit, and delete the service file. (The new agent will install a new service unit):
-
+If the agent has been installed as a `systemd` service, run the following commands to stop and uninstall the service unit, and delete the service file (the new agent will install a new service unit):
 +
 ```shell
 sudo systemctl stop circleci.service
@@ -40,12 +38,11 @@ sudo rm /usr/lib/systemd/system/circleci.service
 . The launch agent binary can now be removed from the machine. The default install location is `/opt/circleci/circleci-launch-agent`, but this may differ on your machine if the agent was installed somewhere else. The entire `/opt/circleci` subdirectory can be removed at this point.
 
 . Finally, move the agent configuration file. The default location for this is `/etc/opt/circleci/launch-agent-config.yaml`. Move the file to `/etc/circleci-runner/circleci-runner-config.yaml` using the following command:
-
 +
 ```shell
 mv /etc/opt/circleci/launch-agent-config.yaml /etc/circleci-runner/c sircleci-runner-config.yaml
 ```
-
++
 Alternatively, you can let the machine agent install process create a config file template and copy the existing config into the newly created file (CROSSLINK)
 
 [#uninstalling-launch-agent-linux-se]
@@ -63,7 +60,6 @@ sudo semodule -r circleci_launch_agent
 Packaged versions of the machine runner 3.0 preview are available for Linux for a streamlined installation experience.
 
 . At present deb and rpm packages are available for linux. Use the following commands to install them
-
 +
 ```shell
 # DEB Commands
@@ -71,7 +67,6 @@ Packaged versions of the machine runner 3.0 preview are available for Linux for 
 curl -s https://packagecloud.io/install/repositories/circleci/runner/script.deb.sh | sudo bash
 sudo apt install circleci-runner
 ```
-
 +
 ```shell
 # RPM Commands
@@ -79,11 +74,10 @@ sudo apt install circleci-runner
 curl -s https://packagecloud.io/install/repositories/circleci/runner/script.rpm.sh | sudo bash
 sudo yum install circleci-runner
 ```
-
 +
-The packages will install the latest version of the agent. They also create a circleci user as well as required directories for operation of the agent.
+The packages installs the latest version of the agent. They also create a circleci user as well as required directories for operation of the agent.
 
-. The packages will create a template configuration file at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, user interaction will be required to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading. 
+. The packages creates a template configuration file at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, you will need to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading. 
 
 +
 Once the config file has been populated, the following command will restart the agent so it can begin claiming:

--- a/jekyll/_cci2/migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview.adoc
+++ b/jekyll/_cci2/migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview.adoc
@@ -1,0 +1,95 @@
+---
+contentTags: 
+  platform:
+  - Cloud
+---
+
+ = Migrating from Launch Agent to the Machine Runner 3.0 Preview
+:page-layout: classic-docs
+:page-liquid:
+:page-description: Instructions on how to migrate from Launch agent to the machine runner 3.0 preview
+:icons: font
+:toc: macro
+:toc-title:
+:machine:
+:experimental:
+:linux:
+
+This page describes how to migrate an existing launch agent installation to machine runner 3.0 preview. The machine runner 3.0 is a new way to run machine jobs for self-hosted runners, with improved network resiliency and simpler installation management strategy utilizing operating system packages.
+
+NOTE: Machine runner 3.0 is currently in open preview
+NOTE: Machine runner 3.0 is currently only available on Linux
+
+Migrating from Launch Agent to the Machine Runner 3.0 preview is a fairly straightforward process. The prerequisites are the same as for Launch Agent. First Launch Agent is uninstalled and removed and then Machine Runner 3.0 agent is installed. The configuration file is 1:1 compatible between the agents so should not need modifying during the migration
+
+[#uninstall-launch-agent]
+== 1. Uninstalling Launch Agent
+
+The first step is to uninstall launch agent. The exact process depends on the platform, as described in the following sections.
+
+If the agent has been installed as a `systemd` service, run the following commands the stop and uninstall the service unit, and delete the service file. (The new agent will install a new service unit):
+
++
+```shell
+sudo systemctl stop circleci.service
+sudo systemctl disable circleci.service
+
+sudo rm /usr/lib/systemd/system/circleci.service
+```
+
+. The launch agent binary can now be removed from the machine. The default install location is `/opt/circleci/circleci-launch-agent`, but this may differ on your machine if the agent was installed somewhere else. The entire `/opt/circleci` subdirectory can be removed at this point.
+
+. Finally, move the agent configuration file. The default location for this is `/etc/opt/circleci/launch-agent-config.yaml`. Move the file to `/etc/circleci-runner/circleci-runner-config.yaml` using the following command:
+
++
+```shell
+mv /etc/opt/circleci/launch-agent-config.yaml /etc/circleci-runner/c sircleci-runner-config.yaml
+```
+
+Alternatively, you can let the machine agent install process create a config file template and copy the existing config into the newly created file (CROSSLINK)
+
+[#uninstalling-launch-agent-linux-se]
+==== RHEL/Rocky Linux
+
+In addition to the steps listed above, the SELinux policy should be uninstalled using the following command:
+
+```shell
+sudo semodule -r circleci_launch_agent
+```
+
+[#install-machine-agent]
+== 2. Installing the Machine Agent
+
+Packaged versions of the machine runner 3.0 preview are available for Linux for a streamlined installation experience.
+
+. At present deb and rpm packages are available for linux. Use the following commands to install them
+
++
+```shell
+# DEB Commands
+# This script installs the package repository to the package manager
+curl -s https://packagecloud.io/install/repositories/circleci/runner/script.deb.sh | sudo bash
+sudo apt install circleci-runner
+```
+
++
+```shell
+# RPM Commands
+# This script installs the package repository to the package manager
+curl -s https://packagecloud.io/install/repositories/circleci/runner/script.rpm.sh | sudo bash
+sudo yum install circleci-runner
+```
+
++
+The packages will install the latest version of the agent. They also create a circleci user as well as required directories for operation of the agent.
+
+. The packages will create a template configuration file at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, user interaction will be required to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading. 
+
++
+Once the config file has been populated, the following command will restart the agent so it can begin claiming:
+
++
+```shell
+sudo systemctl enable circlci-runner
+sudo systemctl start circleci-runner
+```

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -233,7 +233,7 @@ en:
           - name: Install machine runner 3.0 on Linux
             link: install-machine-runner-3-on-linux
           - name: Migrate from launch agent to machine runner 3.0
-            link: migrating-from-launch-agent-to-machine-runner-agent-3
+            link: migrate-from-launch-agent-to-machine-runner-3
           - name: Machine runner (3.0) configuration reference
             link: machine-runner-3-configuration-reference
       - name: Machine runner

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -233,7 +233,7 @@ en:
           - name: Install machine runner 3.0 on Linux
             link: install-machine-runner-3-on-linux
           - name: Migrate from launch agent to machine runner 3.0
-            link: migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview
+            link: migrating-from-launch-agent-to-machine-runner-agent-3
           - name: Machine runner (3.0) configuration reference
             link: machine-runner-3-configuration-reference
       - name: Machine runner

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -232,6 +232,8 @@ en:
         children:
           - name: Install machine runner 3.0 on Linux
             link: install-machine-runner-3-on-linux
+          - name: Migrate from launch agent to machine runner 3.0
+            link: migrating-from-launch-agent-to-the-machine-runner-agent-3-0-preview
           - name: Machine runner (3.0) configuration reference
             link: machine-runner-3-configuration-reference
       - name: Machine runner


### PR DESCRIPTION
# Description
A brief description of the changes.

# Reasons
[A link to a GitHub and/or JIRA issue (if applicable).](https://circleci.atlassian.net/browse/ONPREM-326)
Adding in a reduced version of [this PR](https://github.com/circleci/circleci-docs/pull/8146) to only provide update instructions for linux hosts - the only supported host for the Machine Runner 3.0 preview. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
