### PR TITLE
Org admins can set expression restrictions

### DIFF
--- a/jekyll/_cci2/contexts.adoc
+++ b/jekyll/_cci2/contexts.adoc
@@ -101,6 +101,7 @@ You can combine several contexts for a single job by adding them to the context 
 NOTE: Bitbucket repositories do *not* provide an API that allows CircleCI contexts to be restricted, only GitHub projects include the ability to restrict contexts with security groups. Only GitHub OAuth accounts support security group restrictions. To find out which GitHub account type you have, refer to the xref:github-integration#[GitHub OAuth integration] page.
 
 CircleCI enables you to restrict contexts at run time in the following ways:
+
 * Using security groups
 * Using project restrictions
 * Using expression restrictions
@@ -263,6 +264,8 @@ Rules are expressed in a small language that supports equality checks, numeric c
 
 [#set-an-expression-restriction]
 === Set an expression restriction
+
+NOTE: You must be an organization administrator to set an expression restriction.
 
 Follow these steps to set an expression restriction on a context:
 


### PR DESCRIPTION
# Description
Add note to clarify that you need to be an organization administrator to set an expression restriction

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
