### PR TITLE
Note for readers regarding SSH enabled jobs on rerun workflows

### DIFF
--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -45,6 +45,9 @@ The job virtual machine (VM) will remain available for an SSH connection for **1
 
 If your job has parallel steps, CircleCI launches more than one VM to perform them. You will see more than one 'Enable SSH' and 'Wait for SSH' section in the job output.
 
+If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job.
+{: class="alert alert-info" }
+
 ## Debugging: "permission denied (publickey)"
 {: #debugging-permission-denied-publickey }
 

--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -45,7 +45,7 @@ The job virtual machine (VM) will remain available for an SSH connection for **1
 
 If your job has parallel steps, CircleCI launches more than one VM to perform them. You will see more than one 'Enable SSH' and 'Wait for SSH' section in the job output.
 
-If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job.
+If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job, even after SSH capability has been disabled on the project level.
 {: class="alert alert-info" }
 
 ## Debugging: "permission denied (publickey)"

--- a/jekyll/_cci2/ssh-access-jobs.md
+++ b/jekyll/_cci2/ssh-access-jobs.md
@@ -45,7 +45,7 @@ The job virtual machine (VM) will remain available for an SSH connection for **1
 
 If your job has parallel steps, CircleCI launches more than one VM to perform them. You will see more than one 'Enable SSH' and 'Wait for SSH' section in the job output.
 
-If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job, even after SSH capability has been disabled on the project level.
+If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job, even after SSH capability has been disabled at the project level.
 {: class="alert alert-info" }
 
 ## Debugging: "permission denied (publickey)"

--- a/jekyll/_cci2/workflows.adoc
+++ b/jekyll/_cci2/workflows.adoc
@@ -532,6 +532,8 @@ When you use workflows, you increase your ability to rapidly respond to failures
 
 image::/docs/assets/img/docs/rerun-from-failed.png[CircleCI Workflows Page]
 
+NOTE: If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job.
+
 [#troubleshooting]
 == Troubleshooting
 

--- a/jekyll/_cci2/workflows.adoc
+++ b/jekyll/_cci2/workflows.adoc
@@ -532,7 +532,7 @@ When you use workflows, you increase your ability to rapidly respond to failures
 
 image::/docs/assets/img/docs/rerun-from-failed.png[CircleCI Workflows Page]
 
-NOTE: If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job, even after SSH capability has been disabled on the project level.
+NOTE: If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job, even after SSH capability has been disabled at the project level.
 
 [#troubleshooting]
 == Troubleshooting

--- a/jekyll/_cci2/workflows.adoc
+++ b/jekyll/_cci2/workflows.adoc
@@ -532,7 +532,7 @@ When you use workflows, you increase your ability to rapidly respond to failures
 
 image::/docs/assets/img/docs/rerun-from-failed.png[CircleCI Workflows Page]
 
-NOTE: If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job.
+NOTE: If you rerun a workflow that contains a job which was previously re-run with SSH, the new workflow will be run with SSH enabled for that job, even after SSH capability has been disabled on the project level.
 
 [#troubleshooting]
 == Troubleshooting


### PR DESCRIPTION
# Description
Inform readers that rerunning workflows that contain jobs which were rerun with SSH will have those jobs SSH-enabled in the new workflow.

# Reasons
DOCSS-1186

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
