### PR TITLE
Update android image examples

### DIFF
--- a/jekyll/_cci2/android-machine-image.adoc
+++ b/jekyll/_cci2/android-machine-image.adoc
@@ -20,12 +20,12 @@ The Android machine image is accessed through the xref:configuration-reference#a
 [#using-the-android-machine-image]
 == Using the Android machine image
 
-It is possible to configure the use of the Android image in your configuration with xref:orb-intro#[orbs], as well as manually. The Android orb will simplify your configuration. More complex and custom configurations may benefit from manually configuring your usage instead of using the orb. This document will cover both use cases. Please view the <<#examples,examples>> section below for more details.
+It is possible to configure the use of the Android image in your configuration with xref:orb-intro#[orbs], as well as manually. The Android orb will simplify your configuration. More complex and custom configurations may benefit from manually configuring your usage instead of using the orb. This document will cover both use cases. Refer to the <<examples>> section below for more details.
 
 [#pre-installed-software]
-== Pre-installed Software
+== Pre-installed software
 
-Please view the quarterly update announcement on our link:https://discuss.circleci.com/t/android-machine-executor-images-2022-january-q1-update/42842/1[Discuss] page for a list of current pre-installed software.
+View the quarterly update announcement on our link:https://discuss.circleci.com/t/android-machine-executor-images-2022-january-q1-update/42842/1[Discuss] page for a list of current pre-installed software.
 
 [#examples]
 == Examples
@@ -104,7 +104,7 @@ workflows:
 [#no-orb-example]
 === No-orb example
 
-The following is an example of using the Android machine image, _without_ using the circleci/android link:https://circleci.com/developer/orbs/orb/circleci/android[orb]. These steps are similar to what is run when you use the link:https://circleci.com/developer/orbs/orb/circleci/android#jobs-run-ui-tests[run-ui-tests] job of the orb.
+The following is an example of using the Android machine image, _without_ using the `circleci/android` link:https://circleci.com/developer/orbs/orb/circleci/android[orb]. These steps are similar to what is run when you use the link:https://circleci.com/developer/orbs/orb/circleci/android#jobs-run-ui-tests[`run-ui-tests` job] of the orb.
 
 
 {% raw %}

--- a/jekyll/_cci2/android-machine-image.adoc
+++ b/jekyll/_cci2/android-machine-image.adoc
@@ -141,6 +141,7 @@ jobs:
           # run in parallel with the emulator starting up, to optimize build time
           name: Run assembleDebugAndroidTest task
           command: |
+            export TERM=dumb
             ./gradlew assembleDebugAndroidTest
       - run:
           name: Wait for emulator to start

--- a/jekyll/_cci2/android-machine-image.adoc
+++ b/jekyll/_cci2/android-machine-image.adoc
@@ -114,7 +114,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: android:202102-01
+      image: android:default
     # To optimize build times, we recommend "large" and above for Android-related jobs
     resource_class: large
     steps:

--- a/jekyll/_cci2_ja/android-machine-image.adoc
+++ b/jekyll/_cci2_ja/android-machine-image.adoc
@@ -145,6 +145,7 @@ jobs:
           # run in parallel with the emulator starting up, to optimize build time
           name: Run assembleDebugAndroidTest task
           command: |
+            export TERM=dumb
             ./gradlew assembleDebugAndroidTest
       - run:
           name: Wait for emulator to start

--- a/jekyll/_cci2_ja/android-machine-image.adoc
+++ b/jekyll/_cci2_ja/android-machine-image.adoc
@@ -118,7 +118,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: android:202102-01
+      image: android:default
     # To optimize build times, we recommend "large" and above for Android-related jobs
     resource_class: large
     steps:


### PR DESCRIPTION
# Description

Update the example config.yml for using an android image in order to not use a deprecated image

# Reasons

The image that this example uses is going away, as per [this discuss post](https://discuss.circleci.com/t/android-image-deprecations-and-eol-for-2024/50180)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.

(note, none of the above check list items are relevant)

