### PR TITLE
Fix artefacts download command

### DIFF
--- a/jekyll/_cci2/artifacts.md
+++ b/jekyll/_cci2/artifacts.md
@@ -154,9 +154,9 @@ export CIRCLE_TOKEN=':your_token'
 # then, the result is piped into `grep` to extract the URLs.
 # finally, `wget` is used to download the artifacts to the current directory in your terminal.
 
-curl -H "Circle-Token: $CIRCLE_TOKEN" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts \
-   | grep -o "https://[^"]*" \
-   | wget --verbose --header "Circle-Token: $CIRCLE_TOKEN" --input-file -
+curl -s -H "Circle-Token: $CIRCLE_TOKEN" https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/:build_num/artifacts \
+  | grep -o -E 'https://([^"]*)' \
+  | wget --verbose --header "Circle-Token: $CIRCLE_TOKEN" --input-file -
 ```
 
 Similarly, if you want to download the _latest_ artifacts of a build, replace the curl call with a URL that follows this scheme:


### PR DESCRIPTION
# Description
Fix the artefacts download command from documentation.
Also, add `-s` (silent) option to curl to reduce logs.

# Reasons
#8502

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
