### PR TITLE
Update xcode 15 beta 3 hash typo

### DIFF
--- a/jekyll/_includes/snippets/xcode-intel-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-intel-vm.adoc
@@ -8,7 +8,7 @@
 | Release Notes
 
 | `15.1.0`
-| Xcode 15.1 beta 3 (2B374)
+| Xcode 15.1 beta 3 (23B74)
 | 14.1
 | link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v13795/manifest.txt[Installed software]
 | link:https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876[Release Notes]


### PR DESCRIPTION
The Intel version of the Beta hash is misspelled:

Both the intel and apple silicon hashes should be `23B74` as per the discuss post below

> https://discuss.circleci.com/t/xcode-15-1-beta-3-released/49876

# Description
Updated the Intel hash from `2B374` to `23B74`

# Reasons
There is a typo

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
