### PR TITLE
Jrahme-cci/launch-agent-migration

### DIFF
--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc
@@ -3,20 +3,18 @@ contentTags:
   platform:
   - Cloud
 ---
-= Migrate from launch agent to machine runner 3.0 - Open preview
+= Migrate from launch agent to machine runner 3.0 on Linux - Open preview
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Steps to migrate from using launch agent to the machine runner 3.0 preview
 :icons: font
 :toc: macro
 :toc-title:
-:machine:
 :experimental:
+:machine:
 :linux:
 
 This page describes how to migrate an existing launch agent installation to machine runner 3.0. Machine runner 3.0 includes improved network resiliency, and a simpler installation management strategy, utilizing operating system packages.
-
-NOTE: Machine runner 3.0 is currently in **open preview**, and is currently available on **Linux** only
 
 Migrating from launch agent to machine runner 3.0 is a straightforward process. The prerequisites remain the same. First, uninstall and remove launch agent, then, install the machine runner 3.0 agent. The configuration file is 1:1 compatible between the agents so no modifications are needed during the migration
 

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc
@@ -53,30 +53,7 @@ sudo semodule -r circleci_launch_agent
 
 [#install-machine-agent]
 == 2. Install the machine agent
-
-Packaged versions of the machine runner 3.0 are available for Linux for a streamlined installation experience.
-
-. Deb and rpm packages are available for Linux. Choose your package, and install using the following commands. The packages install the latest version of the agent. They also create a CircleCI user as well as required directories for operation of the agent.
-+
-[tab.package.Deb]
---
-```shell
-# DEB Commands
-# This script installs the package repository to the package manager
-curl -s https://packagecloud.io/install/repositories/circleci/runner/script.deb.sh | sudo bash
-sudo apt install circleci-runner
-```
---
-+
-[tab.package.Rpm]
---
-```shell
-# RPM Commands
-# This script installs the package repository to the package manager
-curl -s https://packagecloud.io/install/repositories/circleci/runner/script.rpm.sh | sudo bash
-sudo yum install circleci-runner
-```
---
+Follow the instructions provided in xref:install-machine-runner-3-on-linux[Install machine runner 3.0 on Linux] to install machine runner 3.0 using the provided packages.
 
 . The packages create template configuration files at `/etc/circleci-runner/circleci-runner-config.yaml`. This configuration is 1:1 compatible with the launch agent configuration, apart from the auto-update feature. Since auto-update has been removed from the new agent, you should use the appropriate package management update tools to get new versions of the package when they are released. When using the `apt` package to update the agent package, you will need to clear the configuration file modified prompt. This can be avoided using the `--force-confold` flag or by removing the modified configuration file before upgrading.
 +
@@ -86,3 +63,7 @@ Once the configuration file has been populated, the following command will resta
 sudo systemctl enable circleci-runner
 sudo systemctl start circleci-runner
 ```
+[#additional-resources]
+== Additional resources
+
+-xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
@@ -29,21 +29,9 @@ sudo rm -f '/Library/LaunchDaemons/com.circleci.runner.plist'
 sudo rm -rf '/opt/circleci'
 ----
 
-[#move-existing-launch-agent-config]
-== 2. Move the existing launch agent config
-Machine runner 3.0 is backwards compatible with the launch agent configuration, it can be reused instead of creating a whole new configuration file and runner token for a macOS machine runner. 
-
-[,shell]
-----
-mkdir -p $HOME/Library/Preferences/com.circleci.runner
-sudo chown $USER: /Library/Preferences/com.circleci.runner
-mv /Library/Preferences/com.circleci.runner/launch-agent-config.yaml $HOME/Library/com.circleci.runner
-sudo rm -rf /Library/Preferences/com.circleci.runner
-----
-
 [#install-macos-machine-runner]
-== 3. Install the macOS Machine Runner 3.0
-Follow the instructions in xref:install-machine-runner-3-on-macos[Install machine runner 3.0 on macOS] to install machine runner 3.0 using a homebrew package.
+== 2. Install the macOS Machine Runner 3.0
+Follow the instructions in xref:install-machine-runner-3-on-macos#install-circleci-runner[Install machine runner 3.0 on macOS] to install machine runner 3.0 using a homebrew package.
 
 [#additional-resources]
 == Additional resources

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
@@ -1,0 +1,51 @@
+---
+contentTags:
+  platform:
+  - Cloud
+---
+= Migrate from launch agent to machine runner 3.0 on Linux - Open preview
+:page-layout: classic-docs
+:page-liquid:
+:page-description: Steps to migrate from using launch agent to the machine runner 3.0 preview
+:icons: font
+:toc: macro
+:toc-title:
+:machine:
+:experimental:
+:macos:
+
+This page describes how to migrate an existing launch agent installation to machine runner 3.0. Machine runner 3.0 includes improved network resiliency, and a simpler installation management strategy, utilizing operating system packages.
+
+Migrating from launch agent to machine runner 3.0 is a straightforward process. The prerequisites remain the same. First, uninstall and remove launch agent, then, install the machine runner 3.0 agent. The configuration file is 1:1 compatible between the agents so no modifications are needed during the migration
+
+[#uninstall-launch-agent]
+== 1. Uninstall launch agent service
+The first step is to uninstall launch-agent. If the agent has been installed as a `launchctl` service run the following commands to stop as well as uninstall the service, and delete the service file. 
+
+[,shell]
+----
+sudo launchtl unload '/Library/LaunchDaemons/com.circleci.runner.plist'
+sudo rm -f '/Library/LaunchDaemons/com.circleci.runner.plist'
+sudo rm -rf '/opt/circleci'
+----
+
+[#move-existing-launch-agent-config]
+== 2. Move the existing launch agent config
+Machine runner 3.0 is backwards compatible with the launch agent configuration, it can be reused instead of creating a whole new configuration file and runner token for a macOS machine runner. 
+
+[,shell]
+----
+mkdir -p $HOME/Library/Preferences/com.circleci.runner
+sudo chown $USER: /Library/Preferences/com.circleci.runner
+mv /Library/Preferences/com.circleci.runner/launch-agent-config.yaml $HOME/Library/com.circleci.runner
+sudo rm -rf /Library/Preferences/com.circleci.runner
+----
+
+[#install-macos-machine-runner]
+== 3. Install the macOS Machine Runner 3.0
+Follow the instructions in xref:install-machine-runner-3-on-macos[Install machine runner 3.0 on macOS] to install machine runner 3.0 using a homebrew package.
+
+[#additional-resources]
+== Additional resources
+
+-xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-windows.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-windows.adoc
@@ -1,0 +1,65 @@
+---
+contentTags:
+  platform:
+  - Cloud
+---
+= Migrate from launch agent to machine runner 3.0 on Windows - Open preview
+:page-layout: classic-docs
+:page-liquid:
+:page-description: Steps to migrate from using launch agent to the machine runner 3.0 preview on Windows
+:icons: font
+:toc: macro
+:toc-title:
+:machine:
+:Windows:
+
+This page describes how to migrate an existing launch agent installation to machine runner 3.0. Machine runner 3.0 on Windows.
+
+Migrating from launch agent to machine runner 3.0 is a straightforward process. The prerequisites remain the same. First, uninstall and remove launch agent, then, install the machine runner 3.0 agent. The configuration file is 1:1 compatible between the agents so no modifications are needed during the migration
+
+[#uninstall-launch-agent]
+1. Uninstall launch agent
+The first step is to uninstall launch agent. 
+
+. Download the https://github.com/CircleCI-Public/runner-installation-files/tree/main/windows-install[`Uninstall-CircleCIRunner.ps1` script] from GitHub to an easily accessible location.
+. Open PowerShell as an administrator and navigate to the directory where you placed the script file.
+
+. Run the following in your PowerShell:
++
+```
+./Uninstall-CircleCIRunner.ps1
+```
+
+[#copy-current-runner-configuration]
+3. Copy current launch agent configuration
+
+. Machine runner 3.0 is backwards compatible with the launch-agent configuration file. Using PowerShell copy the existing launch-agent config for use with the machine runner 3.0 installation.
+
+[,shell]
+----
+$desktopDir = [Environment]::GetFolderPath("Desktop")
+copy "$env:ProgramFiles\CircleCI\runner-agent-config.yaml" "$desktopDir/runner-agent-config.yaml"
+----
+
+[#install-machine-runner]
+2. Install machine runner 3.0
+
+. Download the https://github.com/CircleCI-Public/runner-installation-files/tree/main/windows-install/circleci-runner[`Install-CircleCIRunner.ps1` script] from GitHub to an easily accessible location.
+
+. Open PowerShell as an administrator and navigate to the directory where you placed the script file.
+
+. Run the following in your PowerShell:
++
+[,shell]
+----
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+./Install-CircleCIRunner.ps1
+----
++
+The installation will be output into your PowerShell interface.
+
+. As part of the installation, the configuration file for the machine runner (`launch-agent-config.yaml`) will open in Notepad. Please fill the file out with the information from the previous configuration file copied in the [copy current runner configuration step](#copy-current-runner-configuration). The configuration file is located in the installation directory, `C:\Program Files\CircleCI`, by default.
+
+After setup completes, the machine runner starts automatically and begins looking for jobs to process.
+
+{% include snippets/machine-runner-example.adoc %}


### PR DESCRIPTION
# Description
Add documentation for migration from launch-agent to machine runner 3.0 for macOS and Windows. Also update the Linux migrations to refer to the official installation instructions, instead of duplicating the documentation across two pages. 

As Machine Runner 3.0 is going GA tomorrow there is no need to wait for merging if the PR is approved. 

# Reasons
Bringing parity to migration documentation for Windows and macOS with Linux in prep for Machine Runner 3.0 GA

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
