### PR TITLE
Add SAML warning to GH OAuth app integration page

### DIFF
--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -35,7 +35,7 @@ CircleCI builds push hooks by default. So, builds are triggered for all push hoo
 There are some additional, less common cases where CircleCI uses hooks, as follows:
 
 - CircleCI processes PR hooks (pull request hooks) to store PR information for the CircleCI app. If the **Only build pull requests** setting is enabled within CircleCI, CircleCI will only trigger builds when a PR is opened, or when there is a push to a branch for which there is an existing PR. Even if this setting is enabled, CircleCI will always build all pushes to the project's default branch.
-- If the **Build forked pull requests** setting is enabled in CircleCI, CircleCI will trigger builds in response to PRs created from forked repos.
+- If the **Build forked pull requests** setting is enabled in CircleCI, CircleCI will trigger builds in response to PRs created from forked repositories.
 
 These settings can be found in each project's individual **Project Settings** section of the CircleCI web app.
 
@@ -58,15 +58,23 @@ CircleCI requests the following permissions from GitHub, defined in the link:htt
 
 **Write Permissions**
 
-- Get a list of a user's repos
+- Get a list of a user's repositories
 - Add an SSH key to a user's account
 
 **Admin Permissions**, needed for setting up a project
 
-- Add deploy keys to a repo
-- Add service hooks to a repo
+- Add deploy keys to a repository
+- Add service hooks to a repository
 
-NOTE: CircleCI only asks for permissions that are absolutely necessary. However, as a GitHub OAuth app, CircleCI is constrained by the specific permissions available via GitHub’s OAuth scopes. For example, getting a full list of a user’s repos, public and private, from GitHub, requires the link:https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes[`repo` scope], which is write-level access. GitHub does not provide a read-only OAuth scope for listing all of a user’s repositories.
+NOTE: CircleCI only asks for permissions that are absolutely necessary. However, as a GitHub OAuth app, CircleCI is constrained by the specific permissions available via GitHub’s OAuth scopes. For example, getting a full list of a user’s repository, public and private, from GitHub, requires the link:https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes[`repo` scope], which is write-level access. GitHub does not provide a read-only OAuth scope for listing all of a user’s repositories.
+
+[#saml-sso]
+== SAML SSO
+
+Enabling SAML protection on a GitHub org can cause changes to CircleCI’s settings related to GitHub Checks and GitHub status updates. Please ensure these settings are configured for their desired state after enabling SAML for your organization. You can find these settings at:
+
+* GitHub Checks, from the GitHub website, select menu:Organization Settings[VCS > GitHub Checks]
+* GitHub status updates, from the CircleCI web app menu:Project Settings[Advanced > GitHub Status Updates]
 
 [#connect-a-github-account]
 == Connect a GitHub account
@@ -92,7 +100,7 @@ A user key is user-specific an SSH key-pair. GitHub stores the public key, and C
 
 Deploy keys and user keys are the only key types that GitHub supports. Deploy keys are globally unique (for example, no mechanism exists to make a deploy key with access to multiple repositories) and user keys have no notion of _scope_ separate from the user associated with them.
 
-To achieve fine-grained access to more than one repo, consider creating what GitHub calls a <<#controlling-access-via-a-machine-user,machine user>>. Give this user exactly the permissions your build requires, and then associate its user key with your project on CircleCI.
+To achieve fine-grained access to more than one repository, consider creating what GitHub calls a <<#controlling-access-via-a-machine-user,machine user>>. Give this user exactly the permissions your build requires, and then associate its user key with your project on CircleCI.
 
 [#create-additional-github-ssh-keys]
 === Create additional GitHub SSH keys
@@ -109,7 +117,7 @@ In this example, the GitHub repository is `https://github.com/you/test-repo`, an
 
 . Go to `https://github.com/you/test-repo/settings/keys`, and click **Add Deploy Key**. Enter a title in the "Title" field, then copy and paste the public key you created in step 1. Check **Allow write access**, then click **Add key**.
 
-. Go to your project settings in the CircleCI app, select **SSH Keys**, and **Add SSH key**. In the "Hostname" field, enter `github.com` and add the private key you created in step 1. Then click **Add SSH Key**.
+. Go to your project settings in the CircleCI app, select **SSH Keys**, and **Add SSH key**. In the "hostname" field, enter `github.com` and add the private key you created in step 1. Then click **Add SSH Key**.
 
 . In your `.circleci/config.yml` file, add the fingerprint to a job using the `add_ssh_keys` key:
 +
@@ -165,7 +173,7 @@ Permission denied (publickey).
 ```
 
 [#add-a-circleci-config-file]
-== Add a .circleci/config.yml file
+== Add a `.circleci/config.yml` file
 
 After the necessary permissions have been set up, the next step is adding a `.circleci/config.yml` file to the projects you would like to use with CircleCI. Add a `.circleci` directory to a repository you want to connect to CircleCI. Inside that directory, add a `config.yml` file.
 
@@ -186,9 +194,9 @@ Provide CircleCI with a GitHub user key in your project's **Project Settings** >
 == Best practices for keys
 
 - Use Deploy Keys whenever possible.
-- When Deploy Keys cannot be used, <<#controlling-access-via-a-machine-user,Machine user keys>> must be used, and have their access restricted to the most limited set of repos and permissions necessary.
+- When Deploy Keys cannot be used, <<#controlling-access-via-a-machine-user,Machine user keys>> must be used, and have their access restricted to the most limited set of repository and permissions necessary.
 - Never use non-Machine user keys (keys should be associated with the build, not with a specific person).
-- You must rotate the Deploy or User key as part of revoking user access to that repo.
+- You must rotate the Deploy or User key as part of revoking user access to that repository.
   1. After revoking the user’s access in GitHub, delete keys in GitHub.
   2. Delete the keys in the CircleCI project.
   3. Regenerate the keys in CircleCI project.
@@ -217,7 +225,7 @@ github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+V
 ➜  ~ ✗
 ```
 
-You can add the key to known_hosts by running the following command:
+You can add the key to `known_hosts` by running the following command:
 ```shell
 ssh-keyscan github.com >> ~/.ssh/known_hosts
 ```

--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -76,6 +76,8 @@ Enabling SAML protection on a GitHub org can cause changes to CircleCI’s setti
 * GitHub Checks, from the GitHub website, select menu:Organization Settings[VCS > GitHub Checks]
 * GitHub status updates, from the CircleCI web app menu:Project Settings[Advanced > GitHub Status Updates]
 
+For more information on GitHub Checks and GitHub status updates, see the xref:enable-checks#github-check-and-github-status-updates[Enabling GitHub checks].
+
 [#connect-a-github-account]
 == Connect a GitHub account
 


### PR DESCRIPTION
# Description
Add a short section informing people that if they enable SAML SSO for an org they need to check settings for GH Checks and GH Status updates are correct.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
