### PR TITLE
docs: rm fetching of CIDR block for MP

### DIFF
--- a/jekyll/_cci2/server/v4.3/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-3-execution-environments.adoc
@@ -510,15 +510,12 @@ ifndef::env-gcp[]
 
 . *Get the information needed to create security groups*
 +
-The following command returns your VPC ID (`vpcId`) and CIDR Block (`serviceIpv4Cidr`) which you need throughout this section:
+The following command returns your VPC ID (`vpcId`) which you need throughout this section:
 +
 [source,shell]
 ----
 # Fetch VPC Id
 aws eks describe-cluster --name=<cluster-name> --query "cluster.resourcesVpcConfig.vpcId" --region=<region> --output text | xargs
-
-# Fetch CIDR Block
-aws eks describe-cluster --name=<cluster-name> --query "cluster.kubernetesNetworkConfig.serviceIpv4Cidr" --region=<region> --output text | xargs
 ----
 
 . *Create a security group*


### PR DESCRIPTION
# Description

I removed the mention of fetching CIDR block for the VPC re: Machine Provisioner.

# Reasons

I observed that the CIDR block fetched is not used in the AWS security group created for Machine Provisioner:
https://circleci.com/docs/server/v4.3/installation/phase-3-execution-environments/#set-up-security-group

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
