### PR TITLE
fix missing code in config example for machine runner 3.0

### DIFF
--- a/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
+++ b/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
@@ -163,7 +163,8 @@ Example:
 
 ```yaml
 runner:
-  working_directory: /var/opt/circleci/%s
+  working_directory: "/var/lib/circleci-runner/workdir"
+  cleanup_working_directory: false
 ```
 
 `$CIRCLECI_RUNNER_CLEANUP_WORK_DIR`


### PR DESCRIPTION
# Description
The config example for cleanup_working_directory was missing the actual cleanup_working_directory example. This PR adds them in

The working directory example was also updated to match the example above and the default configuration. 

# Reasons
A note from Logan brought this up while troubleshooting a Machine Runner 3.0 install for a customer. 
https://circleci.atlassian.net/browse/ONPREM-533

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
