### PR TITLE
[SNC-590] Update policy cli command to include Server base url

### DIFF
--- a/jekyll/_cci2/config-policies-for-self-hosted-runner.adoc
+++ b/jekyll/_cci2/config-policies-for-self-hosted-runner.adoc
@@ -23,12 +23,19 @@ Follow this how-to guide to learn how to create a config policy to restrict whic
 * Set up a self-hosted runner. See the xref:runner-overview/#getting-started[Getting started] section of the Self-hosted runners overview.
 
 * Ensure you have **enabled** config policy evaluation for your organization so that project configurations **will** be evaluated against your organization's policies when pipelines are triggered:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy settings --enabled=true --owner-id <your-organization-ID>
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy settings --enabled=true --owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
+----
+
 Example output:
 +
 [source,shell]
@@ -91,9 +98,16 @@ You can now push your new policy to your organization for it to take effect. You
 --
 Create and upload the policy bundle using CircleCI CLI:
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy push ./config-policies –owner-id <your-organization-ID>
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy push ./config-policies –owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
 ----
 
 If the upload was successful, you will see something like the following:

--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -67,20 +67,35 @@ The following config policies sub-commands are currently supported within the CL
 * `push` - pushes the policy bundle (activate policy bundle)
 +
 For example, running the following command activates a policy bundle stored at `./policy_bundle_dir_path`:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy push ./policy_bundle_dir_path --owner-id <your-organization-ID>
 ----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy push ./policy_bundle_dir_path --owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
+----
+
 *  `settings` - used to modify config policies settings as required.
 +
 When the `settings` sub-command is called without any flags, current settings are fetched and printed on console.
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy settings --owner-id <your-organization-ID>
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy settings --owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
+----
+
 Example output:
 +
 [source,shell]
@@ -92,12 +107,19 @@ Example output:
 * `test` - used to run tests on your policies.
 +
 For example, running the following command runs all defined tests in the `policies` directory:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./policies
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./policies --policy-base-url <your-circleci-server-domain>
+----
+
 Example output:
 +
 [source,shell]

--- a/jekyll/_cci2/create-and-manage-config-policies.adoc
+++ b/jekyll/_cci2/create-and-manage-config-policies.adoc
@@ -21,12 +21,19 @@ Follow the how-to guides on this page to manage, create, and use config policies
 Control whether policy evaluation is applied to pipeline configurations within your organization using the `--enabled` flag.
 
 * To **enable** policy evaluation run the following command. This sets `--enabled` to `true`, which means project configurations **will** be evaluated against your organization's policies when pipelines are triggered.:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy settings --enabled=true --owner-id <your-organization-ID>
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy settings --enabled=true --owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
+----
+
 Example output:
 +
 [source,shell]
@@ -37,12 +44,19 @@ Example output:
 ----
 
 * To **disable** policy evaluation run the following command. This sets `--enabled` to `false`, which means project configurations **will not** be evaluated against your organization's policies when pipelines are triggered.:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy settings --enabled=false --owner-id <your-organization-ID>
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy settings --enabled=false --owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
+----
+
 Example output:
 +
 [source,shell]
@@ -221,9 +235,16 @@ You can now push your new policy to your organization for it to take effect. You
 --
 Create and upload the policy bundle using CircleCI CLI:
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy push ./config-policies –-owner-id <your-organization-ID>
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+ push ./config-policies –-owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
 ----
 
 If the upload was successful, you will see something like the following:
@@ -266,9 +287,16 @@ To illustrate making a change to an existing policy, suppose you made an error w
 --
 Create and upload the policy bundle using CircleCI CLI:
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy push ./config-policies –-owner-id <your-organization-ID>
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy push ./config-policies –-owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
 ----
 
 If the upload was successful, you will see something like the following:

--- a/jekyll/_cci2/create-and-manage-config-policies.adoc
+++ b/jekyll/_cci2/create-and-manage-config-policies.adoc
@@ -244,7 +244,7 @@ circleci policy push ./config-policies –-owner-id <your-organization-ID>
 {:.tab.machineblock.Server}
 [source,shell]
 ----
- push ./config-policies –-owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
+circleci policy push ./config-policies –-owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
 ----
 
 If the upload was successful, you will see something like the following:

--- a/jekyll/_cci2/manage-contexts-with-config-policies.adoc
+++ b/jekyll/_cci2/manage-contexts-with-config-policies.adoc
@@ -50,12 +50,19 @@ In the examples on this page, project IDs, branch names, and context names can b
 * Install/update the CircleCI CLI, and ensure you have authenticated with a token before attempting to use the CLI with config policies. See the xref:local-cli#[Installing the Local CLI] page for more information.
 
 * Ensure you have **enabled** config policy evaluation for your organization so that project configurations **will** be evaluated against your organization's policies when pipelines are triggered:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy settings --enabled=true --owner-id <your-organization-ID>
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy settings --enabled=true --owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
+----
+
 Example output:
 +
 [source,shell]
@@ -138,9 +145,16 @@ You can now push your new policy to your organization for it to take effect. You
 --
 Create and upload the policy bundle using CircleCI CLI:
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy push ./config-policies –owner-id <your-organization-ID>
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy push ./config-policies –owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
 ----
 
 If the upload was successful, you will see something like the following:
@@ -298,9 +312,16 @@ You can now push your new policy to your organization for it to take effect. You
 --
 Create and upload the policy bundle using CircleCI CLI:
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy push ./config-policies –owner-id <your-organization-ID>
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy push ./config-policies –owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
 ----
 
 If the upload was successful, you will see something like the following:
@@ -395,9 +416,16 @@ You can now push your new policy to your organization for it to take effect. You
 --
 Create and upload the policy bundle using CircleCI CLI:
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy push ./config-policies –owner-id <your-organization-ID>
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy push ./config-policies –owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
 ----
 
 If the upload was successful, you will see something like the following:
@@ -499,9 +527,16 @@ You can now push your new policy to your organization for it to take effect. You
 --
 Create and upload the policy bundle using CircleCI CLI:
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy push ./config-policies –owner-id <your-organization-ID>
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy push ./config-policies –owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
 ----
 
 If the upload was successful, you will see something like the following:

--- a/jekyll/_cci2/test-config-policies.adoc
+++ b/jekyll/_cci2/test-config-policies.adoc
@@ -83,12 +83,19 @@ test_version_check:
 ----
 
 . Run the `test` command against your `config-policies` directory:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output:
 +
 [source,shell]
@@ -101,12 +108,19 @@ ok    config-policies    0.001s
 NOTE: If you already have multiple policies in your `./config-policies` directory, more than just the `version.rego` file, you will probably see a different output, possibly including failures.
 
 . To see the tests that ran individually, you can also run with the `--verbose` or `-v` flag, as follows:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies --verbose
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies --verbose --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output:
 +
 [source,shell]
@@ -121,12 +135,19 @@ ok    config-policies                          0.001s
 ----
 
 . To run a specific test you can provide a regular expression to the `--run` flag, as follows:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies --verbose --run "absent_version$"
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies --verbose --run "absent_version$" --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output:
 +
 [source,shell]
@@ -138,12 +159,19 @@ ok    config-policies                      0.000s
 ----
 
 . To better understand how the test was executed, including which input and metadata the test was run against, and the raw OPA evaluation, you can pass the `--debug` flag, as follows:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies --verbose --run "absent_version$" --debug
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies --verbose --run "absent_version$" --debug --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output:
 +
 [source,shell]
@@ -176,12 +204,19 @@ ok    config-policies    0.000s
 ----
 
 . To get the test output in JSON format, use the `--format` flag, as follows:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies --format=json
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies --format=json --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output:
 +
 [source,json]
@@ -220,12 +255,19 @@ Expected output:
 ----
 
 . To get the test output in JUnit XML format, use the `--format` flag, as follows:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies --format=junit
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies --format=junit --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output:
 +
 [source,xml]
@@ -333,12 +375,19 @@ test_minimum_remote_docker_version:
 ----
 
 . Run the `test` command against the `config-policies` directory containing two policies and tests:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output. The tests have started to fail:
 +
 [source,shell]
@@ -462,12 +511,19 @@ It is a good idea to have tests that run against the entire bundle that will be 
 ----
 
 . Run all all tests including those in subfolders by appending `/...` to the test path:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies/...
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies/... --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output. Tests are passing again:
 +
 [source,shell]
@@ -542,12 +598,19 @@ test_break_all_rules:
 ----
 
 . Run the full set of tests again in verbose mode:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies/...
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies/... --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output:
 +
 [source,shell]
@@ -604,12 +667,19 @@ test_version_check:
 ----
 
 . Run the tests again to see the results:
-+
+
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy test ./config-policies/version -v
 ----
-+
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy test ./config-policies/version -v --policy-base-url <your-circleci-server-domain>
+----
+
 Expected output:
 +
 [source,shell]

--- a/jekyll/_cci2/use-the-cli-for-config-and-policy-development.adoc
+++ b/jekyll/_cci2/use-the-cli-for-config-and-policy-development.adoc
@@ -26,9 +26,16 @@ The following command requests the specified config input be judged against the 
 
 Example decision command:
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy decide --owner-id $ORG_ID --input $PATH_TO_CONFIG
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy decide --owner-id $ORG_ID --input $PATH_TO_CONFIG --policy-base-url <your-circleci-server-domain>
 ----
 
 Example CircleCI decision:
@@ -60,9 +67,16 @@ way of developing and testing policies. It is similar to the previous command ex
 
 The policy files (*.rego) present in the given policy directory (searched recursively) will form the policy bundle.
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy decide --input $PATH_TO_CONFIG $PATH_TO_POLICY_DIR
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy decide --input $PATH_TO_CONFIG $PATH_TO_POLICY_DIR --policy-base-url <your-circleci-server-domain>
 ----
 
 Policies that use `data.meta...` values like `vcs.branch` or `project_id` should also provide a JSON file mocking those values with `--metafile $PATH_TO_JSON`
@@ -79,9 +93,37 @@ The CLI provides a `policy logs` command to fetch the policy decision logs for y
 
 Following is the output of this command when run with `--help` flag:
 
+{:.tab.machineblock.Cloud}
 [source,shell]
 ----
 circleci policy logs --help
+
+# Returns the following:
+Get policy (decision) logs
+
+
+Usage:
+  circleci policy logs [flags]
+
+Examples:
+policy logs  --owner-id 462d67f8-b232-4da4-a7de-0c86dd667d3f --after 2022/03/14 --out output.json
+
+Flags:
+      --after string        filter decision logs triggered AFTER this datetime
+      --before string       filter decision logs triggered BEFORE this datetime
+      --branch string       filter decision logs based on branch name
+      --context string      policy context (default "config")
+  -h, --help                help for logs
+      --out string          specify output file name
+      --owner-id string     the id of the policy's owner
+      --project-id string   filter decision logs based on project-id
+      --status string       filter decision logs based on their status
+----
+
+{:.tab.machineblock.Server}
+[source,shell]
+----
+circleci policy logs --help --policy-base-url <your-circleci-server-domain>
 
 # Returns the following:
 Get policy (decision) logs


### PR DESCRIPTION
# Description

While testing the policy service before the Server 4.4 release we realized that the public docs are missing a required flag for cli commands meant for use with server. That is, the command needs the `--policy-base-url` url to be set and pointing at the Server instance, instead of the default which is Cloud. 

# Reasons
- See https://circleci.atlassian.net/browse/SNC-590

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
