### PR TITLE
Update attribute mapping example for OIDC

### DIFF
--- a/jekyll/_cci2/openid-connect-tokens.adoc
+++ b/jekyll/_cci2/openid-connect-tokens.adoc
@@ -295,7 +295,7 @@ Configuring the provider attributes provides an opportunity to map claims in Cir
 | google.subject
 | assertion.sub
 
-| attribute.aud
+| attribute.org_id 
 | assertion.aud
 
 | attribute.project


### PR DESCRIPTION
# Description

With the current documentation, the authenticate piece fails with the following error:

```
google.auth.exceptions.OAuthError: ('Error code unauthorized_client: 
The given credential is rejected by the attribute condition.', 
'{"error":"unauthorized_client","error_description":
"The given credential is rejected by the attribute condition."}')
```

# Reasons
It fixed my issue!

# Content Checklist

N/A