### PR TITLE
Rearrange Kubernetes config page to add project ID annotation at start

### DIFF
--- a/jekyll/_cci2/release/configure-your-kubernetes-components.adoc
+++ b/jekyll/_cci2/release/configure-your-kubernetes-components.adoc
@@ -17,22 +17,32 @@ The steps outlined on this page guide you to configure your Kubernetes resources
 [#introduction]
 == Introduction
 
-In this tutorial you will configure your Kubernetes components, adding labels and annotations to enable visibility and control over your deployments.
+In this tutorial you will configure your Kubernetes components, adding labels and annotation, to enable visibility and control over your deployments.
 
 [#prerequisites]
 == Prerequisites
 
-Before following the steps below, ensure the release environment has been set up successfully. Refer to the xref:set-up-a-release-environment#[Set up a release environment] page.
+Before following the steps below, ensure the release environment is set up. Refer to the xref:set-up-a-release-environment#[Set up a release environment] page.
 
 [#add-required-labels]
-== 1. Add required labels to your Deployment/Rollout
+== 1. Add required labels and annotation to your Deployment/Rollout
 
-To enable your release to show up on the releases dashboard in the CircleCI web app, add the following labels to your Kubernetes Deployment or Argo Rollout:
+To enable your release to show up on the releases UI in the CircleCI web app, add the following labels and annotation to your Kubernetes Deployment or Argo Rollout:
 
 * Specify the `app` and `version` label in the Kubernetes object `Metadata.Labels`
 * Specify the `app` and `version` label in the Kubernetes object `Spec.Template.Metadata.Labels`
+* Add the `circleci.com/project-id` annotation with the value set to your project ID
++
+[NOTE]
+====
+**Find your project ID:**
 
-NOTE: Do not add `version` to the selector labels. These labels can not be changed later, and `version` changes frequently.
+. Click **Projects** in the CircleCI web app sidebar and use the search function to find your project
+. Click the ellipsis menu next to your project and click btn:[Project Settings]
+. Your project ID is available to copy from the overview page
++
+image::../../img/docs/project-id.png[Screenshot showing where to find the project ID]
+====
 
 For example:
 
@@ -41,6 +51,8 @@ For example:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    circleci.com/project-id: <your-project-ID>
   labels:
     app: example-deployment
     version: 1.0.0
@@ -56,6 +68,8 @@ spec:
         app: example-deployment
         version: 1.0.0
 ----
+
+NOTE: Do not add `version` to the selector labels. These labels can not be changed later, and `version` changes frequently.
 
 Once you have updated your Deployment or Rollout, check the CircleCI releases dashboard and you should see your release in the timeline view.
 
@@ -84,26 +98,7 @@ metadata:
 [#configure-release-management]
 == 3. Configure release management (optional)
 
-By adding an annotation to your Kubernetes objects (Deployment/Rollout), you can enable additional actions on your releases dashboard. This includes restoring, scaling, and restarting component versions. To get started, add the `circleci.com/project-id` annotation with the value found on the relevant CircleCI project settings page.
-
-[,yaml]
-----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    ...
-    circleci.com/project-id: 9da0c100-3295-49a4-827f-7892f3e8dc83
-----
-
-To find your project ID:
-
-. Click **Projects** in the CircleCI web app sidebar
-. Use the search function to find your project
-. Click the ellipsis menu next to your project and click btn:[Project Settings]
-. Your project ID is available to copy from the overview page
-+
-image::../../img/docs/project-id.png[Screenshot showing where to find the project ID]
+By adding annotations to your Kubernetes objects (Deployment/Rollout), you can enable additional actions on your releases dashboard, including the ability to restore, scale, and restart component versions.
 
 [#helm-rollback]
 === a. Use Helm rollback
@@ -123,7 +118,7 @@ annotations:
 [#operation-timeout]
 === b. Custom operation timeout
 
-NOTE: This option is only available when using Helm to configure your Kubernetes resources.
+CAUTION: This option is only available when using Helm to configure your Kubernetes resources.
 
 The `circleci.com/operation-timeout` annotation allows a custom timeout to be specified for Helm Rollback operations performed as part of a Restore Version command. Valid values are link:https://pkg.go.dev/time#ParseDuration[Go duration strings] (for example, 5m, 10m15s). This option is available if you are using Helm to manage your Kubernetes resources.
 
@@ -144,7 +139,7 @@ metadata:
 
 If you would like to disable any release management features for a specific component, you can do so by adding any of the following annotations with the value `false` to the related Kubernetes Deployment or Argo Rollout.
 
-NOTE: If an annotation is either not specified or is specified with any value _other_ than `false`, the associated feature will be **enabled**. Release management features are enabled by default unless explicitly disabled:
+NOTE: If an annotation is either not specified or is specified with any value _other_ than `false`, the associated feature is **enabled**. Release management features are enabled by default unless explicitly disabled, as follows:
 
 * `circleci.com/restore-version-enabled` toggles the restore version feature on the annotated Kubernetes Deployment or Argo Rollout
 * `circleci.com/scale-component-enabled` toggles the scale component feature on the annotated Kubernetes Deployment or Argo Rollout


### PR DESCRIPTION
# Description
Rearrange sections so the project ID annotation is added in the first section along with the required labels

See changes here once preview is built: https://internal.circleci.com/docs/release/configure-your-kubernetes-components/

# Reasons
Project ID is now required, previously it was optional

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
