### PR TITLE
Updates to templates/template-conceptual.adoc

### DIFF
--- a/jekyll/_cci2/templates/template-conceptual.adoc
+++ b/jekyll/_cci2/templates/template-conceptual.adoc
@@ -29,7 +29,7 @@ This template will help you create a new docs page to provide **conceptual** inf
 * Develop new content quickly
 * Ensure your page conforms to the style guide
 
-To use this template make a copy and place it in the `_cci2` directory. The filename should match the page title. Look at the source file for this page template link:https://github.com/circleci/circleci-docs/blob/master/jekyll/_cci2/template/template-conceptual.adoc?plain=1[here]. There is additional detail in the comments.
+To use this template make a copy and place it in the `_cci2` directory. The filename should match the page title. Look at the source file for this link:https://github.com/circleci/circleci-docs/blob/master/jekyll/_cci2/templates/template-conceptual.adoc?plain=1[page template here]. There is additional detail in the comments.
 
 The opening paragraph should be used to succinctly explain to the reader what value the feature/task provides and what use cases it supports. If possible display the use cases in a bullet list.
 
@@ -45,7 +45,7 @@ Use the introduction to explain more about the feature/task, what it is for, why
 
 You might want to include an image or diagram here to help illustrate the concept. The docs team can work with you to help create helpful image to support explanatory information:
 
-image::{{site.baseurl}}/assets/img/docs/arch.png[Provide some alt text for images here]
+image::{{site.baseurl}}/assets/img/docs/arch.png[Diagram that includes flow from Repository and Apps to CircleCI API, from CircleCI API to Orchestration, from Orchestration to Execution, and from Execution to Deployment.]
 
 [#quickstart]
 == Quickstart


### PR DESCRIPTION
	modified:   jekyll/_cci2/templates/template-conceptual.adoc

- Fixed broken link to page template
- Changed anchor text per accessibility standards
- Added alt text per accessibility standards

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
