### PR TITLE
Fix: Bring back `preview` deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,18 @@ commands:
             --header 'content-type: application/json' \
             --data '{"branch": "main"}'
 
+  trigger-docs-platform-preview-build:
+    description: Call API V2 to deploy content to Docs Platform Preview
+    steps:
+      - run:
+          name: Deploy content to Docs Platform Preview
+          command: |
+            curl --request POST \
+            --url https://circleci.com/api/v2/project/gh/circleci/docs-platform/pipeline \
+            --header "Circle-Token: $CIRCLECI_API_KEY" \
+            --header 'content-type: application/json' \
+            --data '{"branch": "preview"}'
+
 # Workflows orchestrate a set of jobs to be run;
 # the jobs for this pipeline are # configured below
 workflows:
@@ -112,6 +124,12 @@ workflows:
           filters:
             branches:
               only: master
+      - deploy-preview:
+          requires:
+            - build
+          filters:
+            branches:
+              only: preview
 
 
   # We run a nightly build to refresh content and build docs-platform
@@ -278,9 +296,17 @@ jobs:
       - set-jekyll-basename
       - trigger-docs-platform-build
 
+  deploy-preview:
+    docker:
+      - image: cibuilds/aws:1.16.185
+    steps:
+      - attach_workspace:
+          at: ./generated-site
+      - set-jekyll-basename
+      - trigger-docs-platform-preview-build
+
   trigger-deploy:
     docker:
       - image: cibuilds/aws:1.16.185
     steps:
       - trigger-docs-platform-build
-


### PR DESCRIPTION
# Description
- Edit `config.yml` to add `preview` deployment capabilities

# Reasons
This was originally sitting in the `preview` branch but never made it to the `master` branch. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
