### PR TITLE
Document command for waiting on the container runner SSH Gateway to be ready [ONPREM-608]

### DIFF
--- a/jekyll/_cci2/container-runner-installation.adoc
+++ b/jekyll/_cci2/container-runner-installation.adoc
@@ -129,15 +129,20 @@ agent:
   ssh:
     enabled: "true"
 ----
-
+For a full list of SSH configuration options, refer to the link:https://github.com/circleci-public/container-runner-helm-chart#values[Helm chart values].
 . Redeploy the updated manifest:
 +
 [source,shell]
 ----
 helm upgrade <release-name> container-agent/container-agent -n <namespace> -f values.yaml
 ----
-
-For a full list of SSH configuration options, refer to the link:https://github.com/circleci-public/container-runner-helm-chart#values[Helm chart values].
+. Wait for the SSH link:https://gateway-api.sigs.k8s.io/api-types/gateway/#gateway[Gateway] to be programmed:
++
+[source,shell]
+----
+kubectl wait gateway --timeout=5m --all --for=condition=Programmed -n <namespace>
+----
+Container runner is now ready for rerunning jobs with SSH.
 
 [#container-runner-configuration-example]
 == Container runner configuration example

--- a/jekyll/_cci2/container-runner-installation.adoc
+++ b/jekyll/_cci2/container-runner-installation.adoc
@@ -129,19 +129,23 @@ agent:
   ssh:
     enabled: "true"
 ----
++
 For a full list of SSH configuration options, refer to the link:https://github.com/circleci-public/container-runner-helm-chart#values[Helm chart values].
+
 . Redeploy the updated manifest:
 +
 [source,shell]
 ----
 helm upgrade <release-name> container-agent/container-agent -n <namespace> -f values.yaml
 ----
+
 . Wait for the SSH link:https://gateway-api.sigs.k8s.io/api-types/gateway/#gateway[Gateway] to be programmed:
 +
 [source,shell]
 ----
 kubectl wait gateway --timeout=5m --all --for=condition=Programmed -n <namespace>
 ----
++
 Container runner is now ready for rerunning jobs with SSH.
 
 [#container-runner-configuration-example]

--- a/jekyll/_cci2/container-runner-installation.adoc
+++ b/jekyll/_cci2/container-runner-installation.adoc
@@ -136,7 +136,7 @@ For a full list of SSH configuration options, refer to the link:https://github.c
 +
 [source,shell]
 ----
-helm upgrade <release-name> container-agent/container-agent -n <namespace> -f values.yaml
+helm upgrade --wait --timeout=5m <release-name> container-agent/container-agent -n <namespace> -f values.yaml
 ----
 
 . Wait for the SSH link:https://gateway-api.sigs.k8s.io/api-types/gateway/#gateway[Gateway] to be programmed:


### PR DESCRIPTION
# Description
A brief description of the changes.

Add a helpful command to the container runner install docs for waiting on the SSH Gateway to be ready for connections.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.atlassian.net/browse/ONPREM-608

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
