### PR TITLE
Remove open preview references in prep for March 18 GA

### DIFF
--- a/jekyll/_cci2/release/configure-your-kubernetes-components.adoc
+++ b/jekyll/_cci2/release/configure-your-kubernetes-components.adoc
@@ -10,8 +10,6 @@ contentTags:
 :icons: font
 :experimental:
 
-NOTE: CircleCI releases is currently in **open preview**. During open preview release features are available for free. Charges will be associated with release features once they are generally available.
-
 The steps outlined on this page guide you to configure your Kubernetes resources for integration with your release environment.
 
 [#introduction]

--- a/jekyll/_cci2/release/manage-releases.adoc
+++ b/jekyll/_cci2/release/manage-releases.adoc
@@ -10,8 +10,6 @@ contentTags:
 :icons: font
 :experimental:
 
-NOTE: CircleCI releases is currently in **open preview**. During open preview release features are available for free. Charges will be associated with release features once they are generally available.
-
 The steps outlined on this page guide you through the tasks required to manage your releases.
 
 [#prerequisites]

--- a/jekyll/_cci2/release/releases-overview.adoc
+++ b/jekyll/_cci2/release/releases-overview.adoc
@@ -10,8 +10,6 @@ contentTags:
 :icons: font
 :experimental:
 
-NOTE: CircleCI releases is currently in **open preview**. During open preview release features are available for free. Charges will be associated with release features once they are generally available.
-
 Visualise and control your deployments with CircleCI releases. Deployments to Kubernetes and Amazon SageMaker are supported.
 
 [#introduction]
@@ -304,17 +302,6 @@ Releases can be in one of the following states:
 |EXPIRED
 |Release commands failed to be picked up by the release agent within the required time window
 |===
-
-[#coming-soon]
-== Coming soon
-
-A number of features and improvements are planned to be added through open preview and beyond:
-
-* Guided release environment setup experience in the CircleCI web app
-* link:https://argo-rollouts.readthedocs.io/en/stable/features/bluegreen/[Blue Green] deployments via Argo Rollouts
-* Connect releases to your CircleCI workflows
-* Display Argo Rollouts analysis run details in the CircleCI web app
-* Improved searching and filtering on the release dashboard
 
 [#known-limitations]
 == Known limitations

--- a/jekyll/_cci2/release/set-up-a-release-environment.adoc
+++ b/jekyll/_cci2/release/set-up-a-release-environment.adoc
@@ -10,8 +10,6 @@ contentTags:
 :icons: font
 :experimental:
 
-NOTE: CircleCI releases is currently in **open preview**. During open preview release features are available for free. Charges will be associated with release features once they are generally available.
-
 Visualise and control deployments to your Kubernetes cluster with CircleCI releases. The steps outlined on this page guide you to set up a release environment and install the CircleCI release agent into your Kubernetes cluster.
 
 [#introduction]

--- a/jekyll/_cci2/release/update-the-kubernetes-release-agent.adoc
+++ b/jekyll/_cci2/release/update-the-kubernetes-release-agent.adoc
@@ -10,8 +10,6 @@ contentTags:
 :icons: font
 :experimental:
 
-NOTE: CircleCI releases is currently in **open preview**. During open preview release features are available for free. Charges will be associated with release features once they are generally available.
-
 Follow the steps on this page to update the release agent installed in your Kubernetes cluster.
 
 Refer to the link:https://circleci.com/changelog/[CircleCI Change log] to find out about new release agent versioning, updates, and fixes.


### PR DESCRIPTION
## *DO NOT MERGE UNTIL MARCH 15!!*

# Description
Remove open preview banners and `Coming soon` section.

# Reasons
We are going GA on March 18 and no longer need references to open preview. Since we are going GA, we will use the public roadmap for future improvements, rather than maintaining a `Coming soon` section.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
