### PR TITLE
Delete_prometheus_values_doesn_not_exist_on_server4.3

### DIFF
--- a/jekyll/_cci2/server/v4.3/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/installation-reference.adoc
@@ -918,51 +918,6 @@ a|AWS Authentication Config.
 |`false`
 |CA Certificate filename used in your `certificatesSecret`. If provided, PostgreSQL will authenticate TLS/SSL clients by requesting a certificate from them.
 
-|`prometheus.alertmanager.enabled`
-|boolean
-|`false`
-|
-
-|`prometheus.enabled`
-|boolean
-|`false`
-|
-
-|`prometheus.extraScrapeConfigs`
-|string
-|`"- job_name: 'telegraf-metrics'\n  scheme: http\n  metrics_path: /metrics\n  static_configs:\n  - targets:\n    - \"telegraf:9273\"\n    labels:\n      service: telegraf\n"`
-|
-
-|`prometheus.fullnameOverride`
-|string
-|`"prometheus"`
-|
-
-|`prometheus.nodeExporter.fullnameOverride`
-|string
-|`"node-exporter"`
-|
-
-|`prometheus.pushgateway.enabled`
-|boolean
-|`false`
-|
-
-|`prometheus.server.emptyDir.sizeLimit`
-|string
-|`"8Gi"`
-|
-
-|`prometheus.server.fullnameOverride`
-|string
-|`"prometheus-server"`
-|
-
-|`prometheus.server.persistentVolume.enabled`
-|boolean
-|`false`
-|
-
 |`proxy.enabled`
 |boolean
 |`false`
@@ -1220,11 +1175,6 @@ a|Session cookie key. Must be exactly 16 bytes.
 |`telegraf.config.inputs[0].statsd.service_address`
 |string
 |`":8125"`
-|
-
-|`telegraf.config.outputs[0].prometheus_client.listen`
-|string
-|`":9273"`
 |
 
 |`telegraf.fullnameOverride`


### PR DESCRIPTION
# Description
Removing description about prometheus on server4.3 installation reference.

# Reasons
Prometheus has been deprecated on server4.3, applying it on docs as well.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
