### PR TITLE
Windows Known Issues update

### DIFF
--- a/jekyll/_cci2/using-windows.md
+++ b/jekyll/_cci2/using-windows.md
@@ -342,7 +342,7 @@ You can read more about using SSH in your builds [here]({{site.baseurl}}/ssh-acc
 
 These are the issues with the Windows executor that we are aware of and will address as soon as we can:
 
-* Connecting to a Windows job via SSH and using the `bash` shell results in an empty terminal prompt.
+* The `add_ssh_keys` step is required for _any_ SSH key used in the job
 * It is currently not possible to do nested virtualization (for example, using the `--platform linux` flag).
 * The Windows executor currently only supports Windows containers. Running Linux containers on Windows is not possible for now.
 


### PR DESCRIPTION
# Description
- Removed "Connecting to a Windows job via SSH and using the `bash` shell results in an empty terminal prompt."
- Replaced with note that `add_ssh_keys` step is required

# Reasons
This is part of a discussion in a private channel with @makotom to update known issues and limitations with Windows

- it no longer mentions "rerun with SSH with Bash" as a limitation (see screenshot below)
- it adds instead that explicit add_ssh_keys will be needed for any SSH key used in the job in any case (the key is used only in the checkout step) 
![image (2)](https://github.com/circleci/circleci-docs/assets/104026596/63e3af8e-a624-4996-be12-6175f13e3ca2)


# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
