### PR TITLE
(CIRCLE-40436) Update docs to indicate sha256 support in `add-ssh-keys` step

### DIFF
--- a/jekyll/_cci2/add-ssh-key.adoc
+++ b/jekyll/_cci2/add-ssh-key.adoc
@@ -52,9 +52,11 @@ Since CircleCI cannot decrypt SSH keys, every new key must have an empty passphr
 
 Even though all CircleCI jobs use `ssh-agent` to automatically sign all added SSH keys, you *must* use the `add_ssh_keys` key to actually add keys to a container.
 
-To add a set of SSH keys to a container, use the `add_ssh_keys` xref:configuration-reference#add_ssh_keys[special step] within the appropriate xref:jobs-steps#[job] in your configuration file. The fingerprint must be the MD5 hash, not SHA256. When you add your key to CircleCI in menu:Project Settings[SSH keys > Additional SSH keys] the MD5 hash will be visible.
+To add a set of SSH keys to a container, use the `add_ssh_keys` xref:configuration-reference#add_ssh_keys[special step] within the appropriate xref:jobs-steps#[job] in your configuration file. The fingerprint can be SHA256 or MD5. SHA256 fingerprints should be prefixed with `SHA256:` and MD5 fingerprints should include the colons between character pairs. When you add your key to CircleCI in menu:Project Settings[SSH keys > Additional SSH keys] the SHA256 fingerprint will be visible.
 
-For a self-hosted runner, ensure that you have an `ssh-agent` on your system to successfully use the `add_ssh_keys` step. The SSH key is written to `$HOME/.ssh/id_rsa_<fingerprint>`, where `$HOME` is the home directory of the user configured to execute jobs, and `<fingerprint>` is the fingerprint of the key. A host entry is also appended to `$HOME/.ssh/config`, along with a relevant `IdentityFile` option to use the key.
+CAUTION: **Using server?** only MD5 fingerprints are supported. In CircleCI in menu:Project Settings[SSH keys > Additional SSH keys] the MD5 fingerprint will be visible. SHA256 support is planned for an upcoming server release.
+
+For a self-hosted runner, ensure that you have an `ssh-agent` on your system to successfully use the `add_ssh_keys` step. The SSH key is written to `$HOME/.ssh/id_rsa_<fingerprint>`, where `$HOME` is the home directory of the user configured to execute jobs, and `<fingerprint>` is the MD5 fingerprint of the key. A host entry is also appended to `$HOME/.ssh/config`, along with a relevant `IdentityFile` option to use the key.
 
 [source,yaml]
 ----
@@ -65,6 +67,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "SO:ME:FIN:G:ER:PR:IN:T"
+            - "SHA256:NPj4IcXxqQEKGXOghi/QbG2sohoNfvZ30JwCcdSSNM0"
 ----
 
 All fingerprints in the `fingerprints` list must correspond to keys that have been added through the CircleCI application. Fingerprints in CircleCI environment variables will fail.

--- a/jekyll/_cci2/add-ssh-key.adoc
+++ b/jekyll/_cci2/add-ssh-key.adoc
@@ -29,7 +29,7 @@ For more information about the differences, see the link:https://docs.github.com
 
 If you want to set up an SSH key in order to checkout code from additional repositories in GitHub (xref:github-integration#[GitHub OAuth app only]) or Bitbucket within a job, refer to the xref:github-integration#enable-your-project-to-check-out-additional-private-repositories[GitHub] or xref:bitbucket-integration#enable-your-project-to-check-out-additional-private-repositories[Bitbucket] integration pages.  If you need additional SSH keys to access other services and your org is set up to the use xref:github-integration#[GitHub OAuth app] or BitBucket, follow the steps below.
 
-If you want to set up an SSH key in order to checkout code from additional repositories or to access other services from within your job and your org is authorized with GitHub App or you use GitLab as your VCS, follow the steps below to add an SSH key to your project.  
+If you want to set up an SSH key in order to checkout code from additional repositories or to access other services from within your job and your org is authorized with GitHub App or you use GitLab as your VCS, follow the steps below to add an SSH key to your project.
 
 You may need to add the public key to `~/.ssh/authorized_keys` in order to add SSH keys.
 
@@ -54,7 +54,7 @@ Even though all CircleCI jobs use `ssh-agent` to automatically sign all added SS
 
 To add a set of SSH keys to a container, use the `add_ssh_keys` xref:configuration-reference#add_ssh_keys[special step] within the appropriate xref:jobs-steps#[job] in your configuration file. The fingerprint can be SHA256 or MD5. SHA256 fingerprints should be prefixed with `SHA256:` and MD5 fingerprints should include the colons between character pairs. When you add your key to CircleCI in menu:Project Settings[SSH keys > Additional SSH keys] the SHA256 fingerprint will be visible.
 
-CAUTION: **Using server?** only MD5 fingerprints are supported. In CircleCI in menu:Project Settings[SSH keys > Additional SSH keys] the MD5 fingerprint will be visible. SHA256 support is planned for an upcoming server release.
+CAUTION: **Using server?** Only MD5 fingerprints are supported. In CircleCI in menu:Project Settings[SSH keys > Additional SSH keys] the MD5 fingerprint will be visible. SHA256 support is planned for an upcoming server release.
 
 For a self-hosted runner, ensure that you have an `ssh-agent` on your system to successfully use the `add_ssh_keys` step. The SSH key is written to `$HOME/.ssh/id_rsa_<fingerprint>`, where `$HOME` is the home directory of the user configured to execute jobs, and `<fingerprint>` is the MD5 fingerprint of the key. A host entry is also appended to `$HOME/.ssh/config`, along with a relevant `IdentityFile` option to use the key.
 

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1847,7 +1847,8 @@ The lifetime of artifacts, workspaces, and caches can be customized on the [Circ
 
 Special step that adds SSH keys from a project's settings to a container. Also configures SSH to use these keys. For more information on SSH keys see the [Create additional GitHub SSH keys]({{site.baseurl}}/github-integration/#create-additional-github-ssh-keys) page.
 
-CAUTION: **Using server?** only MD5 fingerprints are supported. In CircleCI in menu:Project Settings[SSH keys > Additional SSH keys] the MD5 fingerprint will be visible. SHA256 support is planned for an upcoming server release.
+**Using server?** only MD5 fingerprints are supported. In CircleCI in **Project Settings > SSH keys > Additional SSH keys** the MD5 fingerprint will be visible. SHA256 support is planned for an upcoming server release.
+{: class="alert alert-warning" }
 
 Key | Required | Type | Description
 ----|-----------|------|------------

--- a/jekyll/_cci2/configuration-reference.md
+++ b/jekyll/_cci2/configuration-reference.md
@@ -1113,6 +1113,7 @@ jobs:
         - add_ssh_keys:
             fingerprints:
               - "SO:ME:FIN:G:ER:PR:IN:T"
+              - "SHA256:NPj4IcXxqQEKGXOghi/QbG2sohoNfvZ30JwCcdSSNM0"
         - checkout
         - run: Write-Host 'Hello, Windows'
 ```
@@ -1846,6 +1847,8 @@ The lifetime of artifacts, workspaces, and caches can be customized on the [Circ
 
 Special step that adds SSH keys from a project's settings to a container. Also configures SSH to use these keys. For more information on SSH keys see the [Create additional GitHub SSH keys]({{site.baseurl}}/github-integration/#create-additional-github-ssh-keys) page.
 
+CAUTION: **Using server?** only MD5 fingerprints are supported. In CircleCI in menu:Project Settings[SSH keys > Additional SSH keys] the MD5 fingerprint will be visible. SHA256 support is planned for an upcoming server release.
+
 Key | Required | Type | Description
 ----|-----------|------|------------
 fingerprints | N | List | List of fingerprints corresponding to the keys to be added (default: all keys added)
@@ -1856,6 +1859,7 @@ steps:
   - add_ssh_keys:
       fingerprints:
         - "b7:35:a6:4e:9b:0d:6d:d4:78:1e:9a:97:2a:66:6b:be"
+        - "SHA256:NPj4IcXxqQEKGXOghi/QbG2sohoNfvZ30JwCcdSSNM0"
 ```
 
 **Note:**


### PR DESCRIPTION
# Description

We now support sha256 keys in the Add ssh keys step. This commit updates the docs to indicate this.

# Reasons
https://circleci.atlassian.net/browse/CIRCLE-40436

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
