### PR TITLE
Update Server 4.x docs for the removal of the disable_concurrency flag [ONPREM-742]

### DIFF
--- a/jekyll/_cci2/server/v4.1/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/troubleshooting-and-support.adoc
@@ -135,7 +135,7 @@ kill $!
 
 We recommend disabling concurrency limits for your CircleCI server installation. Disable concurrency limits by setting the following in your `values.yaml`:
 
-NOTE: Concurrency limits are disabled by default from server v4.1.5
+NOTE: Concurrency limits are disabled by default from server v4.1.5. From server v4.1.6, the `distributor_dispatcher.disable_concurrency` flag has been removed and concurrency limits are permanently disabled.
 
 [source,yaml]
 ----

--- a/jekyll/_cci2/server/v4.2/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/v4.2/operator/troubleshooting-and-support.adoc
@@ -138,7 +138,7 @@ kill $!
 
 We recommend disabling concurrency limits for your CircleCI server installation. Disable concurrency limits by setting the following in your `values.yaml`:
 
-NOTE: Concurrency limits are disabled by default from server v4.2.1
+NOTE: Concurrency limits are disabled by default from server v4.2.1. From server v4.2.2, the `distributor_dispatcher.disable_concurrency` flag has been removed and concurrency limits are permanently disabled.
 
 [source,yaml]
 ----


### PR DESCRIPTION
# Description
A brief description of the changes.

This flag was removed in [ONPREM-512](https://circleci.atlassian.net/browse/ONPREM-512), permanently disabling concurrency limits for distributor-dispatcher. The docs should be updated to reflect that change.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.atlassian.net/browse/ONPREM-742

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.


[ONPREM-512]: https://circleci.atlassian.net/browse/ONPREM-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ