### PR TITLE
[Machine Runner 3.0] Clarify non-support of `%s` substitution feature for working directory

### DIFF
--- a/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
+++ b/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
@@ -150,6 +150,9 @@ This directory takes a fully qualified path and allows you to control the defaul
 
 NOTE: These directories will not automatically be removed, please see `cleanup_working_directory` to configure cleanup of directory.
 
+NOTE: For Machine Runner 3.0, there is no replacement of the `%s` placeholder to a unique value.
+The `%s` value in the working directory path would be interpreted as a literal value.
+
 Example:
 
 ```yaml
@@ -159,18 +162,6 @@ runner:
 
 [#runner-cleanup-working-directory]
 === runner.cleanup_working_directory
-`$CIRCLECI_RUNNER_CLEANUP_WORK_DIR`
-
-CircleCI recommends using a knowable directory, however it is possible to specify `%s` in the path. This value will be replaced with a different value for each job. This is a substitution that is only knowable at job runtime, under the environment variable `$CIRCLE_WORKING_DIRECTORY`.
-
-Example:
-
-```yaml
-runner:
-  working_directory: "/var/lib/circleci-runner/workdir"
-  cleanup_working_directory: false
-```
-
 `$CIRCLECI_RUNNER_CLEANUP_WORK_DIR`
 
 This flag enables you to control the working directory cleanup after each job.

--- a/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
+++ b/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
@@ -150,7 +150,7 @@ This directory takes a fully qualified path and allows you to control the defaul
 
 NOTE: These directories will not automatically be removed, please see `cleanup_working_directory` to configure cleanup of directory.
 
-NOTE: For Machine Runner 3.0, there is no replacement of the `%s` placeholder to a unique value.
+NOTE: For Machine Runner 3.0, the `%s` substitution feature is not supported.
 The `%s` value in the working directory path would be interpreted as a literal value.
 
 Example:

--- a/jekyll/_cci2/machine-runner-3-manual-installation.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation.adoc
@@ -76,7 +76,7 @@ Update permissions for your CircleCI machine runner to enable running its binary
 
 [,shell]
 ----
-chomd +x $HOME/circleci-runner
+chmod +x $HOME/circleci-runner
 ----
 
 [#create-configuration-and-working-directory]


### PR DESCRIPTION
# Description

https://circleci.atlassian.net/browse/ONPREM-849

Mentions the non-support of the `%s` substitution for working directory in Machine Runner 3.0.

Also, fixes a tiny typo re: chmod.

# Reasons

We do not support the `%s` substitution for working directory value in Machine Runner 3.0 config.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
