### PR TITLE
Update server changelog links to new format

### DIFF
--- a/jekyll/_cci2/server/overview/release-notes.adoc
+++ b/jekyll/_cci2/server/overview/release-notes.adoc
@@ -42,7 +42,7 @@ For full details of this release see the link:https://circleci.com/changelog/ser
 [#changelog-4-0-5]
 === Changelog
 
-For full details of this release see the https://circleci.com/server/changelog/#release-4-0-5[changelog].
+For full details of this release see the https://circleci.com/changelog/server-release-4-0-5[changelog].
 
 [#release-4-0-4]
 == Release 4.0.4
@@ -50,7 +50,7 @@ For full details of this release see the https://circleci.com/server/changelog/#
 [#changelog-4-0-4]
 === Changelog
 
-For full details of this release see the https://circleci.com/server/changelog/#release-4-0-4[changelog].
+For full details of this release see the https://circleci.com/changelog/release-4-0-4[changelog].
 
 [#release-4-0-3]
 == Release 4.0.3
@@ -58,7 +58,7 @@ For full details of this release see the https://circleci.com/server/changelog/#
 [#changelog-4-0-3]
 === Changelog
 
-For full details of this release see the https://circleci.com/server/changelog/#release-4-0-3[changelog].
+For full details of this release see the https://circleci.com/changelog/release-4-0-3[changelog].
 
 [#release-4-0-2]
 == Release 4.0.2
@@ -66,7 +66,7 @@ For full details of this release see the https://circleci.com/server/changelog/#
 [#changelog-4-0-2]
 === Changelog
 
-For full details of this release see the https://circleci.com/server/changelog/#release-4-0-2[changelog].
+For full details of this release see the https://circleci.com/changelog/release-4-0-2[changelog].
 
 [#release-4-0-1]
 == Release 4.0.1
@@ -74,7 +74,7 @@ For full details of this release see the https://circleci.com/server/changelog/#
 [#changelog-4-0-1]
 === Changelog
 
-For full details of this release see the https://circleci.com/server/changelog/#release-4-0-1[changelog].
+For full details of this release see the https://circleci.com/changelog/release-4-0-1[changelog].
 
 [#release-4-0-0]
 == Release 4.0.0
@@ -82,4 +82,4 @@ For full details of this release see the https://circleci.com/server/changelog/#
 [#changelog-4-0-0]
 === Changelog
 
-For full details of this release see the https://circleci.com/server/changelog/#release-4-0-0[changelog].
+For full details of this release see the https://circleci.com/changelog/release-4-0-0[changelog].

--- a/jekyll/_cci2/server/v4.1/overview/release-notes.adoc
+++ b/jekyll/_cci2/server/v4.1/overview/release-notes.adoc
@@ -62,7 +62,7 @@ For full details of this release see the link:https://circleci.com/changelog/rel
 [#changelog-4-1-4]
 === Changelog
 
-For full details of this release see the link:https://circleci.com/server/changelog/#release-4-1-4[changelog].
+For full details of this release see the link:https://circleci.com/changelog/release-4-1-4[changelog].
 
 [#release-4-1-3]
 == Release 4.1.3
@@ -70,7 +70,7 @@ For full details of this release see the link:https://circleci.com/server/change
 [#changelog-4-1-3]
 === Changelog
 
-For full details of this release see the link:https://circleci.com/server/changelog/#release-4-1-3[changelog].
+For full details of this release see the link:https://circleci.com/changelog/release-4-1-3[changelog].
 
 [#release-4-1-2]
 == Release 4.1.2
@@ -78,7 +78,7 @@ For full details of this release see the link:https://circleci.com/server/change
 [#changelog-4-1-2]
 === Changelog
 
-For full details of this release see the link:https://circleci.com/server/changelog/#release-4-1-2[changelog].
+For full details of this release see the link:https://circleci.com/changelog/release-4-1-2[changelog].
 
 [#release-4-1-1]
 == Release 4.1.1
@@ -86,7 +86,7 @@ For full details of this release see the link:https://circleci.com/server/change
 [#changelog-4-1-1]
 === Changelog
 
-For full details of this release see the link:https://circleci.com/server/changelog/#release-4-1-1[changelog].
+For full details of this release see the link:https://circleci.com/changelog/release-4-1-1[changelog].
 
 [#release-4-1-0]
 == Release 4.1.0
@@ -94,4 +94,4 @@ For full details of this release see the link:https://circleci.com/server/change
 [#changelog-4-1-0]
 === Changelog
 
-For full details of this release see the link:https://circleci.com/server/changelog/#release-4-1-0[changelog].
+For full details of this release see the link:https://circleci.com/changelog/release-4-1-0[changelog].

--- a/jekyll/_cci2/server/v4.2/overview/release-notes.adoc
+++ b/jekyll/_cci2/server/v4.2/overview/release-notes.adoc
@@ -41,7 +41,7 @@ CAUTION: If you are upgrading from server v4.1.x and have user-managed secrets, 
 [#changelog-4-2-4]
 === Changelog
 
-For full details of this release see the link:https://circleci.com/server/changelog/#server-release-4-2-4[changelog].
+For full details of this release see the link:https://circleci.com/changelog/server-release-4-2-4[changelog].
 
 
 [#release-4-2-3]
@@ -50,7 +50,7 @@ For full details of this release see the link:https://circleci.com/server/change
 [#changelog-4-2-3]
 === Changelog
 
-For full details of this release see the link:https://circleci.com/server/changelog/#server-release-4-2-3[changelog].
+For full details of this release see the link:https://circleci.com/changelog/server-release-4-2-3[changelog].
 
 
 [#release-4-2-2]
@@ -75,4 +75,4 @@ For full details of this release see the link:https://circleci.com/changelog/rel
 [#changelog-4-2-0]
 === Changelog
 
-For full details of this release see the link:https://circleci.com/server/changelog/#release-4-2-0[changelog].
+For full details of this release see the link:https://circleci.com/changelog/release-4-2-0[changelog].

--- a/jekyll/_cci2/server/v4.3/overview/release-notes.adoc
+++ b/jekyll/_cci2/server/v4.3/overview/release-notes.adoc
@@ -55,4 +55,4 @@ For full details of this release see the link:https://circleci.com/changelog/ser
 [#changelog-4-3-0]
 === Changelog
 
-For full details of this release see the link:https://circleci.com/server/changelog/#release-4-3-0[changelog].
+For full details of this release see the link:https://circleci.com/changelog/server-release-4-3/[changelog].


### PR DESCRIPTION
# Description

Update server changelog links to new format to fix some brokken links

# Reasons

The changelog link format has changed recently so some old server links pointed to the top of the changelog, rather than the specific entry

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
