### PR TITLE
Update github-integration.adoc

### DIFF
--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -60,6 +60,7 @@ CircleCI requests the following permissions from GitHub, defined in the link:htt
 
 - Get a list of a user's repos
 - Add an SSH key to a user's account
+- Add Environment Variables to Project Settings
 
 **Admin Permissions**, needed for setting up a project
 


### PR DESCRIPTION
# Description
A brief description of the changes.

Add a mention of Env Vars for write access since we mention SSH keys and no mentions of permissions needed elsewhere

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).

User wrote in about this in a ticket 
https://circleci.zendesk.com/agent/tickets/140038

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
