### PR TITLE
Remove one level of escaping in expression string docs

### DIFF
--- a/jekyll/_cci2/contexts.adoc
+++ b/jekyll/_cci2/contexts.adoc
@@ -428,9 +428,9 @@ Numeric literals are whole integers (longs). For example, `1` or `768`.
 ==== Strings
 
 String literals are enclosed within double-quotes `" "`.
-The `\\` character is used to escape an embedded quote, or to escape an embedded `\\`.
+The `\` character is used to escape an embedded quote, or to escape an embedded `\`.
 
-For example, `"the quick brown fox"`, `"You can embed \\" and \\\\ characters"`
+For example, `"the quick brown fox"`, `"You can embed \" and \\ characters"`
 
 ==== Booleans
 


### PR DESCRIPTION
There's one too many escapes in the rendered documentation, which changes the meaning slightly.