### PR TITLE
Fix broken CircleCI link on datadog-integration.adoc

### DIFF
--- a/jekyll/_cci2/datadog-integration.adoc
+++ b/jekyll/_cci2/datadog-integration.adoc
@@ -24,7 +24,7 @@ The link:https://docs.datadoghq.com/integrations/circleci/[Datadog CircleCI inte
 
 Complete the following steps to set up a CircleCI webhook to forward your logs to Datadog.
 
-. Log in to the link:https://app.circleci.com/projects)[CircleCI web app]
+. Log in to the link:https://app.circleci.com/projects[CircleCI web app]
 
 . Access one of your CircleCI projects
 


### PR DESCRIPTION
# Description

Removes the trailing `)` character from the link `https://app.circleci.com/projects)`

# Reasons

This fixes an invalid URL link on https://circleci.com/docs/datadog-integration/

# Content Checklist

Not Applicable to this PR

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
