### PR TITLE
Remove ambiguous content

### DIFF
--- a/jekyll/_cci2/code-coverage.md
+++ b/jekyll/_cci2/code-coverage.md
@@ -23,11 +23,6 @@ You can upload your code coverage reports directly to CircleCI. First, add a cov
 
 ![Artifacts tab in the web app]({{site.baseurl}}/assets/img/docs/artifacts.png)
 
-## Code coverage and parallelism
-{: #code-coverage-and-parallelism }
-
-Code coverage reports are saved as [build artifacts](/docs/artifacts/). If you wish to take advantage of CircleCI test splitting and parallelism, you will also need to save your test results using the [`store_test_results` key](/docs/configuration-reference/#storetestresults). For more information on test splitting and parallelism, see the [Test splitting and parallelism overview](/docs/parallelism-faster-jobs/) and the [Test splitting tutorial](/docs/test-splitting-tutorial/).
-
 ## Language-specific code coverage options
 {: #language-specific-code-coverage-options}
 


### PR DESCRIPTION
# Description
fixes #8258 
Removes a section that was recently added to try to inform people that if they want to use test splitting and also generate code coverage reports they would need to use the store test results and the store artifacts keys. This paragraph was clearly confusing, and along with other supporting content I don't think we need it so this PR just removes the paragraph.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
