### PR TITLE
SNC-520: Add multi oidc tokens with custom claims to docs

### DIFF
--- a/jekyll/_cci2/oidc-tokens-with-custom-claims.adoc
+++ b/jekyll/_cci2/oidc-tokens-with-custom-claims.adoc
@@ -3,20 +3,20 @@ contentTags:
   platform:
   - Cloud
 ---
-= On-demand OIDC tokens with custom claims
+= OIDC tokens with custom claims
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Learn about the capabilities to customize claims in OIDC tokens.
 :icons: font
 :experimental:
 
-Use OpenID Connect (OIDC) tokens to connect your pipelines to compatible cloud services without the need to manage long-lived secrets in CircleCI. Create CircleCI OIDC tokens on demand using the CircleCI CLI, and customize your claims to meet the unique needs of different cloud services.
+Use OpenID Connect (OIDC) tokens to connect your pipelines to compatible cloud services without the need to manage long-lived secrets in CircleCI. Create CircleCI OIDC tokens using the CircleCI CLI, and customize your claims to meet the unique needs of different cloud services.
 See xref:openid-connect-tokens#[Default OpenID Connect tokens in jobs] for more information on default OIDC tokens provided by CircleCI in jobs.
 
-[#create-oidc-token-on-demand-in-a-job]
-== Create an OIDC token on demand in a job
+[#create-oidc-token-in-a-job-with-custom-claims]
+== Create OIDC token in a job with custom claims
 
-CircleCI allows creation of OIDC tokens on demand in a job. Multiple OIDC tokens can be created in a job with the option to customize claims. The CircleCI CLI may be used in a step to do this, as follows:
+CircleCI allows creation of OIDC tokens in a job. Multiple OIDC tokens can be created in a job with the option to customize claims. The CircleCI CLI may be used in a step to do this, as follows:
 
 [source,shell]
 ----
@@ -31,7 +31,7 @@ CAUTION: **The OIDC token** created by the above command can be printed with no 
 [#example-configuration]
 == Example configuration
 
-Below is an example configuration that deploys a static HTML webpage to AWS S3 using on-demand OIDC token generation, with a customized `aud` claim in a job.
+Below is an example configuration that deploys a static HTML webpage to AWS S3 using OIDC token, with a customized `aud` claim in a job.
 
 ```yaml
 version: 2.1
@@ -64,7 +64,7 @@ jobs:
           command: |
             # set the variable AWS_WEB_IDENTITY_TOKEN_FILE to a temporary file that will hold the OIDC token
             export AWS_WEB_IDENTITY_TOKEN_FILE="$(mktemp -u)"
-            # create an on-demand OIDC token with customized aud claim of org-id
+            # create OIDC token with customized aud claim of org-id
             OIDC_TOKEN=$(circleci run oidc get --claims '{"aud": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"}')
             # copy the OIDC token to the AWS_WEB_IDENTITY_TOKEN_FILE created earlier
             echo $OIDC_TOKEN > "$AWS_WEB_IDENTITY_TOKEN_FILE"

--- a/jekyll/_cci2/oidc-tokens-with-custom-claims.adoc
+++ b/jekyll/_cci2/oidc-tokens-with-custom-claims.adoc
@@ -14,6 +14,7 @@ contentTags:
 == Introduction
 
 OpenID Connect (OIDC) tokens allow you to connect your pipelines to compatible cloud services without the need to manage long-lived secrets in CircleCI. CircleCI OIDC tokens can be customized to meet the unique needs of different cloud services.
+See xref:openid-connect-tokens#[Default OpenID Connect tokens in jobs] for more information on default OIDC tokens provided by CircleCI in jobs.
 
 [#on-demand-openid-connect-id-tokens]
 == On demand OpenID Connect ID tokens
@@ -23,10 +24,58 @@ The circleci cli may be used in a step to do this.
 
 [source,shell]
 ----
-circleci run oidc get --claims '{"aud"="audience_name"}'
+circleci run oidc get --claims '{"aud": "audience_name"}'
 ----
 
 The above command will create an OIDC token with the `aud` claim set to "audience_name", and return the token to `stdout`.
 You may pass this value to a variable and use the variable to call the cloud service for authentication.
 
-NOTE: **The OIDC token** created by the above command can be printed without masking, so care should be taken to not log/print the token in the CI.
+NOTE: **The OIDC token** created by the above command can be printed with no masking, care should be taken to not log/print the token in the job steps.
+
+Below is an example configuration that deploys a static html webpage to AWS S3 using On-demand OIDC token with customized `aud` claim in a job.
+
+```yaml
+version: 2.1
+
+commands:
+  install-awscli: # https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
+    steps:
+      - run:
+          name: Install awscli
+          working_directory: /tmp/awscli
+          command: |
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            ./aws/install
+            echo 'export AWS_PAGER=""' | tee -a $BASH_ENV
+
+jobs:
+  deploy-to-s3:
+    docker:
+      - image: node:current-bullseye
+    environment:
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/S3-READ-WRITE-OIDC-ROLE"
+      S3_TARGET: s3://test-app-oidc-token-test-bucket
+    steps:
+      - checkout
+      - install-awscli
+      - run: 
+          name: Deploy to S3
+          command: |
+            # set the variable AWS_WEB_IDENTITY_TOKEN_FILE to a temporary file that will hold the OIDC token
+            export AWS_WEB_IDENTITY_TOKEN_FILE="$(mktemp -u)"
+            # create an on-demand OIDC token with customized aud claim of org-id
+            OIDC_TOKEN=$(circleci run oidc get --claims '{"aud": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"}')
+            # copy the OIDC token to the AWS_WEB_IDENTITY_TOKEN_FILE created earlier
+            echo $OIDC_TOKEN > "$AWS_WEB_IDENTITY_TOKEN_FILE"
+            # make AWS cli calls
+            aws sts get-caller-identity
+            # copy the index.html file of the static site to the specified S3_TARGET location
+            aws s3 cp ./index.html $S3_TARGET
+
+workflows:
+  build-and-deploy:
+    jobs:
+      - deploy-to-s3
+```

--- a/jekyll/_cci2/oidc-tokens-with-custom-claims.adoc
+++ b/jekyll/_cci2/oidc-tokens-with-custom-claims.adoc
@@ -1,0 +1,32 @@
+---
+contentTags:
+  platform:
+  - Cloud
+---
+= Customize claims in the OIDC token
+:page-layout: classic-docs
+:page-liquid:
+:page-description: Learn about the capabilities to customize claims in OIDC tokens.
+:icons: font
+:experimental:
+
+[#introduction]
+== Introduction
+
+OpenID Connect (OIDC) tokens allow you to connect your pipelines to compatible cloud services without the need to manage long-lived secrets in CircleCI. CircleCI OIDC tokens can be customized to meet the unique needs of different cloud services.
+
+[#on-demand-openid-connect-id-tokens]
+== On demand OpenID Connect ID tokens
+
+CircleCI allows creation of OIDC tokens on demand in a job. Mulitple OIDC tokens can be created in a job with options to customize claims.
+The circleci cli may be used in a step to do this.
+
+[source,shell]
+----
+circleci run oidc get --claims '{"aud"="audience_name"}'
+----
+
+The above command will create an OIDC token with the `aud` claim set to "audience_name", and return the token to `stdout`.
+You may pass this value to a variable and use the variable to call the cloud service for authentication.
+
+NOTE: **The OIDC token** created by the above command can be printed without masking, so care should be taken to not log/print the token in the CI.

--- a/jekyll/_cci2/on-demand-oidc-tokens-with-custom-claims.adoc
+++ b/jekyll/_cci2/on-demand-oidc-tokens-with-custom-claims.adoc
@@ -3,24 +3,20 @@ contentTags:
   platform:
   - Cloud
 ---
-= Customize claims in the OIDC token
+= On-demand OIDC tokens with custom claims
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Learn about the capabilities to customize claims in OIDC tokens.
 :icons: font
 :experimental:
 
-[#introduction]
-== Introduction
-
-OpenID Connect (OIDC) tokens allow you to connect your pipelines to compatible cloud services without the need to manage long-lived secrets in CircleCI. CircleCI OIDC tokens can be customized to meet the unique needs of different cloud services.
+Use OpenID Connect (OIDC) tokens to connect your pipelines to compatible cloud services without the need to manage long-lived secrets in CircleCI. Create CircleCI OIDC tokens on demand using the CircleCI CLI, and customize your claims to meet the unique needs of different cloud services.
 See xref:openid-connect-tokens#[Default OpenID Connect tokens in jobs] for more information on default OIDC tokens provided by CircleCI in jobs.
 
-[#on-demand-openid-connect-id-tokens]
-== On demand OpenID Connect ID tokens
+[#create-oidc-token-on-demand-in-a-job]
+== Create an OIDC token on demand in a job
 
-CircleCI allows creation of OIDC tokens on demand in a job. Mulitple OIDC tokens can be created in a job with options to customize claims.
-The circleci cli may be used in a step to do this.
+CircleCI allows creation of OIDC tokens on demand in a job. Multiple OIDC tokens can be created in a job with the option to customize claims. The CircleCI CLI may be used in a step to do this, as follows:
 
 [source,shell]
 ----
@@ -30,9 +26,12 @@ circleci run oidc get --claims '{"aud": "audience_name"}'
 The above command will create an OIDC token with the `aud` claim set to "audience_name", and return the token to `stdout`.
 You may pass this value to a variable and use the variable to call the cloud service for authentication.
 
-NOTE: **The OIDC token** created by the above command can be printed with no masking, care should be taken to not log/print the token in the job steps.
+CAUTION: **The OIDC token** created by the above command can be printed with no masking, care should be taken to not log/print the token in the job steps.
 
-Below is an example configuration that deploys a static html webpage to AWS S3 using On-demand OIDC token with customized `aud` claim in a job.
+[#example-configuration]
+== Example configuration
+
+Below is an example configuration that deploys a static HTML webpage to AWS S3 using on-demand OIDC token generation, with a customized `aud` claim in a job.
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -472,4 +472,4 @@ You have the ability to use multiple service accounts from the _same_ GCP projec
 
 [#next-steps]
 == Next Steps
-- xref:on-demand-oidc-tokens-with-custom-claims#[On demand OpenID Connect tokens with custom claims]
+- xref:oidc-tokens-with-custom-claims#[OpenID Connect tokens with custom claims]

--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -469,3 +469,7 @@ workflows:
 ```
 
 You have the ability to use multiple service accounts from the _same_ GCP project, or multiple service accounts from _multiple_ GCP projects. You can read about these methods and find an example in CircleCI's link:https://github.com/jtreutel/circleci-gcp-oidc-test#usage[example repository].
+
+[#next-steps]
+== Next Steps
+- xref:oidc-tokens-with-custom-claims#[On demand OpenID Connect tokens with custom claims]

--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -472,4 +472,4 @@ You have the ability to use multiple service accounts from the _same_ GCP projec
 
 [#next-steps]
 == Next Steps
-- xref:oidc-tokens-with-custom-claims#[On demand OpenID Connect tokens with custom claims]
+- xref:on-demand-oidc-tokens-with-custom-claims#[On demand OpenID Connect tokens with custom claims]

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -515,7 +515,7 @@ en:
           - name: Use OpenID Connect tokens in jobs
             link: openid-connect-tokens
           - name: On demand OIDC tokens with custom claims
-            link: oidc-tokens-with-custom-claims
+            link: on-demand-oidc-tokens-with-custom-claims
       - name: How-to guides
         children:
           - name: Manage roles and permissions

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -514,8 +514,8 @@ en:
         children:
           - name: Use OpenID Connect tokens in jobs
             link: openid-connect-tokens
-          - name: On demand OIDC tokens with custom claims
-            link: on-demand-oidc-tokens-with-custom-claims
+          - name: OIDC tokens with custom claims
+            link: oidc-tokens-with-custom-claims
       - name: How-to guides
         children:
           - name: Manage roles and permissions

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -514,6 +514,8 @@ en:
         children:
           - name: Use OpenID Connect tokens in jobs
             link: openid-connect-tokens
+          - name: On demand OIDC tokens with custom claims
+            link: oidc-tokens-with-custom-claims
       - name: How-to guides
         children:
           - name: Manage roles and permissions


### PR DESCRIPTION
# Description
Add a new page for multi oidc tokens custom claims to docs under "Security and Permissions -> Authentication"
Also, add link from the default oidc token overview to the multi oidc token with custom claims doc.

# Reasons
https://circleci.atlassian.net/browse/SNC-520

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
