### PR TITLE
Fix xcode intel warning

### DIFF
--- a/jekyll/_includes/snippets/xcode-intel-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-intel-vm.adoc
@@ -60,7 +60,7 @@
 ====
 *We are deprecating support for all Intel-based macOS resources.*
 
-The `macos.x86.medium.gen2` resource class is being deprecated on January 31, 2024. Xcode v15.1 is the latest version that will be supported by this macOS resource.
+The `macos.x86.medium.gen2` resource class is being deprecated on June 28, 2024. Xcode v15.1 is the latest version that will be supported by this macOS resource.
 
 See our link:https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718[announcement] for more details.
 ====

--- a/jekyll/_includes/snippets/xcode-intel-vm.md
+++ b/jekyll/_includes/snippets/xcode-intel-vm.md
@@ -13,7 +13,7 @@
 **We are deprecating support for all Intel-based macOS resources.**
 <br>
 <br>
-The `macos.x86.medium.gen2` resource class is being deprecated on January 31, 2024. Xcode v15.1 is the latest version that will be supported by this macOS resource.
+The `macos.x86.medium.gen2` resource class is being deprecated on June 28, 2024. Xcode v15.1 is the latest version that will be supported by this macOS resource.
 <br>
 <br>
 See our [announcement](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718) for more details.


### PR DESCRIPTION
# Description
The date for the EOL of intel macOS resources below the supported Intel Xcode versions table wasn't updated to reflect the new deprecation date of June 28, 2024.

# Reasons
We want to ensure that people who read the docs are getting accurate information.

# Content Checklist
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
