### PR TITLE
Use the pinned build-agent version on air-gapped server instead of latest [ONPREM-888]

### DIFF
--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -10,6 +10,7 @@ contentTags:
 :page-description: How to configure object storage through MinIO to run CircleCI server in an air-gapped environment.
 :icons: font
 :experimental:
+:circleci-agent-version: 1.0.213499-server-4.1-ecdb045d
 
 [#create-buckets-in-minio]
 == 1. Create buckets in MinIO
@@ -33,39 +34,28 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 
 [#copy-circleci-build-agent]
 == 2. Copy the CircleCI build agent
-Copy the latest CircleCI build agent into MinIO within your air-gapped environment.
-
-[#download-latest-release-txt]
-=== a. Download the latest release.txt file
-Download the latest link:https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/release.txt[release.txt file] from CircleCI's public S3 bucket.
-
-[source, bash]
-----
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/release.txt
-----
+Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
 [#copy-release-txt]
-=== b. Copy the release.txt file to MinIO
-Copy the `release.txt` file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
+=== a. Create a release.txt file and copy to MinIO
+Create a `release.txt` file with the value `{circleci-agent-version}`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
 
-[#retrieve-latest-release-bin]
-=== c. Retrieve the latest release binary
-Using the `release.txt` file, retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
+[#retrieve-pinned-agent-bin]
+=== b. Retrieve the pinned agent binary
+Retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
 
-[source, bash]
+[source, bash,subs="attributes+"]
 ----
-LATEST_RELEASE=$(cat release.txt)
-
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$LATEST_RELEASE/linux/amd64/circleci-agent
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$LATEST_RELEASE/checksums.txt
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/checksums.txt
 ----
 
 [#create-release-dir]
 === d. Create a release directory in the circleci-data bucket
-Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `1.0.164633-f867f14f`
+Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `{circleci-agent-version}`
 
 image::./minio/minio_create_release_dir.png[Creating a directory in the circleci-data bucket]
 
@@ -73,11 +63,12 @@ image::./minio/minio_create_release_dir.png[Creating a directory in the circleci
 === e. Upload the checksums.txt file to the newly created directory.
 Copy the downloaded `checksums.txt` file (step c) to your virtual environment, and place it in MinIO nested under the newly created release directory (step d).
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The structure of the directory should now look like this
-1.0.164633-f867f14f/
+{circleci-agent-version}/
 └── checksums.txt
+
 ----
 
 image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the release directory]
@@ -86,10 +77,10 @@ image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the relea
 === f. Create two new subdirectories in the release directory
 Within the release directory (step d), create two new nested subdirectories, first `linux`, and then within it, `amd64`.
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The structure of the directory of the bucket should look like this:
-1.0.164633-f867f14f/
+{circleci-agent-version}/
 ├── checksums.txt
 └── linux/
     └── amd64/
@@ -103,10 +94,10 @@ image::./minio/minio_create_amd_dir.png[Creating an amd dir]
 === g. Copy the downloaded circleci-agent file
 Copy the downloaded `circleci-agent` file (step c) to your virtual environment, and place it in the amd64 directory you just created.
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The final structure of the bucket should look similar to this:
-1.0.137184-db08738f/
+{circleci-agent-version}/
 ├── checksums.txt
 └── linux/
     └── amd64/

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -10,7 +10,6 @@ contentTags:
 :page-description: How to configure object storage through MinIO to run CircleCI server in an air-gapped environment.
 :icons: font
 :experimental:
-:circleci-agent-version: 1.0.213499-server-4.1-ecdb045d
 
 [#create-buckets-in-minio]
 == 1. Create buckets in MinIO
@@ -36,26 +35,42 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 == 2. Copy the CircleCI build agent
 Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
+[#retrieve-pinned-agent-version]
+=== a. Extract the pinned agent version from the Helm chart
+Fetch the `circleci-server` Helm chart and extract the pinned agent version from it. Set this to the environment variable `$CIRCLE_AGENT_VERSION` so that it can be referenced in later steps.
+
+[source, bash]
+----
+# Fetch the Helm chart for inspection. Replace `<version>` with the full version of CircleCI server.
+$ helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
+
+# Set `$CIRCLE_AGENT_VERSION` to the value of `circleci/picard` in `images.yaml`.
+$ export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
+
+# Verify `$CIRCLE_AGENT_VERSION` is set. The value should be similar in form to `1.0.217358-0b5336a7`.
+$ echo $CIRCLE_AGENT_VERSION
+----
+
 [#copy-release-txt]
-=== a. Create a release.txt file and copy to MinIO
-Create a `release.txt` file with the value `{circleci-agent-version}`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
+=== b. Create a release.txt file and copy to MinIO
+Create a `release.txt` file with the value of `$CIRCLE_AGENT_VERSION`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
 
 [#retrieve-pinned-agent-bin]
-=== b. Retrieve the pinned agent binary
-Retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
+=== c. Retrieve the pinned agent binary
+Retrieve and download the pinned `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
 
-[source, bash,subs="attributes+"]
+[source, bash]
 ----
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/linux/amd64/circleci-agent
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/checksums.txt
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
 ----
 
 [#create-release-dir]
 === d. Create a release directory in the circleci-data bucket
-Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `{circleci-agent-version}`
+Using the version specified by `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In the following examples, a directory is created at the root of `circleci-data` in MinIO with the name `$CIRCLE_AGENT_VERSION`. Note `$CIRCLE_AGENT_VERSION` is not a literal string, but the value of the environment variable we set earlier.
 
 image::./minio/minio_create_release_dir.png[Creating a directory in the circleci-data bucket]
 
@@ -63,12 +78,12 @@ image::./minio/minio_create_release_dir.png[Creating a directory in the circleci
 === e. Upload the checksums.txt file to the newly created directory.
 Copy the downloaded `checksums.txt` file (step c) to your virtual environment, and place it in MinIO nested under the newly created release directory (step d).
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
-# The structure of the directory should now look like this
-{circleci-agent-version}/
+# The structure of the directory should now look like this.
+# Note `$CIRCLE_AGENT_VERSION` is not a literal string, but the value of the environment variable we set earlier.
+$CIRCLE_AGENT_VERSION/
 └── checksums.txt
-
 ----
 
 image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the release directory]
@@ -77,10 +92,10 @@ image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the relea
 === f. Create two new subdirectories in the release directory
 Within the release directory (step d), create two new nested subdirectories, first `linux`, and then within it, `amd64`.
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
 # The structure of the directory of the bucket should look like this:
-{circleci-agent-version}/
+$CIRCLE_AGENT_VERSION/
 ├── checksums.txt
 └── linux/
     └── amd64/
@@ -94,10 +109,10 @@ image::./minio/minio_create_amd_dir.png[Creating an amd dir]
 === g. Copy the downloaded circleci-agent file
 Copy the downloaded `circleci-agent` file (step c) to your virtual environment, and place it in the amd64 directory you just created.
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
 # The final structure of the bucket should look similar to this:
-{circleci-agent-version}/
+$CIRCLE_AGENT_VERSION/
 ├── checksums.txt
 └── linux/
     └── amd64/

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -33,7 +33,7 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 
 [#copy-circleci-build-agent]
 == 2. Copy the CircleCI build agent
-Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
+Follow the steps in this section to copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
 [#retrieve-pinned-agent-version]
 === a. Extract the pinned agent version from the Helm chart
@@ -42,13 +42,13 @@ Fetch the `circleci-server` Helm chart and extract the pinned agent version from
 [source, bash]
 ----
 # Fetch the Helm chart for inspection. Replace `<version>` with the full version of CircleCI server.
-$ helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
+helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
 
 # Set `$CIRCLE_AGENT_VERSION` to the value of `circleci/picard` in `images.yaml`.
-$ export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
+export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
 
 # Verify `$CIRCLE_AGENT_VERSION` is set. The value should be similar in form to `1.0.217358-0b5336a7`.
-$ echo $CIRCLE_AGENT_VERSION
+echo $CIRCLE_AGENT_VERSION
 ----
 
 [#copy-release-txt]

--- a/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -34,7 +34,7 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 
 [#copy-circleci-build-agent]
 == 2. Copy the CircleCI build agent
-Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
+Follow the steps in this section to copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
 [#retrieve-pinned-agent-version]
 === a. Extract the pinned agent version from the Helm chart
@@ -43,13 +43,13 @@ Fetch the `circleci-server` Helm chart and extract the pinned agent version from
 [source, bash]
 ----
 # Fetch the Helm chart for inspection. Replace `<version>` with the full version of CircleCI server.
-$ helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
+helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
 
 # Set `$CIRCLE_AGENT_VERSION` to the value of `circleci/picard` in `images.yaml`.
-$ export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
+export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
 
 # Verify `$CIRCLE_AGENT_VERSION` is set. The value should be similar in form to `1.0.217358-0b5336a7`.
-$ echo $CIRCLE_AGENT_VERSION
+echo $CIRCLE_AGENT_VERSION
 ----
 
 [#copy-release-txt]

--- a/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -11,7 +11,6 @@ contentTags:
 :icons: font
 :toc: macro
 :toc-title:
-:circleci-agent-version: 1.0.213497-server-4.2-0f31974a
 
 [#create-buckets-in-minio]
 == 1. Create buckets in MinIO
@@ -37,26 +36,42 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 == 2. Copy the CircleCI build agent
 Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
+[#retrieve-pinned-agent-version]
+=== a. Extract the pinned agent version from the Helm chart
+Fetch the `circleci-server` Helm chart and extract the pinned agent version from it. Set this to the environment variable `$CIRCLE_AGENT_VERSION` so that it can be referenced in later steps.
+
+[source, bash]
+----
+# Fetch the Helm chart for inspection. Replace `<version>` with the full version of CircleCI server.
+$ helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
+
+# Set `$CIRCLE_AGENT_VERSION` to the value of `circleci/picard` in `images.yaml`.
+$ export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
+
+# Verify `$CIRCLE_AGENT_VERSION` is set. The value should be similar in form to `1.0.217358-0b5336a7`.
+$ echo $CIRCLE_AGENT_VERSION
+----
+
 [#copy-release-txt]
-=== a. Create a release.txt file and copy to MinIO
-Create a `release.txt` file with the value `{circleci-agent-version}`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
+=== b. Create a release.txt file and copy to MinIO
+Create a `release.txt` file with the value of `$CIRCLE_AGENT_VERSION`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
 
 [#retrieve-pinned-agent-bin]
-=== b. Retrieve the pinned agent binary
-Retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
+=== c. Retrieve the pinned agent binary
+Retrieve and download the pinned `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
 
-[source, bash,subs="attributes+"]
+[source, bash]
 ----
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/linux/amd64/circleci-agent
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/checksums.txt
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
 ----
 
 [#create-release-dir]
 === d. Create a release directory in the circleci-data bucket
-Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `{circleci-agent-version}`
+Using the version specified by `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In the following examples, a directory is created at the root of `circleci-data` in MinIO with the name `$CIRCLE_AGENT_VERSION`. Note `$CIRCLE_AGENT_VERSION` is not a literal string, but the value of the environment variable we set earlier.
 
 image::./minio/minio_create_release_dir.png[Creating a directory in the circleci-data bucket]
 
@@ -64,12 +79,12 @@ image::./minio/minio_create_release_dir.png[Creating a directory in the circleci
 === e. Upload the checksums.txt file to the newly created directory.
 Copy the downloaded `checksums.txt` file (step c) to your virtual environment, and place it in MinIO nested under the newly created release directory (step d).
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
-# The structure of the directory should now look like this
-{circleci-agent-version}/
+# The structure of the directory should now look like this.
+# Note `$CIRCLE_AGENT_VERSION` is not a literal string, but the value of the environment variable we set earlier.
+$CIRCLE_AGENT_VERSION/
 └── checksums.txt
-
 ----
 
 image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the release directory]
@@ -78,10 +93,10 @@ image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the relea
 === f. Create two new subdirectories in the release directory
 Within the release directory (step d), create two new nested subdirectories, first `linux`, and then within it, `amd64`.
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
 # The structure of the directory of the bucket should look like this:
-{circleci-agent-version}/
+$CIRCLE_AGENT_VERSION/
 ├── checksums.txt
 └── linux/
     └── amd64/
@@ -95,10 +110,10 @@ image::./minio/minio_create_amd_dir.png[Creating an amd dir]
 === g. Copy the downloaded circleci-agent file
 Copy the downloaded `circleci-agent` file (step c) to your virtual environment, and place it in the amd64 directory you just created.
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
 # The final structure of the bucket should look similar to this:
-{circleci-agent-version}/
+$CIRCLE_AGENT_VERSION/
 ├── checksums.txt
 └── linux/
     └── amd64/

--- a/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -11,6 +11,7 @@ contentTags:
 :icons: font
 :toc: macro
 :toc-title:
+:circleci-agent-version: 1.0.213497-server-4.2-0f31974a
 
 [#create-buckets-in-minio]
 == 1. Create buckets in MinIO
@@ -34,39 +35,28 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 
 [#copy-circleci-build-agent]
 == 2. Copy the CircleCI build agent
-Copy the latest CircleCI build agent into MinIO within your air-gapped environment.
-
-[#download-latest-release-txt]
-=== a. Download the latest release.txt file
-Download the latest link:https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/release.txt[release.txt file] from CircleCI's public S3 bucket.
-
-[source, bash]
-----
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/release.txt
-----
+Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
 [#copy-release-txt]
-=== b. Copy the release.txt file to MinIO
-Copy the `release.txt` file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
+=== a. Create a release.txt file and copy to MinIO
+Create a `release.txt` file with the value `{circleci-agent-version}`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
 
-[#retrieve-latest-release-bin]
-=== c. Retrieve the latest release binary
-Using the `release.txt` file, retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
+[#retrieve-pinned-agent-bin]
+=== b. Retrieve the pinned agent binary
+Retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
 
-[source, bash]
+[source, bash,subs="attributes+"]
 ----
-LATEST_RELEASE=$(cat release.txt)
-
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$LATEST_RELEASE/linux/amd64/circleci-agent
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$LATEST_RELEASE/checksums.txt
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/checksums.txt
 ----
 
 [#create-release-dir]
 === d. Create a release directory in the circleci-data bucket
-Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `1.0.164633-f867f14f`
+Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `{circleci-agent-version}`
 
 image::./minio/minio_create_release_dir.png[Creating a directory in the circleci-data bucket]
 
@@ -74,11 +64,12 @@ image::./minio/minio_create_release_dir.png[Creating a directory in the circleci
 === e. Upload the checksums.txt file to the newly created directory.
 Copy the downloaded `checksums.txt` file (step c) to your virtual environment, and place it in MinIO nested under the newly created release directory (step d).
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The structure of the directory should now look like this
-1.0.164633-f867f14f/
+{circleci-agent-version}/
 └── checksums.txt
+
 ----
 
 image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the release directory]
@@ -87,10 +78,10 @@ image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the relea
 === f. Create two new subdirectories in the release directory
 Within the release directory (step d), create two new nested subdirectories, first `linux`, and then within it, `amd64`.
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The structure of the directory of the bucket should look like this:
-1.0.164633-f867f14f/
+{circleci-agent-version}/
 ├── checksums.txt
 └── linux/
     └── amd64/
@@ -104,10 +95,10 @@ image::./minio/minio_create_amd_dir.png[Creating an amd dir]
 === g. Copy the downloaded circleci-agent file
 Copy the downloaded `circleci-agent` file (step c) to your virtual environment, and place it in the amd64 directory you just created.
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The final structure of the bucket should look similar to this:
-1.0.137184-db08738f/
+{circleci-agent-version}/
 ├── checksums.txt
 └── linux/
     └── amd64/

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -34,7 +34,7 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 
 [#copy-circleci-build-agent]
 == 2. Copy the CircleCI build agent
-Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
+Follow the steps in this section to copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
 [#retrieve-pinned-agent-version]
 === a. Extract the pinned agent version from the Helm chart
@@ -43,13 +43,13 @@ Fetch the `circleci-server` Helm chart and extract the pinned agent version from
 [source, bash]
 ----
 # Fetch the Helm chart for inspection. Replace `<version>` with the full version of CircleCI server.
-$ helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
+helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
 
 # Set `$CIRCLE_AGENT_VERSION` to the value of `circleci/picard` in `images.yaml`.
-$ export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
+export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
 
 # Verify `$CIRCLE_AGENT_VERSION` is set. The value should be similar in form to `1.0.217358-0b5336a7`.
-$ echo $CIRCLE_AGENT_VERSION
+echo $CIRCLE_AGENT_VERSION
 ----
 
 [#copy-release-txt]

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -11,6 +11,7 @@ contentTags:
 :icons: font
 :toc: macro
 :toc-title:
+:circleci-agent-version: 1.0.220822-server-4.3-6c0dbcf2
 
 [#create-buckets-in-minio]
 == 1. Create buckets in MinIO
@@ -34,39 +35,28 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 
 [#copy-circleci-build-agent]
 == 2. Copy the CircleCI build agent
-Copy the latest CircleCI build agent into MinIO within your air-gapped environment.
-
-[#download-latest-release-txt]
-=== a. Download the latest release.txt file
-Download the latest link:https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/release.txt[release.txt file] from CircleCI's public S3 bucket.
-
-[source, bash]
-----
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/release.txt
-----
+Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
 [#copy-release-txt]
-=== b. Copy the release.txt file to MinIO
-Copy the `release.txt` file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
+=== a. Create a release.txt file and copy to MinIO
+Create a `release.txt` file with the value `{circleci-agent-version}`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
 
-[#retrieve-latest-release-bin]
-=== c. Retrieve the latest release binary
-Using the `release.txt` file, retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
+[#retrieve-pinned-agent-bin]
+=== b. Retrieve the pinned agent binary
+Retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
 
-[source, bash]
+[source, bash,subs="attributes+"]
 ----
-LATEST_RELEASE=$(cat release.txt)
-
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$LATEST_RELEASE/linux/amd64/circleci-agent
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$LATEST_RELEASE/checksums.txt
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/checksums.txt
 ----
 
 [#create-release-dir]
 === d. Create a release directory in the circleci-data bucket
-Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `1.0.164633-f867f14f`
+Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `{circleci-agent-version}`
 
 image::./minio/minio_create_release_dir.png[Creating a directory in the circleci-data bucket]
 
@@ -74,11 +64,12 @@ image::./minio/minio_create_release_dir.png[Creating a directory in the circleci
 === e. Upload the checksums.txt file to the newly created directory.
 Copy the downloaded `checksums.txt` file (step c) to your virtual environment, and place it in MinIO nested under the newly created release directory (step d).
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The structure of the directory should now look like this
-1.0.164633-f867f14f/
+{circleci-agent-version}/
 └── checksums.txt
+
 ----
 
 image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the release directory]
@@ -87,10 +78,10 @@ image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the relea
 === f. Create two new subdirectories in the release directory
 Within the release directory (step d), create two new nested subdirectories, first `linux`, and then within it, `amd64`.
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The structure of the directory of the bucket should look like this:
-1.0.164633-f867f14f/
+{circleci-agent-version}/
 ├── checksums.txt
 └── linux/
     └── amd64/
@@ -104,10 +95,10 @@ image::./minio/minio_create_amd_dir.png[Creating an amd dir]
 === g. Copy the downloaded circleci-agent file
 Copy the downloaded `circleci-agent` file (step c) to your virtual environment, and place it in the amd64 directory you just created.
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The final structure of the bucket should look similar to this:
-1.0.137184-db08738f/
+{circleci-agent-version}/
 ├── checksums.txt
 └── linux/
     └── amd64/

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -11,7 +11,6 @@ contentTags:
 :icons: font
 :toc: macro
 :toc-title:
-:circleci-agent-version: 1.0.220822-server-4.3-6c0dbcf2
 
 [#create-buckets-in-minio]
 == 1. Create buckets in MinIO
@@ -37,26 +36,42 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 == 2. Copy the CircleCI build agent
 Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
+[#retrieve-pinned-agent-version]
+=== a. Extract the pinned agent version from the Helm chart
+Fetch the `circleci-server` Helm chart and extract the pinned agent version from it. Set this to the environment variable `$CIRCLE_AGENT_VERSION` so that it can be referenced in later steps.
+
+[source, bash]
+----
+# Fetch the Helm chart for inspection. Replace `<version>` with the full version of CircleCI server.
+$ helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
+
+# Set `$CIRCLE_AGENT_VERSION` to the value of `circleci/picard` in `images.yaml`.
+$ export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
+
+# Verify `$CIRCLE_AGENT_VERSION` is set. The value should be similar in form to `1.0.217358-0b5336a7`.
+$ echo $CIRCLE_AGENT_VERSION
+----
+
 [#copy-release-txt]
-=== a. Create a release.txt file and copy to MinIO
-Create a `release.txt` file with the value `{circleci-agent-version}`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
+=== b. Create a release.txt file and copy to MinIO
+Create a `release.txt` file with the value of `$CIRCLE_AGENT_VERSION`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
 
 [#retrieve-pinned-agent-bin]
-=== b. Retrieve the pinned agent binary
-Retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
+=== c. Retrieve the pinned agent binary
+Retrieve and download the pinned `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
 
-[source, bash,subs="attributes+"]
+[source, bash]
 ----
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/linux/amd64/circleci-agent
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/checksums.txt
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
 ----
 
 [#create-release-dir]
 === d. Create a release directory in the circleci-data bucket
-Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `{circleci-agent-version}`
+Using the version specified by `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In the following examples, a directory is created at the root of `circleci-data` in MinIO with the name `$CIRCLE_AGENT_VERSION`. Note `$CIRCLE_AGENT_VERSION` is not a literal string, but the value of the environment variable we set earlier.
 
 image::./minio/minio_create_release_dir.png[Creating a directory in the circleci-data bucket]
 
@@ -64,12 +79,12 @@ image::./minio/minio_create_release_dir.png[Creating a directory in the circleci
 === e. Upload the checksums.txt file to the newly created directory.
 Copy the downloaded `checksums.txt` file (step c) to your virtual environment, and place it in MinIO nested under the newly created release directory (step d).
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
-# The structure of the directory should now look like this
-{circleci-agent-version}/
+# The structure of the directory should now look like this.
+# Note `$CIRCLE_AGENT_VERSION` is not a literal string, but the value of the environment variable we set earlier.
+$CIRCLE_AGENT_VERSION/
 └── checksums.txt
-
 ----
 
 image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the release directory]
@@ -78,10 +93,10 @@ image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the relea
 === f. Create two new subdirectories in the release directory
 Within the release directory (step d), create two new nested subdirectories, first `linux`, and then within it, `amd64`.
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
 # The structure of the directory of the bucket should look like this:
-{circleci-agent-version}/
+$CIRCLE_AGENT_VERSION/
 ├── checksums.txt
 └── linux/
     └── amd64/
@@ -95,10 +110,10 @@ image::./minio/minio_create_amd_dir.png[Creating an amd dir]
 === g. Copy the downloaded circleci-agent file
 Copy the downloaded `circleci-agent` file (step c) to your virtual environment, and place it in the amd64 directory you just created.
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
 # The final structure of the bucket should look similar to this:
-{circleci-agent-version}/
+$CIRCLE_AGENT_VERSION/
 ├── checksums.txt
 └── linux/
     └── amd64/

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -11,7 +11,6 @@ contentTags:
 :icons: font
 :toc: macro
 :toc-title:
-:circleci-agent-version: 1.0.220852-server-4.4-867103db
 
 [#create-buckets-in-minio]
 == 1. Create buckets in MinIO
@@ -37,26 +36,42 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 == 2. Copy the CircleCI build agent
 Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
+[#retrieve-pinned-agent-version]
+=== a. Extract the pinned agent version from the Helm chart
+Fetch the `circleci-server` Helm chart and extract the pinned agent version from it. Set this to the environment variable `$CIRCLE_AGENT_VERSION` so that it can be referenced in later steps.
+
+[source, bash]
+----
+# Fetch the Helm chart for inspection. Replace `<version>` with the full version of CircleCI server.
+$ helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
+
+# Set `$CIRCLE_AGENT_VERSION` to the value of `circleci/picard` in `images.yaml`.
+$ export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
+
+# Verify `$CIRCLE_AGENT_VERSION` is set. The value should be similar in form to `1.0.217358-0b5336a7`.
+$ echo $CIRCLE_AGENT_VERSION
+----
+
 [#copy-release-txt]
-=== a. Create a release.txt file and copy to MinIO
-Create a `release.txt` file with the value `{circleci-agent-version}`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
+=== b. Create a release.txt file and copy to MinIO
+Create a `release.txt` file with the value of `$CIRCLE_AGENT_VERSION`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
 
 [#retrieve-pinned-agent-bin]
-=== b. Retrieve the pinned agent binary
-Retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
+=== c. Retrieve the pinned agent binary
+Retrieve and download the pinned `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
 
-[source, bash,subs="attributes+"]
+[source, bash]
 ----
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/linux/amd64/circleci-agent
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/checksums.txt
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
 ----
 
 [#create-release-dir]
 === d. Create a release directory in the circleci-data bucket
-Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `{circleci-agent-version}`
+Using the version specified by `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In the following examples, a directory is created at the root of `circleci-data` in MinIO with the name `$CIRCLE_AGENT_VERSION`. Note `$CIRCLE_AGENT_VERSION` is not a literal string, but the value of the environment variable we set earlier.
 
 image::./minio/minio_create_release_dir.png[Creating a directory in the circleci-data bucket]
 
@@ -64,12 +79,12 @@ image::./minio/minio_create_release_dir.png[Creating a directory in the circleci
 === e. Upload the checksums.txt file to the newly created directory.
 Copy the downloaded `checksums.txt` file (step c) to your virtual environment, and place it in MinIO nested under the newly created release directory (step d).
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
-# The structure of the directory should now look like this
-{circleci-agent-version}/
+# The structure of the directory should now look like this.
+# Note `$CIRCLE_AGENT_VERSION` is not a literal string, but the value of the environment variable we set earlier.
+$CIRCLE_AGENT_VERSION/
 └── checksums.txt
-
 ----
 
 image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the release directory]
@@ -78,10 +93,10 @@ image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the relea
 === f. Create two new subdirectories in the release directory
 Within the release directory (step d), create two new nested subdirectories, first `linux`, and then within it, `amd64`.
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
 # The structure of the directory of the bucket should look like this:
-{circleci-agent-version}/
+$CIRCLE_AGENT_VERSION/
 ├── checksums.txt
 └── linux/
     └── amd64/
@@ -95,10 +110,10 @@ image::./minio/minio_create_amd_dir.png[Creating an amd dir]
 === g. Copy the downloaded circleci-agent file
 Copy the downloaded `circleci-agent` file (step c) to your virtual environment, and place it in the amd64 directory you just created.
 
-[source,shell,subs="attributes+"]
+[source,shell]
 ----
 # The final structure of the bucket should look similar to this:
-{circleci-agent-version}/
+$CIRCLE_AGENT_VERSION/
 ├── checksums.txt
 └── linux/
     └── amd64/

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -11,6 +11,7 @@ contentTags:
 :icons: font
 :toc: macro
 :toc-title:
+:circleci-agent-version: 1.0.220852-server-4.4-867103db
 
 [#create-buckets-in-minio]
 == 1. Create buckets in MinIO
@@ -34,39 +35,28 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 
 [#copy-circleci-build-agent]
 == 2. Copy the CircleCI build agent
-Copy the latest CircleCI build agent into MinIO within your air-gapped environment.
-
-[#download-latest-release-txt]
-=== a. Download the latest release.txt file
-Download the latest link:https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/release.txt[release.txt file] from CircleCI's public S3 bucket.
-
-[source, bash]
-----
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/release.txt
-----
+Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
 [#copy-release-txt]
-=== b. Copy the release.txt file to MinIO
-Copy the `release.txt` file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
+=== a. Create a release.txt file and copy to MinIO
+Create a `release.txt` file with the value `{circleci-agent-version}`. Copy this file to your air-gapped environment and place it in the root of the `circleci-data` bucket in MinIO.
 
-[#retrieve-latest-release-bin]
-=== c. Retrieve the latest release binary
-Using the `release.txt` file, retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
+[#retrieve-pinned-agent-bin]
+=== b. Retrieve the pinned agent binary
+Retrieve and download the latest `circleci-agent` release and checksums from the CircleCI binary releases public bucket.
 
-[source, bash]
+[source, bash,subs="attributes+"]
 ----
-LATEST_RELEASE=$(cat release.txt)
-
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$LATEST_RELEASE/linux/amd64/circleci-agent
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$LATEST_RELEASE/checksums.txt
+wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/{circleci-agent-version}/checksums.txt
 ----
 
 [#create-release-dir]
 === d. Create a release directory in the circleci-data bucket
-Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `1.0.164633-f867f14f`
+Using the version specified in `release.txt`, create a new directory in the root of the `circleci-data` bucket with the name of that release. In this example, a directory is created at the root of `circleci-data` in MinIO with the following name: `{circleci-agent-version}`
 
 image::./minio/minio_create_release_dir.png[Creating a directory in the circleci-data bucket]
 
@@ -74,11 +64,12 @@ image::./minio/minio_create_release_dir.png[Creating a directory in the circleci
 === e. Upload the checksums.txt file to the newly created directory.
 Copy the downloaded `checksums.txt` file (step c) to your virtual environment, and place it in MinIO nested under the newly created release directory (step d).
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The structure of the directory should now look like this
-1.0.164633-f867f14f/
+{circleci-agent-version}/
 └── checksums.txt
+
 ----
 
 image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the release directory]
@@ -87,10 +78,10 @@ image::./minio/minio_upload_checksums.png[Uploading checksums.txt into the relea
 === f. Create two new subdirectories in the release directory
 Within the release directory (step d), create two new nested subdirectories, first `linux`, and then within it, `amd64`.
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The structure of the directory of the bucket should look like this:
-1.0.164633-f867f14f/
+{circleci-agent-version}/
 ├── checksums.txt
 └── linux/
     └── amd64/
@@ -104,10 +95,10 @@ image::./minio/minio_create_amd_dir.png[Creating an amd dir]
 === g. Copy the downloaded circleci-agent file
 Copy the downloaded `circleci-agent` file (step c) to your virtual environment, and place it in the amd64 directory you just created.
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # The final structure of the bucket should look similar to this:
-1.0.137184-db08738f/
+{circleci-agent-version}/
 ├── checksums.txt
 └── linux/
     └── amd64/

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -34,7 +34,7 @@ image::./minio/minio_modify_access_policy.png[Setting circleci-data bucket acces
 
 [#copy-circleci-build-agent]
 == 2. Copy the CircleCI build agent
-Copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
+Follow the steps in this section to copy the pinned CircleCI build agent into MinIO within your air-gapped environment.
 
 [#retrieve-pinned-agent-version]
 === a. Extract the pinned agent version from the Helm chart
@@ -43,13 +43,13 @@ Fetch the `circleci-server` Helm chart and extract the pinned agent version from
 [source, bash]
 ----
 # Fetch the Helm chart for inspection. Replace `<version>` with the full version of CircleCI server.
-$ helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
+helm fetch oci://cciserver.azurecr.io/circleci-server --version <version> --untar
 
 # Set `$CIRCLE_AGENT_VERSION` to the value of `circleci/picard` in `images.yaml`.
-$ export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
+export CIRCLE_AGENT_VERSION=$(grep 'circleci/picard:' ./circleci-server/images.yaml | cut -d' ' -f2)
 
 # Verify `$CIRCLE_AGENT_VERSION` is set. The value should be similar in form to `1.0.217358-0b5336a7`.
-$ echo $CIRCLE_AGENT_VERSION
+echo $CIRCLE_AGENT_VERSION
 ----
 
 [#copy-release-txt]


### PR DESCRIPTION
# Description
A brief description of the changes.

Context in this [Slack thread](https://circleci.slack.com/archives/C05LH7BMR2A/p1707237100251759). Essentially, we _shouldn't_ be recommending users host the _current_ version of build-agent in air-gapped server. Each server version should have their own specified version pinned.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.atlassian.net/browse/ONPREM-888

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
