### PR TITLE
Fix Playwright Sharding command

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -270,7 +270,7 @@ suite. These applications are not developed or supported by CircleCI. Please che
     executor: pw-focal-development
     parallelism: 4
     steps:
-      - run: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+      - run: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
   ```
 
 ## Next steps


### PR DESCRIPTION
The `npx playwright test -- --shard=${shard}` command has an extra `--` in it, causing it to not actually shard. When passing arguments to the command through `npm run test`, any arguments passed before the `--` will be interpreted by `npm`, and any after by the command - so `playwright`, in this instance. But with `npx`, arguments are passed straight to the command being run - in this instance, `playwright`, so the `--` is both unnecesary and causes the sharding to not work.

A colleague of mine spent a while trying to make this work, so I figured I'd update it for anybody coming later.

Edit: I'm worried that comes off a little harsh. To be clear, I'm very grateful for this documentation!