### PR TITLE
Update pull-an-image-from-aws-ecr-with-oidc.adoc

### DIFF
--- a/jekyll/_cci2/pull-an-image-from-aws-ecr-with-oidc.adoc
+++ b/jekyll/_cci2/pull-an-image-from-aws-ecr-with-oidc.adoc
@@ -93,5 +93,17 @@ jobs:
 
 . Replace `<your-iam-role-arn>` with the ARN of the IAM role you want to assume. This is the role you created in the last section.
 
+. There must be at least one context present in your job before CircleCI will generate the $CIRCLE_OIDC_TOKEN environment variable.
+
+[source,yaml]
+----
+workflows:
+  workflow_name:
+    jobs:
+      - job_name:
+          context: aws
+----
+
+
 . Save the changes to your CircleCI configuration file. Next time the job runs, CircleCI will use the specified IAM role and act as an OIDC provider to authenticate and pull your specified ECR image.
 


### PR DESCRIPTION
Adds instructions to include a context when using OIDC to pull an image from AWS ECR so that the $CIRCLE_OIDC_TOKEN is generated.

# Description
Adds instructions to include a context when using OIDC to pull an image from AWS ECR so that the $CIRCLE_OIDC_TOKEN is generated.

# Reasons
Was unable to pull an image from ECR using OIDC until a context was added per 
https://support.circleci.com/hc/en-us/articles/13832176226203-Troubleshooting-OIDC-in-CircleCI

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
