### PR TITLE
Correct the valid --timings-type values

### DIFF
--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -56,7 +56,7 @@ jobs:
     parallelism: 4
     resource_class: large
     steps:
-      - run: go list ./... | circleci tests run --command "xargs gotestsum --junitfile junit.xml --format testname --" --split-by=timings --timings-type=name
+      - run: go list ./... | circleci tests run --command "xargs gotestsum --junitfile junit.xml --format testname --" --split-by=timings --timings-type=filename
 ```
 
 ![Parallelism]({{site.baseurl}}/assets/img/docs/executor_types_plus_parallelism.png)
@@ -112,14 +112,15 @@ CircleCI's test splitting feature allows you to specify a number of identical ex
       parallelism: 4
       resource_class: large
       steps:
-        - run: go list ./... | circleci tests run --command "xargs gotestsum --junitfile junit.xml --format testname --" --split-by=timings --timings-type=name
+        - run: go list ./... | circleci tests run --command "xargs gotestsum --junitfile junit.xml --format testname --" --split-by=timings --timings-type=filename
   ```
 
 When using timing-based test splitting, the CLI attempts to auto detect the granularity of the test split (for example, whether to split by file name, or down to class name) based on the input to the split command. You may need to choose a different timing type depending on how your test coverage output is formatted, using the `--timings-type` option. Valid timing types are:
 
-* `name` - test name
+* `testname` - test name
 * `classname`  class name
-* `file` - file name
+* `filename` - file name
+* `autodetect` - autodetect to test name, class name or file name
 
 ### Example using timing-based test splitting
 {: #example-using-timing-based-test-splitting}
@@ -155,7 +156,7 @@ jobs:
     parallelism: 4
     resource_class: large
     steps:
-      - run: go list ./... | circleci tests run --command "xargs gotestsum --junitfile junit.xml --format testname --" --split-by=timings --timings-type=name
+      - run: go list ./... | circleci tests run --command "xargs gotestsum --junitfile junit.xml --format testname --" --split-by=timings --timings-type=filename
 ```
 
 For a more detailed walkthrough, read the [guide to using the CLI to split tests](/docs/use-the-circleci-cli-to-split-tests), or follow our [Test splitting tutorial](/docs/test-splitting-tutorial).

--- a/jekyll/_cci2/parallelism-faster-jobs.md
+++ b/jekyll/_cci2/parallelism-faster-jobs.md
@@ -176,7 +176,7 @@ Flag | Type | Description | Required?
 `--command` | string | The command string is the script that will be run for a list of tests determined by the options provided to the plugin | Yes
 `--index` | uint | index of node can also be set with CIRCLE_NODE_INDEX. (default 1) | No
 `--split-by` | string | how to weight the split, allowed values are "name", "filesize", and "timings". (default "name") | No
-`--timings-type` | string | name of the field to use from historical test results when matching against the test names given to the command in order to determine their historical timings, previous status and flakiness. Available values: `classname`, `name`, `file` (default). | No
+`--timings-type` | string | name of the field to use from historical test results when matching against the test names given to the command in order to determine their historical timings, previous status and flakiness. Available values: `classname`, `testname`, `filename` (default). | No
 `--total` | uint | number of nodes can also be set with CIRCLE_NODE_TOTAL. (default 2) | No
 `-v`, `--verbose` | --- | enable verbose logging output. | No
 {: class="table table-striped"}


### PR DESCRIPTION
# Description
When running test splitting on a project I came up against this error: 
```Error: invalid argument "name" for "--timings-type" flag: unknown timings type, allowed values are "filename", "classname", "testname", and "autodetect"``` 

These values are incorrectly documented in the docs as:
```
name - test name
classname class name
file - file name
```
[shown in this section](https://circleci.com/docs/parallelism-faster-jobs/#how-test-splitting-works)
[also a problem here](https://circleci.com/docs/parallelism-faster-jobs/#the-tests-run-command)

# Reasons
This is to correct the documentation to show the expected inputs for `--timings-type`
https://github.com/circleci/circleci-docs/issues/8660

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
