### PR TITLE
Update docker-compose.md for Compose v2

### DIFF
--- a/jekyll/_cci2/docker-compose.md
+++ b/jekyll/_cci2/docker-compose.md
@@ -16,7 +16,7 @@ If you are new to Docker Compose, do consider reviewing the [official Docker Com
 * TOC
 {:toc}
 
-The `docker-compose` utility is [pre-installed in the CircleCI convenience
+The `docker compose` utility is [pre-installed in the CircleCI convenience
 images]({{ site.baseurl }}/circleci-images/#pre-installed-tools) and machine executor images.
 
 If you are using the Docker executor and **are not** using a convenience image, you can install Docker Compose into your [primary container]({{ site.baseurl }}/glossary/#primary-container) during the job execution with the Remote Docker Environment activated by adding the following to your [`.circleci/config.yml`]({{ site.baseurl }}/configuration-reference/) file:
@@ -25,11 +25,12 @@ If you are using the Docker executor and **are not** using a convenience image, 
       - run:
           name: Install Docker Compose
           environment:
-            COMPOSE_VERSION: '1.29.2'
+            COMPOSE_VERSION: 'v2.25.0'
           command: |
-            curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
+            curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
+            mkdir -p ~/.docker/cli-plugins
             chmod +x ~/docker-compose
-            sudo mv ~/docker-compose /usr/local/bin/docker-compose
+            mv ~/docker-compose ~/.docker/cli-plugins/docker-compose
 ```
 
 The above code example assumes that you will also have `curl` available in your
@@ -42,12 +43,12 @@ Then, to activate the Remote Docker Environment, add the `setup_remote_docker` s
       - setup_remote_docker
 ```
 
-This step enables you to run `docker-compose` commands to build images:
+This step enables you to run `docker compose` commands to build images:
 
 ```yml
       - run:
           name: Build images of services declared in docker-compose.yml
-          command: docker-compose build
+          command: docker compose build
 ```
 
 Or to run the whole system:
@@ -55,18 +56,18 @@ Or to run the whole system:
 ```yml
       - run:
           name: Start all services declared in docker-compose.yml
-          command: docker-compose up -d
+          command: docker compose up -d
 ```
 
 Or to also verify if a service is running for example:
 
 ```yml
       - run:
-          name: Start docker-compose and verify service(s)
+          name: Start docker compose and verify service(s)
           command: |
             # Setting the Docker Compose project name to "circleci-demo-docker" means
             # the names of our services' containers would be prefixed with "circleci-demo-docker".
-            docker-compose --project circleci-demo-docker up -d
+            docker compose --project circleci-demo-docker up -d
 
             # In this example, we have a "contacts" service, and
             # we are trying to check, via `dockerize`, if the service is ready.
@@ -87,7 +88,7 @@ See the [Example docker-compose Project](https://github.com/circleci/cci-demo-do
 ## Using Docker Compose with machine executor
 {: #using-docker-compose-with-machine-executor }
 
-If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `.circleci/config.yml` file and use `docker-compose` as you would normally (see Linux VM execution environment documentation [here]({{site.baseurl}}/using-linuxvm) for more details). That is, if you have a Docker Compose file that shares local directories with a container, this will work as expected. Refer to Docker's documentation of [Your first docker-compose.yml file](https://docs.docker.com/get-started/part3/#your-first-docker-composeyml-file) for details.
+If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `.circleci/config.yml` file and use `docker compose` as you would normally (see Linux VM execution environment documentation [here]({{site.baseurl}}/using-linuxvm) for more details). That is, if you have a Docker Compose file that shares local directories with a container, this will work as expected. Refer to Docker's documentation of [Your first docker-compose.yml file](https://docs.docker.com/get-started/part3/#your-first-docker-composeyml-file) for details.
 
 
 ## Using Docker Compose with docker executor
@@ -100,7 +101,7 @@ This combination is required if you want to build docker images for deployment.
 ## Limitations
 {: #limitations }
 
-Using `docker-compose` with the `macos` executor is not supported.
+Using `docker compose` with the `macos` executor is not supported.
 See [our support article for more information](https://support.circleci.com/hc/en-us/articles/360045029591-Can-I-use-Docker-within-the-macOS-executor-).
 
 ## See also


### PR DESCRIPTION


# Description
Compose V1 has been end-of-life'd

Compose V2 is a Docker CLI plugin and installed a bit differently.

This updates the CircleCI docs with the new way to install it.

# Reasons
https://github.com/docker/roadmap/issues/257

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
