### PR TITLE
Update ip-ranges.md

### DIFF
--- a/jekyll/_cci2/ip-ranges.md
+++ b/jekyll/_cci2/ip-ranges.md
@@ -156,10 +156,6 @@ CircleCI *does not recommend* configuring an IP-based firewall based on the AWS 
 
 In addition to AWS and GCP (see above), CircleCI's macOS Cloud hosts jobs executed by machines. The following IP address ranges are used by CircleCI macOS Cloud:
 
-- 38.39.188.0/24
-- 38.39.189.0/24
-- 38.39.186.0/24
-- 38.39.187.0/24
 - 38.39.184.0/24
 - 38.39.185.0/24
 - 38.39.183.0/24


### PR DESCRIPTION
# Description

The macOS team has decommissioned the hardware that launched VMs into these IP ranges. 
See the epic [MAC-1729](https://circleci.atlassian.net/browse/MAC-1729) and related issue: [MAC-1724](https://circleci.atlassian.net/browse/MAC-1724)

# Reasons
[Discuss post announcing EOL of medium and large resource classes](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718)

[MAC-1729]: https://circleci.atlassian.net/browse/MAC-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAC-1724]: https://circleci.atlassian.net/browse/MAC-1724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ