### PR TITLE
Remove Web App instructions for Machine Runner 3.0 on Linux

### DIFF
--- a/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
@@ -29,14 +29,7 @@ This page describes how to install CircleCI's machine runner 3.0 on Linux.
 [#create-namespace-and-resource-class]
 == 1. Create namespace and resource class
 
-[.tab.machine-runner.Web_app_installation]
---
-{% include snippets/runner/install-with-web-app-steps.adoc %}
---
-[.tab.machine-runner.CLI_installation]
---
 {% include snippets/runner/install-with-cli-steps.adoc %}
---
 
 [#install-circleci-runner]
 == 2. Install CircleCI runner


### PR DESCRIPTION
The Web App installation instructions still refer to launch agent and aren't updated for this preview

# Description
A brief description of the changes.

Followup to PR #8342. The Web App installation guide is only for launch agent, and therefore isn't applicable to setting up Machine Runner 3.0 on Linux at this time. For now, we should just have the CLI instructions for creating a namespace and resource class.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

The Web App installation instructions still refer to launch agent and aren't updated for this preview

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
