### PR TITLE
Fix line number referencing docker layer caching in yaml

### DIFF
--- a/jekyll/_cci2/building-docker-images.adoc
+++ b/jekyll/_cci2/building-docker-images.adoc
@@ -80,7 +80,7 @@ Below is a break down of what is happening during this build's execution:
 
 * All commands execute in the xref:glossary#primary-container[primary-container]. (line 5)
 * Once you call `setup_remote_docker`, all Docker-related commands execute locally. (line 12)
-* Enable xref:glossary#docker-layer-caching[Docker Layer Caching] (DLC) to speed up image building. (line 14)
+* Enable xref:glossary#docker-layer-caching[Docker Layer Caching] (DLC) to speed up image building. (line 13)
 * We use xref:set-environment-variable#set-an-environment-variable-in-a-project[project environment variables] to store credentials for Docker Hub. (line 19)
 
 [#resource-classes]


### PR DESCRIPTION
# Description
The `docker_layer_caching: true` is on line 13, not 14, as seen here: https://circleci.com/docs/building-docker-images/#run-docker-commands-using-the-docker-executor

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
