### PR TITLE
[MAC-1930] chore: update Xcode 15.1 Beta 3

### DIFF
--- a/jekyll/_includes/snippets/xcode-intel-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-intel-vm.adoc
@@ -9,7 +9,7 @@
 
 | `15.1.0`
 | Xcode 15.1 beta 2 (15C5042i)
-| 13.6  
+| 14.1
 | link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt[Installed software]
 | link:https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816[Release Notes]
 

--- a/jekyll/_includes/snippets/xcode-intel-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-intel-vm.adoc
@@ -8,7 +8,7 @@
 | Release Notes
 
 | `15.1.0`
-| Xcode 15.1 beta 2 (2B374)
+| Xcode 15.1 beta 3 (2B374)
 | 14.1
 | link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13795/manifest.txt[Installed software]
 | link:https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876[Release Notes]

--- a/jekyll/_includes/snippets/xcode-intel-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-intel-vm.adoc
@@ -10,8 +10,8 @@
 | `15.1.0`
 | Xcode 15.1 beta 2 (15C5042i)
 | 13.6  
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13665/manifest.txt[Installed software]
-| link:https://discuss.circleci.com/t/xcode-15-1-beta-2-released/49688[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt[Installed software]
+| link:https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816[Release Notes]
 
 | `15.0.0`
 | Xcode 15 (15A240d)

--- a/jekyll/_includes/snippets/xcode-intel-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-intel-vm.adoc
@@ -8,10 +8,10 @@
 | Release Notes
 
 | `15.1.0`
-| Xcode 15.1 beta 2 (15C5042i)
+| Xcode 15.1 beta 2 (2B374)
 | 14.1
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt[Installed software]
-| link:https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13795/manifest.txt[Installed software]
+| link:https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876[Release Notes]
 
 | `15.0.0`
 | Xcode 15 (15A240d)

--- a/jekyll/_includes/snippets/xcode-intel-vm.md
+++ b/jekyll/_includes/snippets/xcode-intel-vm.md
@@ -1,6 +1,6 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
-`15.1.0 | Xcode 15 beta 2 (23B74) | 14.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13795/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876)
+`15.1.0 | Xcode 15 beta 3 (23B74) | 14.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13795/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876)
  `15.0.0` | Xcode 15 (15A240d) | 13.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13456/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-rc-released-important-notice-for-visionos-sdk-users/49278)
 `14.3.1` | Xcode 14.3.1 (14E300b) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12131/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
  `14.2.0` | Xcode 14.2 (14C18) | 12.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v10821/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-2-rc-released-breaking-changes/46303)

--- a/jekyll/_includes/snippets/xcode-intel-vm.md
+++ b/jekyll/_includes/snippets/xcode-intel-vm.md
@@ -1,6 +1,6 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
-`15.1.0 | Xcode 15 beta 2 (15C5042i) | 13.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816)
+`15.1.0 | Xcode 15 beta 2 (15C5042i) | 14.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816)
  `15.0.0` | Xcode 15 (15A240d) | 13.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13456/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-rc-released-important-notice-for-visionos-sdk-users/49278)
 `14.3.1` | Xcode 14.3.1 (14E300b) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12131/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
  `14.2.0` | Xcode 14.2 (14C18) | 12.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v10821/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-2-rc-released-breaking-changes/46303)

--- a/jekyll/_includes/snippets/xcode-intel-vm.md
+++ b/jekyll/_includes/snippets/xcode-intel-vm.md
@@ -1,6 +1,6 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
-`15.1.0 | Xcode 15 beta 2 (15C5042i) | 13.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13665/manifest.txt) | [Release Notes](https://https://discuss.circleci.com/t/xcode-15-1-beta-2-released/49688)
+`15.1.0 | Xcode 15 beta 2 (15C5042i) | 13.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816)
  `15.0.0` | Xcode 15 (15A240d) | 13.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13456/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-rc-released-important-notice-for-visionos-sdk-users/49278)
 `14.3.1` | Xcode 14.3.1 (14E300b) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12131/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
  `14.2.0` | Xcode 14.2 (14C18) | 12.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v10821/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-2-rc-released-breaking-changes/46303)

--- a/jekyll/_includes/snippets/xcode-intel-vm.md
+++ b/jekyll/_includes/snippets/xcode-intel-vm.md
@@ -1,6 +1,6 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
-`15.1.0 | Xcode 15 beta 2 (15C5042i) | 14.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816)
+`15.1.0 | Xcode 15 beta 2 (23B74) | 14.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13795/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876)
  `15.0.0` | Xcode 15 (15A240d) | 13.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13456/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-rc-released-important-notice-for-visionos-sdk-users/49278)
 `14.3.1` | Xcode 14.3.1 (14E300b) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12131/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
  `14.2.0` | Xcode 14.2 (14C18) | 12.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v10821/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-2-rc-released-breaking-changes/46303)

--- a/jekyll/_includes/snippets/xcode-silicon-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.adoc
@@ -10,8 +10,8 @@
 | `15.1.0`
 | Xcode 15.1 beta 2 (15C5042i)
 | 13.6
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13624/manifest.txt[Installed software]
-| link:https://discuss.circleci.com/t/xcode-15-1-beta-2-released/49688[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt[Installed software]
+| link:https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816[Release Notes]
 
 | `15.0.0`
 | Xcode 15 (15A240d)

--- a/jekyll/_includes/snippets/xcode-silicon-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.adoc
@@ -8,10 +8,10 @@
 | Release Notes
 
 | `15.1.0`
-| Xcode 15.1 beta 2 (15C5042i)
+| Xcode 15.1 beta 2 (23B74)
 | 14.1
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt[Installed software]
-| link:https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13844/manifest.txt[Installed software]
+| link:https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876[Release Notes]
 
 | `15.0.0`
 | Xcode 15 (15A240d)

--- a/jekyll/_includes/snippets/xcode-silicon-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.adoc
@@ -9,7 +9,7 @@
 
 | `15.1.0`
 | Xcode 15.1 beta 2 (15C5042i)
-| 13.6
+| 14.1
 | link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt[Installed software]
 | link:https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816[Release Notes]
 

--- a/jekyll/_includes/snippets/xcode-silicon-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.adoc
@@ -8,7 +8,7 @@
 | Release Notes
 
 | `15.1.0`
-| Xcode 15.1 beta 2 (23B74)
+| Xcode 15.1 beta 3 (23B74)
 | 14.1
 | link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13844/manifest.txt[Installed software]
 | link:https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876[Release Notes]

--- a/jekyll/_includes/snippets/xcode-silicon-vm.md
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.md
@@ -1,6 +1,6 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
-`15.1.0` | Xdode 15.1 beta 2 (15C5042i) | 13.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt)  | [Release Notes]https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816)
+`15.1.0` | Xdode 15.1 beta 2 (15C5042i) | 14.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt)  | [Release Notes]https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816)
  `15.0.0` | Xcode 15 (15A240d) | 13.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13456/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-rc-released-important-notice-for-visionos-sdk-users/49278)
  `14.3.1` | Xcode 14.3.1 (14E300b) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12128/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
  `14.2.0` | Xcode 14.2 (14C18) | 12.6.3 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11441/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/announcing-apple-silicon-m1-support-now-available/46908)

--- a/jekyll/_includes/snippets/xcode-silicon-vm.md
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.md
@@ -1,6 +1,6 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
-`15.1.0` | Xdode 15.1 beta 2 (15C5042i) | 14.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt)  | [Release Notes]https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816)
+`15.1.0` | Xdode 15.1 beta 3 (23B74) | 14.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13844/manifest.txt)  | [Release Notes]https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876)
  `15.0.0` | Xcode 15 (15A240d) | 13.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13456/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-rc-released-important-notice-for-visionos-sdk-users/49278)
  `14.3.1` | Xcode 14.3.1 (14E300b) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12128/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
  `14.2.0` | Xcode 14.2 (14C18) | 12.6.3 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11441/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/announcing-apple-silicon-m1-support-now-available/46908)

--- a/jekyll/_includes/snippets/xcode-silicon-vm.md
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.md
@@ -1,6 +1,6 @@
  Config   | Xcode Version                   | macOS Version | VM Software Manifest | Release Notes
 ----------|---------------------------------|---------------|----------------------------|--------------
-`15.1.0` | Xdode 15.1 beta 2 (15C5042i) | 13.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13624/manifest.txt)  | [Release Notes](https://discuss.circleci.com/t/xcode-15-1-beta-2-released/49688)
+`15.1.0` | Xdode 15.1 beta 2 (15C5042i) | 13.6 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13764/manifest.txt)  | [Release Notes]https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816)
  `15.0.0` | Xcode 15 (15A240d) | 13.5.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13456/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-15-rc-released-important-notice-for-visionos-sdk-users/49278)
  `14.3.1` | Xcode 14.3.1 (14E300b) | 13.2.1 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12128/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/xcode-14-3-1-rc-released/48152)
  `14.2.0` | Xcode 14.2 (14C18) | 12.6.3 | [Installed software](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11441/manifest.txt) | [Release Notes](https://discuss.circleci.com/t/announcing-apple-silicon-m1-support-now-available/46908)


### PR DESCRIPTION
xcode 15.1 beta 2 was rerolled last night to update the OS to Sonoma so the manifest and discuss posts are now different