### PR TITLE
Update run-a-job-in-a-container.adoc

### DIFF
--- a/jekyll/_cci2/run-a-job-in-a-container.adoc
+++ b/jekyll/_cci2/run-a-job-in-a-container.adoc
@@ -70,7 +70,7 @@ Further, not all commands may work on your local machine as they do online. For 
 
 **Environment variables and contexts**
 
-For security reasons, encrypted environment variables or Contexts configured in the link:https://app.circleci.com/[web application] will not be imported into local builds. As an alternative, you can specify environment variables to the CLI with the `-e` flag. See the output of the following command for more information.
+For security reasons, encrypted environment variables or contexts configured in the link:https://app.circleci.com/[web application] will not be imported into local builds. As an alternative, you can specify environment variables to the CLI with the `-e` flag. See the output of the following command for more information.
 
 ```shell
 circleci help build

--- a/jekyll/_cci2/run-a-job-in-a-container.adoc
+++ b/jekyll/_cci2/run-a-job-in-a-container.adoc
@@ -68,9 +68,9 @@ Caching is not currently supported in local jobs. When you have either a <<confi
 
 Further, not all commands may work on your local machine as they do online. For example, the Golang build reference above runs a <<configuration-reference#storeartifacts,`store_artifacts`>> step, however, local builds will not upload artifacts. If a step is not available on a local build you will see an error in the console.
 
-**Environment variables**
+**Environment variables and Contexts**
 
-For security reasons, encrypted environment variables configured in the link:https://app.circleci.com/[web application] will not be imported into local builds. As an alternative, you can specify environment variables to the CLI with the `-e` flag. See the output of the following command for more information.
+For security reasons, encrypted environment variables or Contexts configured in the link:https://app.circleci.com/[web application] will not be imported into local builds. As an alternative, you can specify environment variables to the CLI with the `-e` flag. See the output of the following command for more information.
 
 ```shell
 circleci help build

--- a/jekyll/_cci2/run-a-job-in-a-container.adoc
+++ b/jekyll/_cci2/run-a-job-in-a-container.adoc
@@ -68,7 +68,7 @@ Caching is not currently supported in local jobs. When you have either a <<confi
 
 Further, not all commands may work on your local machine as they do online. For example, the Golang build reference above runs a <<configuration-reference#storeartifacts,`store_artifacts`>> step, however, local builds will not upload artifacts. If a step is not available on a local build you will see an error in the console.
 
-**Environment variables and Contexts**
+**Environment variables and contexts**
 
 For security reasons, encrypted environment variables or Contexts configured in the link:https://app.circleci.com/[web application] will not be imported into local builds. As an alternative, you can specify environment variables to the CLI with the `-e` flag. See the output of the following command for more information.
 


### PR DESCRIPTION
# Description
Specify that Contexts are also not supported with local containers.

# Reasons
This was feedback we got from a customer when trying to use the local job runner.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
