### PR TITLE
(CIRCLE-40436) Update v1 key docs to show support for sha256

### DIFF
--- a/src-api/source/includes/_keys.md
+++ b/src-api/source/includes/_keys.md
@@ -58,11 +58,11 @@ curl https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout
   }
 ```
 
-**`GET` Request**: Returns an individual checkout key.
+**`GET` Request**: Returns an individual checkout key. Supply fingerprint as a path parameter. Fingerprint can be of type md5 or sha256. sha256 fingerprints should be URL-encoded.
 
 ## Delete Checkout Key
 
-**`DELETE` Request:** Deletes the checkout key.
+**`DELETE` Request:** Deletes a checkout key by fingerprint. Supply fingerprint as a path parameter. Fingerprint can be of type md5 or sha256. sha256 fingerprints should be URL-encoded.
 
 ```sh
 curl -X DELETE https://circleci.com/api/v1.1/project/:vcs-type/:username/:project/checkout-key/:fingerprint -H "Circle-Token: <circle-token>"
@@ -94,7 +94,7 @@ curl -X DELETE --header "Content-Type: application/json" -d {"fingerprint":"Fing
 # no response expected
 ```
 
-**`DELETE` Request:** Deletes an SSH key from the system.
+**`DELETE` Request:** Deletes an SSH key from the system by fingerprint. Supply `fingerprint` in request body. Fingerprint can be of type md5 or sha256.
 
 
 ## Heroku Keys


### PR DESCRIPTION
# Description
This PR updates the v1 API docs to indicate recently added support for sha256-type fingerprints on checkout and ssh key operations.

# Reasons
API supports sha256 fingerprints now, so updating docs

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
