### PR TITLE
make prerequs work for all OS options

### DIFF
--- a/jekyll/_includes/snippets/runner/machine-runner-prereq.adoc
+++ b/jekyll/_includes/snippets/runner/machine-runner-prereq.adoc
@@ -3,14 +3,28 @@
 
 To install machine runners and run jobs, you will need to have root access, and have the following utilities and tools installed on your system:
 
+ifdef::linux[]
 * https://www.gnu.org/software/coreutils/[coreutils] (Linux only)
+endif::[]
+
+ifdef::macOS[]
+* https://brew.sh/[Homebrew]
+endif::[]
+
 * https://curl.se/[curl] (installed by default on macOS)
 * sha256sum (if not pre-installed):
-  - `brew install coreutils` for macOS (requires https://brew.sh/[Homebrew])
-  - `sudo apt install coreutils` for Ubuntu/Debain
-  - `sudo yum install coreutils` for Red Hat
+** `brew install coreutils` for macOS
+** `sudo apt install coreutils` for Ubuntu/Debain
+** `sudo yum install coreutils` for Red Hat
 * https://www.gnu.org/software/tar/[tar]
+
+ifndef::macOS[]
 * https://www.gnu.org/software/gzip/[gzip]
+endif::[]
+
+ifdef::linux[]
 * sepolicy (https://www.redhat.com/en/enterprise-linux-8/details[RHEL 8] only)
 * rpmbuild (https://www.redhat.com/en/enterprise-linux-8/details[RHEL 8] only)
+endif::[]
+
 * The xref:local-cli#[CircleCI CLI] if you wish to install runners from the command line


### PR DESCRIPTION
# Description

Fixes #8554 

Prerequisites were just listed the same for all installation options. This PR uses the OS attributes to create prerequisites that are correct for each runner installation guide

# Reasons
Reports that current situation is confusing, and it is incorrect

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
