### PR TITLE
add missing parameter to machine runner manual start

### DIFF
--- a/jekyll/_cci2/machine-runner-3-manual-installation.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation.adoc
@@ -100,7 +100,7 @@ api:
 
 [,shell]
 ----
-$HOME/circleci-runner --config $HOME/circleci-runner-config.yaml
+$HOME/circleci-runner machine --config $HOME/circleci-runner-config.yaml
 ----
 
 [#additional-resources]


### PR DESCRIPTION
# Description
A parameter was missing for the machine runner manual invocation in the documentation. This PR adds the missing parameter. 