### PR TITLE
[FIX]: Remove incorrect info about pinning date for remote docker

### DIFF
--- a/jekyll/_cci2/remote-docker-images-support-policy.adoc
+++ b/jekyll/_cci2/remote-docker-images-support-policy.adoc
@@ -39,7 +39,7 @@ For the latest major version of Docker:
 
 - `previous`: Once an `edge` image is promoted to `default`, the previous `default` image is moved to the `previous` tag.
 
-For the previous major version of Docker, we support a single tag following the format of `dockerXX`, for example, `docker23` for Docker 23. This tag will point to the latest patch version of the major release, and will be updated if any patch versions are issued upstream. We recommend using the default version and not pinning to a date version.
+For the previous major version of Docker, we support a single tag following the format of `dockerXX`, for example, `docker23` for Docker 23. This tag will point to the latest patch version of the major release, and will be updated if any patch versions are issued upstream. We recommend using the default version.
 
 [#critical-cve-patches]
 == Critical CVE patches


### PR DESCRIPTION
You cannot pin a date tag for remote docker so this is incorrect information