### PR TITLE
ONPREM-632 | Added TLS cert options

### DIFF
--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -333,7 +333,7 @@ endif::env-aws[]
 
 [#frontend-tls-certificates]
 == 5. Frontend TLS certificates
-By default, CircleCI server creates self-signed certificates to get you started. In production, you should supply a certificate from a trusted certificate authority. The link:https://letsencrypt.org/[Let's Encrypt] certificate authority, for example, can issue a free certificate using their link:https://certbot.eff.org/[Certbot] tool. The sections below cover using Google Cloud DNS and AWS Route 53.
+You should supply a certificate from a trusted certificate authority. The link:https://letsencrypt.org/[Let's Encrypt] certificate authority, for example, can issue a free certificate using their link:https://certbot.eff.org/[Certbot] tool. The sections below cover using Google Cloud DNS and AWS Route 53.
 
 CAUTION: It is important that your certificate contains both your domain and the `app.*` subdomain as subjects. For example, if you host your installation at `server.example.com`, your certificate must cover `app.server.example.com` and `server.example.com`.
 

--- a/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
@@ -446,20 +446,11 @@ endif::env-aws[]
 
 [#tls]
 === j. TLS
-For TLS, you have 4 options:
-
-[.tab.tls.Do_nothing]
---
-*Do nothing*
-
-Do nothing. Self-signed certificates will automatically be generated for you.  This is a good option for trials but not recommended for production use.
-
-NOTE: These self-signed certificates will not be trusted by your browser.  You will need to add an exception to your browser to access the application. Additionally, the certificates will be updated with new self-signed certificates when an update is pushed.
---
+For TLS, you have 5 options:
 
 [.tab.tls.Lets_Encrypt]
 --
-*Let's Encrypt*
+**Option 1:** *Let's Encrypt*
 
 https://letsencrypt.org/[Let's Encrypt] will request and manage certificates for you.  This is a good option when the load balancer is publicly accessible. The following snippet (using your own email) can be added to `values.yaml`:
 
@@ -474,9 +465,32 @@ kong:
 NOTE: Let's Encrypt may take up to 30 minutes to be reflected in your browser.
 --
 
+[.tab.tls.You_create_Secret]
+--
+**Option 2:** *Create the Kubernetes Secret yourself*
+
+You can create the k8s secret `kong-tls` from your certificate and key files.
+
+[source,shell]
+----
+kubectl -n <namespace> create secret tls kong-tls \
+  --cert=/etc/letsencrypt/live/<CIRCLECI_SERVER_DOMAIN>/fullchain.pem \
+  --key=/etc/letsencrypt/live/<CIRCLECI_SERVER_DOMAIN>/privkey.pem
+
+kubectl -n <namespace> annotate secretkong-tls \
+  meta.helm.sh/release-name=<helm-release-name> \
+  meta.helm.sh/release-namespace=<namespace> \
+  helm.sh/resource-policy=keep --overwrite
+
+kubectl -n <namespace>  label secret/kong-tls \
+  app.kubernetes.io/managed-by=Helm --overwrite
+
+----
+--
+
 [.tab.tls.Supply_private_key_and_certificate]
 --
-*Supply a private key and certificate*
+**Option 3:** *Supply a private key and certificate*
 
 You can supply a private key and certificate, which you may have created during the prerequisites steps. The key and certificates will need to be base64 encoded. You can retrieve and encode the values with the following commands:
 
@@ -498,7 +512,7 @@ tls:
 
 [.tab.tls.Use_AWS_Certificate_Manager]
 --
-*Use ACM*
+**Option 4:** *Use ACM*
 
 Have link:https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html[AWS Certificate Manager (ACM)] automatically request and manage certificates for you. Follow the link:https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html[ACM documentation] for instructions on how to generate ACM certificates.
 
@@ -522,7 +536,7 @@ You will need to update your DNS records to the new load balancer once you have 
 
 [.tab.tls.Terminate_TLS_upstream]
 --
-*Disable TLS within CircleCI*
+**Option 5:** *Disable TLS within CircleCI*
 
 You can choose to disable TLS termination within CircleCI. The system will still need to be accessed over HTTPS, so TLS termination will be required somewhere upstream of CircleCI. Implement this by following the first option (do nothing) and forward the following ports to your CircleCI load balancer:
 


### PR DESCRIPTION
# Description
With Server 4.4, It support pre-existing TLS secret `kong-tls` to setup TLS. 

# Reasons
https://circleci.atlassian.net/browse/ONPREM-632


# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
