### PR TITLE
docs(rerun failed tests): Update outdated example of the RSpec integration with Knapsack Pro.

### DIFF
--- a/jekyll/_cci2/rerun-failed-tests.adoc
+++ b/jekyll/_cci2/rerun-failed-tests.adoc
@@ -193,15 +193,14 @@ gem 'rspec_junit_formatter'
  - run:
     name: RSpec with Knapsack Pro
     command: |
-      export CIRCLE_TEST_REPORTS=/tmp/test-results
-      mkdir -p $CIRCLE_TEST_REPORTS
+      mkdir -p /tmp/test-results
 
       export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
 
       export KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE=/tmp/tests_to_run.txt
       # Retrieve the tests to run (all or just the failed ones), and let Knapsack Pro split them optimally.
       circleci tests glob "spec/**/*_spec.rb" | circleci tests run --index 0 --total 1 --command ">$KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE xargs -n1 echo" --verbose
-      bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RspecJunitFormatter --out tmp/rspec.xml]"
+      bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RspecJunitFormatter --out /tmp/test-results/rspec.xml]"
 
  - store_test_results:
      path: /tmp/test-results


### PR DESCRIPTION
# Description

This PR fixes outdated docs for:
https://circleci.com/docs/rerun-failed-tests/#configure-a-job-running-ruby-rspec-tests-across-parallel-ci-nodes-with-knapsack-pro

The documentation was introduced some time ago after one of CircleCI engineers contacted us:

* https://github.com/circleci/circleci-docs/pull/8542

Current PR changes:

* Update outdated example of the RSpec integration with Knapsack Pro.
  * We released [the knapsack_pro gem 7.0.0](https://github.com/KnapsackPro/knapsack_pro-ruby/blob/master/CHANGELOG.md#700) that simplifies integration with the [rspec_junit_formatter](https://github.com/sj26/rspec_junit_formatter) gem. This simplifies [the integration with CircleCI rerun only failed tests feature](https://docs.knapsackpro.com/ruby/circleci/#rerun-only-failed-tests).
* Remove outdated `$CIRCLE_TEST_REPORTS` env var.


# Reasons

* update outdated docs

# Content Checklist

Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
