### PR TITLE
Linux CUDA brownout 25th Sept

### DIFF
--- a/jekyll/_cci2/linux-cuda-images-support-policy.adoc
+++ b/jekyll/_cci2/linux-cuda-images-support-policy.adoc
@@ -13,7 +13,7 @@ contentTags:
 :toc: macro
 :toc-title:
 
-{% include snippets/linux-cuda-deprecation-notice.adoc %}
+{% include snippets/linux-cuda-brownout.adoc %}
 
 [#overview]
 == Overview

--- a/jekyll/_cci2/using-gpu.md
+++ b/jekyll/_cci2/using-gpu.md
@@ -9,7 +9,7 @@ plan:
 - Scale
 ---
 
-{% include snippets/linux-cuda-deprecation-notice.md %}
+{% include snippets/linux-cuda-brownout.md %}
 
 You can run your jobs in the GPU execution environment, using either Windows or Linux virtual machines, for access to Nvidia GPUs for specialized workloads.
 


### PR DESCRIPTION
# Description
Update Linux CUDA pages to display brownout notice (brownout #3, 25th Sept)

# Reasons
Final scheduled brownout https://discuss.circleci.com/t/linux-cuda-deprecation-and-image-policy/48568
Images removed 30th of September

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
