### PR TITLE
Remove references to the machine runner 3.0 open preview on Linux [ONPREM-429]

### DIFF
--- a/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
@@ -3,16 +3,13 @@ contentTags:
   platform:
   - Cloud
 ---
-= Install machine runner 3.0 on Linux - Open preview
+= Install machine runner 3.0 on Linux
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Instructions on how to install CircleCI's self-hosted machine runner (3.0) on Linux.
 :icons: font
-:experimental:
 :machine:
 :linux:
-
-NOTE: Machine runner 3.0 is currently in open preview
 
 This page describes how to install CircleCI's machine runner 3.0 on Linux.
 

--- a/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
+++ b/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
@@ -3,13 +3,10 @@ contentTags:
   platform:
   - Cloud
 ---
-= Machine runner 3.0 configuration reference - Open preview
+= Machine runner 3.0 configuration reference
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:experimental:
-
-NOTE: Machine runner 3.0 is currently in open preview
 
 A YAML file is used to configure the machine runner, how it communicates with CircleCI's servers, and how it will launch the task-agent. This page explains all available parameters.
 

--- a/jekyll/_cci2/machine-runner-3-manual-installation.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation.adoc
@@ -3,17 +3,14 @@ contentTags:
   platform:
   - Cloud
 ---
-= Machine runner 3.0 manual installation - Open preview
+= Machine runner 3.0 manual installation
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Instructions on how to manually start CircleCI's self-hosted machine runner 3.0 on macOS and Linux.
 :icons: font
-:experimental:
 :machine:
 :macOS:
 :linux:
-
-NOTE: Machine runner 3.0 is currently in open preview
 
 This page describes how to manually start CircleCI's machine runner 3.0 on macOS and Linux.
 


### PR DESCRIPTION
# Description

Move machine runner 3.0 on Linux out of open preview, as the GA date is today. Similar updates for the migration from launch-agent docs have been made in PR #8438.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.atlassian.net/browse/ONPREM-429

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
