### PR TITLE
Document job name requirement for local running

### DIFF
--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -255,6 +255,20 @@ circleci config process .circleci/config.yml > process.yml
 circleci local execute -c process.yml JOB_NAME
 ```
 
+Note that JOB_NAME is the value of the key-value pair: for example, given 
+
+```yaml
+jobs:
+  test:
+    name: "Test Application"
+```
+
+the invocation would be
+
+```shell
+circleci local execute -c process.yml "Test Application"
+```
+
 The following commands will run an example build on your local machine on one of CircleCI's demo applications:
 
 ```shell

--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -255,19 +255,24 @@ circleci config process .circleci/config.yml > process.yml
 circleci local execute -c process.yml JOB_NAME
 ```
 
-Note that JOB_NAME is the value of the key-value pair: for example, given 
+[NOTE]
+====
+`JOB_NAME` is the value of the key-value pair. For example, given:
 
-```yaml
+[,yaml]
+----
 jobs:
   test:
     name: "Test Application"
-```
+----
 
-the invocation would be
+The invocation would be:
 
-```shell
+[,shell]
+----
 circleci local execute -c process.yml "Test Application"
-```
+----
+====
 
 The following commands will run an example build on your local machine on one of CircleCI's demo applications:
 


### PR DESCRIPTION
# Description
Document job name requirement for local running.

# Reasons
When running `circleci local execute`, the job name required is exactly that; the job *name*, not its *key*. I thought it might be useful to make that clear.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
