### PR TITLE
[ONPREM-330] Add link to container runner helm repo in reference docs

### DIFF
--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -127,7 +127,9 @@ Even if there is no further pod configuration, the resource class must be presen
 Additional instructions can be found in our link:https://support.circleci.com/hc/en-us/articles/15773444776731-How-to-use-customSecret-on-Container-Runner[Support Center].
 
 [#parameters]
-=== Helm Chart Parameters
+== Helm Chart Parameters
+
+The container runner helm chart is hosted in a link:https://github.com/CircleCI-Public/container-runner-helm-chart[github repo].
 
 The following are **CircleCI specific settings**:
 

--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -129,7 +129,7 @@ Additional instructions can be found in our link:https://support.circleci.com/hc
 [#parameters]
 == Helm Chart Parameters
 
-The container runner helm chart is hosted in a link:https://github.com/CircleCI-Public/container-runner-helm-chart[github repo].
+The container runner helm chart is hosted link:https://github.com/CircleCI-Public/container-runner-helm-chart[here].
 
 The following are **CircleCI specific settings**:
 


### PR DESCRIPTION
# Description

Add link to container runner helm repo in reference docs

# Reasons

The container runner helm chart repo is now public. This PR adds a link to the repo in the reference docs for container runner

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
