### PR TITLE
fix: Uncompress picard binary

### DIFF
--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -65,7 +65,7 @@ Retrieve and download the pinned `circleci-agent` release and checksums from the
 curl -O --compressed https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
+curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
 ----
 
 [#create-release-dir]

--- a/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.1/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -62,7 +62,7 @@ Retrieve and download the pinned `circleci-agent` release and checksums from the
 [source, bash]
 ----
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
+curl -O --compressed https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
 wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt

--- a/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -66,7 +66,7 @@ Retrieve and download the pinned `circleci-agent` release and checksums from the
 curl -O --compressed https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
+curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
 ----
 
 [#create-release-dir]

--- a/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.2/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -63,7 +63,7 @@ Retrieve and download the pinned `circleci-agent` release and checksums from the
 [source, bash]
 ----
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
+curl -O --compressed https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
 wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -66,7 +66,7 @@ Retrieve and download the pinned `circleci-agent` release and checksums from the
 curl -O --compressed https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
+curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
 ----
 
 [#create-release-dir]

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -63,7 +63,7 @@ Retrieve and download the pinned `circleci-agent` release and checksums from the
 [source, bash]
 ----
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
+curl -O --compressed https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
 wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -66,7 +66,7 @@ Retrieve and download the pinned `circleci-agent` release and checksums from the
 curl -O --compressed https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
+curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
 ----
 
 [#create-release-dir]

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -63,7 +63,7 @@ Retrieve and download the pinned `circleci-agent` release and checksums from the
 [source, bash]
 ----
 # Download circleci-agent
-wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
+curl -O --compressed https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
 
 # Download checksums
 wget https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt


### PR DESCRIPTION
This came out of some work with Adobe. Turns out the picard binary needs to be uncompressed to match the checksum file.

```
$ echo $CIRCLE_AGENT_VERSION 
1.0.225796-1dfdc7bb
$ curl -O --compressed https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/linux/amd64/circleci-agent
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10.1M  100 10.1M    0     0  11.3M      0 --:--:-- --:--:-- --:--:-- 11.3M
$ curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/$CIRCLE_AGENT_VERSION/checksums.txt
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   752  100   752    0     0   3342      0 --:--:-- --:--:-- --:--:--  3342
$ cat checksums.txt 
323379845c5fe9343f7d0eb1d3477c5fbb090206fbf19a2ce1c82ac74283edd5 *darwin/amd64/circleci-agent
673b75887b27926e2fbb64ca591a348343f8ccbda61e675fd48e8b8e684b6eec *darwin/arm64/circleci-agent
608a2fb2e951774165d241568ac6a98e487a20bdf7024a0935cb228556c93fa0 *linux/amd64/circleci-agent
c689a849506a148a9f39d2d5e109302e621b45c3daf6425ca3e372013674aae4 *linux/arm/circleci-agent
36021486f022678a2d3fbf20ea8629bdc0156f0455ef73f72aaf8905117c39d3 *linux/arm64/circleci-agent
71434bcfb972f5bd7f20d172fca3a3356a9cd832d809c7cd3315c4b070d81d77 *linux/ppc64le/circleci-agent
268177c20cbb4cca3008b26657327bb6248935cde5aa4652c5f9e2dd455f8371 *linux/s390x/circleci-agent
2bb7e2b8ba3fbff80e062d66676ad6dcca1dad795363844c9418c53165e26e4b *windows/amd64/circleci-agent.exe
$ sha256sum circleci-agent 
608a2fb2e951774165d241568ac6a98e487a20bdf7024a0935cb228556c93fa0  circleci-agent
```