### PR TITLE
[PEMON-596] update docs to note that success rate now excludes cancelled runs

### DIFF
--- a/jekyll/_cci2/insights-glossary.md
+++ b/jekyll/_cci2/insights-glossary.md
@@ -28,7 +28,7 @@ count of workflow executions or jobs, depending on the context.
 | {::nomarkdown}<div id="p95Duration-definition">P95 Duration</div>{:/}            | The 95th percentile of execution times for an entity in a selected time window (i.e. 95% of runs completed in the same or less amount of this time). <br/> _The 95th percentile is a standard measure used to interpret performance data. It provides a measure of max value when outlier or transient values are excluded._ |
 | {::nomarkdown}<div id="p50Duration-definition">P50 (median) Duration</div>{:/} | The median execution time. <br/> _Medians are a better measure of central tendency than arithmetic means because they are more resilient to_ skewness _in datasets_.                                                                                                                                                         |
 | {::nomarkdown}<div id="totalCredits-general-definition">Total Credits</div>{:/}         | The sum of credits consumed during execution.                                                                                                                                                                                                                                                                          |
-| {::nomarkdown}<div id="successRate-definition">Success Rate</div>{:/}         | The percentage of runs that completed successfully, calculated by `100 x (Successful Runs / All Runs)`                                                                                                                                                                                                                   |
+| {::nomarkdown}<div id="successRate-definition">Success Rate</div>{:/}         | The percentage of runs that completed successfully, excluding cancelled runs. Calculated by `100 x (Successful Runs / All Runs - Cancelled Runs)`                                                                                                                                                                                                                   |
 {: class="table table-striped"}
 {: #insights-table}
 
@@ -44,7 +44,7 @@ Organization-level metrics allow you to analyze your organization’s performanc
 | {::nomarkdown}<div id="workflowRuns-definition">Workflow Runs</div>{:/} | The count of all workflows executions for an organization for the selected projects in the selected time frame. |
 | {::nomarkdown}<div id="totalWorkflowDuration-definition">Total Workflow Duration</div>{:/} | The total execution time of all workflows runs for an organization within the selected projects and time frame. |
 | {::nomarkdown}<div id="totalCredits-organization-definition">Total Credits</div>{:/} | The total credits consumed across all selected projects in an organization. |
-| {::nomarkdown}<div id="overallSuccesRate-definition">Overall Success Rate</div>{:/} | The percentage of runs that completed successfully across all runs in the selected projects and workflows. (calculated by `100 x (All Successful Runs/ All Runs)`) |
+| {::nomarkdown}<div id="overallSuccesRate-definition">Overall Success Rate</div>{:/} | The percentage of runs that completed successfully across all runs in the selected projects and workflows. Excludes cancelled runs. (calculated by `100 x (All Successful Runs/ All Runs - Cancelled Runs)`) |
 {: class="table table-striped"}
 {: #insights-table}
 


### PR DESCRIPTION
# Description
Update Insights Metrics glossary to note that success rate calculation now excludes cancelled runs.

# Reasons
We recently made a change which excludes cancelled runs from this calculation.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
