### PR TITLE
[FIX]: Cleanup link and typo in remote docker policy

### DIFF
--- a/jekyll/_cci2/remote-docker-images-support-policy.adoc
+++ b/jekyll/_cci2/remote-docker-images-support-policy.adoc
@@ -15,7 +15,7 @@ contentTags:
 [#overview]
 == Overview
 
-This document outlines the [CircleCI remote Docker image](https://circleci.com/docs/building-docker-images/) release, update, and deprecation policy. This policy applies to all CircleCI remote Docker images built for the remote Docker feature (setup_remote_docker).
+This document outlines the link:https://circleci.com/docs/building-docker-images/[CircleCI remote Docker image] release, update, and deprecation policy. This policy applies to all CircleCI remote Docker images built for the remote Docker feature (setup_remote_docker).
 
 [#release-policy]
 == Release policy
@@ -33,7 +33,7 @@ We support various tags for the remote Docker environment to allow you to choose
 
 For the latest major version of Docker:
 
-- `default`: This image is the current stable image. Jobs will defauly to this if no tag is specified.
+- `default`: This image is the current stable image. Jobs will default to this if no tag is specified.
 
 - `edge`: This tag is reserved for previews of new releases, which will initially point to this tag. The tag may include incremental updates relative to the current quarterly image release, which may change without notice, and is not recommended for production CI workloads.
 


### PR DESCRIPTION
# Description
A brief description of the changes.

Typo issues fixes
