### PR TITLE
add banner to introduce the config translator

### DIFF
--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -13,7 +13,7 @@ contentTags:
 
 This document provides an overview of how to migrate from GitHub Actions to CircleCI.
 
-NOTE: The link:https://circleci.com/developer/tools/configTranslator[CircleCI configuration translator] provides a way to convert your GitHub Actions or GitLab config into a CircleCI `config.yml` file. The configuration translator is currently in open preview.
+TIP: The link:https://circleci.com/developer/tools/configTranslator[CircleCI configuration translator] provides a way to convert your GitHub Actions or GitLab config into a CircleCI `config.yml` file. The configuration translator is currently in open preview.
 
 [#concepts]
 == Concepts

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -13,6 +13,8 @@ contentTags:
 
 This document provides an overview of how to migrate from GitHub Actions to CircleCI.
 
+NOTE: The link:https://circleci.com/developer/tools/configTranslator[CircleCI configuration translator] provides a way to convert your GitHub Actions or GitLab config into a CircleCI `config.yml` file. The configuration translator is currently in open preview.
+
 [#concepts]
 == Concepts
 
@@ -75,7 +77,7 @@ workflows:
 === Actions vs. orbs
 "Actions" in GitHub are reusable commands or tasks to run inside a job. However, they are written for execution inside a Docker container or coded as individual steps using JavaScript. This adds additional work and limits the scope in which they can be applied.
 
-CircleCI offers similar functionality in our https://circleci.com/docs/orb-intro/#section=configuration[orbs]. The primary difference is that CircleCI orbs are just packaged, reusable YAML, so you can orbify reusable jobs, executors, or commands, and use them however you see fit in any of your jobs or workflows.
+CircleCI offers similar functionality in our xref:orb-intro#[orbs]. The primary difference is that CircleCI orbs are just packaged, reusable YAML, so you can create orbs with reusable jobs, executors, or commands, and use them however you see fit in any of your jobs or workflows.
 
 GitHub offers browsing of Actions in their Marketplace; CircleCI has an https://circleci.com/developer/orbs[Orb Registry] as well as an https://circleci.com/integrations/[Integrations Page] containing numerous Certified, Partner, and community orbs / integrations.
 

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -13,9 +13,9 @@ contentTags:
 
 This document provides an overview of how to migrate from GitLab to CircleCI.
 
-NOTE: The link:https://circleci.com/developer/tools/configTranslator[CircleCI configuration translator] provides a way to convert your GitHub Actions or GitLab config into a CircleCI `config.yml` file. The configuration translator is currently in open preview.
+TIP: The link:https://circleci.com/developer/tools/configTranslator[CircleCI configuration translator] provides a way to convert your GitHub Actions or GitLab config into a CircleCI `config.yml` file. The configuration translator is currently in open preview.
 
-NOTE: **Tips provided by ImagineX Consulting**
+**Tips provided by ImagineX Consulting**
 
 [#sign-up-with-gitlab]
 == Sign up with GitLab

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -13,6 +13,8 @@ contentTags:
 
 This document provides an overview of how to migrate from GitLab to CircleCI.
 
+NOTE: The link:https://circleci.com/developer/tools/configTranslator[CircleCI configuration translator] provides a way to convert your GitHub Actions or GitLab config into a CircleCI `config.yml` file. The configuration translator is currently in open preview.
+
 NOTE: **Tips provided by ImagineX Consulting**
 
 [#sign-up-with-gitlab]

--- a/jekyll/_cci2/migration-intro.adoc
+++ b/jekyll/_cci2/migration-intro.adoc
@@ -11,7 +11,7 @@ contentTags:
 :icons: font
 :experimental:
 
-NOTE: The link:https://circleci.com/developer/tools/configTranslator[CircleCI configuration translator] provides a way to convert your GitHub Actions or GitLab config into a CircleCI `config.yml` file. The configuration translator is currently in open preview.
+TIP: The link:https://circleci.com/developer/tools/configTranslator[CircleCI configuration translator] provides a way to convert your GitHub Actions or GitLab config into a CircleCI `config.yml` file. The configuration translator is currently in open preview.
 
 [#why-migrate-to-circleci]
 == Why migrate to CircleCI?

--- a/jekyll/_cci2/migration-intro.adoc
+++ b/jekyll/_cci2/migration-intro.adoc
@@ -11,6 +11,8 @@ contentTags:
 :icons: font
 :experimental:
 
+NOTE: The link:https://circleci.com/developer/tools/configTranslator[CircleCI configuration translator] provides a way to convert your GitHub Actions or GitLab config into a CircleCI `config.yml` file. The configuration translator is currently in open preview.
+
 [#why-migrate-to-circleci]
 == Why migrate to CircleCI?
 

--- a/styles/config/vocabularies/Docs/accept.txt
+++ b/styles/config/vocabularies/Docs/accept.txt
@@ -21,6 +21,7 @@
 [Uu]ncheck
 [Uu]nversioned
 [Ww]alkthrough
+[Aa]ctions
 Airtable
 Android
 [Aa]llowlist?
@@ -139,6 +140,7 @@ reprovisioned
 [Rr]eusability
 Rollouts?
 Route 53
+[Rr]unbook
 RSpec
 Ruby
 [Rr]unner


### PR DESCRIPTION
# Description
Add banner to relevant migration guides to direct people to the config translator

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
