### PR TITLE
Update Gen 2 Intel Deprecation date to June 28, 2024

### DIFF
--- a/jekyll/_includes/snippets/macos-resource-table.adoc
+++ b/jekyll/_includes/snippets/macos-resource-table.adoc
@@ -26,7 +26,7 @@
 ====
 *We are deprecating support for all Intel-based macOS resources.*
 
-The `macos.x86.medium.gen2` resource class is being deprecated on January 31, 2024. Xcode v15.1 is the latest version that will be supported by this macOS resource.
+The `macos.x86.medium.gen2` resource class is being deprecated on June 28, 2024. Xcode v15.1 is the latest version that will be supported by this macOS resource.
 
 See our link:https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718[announcement] for more details.
 ====

--- a/jekyll/_includes/snippets/macos-resource-table.md
+++ b/jekyll/_includes/snippets/macos-resource-table.md
@@ -8,7 +8,7 @@ macos.m1.large.gen1 | 8 @ 3.2 GHz | 12GB | <i class="fa fa-check" aria-hidden="t
 **We are deprecating support for all Intel-based macOS resources.**
 <br>
 <br>
-The `macos.x86.medium.gen2` resource class is being deprecated on January 31, 2024. Xcode v15.1 is the latest version that will be supported by this macOS resource.
+The `macos.x86.medium.gen2` resource class is being deprecated on June 28, 2024. Xcode v15.1 is the latest version that will be supported by this macOS resource.
 <br>
 <br>
 See our [announcement](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718) for more details.


### PR DESCRIPTION
# Description
Updated Gen2 deprecation date to June 28 from Jan 31

# Reasons
Date was changed to June 

- Context: https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718#:~:text=The%20sunsetting%20of%20Intel%20resources%20is%20now%20June%2028%2C%202024

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
