### PR TITLE
Add attribute to display table

### DIFF
--- a/jekyll/_cci2_ja/runner-installation-mac.adoc
+++ b/jekyll/_cci2_ja/runner-installation-mac.adoc
@@ -12,6 +12,7 @@ contentTags:
 :icons: font
 :toc: macro
 :toc-title:
+:macos:
 
 このページでは、macOS に CircleCI のマシンランナーをインストールする方法を説明します。
 
@@ -26,7 +27,7 @@ contentTags:
 {% include snippets/runner/ja/terms.adoc %}
 
 [#create-namespace-and-resource-class]
-== 1. ネームスペースとリソースクラスの作成 
+== 1. ネームスペースとリソースクラスの作成
 
 [.tab.machine-runner.Web_app_installation]
 --


### PR DESCRIPTION
# Description
Add the macos attribute the main page to display table content in macos machine runner installation docs 

# Reasons
Table was not showing because the macos attribute was not set correctly

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
