### PR TITLE
Add config policies to the CLI usage guide

### DIFF
--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -1,13 +1,16 @@
 ---
-layout: classic-docs
-title: How to use the CircleCI local CLI
-description: How to use the CircleCI local CLI
 contentTags:
   platform:
   - Cloud
   - Server v4.x
   - Server v3.x
 ---
+= How to use the CircleCI local CLI
+:page-description: How to use the CircleCI local CLI
+:experimental:
+:icons: font
+:page-layout: classic-docs
+:page-liquid:
 
 This page describes how to use some features of the CircleCI CLI.
 
@@ -23,55 +26,82 @@ To follow the guides on this page you will need the following:
 [#validate-a-circleci-config]
 == Validate a CircleCI config
 
-You can avoid pushing additional commits to test your `.circleci/config.yml` by using the CLI to validate your configuration locally.
+TIP: *Using VS Code?* You can validate you CircleCI configuration using the VS Code extension. For full information about the features provided in the VS Code extension, see the xref:vs-code-extension-overview#[VS Code n overview] page.
 
-To validate your configuration, navigate to a directory with a `.circleci/config.yml` file and run:
+You can avoid pushing additional commits to test your `.circleci/config.yml` by using the CLI to validate your configuration locally. Follow these steps:
 
-```shell
-circleci config validate
-# Config file at .circleci/config.yml is valid
-```
+. Navigate to your project directory. You can  a directory with a `.circleci/config.yml` file
+. Run the following, providing the path to your `.circleci/config.yml`:
++
+[,shell]
+----
+circleci config validate <path-to-config.yml>
+----
+
+. If your configuration is valid, you should see the following:
++
+[,shell]
+----
+Config file at .circleci/config.yml is valid
+----
++
+Otherwise you will see errors, for example:
++
+[,shell]
+----
+Error: config compilation contains errors: config compilation contains errors:
+	- Unable to parse YAML
+	- mapping values are not allowed here
+	-  in 'string', line 20, column 22:
+	-               environment:
+	-                          ^
+----
 
 [#orb-development-kit]
 == Orb development kit
 
 The <<orb-author#create-test-and-publish-an-orb,orb development kit>> refers to a suite of tools that work together to simplify the <<orb-intro#,orb>> development process, with automatic testing and deployment on CircleCI. There are two commands in the CLI that are a part of the orb development kit:
 
-The following command link:https://circleci-public.github.io/circleci-cli/circleci_orb_init.html[initializes a new orb project]:
-```shell
+* The following command link:https://circleci-public.github.io/circleci-cli/circleci_orb_init.html[initializes a new orb project]:
++
+[,shell]
+----
 circleci orb init
-```
+----
 
-The following command link:https://circleci-public.github.io/circleci-cli/circleci_orb_pack.html[packs an orb with local scripts]:
-```shell
+* The following command link:https://circleci-public.github.io/circleci-cli/circleci_orb_pack.html[packs an orb with local scripts]:
++
+[,shell]
+----
 circleci orb pack
-```
+----
 
-For more information on orb packing, see the <<orb-concepts#orb-packing,Orbs Concepts>> page.
+For more information on orb packing, see the xref:orb-concepts#orb-packing[Orbs Concepts] page.
 
 [#validate-an-orb-in-your-configuration-file]
 == Validate an orb in your configuration file
 
 You can validate your orb with the following:
 
-```shell
-circleci orb validate /tmp/my_orb.yml
-```
-
-The above command will look for an orb called `my_orb.yml` in the `/tmp` folder of the directory in which you ran the command.
+[,shell]
+----
+circleci orb validate <path-to-your-orb.yml>
+----
 
 [#packing-a-config]
 == Packing a config
 
-```shell
+[,shell]
+----
 circleci config pack
-```
+----
 
-This CLI pack command (separate to `circleci orb pack` described above) allows you to create a single YAML file from several separate files (based on directory structure and file contents). The `pack` command implements link:https://github.com/CircleCI-Public/fyaml[FYAML], a scheme for breaking YAML documents across files in a directory tree. This is particularly useful for breaking up source code for large orbs and allows custom organization of your orbs' YAML configuration.
+This CLI pack command (separate to `circleci orb pack` described above) allows you to create a single YAML file from several separate files (based on directory structure and file contents). The `pack` command implements link:https://github.com/CircleCI-Public/fyaml[FYAML], a scheme for breaking YAML documents across files in a directory tree. This is useful for breaking up source code for large orbs and allows custom organization of your orbs' YAML configuration.
 
 How you **name** and **organize** your files when using the `pack` command will determine the final `orb.yml` output. Consider the following folder structure example:
 
-```shell
+[,shell]
+----
 $ tree
 .
 └── your-orb-source
@@ -82,19 +112,21 @@ $ tree
         └── bar.yml
 
 3 directories, 3 files
-```
+----
 
 The UNIX `tree` command is great for printing out folder structures. In the example tree structure above, the `pack` command will map the folder names and file names to **YAML keys**, and map the file contents as the **values** to those keys.
 
 The following command will `pack` up the example folder from above:
 
-```shell
-$ circleci config pack your-orb-source
-```
+[,shell]
+----
+circleci config pack your-orb-source
+----
 
 And the output will be in your `.yml` file:
 
-```yaml
+[,yaml]
+----
 # Contents of @orb.yml appear here
 commands:
   foo:
@@ -102,39 +134,47 @@ commands:
 jobs:
   bar:
     # contents of bar.yml appear here
-```
+----
 
 [#other-configuration-packing-capabilities]
 === Other configuration packing capabilities
 
 A file beginning with `@` will have its contents merged into its parent folder level. This can be useful at the top level of an orb, when one might want generic `orb.yml` to contain metadata, but not to map into an `orb` key-value pair.
 
-Thus:
+For example, the following structure:
 
-```shell
+{% raw %}
+
+[,shell]
+----
 cat foo/bar/@baz.yml
 \{baz: qux}
-```
+----
 
-Is mapped to:
+{% endraw %}
 
-```yaml
+Maps to:
+
+[,yaml]
+----
 bar:
   baz: qux
-```
+----
 
 [#processing-a-config]
 == Processing a config
 
-Running the following command validates your config, but will also display expanded source configuration alongside your original configuration (useful if you are using orbs):
+Running the following command validates your config, but will also display expanded source configuration alongside your original configuration. This is particularly useful if you are using orbs:
 
-```shell
+[,shell]
+----
 circleci config process
-```
+----
 
 Consider the following example configuration that uses the link:https://circleci.com/developer/orbs/orb/circleci/node[`node`] orb:
 
-```yml
+[,yml]
+----
 version: 2.1
 
 orbs:
@@ -144,15 +184,19 @@ workflows:
   example-workflow:
       jobs:
         - node/test
-```
+----
 
-Running the following command will output a YAML file like the example below (which is a mix of the expanded source and the original configuration commented out):
+Running the following command will output a YAML file like the example below. This is the expanded source configuration using `version: 2` syntax. All `version: 2.1` elements are processed:
 
-```shell
+[,shell]
+----
 circleci config process .circleci/config.yml
-```
+----
 
-```yaml
+{% raw %}
+
+[,yml]
+----
 # Orb 'circleci/node@4.7.0' resolved to 'circleci/node@4.7.0'
 version: 2
 jobs:
@@ -216,24 +260,14 @@ workflows:
   example-workflow:
     jobs:
     - node/test
+----
 
-# Original config.yml file:
-# version: 2.1
-#
-# orbs:
-#   node: circleci/node@4.7.0
-#
-# workflows:
-#   version: 2
-#   example-workflow:
-#       jobs:
-#         - node/test
-```
+{% endraw %}
 
 [#run-a-job-in-a-container-on-your-machine]
 == Run a job in a container on your machine
 
-The CLI enables you to run jobs in your configuration with Docker. This can be useful to run tests before pushing configuration changes, or debugging your build process without impacting your build queue.
+The CircleCI CLI enables you to run a job from your configuration locally with Docker. This can be useful to run tests before pushing configuration changes, or debugging your build process without impacting your build queue. Only single jobs can be run locally, not workflows.
 
 [#run-job-prerequisites]
 === Prerequisites
@@ -241,96 +275,80 @@ The CLI enables you to run jobs in your configuration with Docker. This can be u
 You will need to have link:https://www.docker.com/products/docker-desktop[Docker] installed on your system, as well as the most recent version of the CLI. You will also need to have a project with a valid `.circleci/config.yml` file in it.
 
 [#running-a-job]
-=== Running a job
+=== Run a job
 
-The CLI allows you to run a single job from CircleCI on your desktop using Docker with the following command:
+. Navigate to the root of your project containing the `.circleci/config.yml` file.
 
-```shell
-$ circleci local execute JOB_NAME
-```
-
-If your CircleCI configuration is set to version 2.1 or greater, you must first export your configuration to `process.yml`, and specify it when executing with the following commands:
-
-```shell
-circleci config process .circleci/config.yml > process.yml
-circleci local execute -c process.yml JOB_NAME
-```
-
-[NOTE]
-====
-`JOB_NAME` is the value of the key-value pair. For example, given:
-
-[,yaml]
-----
-jobs:
-  test:
-    name: "Test Application"
-----
-
-The invocation would be:
+. Run the following command, specifying the job you would like to run:
 
 [,shell]
 ----
-circleci local execute -c process.yml "Test Application"
+circleci local execute <job-name>
 ----
-====
 
-The following commands will run an example build on your local machine on one of CircleCI's demo applications:
+If your CircleCI configuration is set to version 2.1, you must first export your configuration to `process.yml`, and specify it when executing with the following commands:
 
-```shell
-git clone https://github.com/CircleCI-Public/circleci-demo-go.git
-cd circleci-demo-go
-circleci local execute build
-```
+[,shell]
+----
+circleci config process .circleci/config.yml > process.yml
+circleci local execute -c process.yml <job-name>
+----
 
-The commands above will run the entire `build` job (only jobs, not workflows, can be run locally). The CLI will use Docker to pull down the requirements for the build and then execute your CI steps locally. In this case, Golang and PostgreSQL Docker images are pulled down, allowing the build to install dependencies, run the unit tests, test the service is running, and so on.
+The commands above will run the job you specify by name. The CLI uses Docker to pull down the requirements for the build and then execute your CI steps locally.
 
 [#limitations-of-running-jobs-locally]
 === Limitations of running jobs locally
 
 Although running jobs locally with `circleci` is very helpful, there are some limitations.
 
-**Executors**
+[#executors]
+==== Executors
 
-The CLI does not support running jobs that use a <<executor-intro#linux-vm,machine>> (`machine`) or <<executor-intro#macos,macOS>> (`macos`) executor locally. This is because these executors require running an additional virtual machine. Only jobs that use a <<executor-intro#docker,Docker>> (`docker`) executor can be run locally.
+The CLI does not support running jobs that use a xref:executor-intro#linux-vm[machine] (`machine`) or xref:executor-intro#macos[macOS] (`macos`) executor locally. This is because these executors require running an additional virtual machine. Only jobs that use a xref:executor-intro#docker[Docker] (`docker`) executor can be run locally.
 
-**Add SSH keys**
+[#add-ssh-keys]
+==== Add SSH keys
 
 It is currently not possible to add SSH keys using the `add_ssh_keys` CLI command.
 
-**Workflows**
+[#workflows]
+==== Workflows
 
 The CLI tool does not provide support for running workflows. By nature, workflows leverage running jobs concurrently on multiple machines allowing you to achieve faster, more complex builds. Because the CLI is only running on your machine, it can only run single jobs (which make up parts of a workflow).
 
-**Caching and online-only Commands**
+[#caching-and-online-only-commands]
+==== Caching and online-only commands
 
 Caching is not currently supported in local jobs. When you have either a <<configuration-reference#savecache,`save_cache`>> or <</configuration-reference#restorecache,`restore_cache`>> step in your config, `circleci` will skip them and display a warning.
 
 Further, not all commands may work on your local machine as they do online. For example, the Golang build reference above runs a <<configuration-reference#storeartifacts,`store_artifacts`>> step, however, local builds will not upload artifacts. If a step is not available on a local build you will see an error in the console.
 
-**Environment variables**
+[#environment-variables]
+==== Environment variables
 
 For security reasons, encrypted environment variables configured in the link:https://app.circleci.com/[web application] will not be imported into local builds. As an alternative, you can specify environment variables to the CLI with the `-e` flag. See the output of the following command for more information.
 
-```shell
+[,shell]
+----
 circleci help build
-```
+----
 
 If you have multiple environment variables, you must use the flag for each variable, for example:
 
-```shell
+[,shell]
+----
 circleci build -e VAR1=FOO -e VAR2=BAR
-```
+----
 
 [#test-splitting]
 == Test splitting
 
-The CircleCI CLI is also used for some advanced features during job runs, for example <<parallelism-faster-jobs#using-the-circleci-cli-to-split-tests,test splitting>> for build time optimization.
+The CircleCI CLI is also used for some advanced features during job runs, for example xref:parallelism-faster-jobs#using-the-circleci-cli-to-split-tests[test splitting] for build time optimization.
 
 [#context-management]
 == Context management
 
-<<contexts#,Contexts>> provide a mechanism for securing and sharing environment variables across projects. While contexts have been traditionally managed on the CircleCI web application, the CircleCI CLI provides an alternative method for managing the usage of contexts in your projects. With the CLI, you can execute several context-oriented commands:
+xref:contexts#[Contexts] provide a mechanism for securing and sharing environment variables across projects. While contexts have been traditionally managed on the CircleCI web application, the CircleCI CLI provides an alternative method for managing the usage of contexts in your projects. With the CLI, you can execute several context-oriented commands:
 
 - `create` - Create a new context
 - `delete` - Delete the named context
@@ -352,4 +370,4 @@ Refer to the link:https://circleci-public.github.io/circleci-cli/circleci_contex
 
 [#next-steps]
 == Next steps
-- <<executor-intro#,Introduction to Execution Environments>>
+- xref:executor-intro#[Introduction to Execution Environments]

--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -371,65 +371,9 @@ Refer to the link:https://circleci-public.github.io/circleci-cli/circleci_contex
 [#config-policy-management]
 == Config policy management
 
-The CircleCI CLI can be used to manage config policies for your projects. Config policies allow you to enforce best practices and standards across your organization. With the CLI, you can execute several config policy-related commands:
+The CircleCI CLI can be used to manage config policies for your projects. Config policies allow you to enforce best practices and standards across your organization.
 
-[NOTE]
-====
-**Using server?** When using the `circleci policy` commands with CircleCI server, you will need to use the `policy-base-url` flag to provide your CircleCI server domain. For example:
-[source,shell]
-----
-circleci policy settings --enabled=true --owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
-----
-====
-
-Config policies sub-commands are grouped under the `circleci policy` command.
-
-The following config policies sub-commands are supported within the CLI:
-
-* `diff` - shows the difference between local and remote policy bundles
-* `fetch` - fetches the policy bundle (or one policy, based on name) from remote
-* `push` - pushes the policy bundle (activate policy bundle)
-+
-For example, running the following command activates a policy bundle stored at `./policy_bundle_dir_path`:
-+
-[source,shell]
-----
-circleci policy push ./policy_bundle_dir_path --owner-id <your-organization-ID>
-----
-*  `settings` - used to modify config policies settings as required.
-+
-When the `settings` sub-command is called without any flags, current settings are fetched and printed on console.
-+
-[source,shell]
-----
-circleci policy settings --owner-id <your-organization-ID>
-----
-+
-Example output:
-+
-[source,shell]
-----
-{
-  "enabled": false
-}
-----
-* `test` - used to run tests on your policies.
-+
-For example, running the following command runs all defined tests in the `policies` directory:
-+
-[source,shell]
-----
-circleci policy test ./policies
-----
-+
-Example output:
-+
-[source,shell]
-----
-ok    policies    0.001s
-
-3/3 tests passed (0.001s)
-----
+For full details on creating, testing, and managing config policies for your organization, including how-to guides, see the xref:config-policy-management-overview#[Manage config policies] section.
 
 [#next-steps]
 == Next steps

--- a/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
+++ b/jekyll/_cci2/how-to-use-the-circleci-local-cli.adoc
@@ -168,7 +168,7 @@ Running the following command validates your config, but will also display expan
 
 [,shell]
 ----
-circleci config process
+circleci config process <path-to-config.yml>
 ----
 
 Consider the following example configuration that uses the link:https://circleci.com/developer/orbs/orb/circleci/node[`node`] orb:
@@ -186,12 +186,7 @@ workflows:
         - node/test
 ----
 
-Running the following command will output a YAML file like the example below. This is the expanded source configuration using `version: 2` syntax. All `version: 2.1` elements are processed:
-
-[,shell]
-----
-circleci config process .circleci/config.yml
-----
+Processing this config file will output a YAML file like the example below. This is the expanded source configuration using `version: 2` syntax. All `version: 2.1` elements are processed:
 
 {% raw %}
 
@@ -267,31 +262,36 @@ workflows:
 [#run-a-job-in-a-container-on-your-machine]
 == Run a job in a container on your machine
 
-The CircleCI CLI enables you to run a job from your configuration locally with Docker. This can be useful to run tests before pushing configuration changes, or debugging your build process without impacting your build queue. Only single jobs can be run locally, not workflows.
+The CircleCI CLI enables you to run a job from your configuration locally with Docker. This can be useful for the following:
+
+* To run tests before pushing configuration changes
+* Debugging your build process without impacting your build queue
+
+Only single jobs can be run locally, not workflows.
 
 [#run-job-prerequisites]
 === Prerequisites
 
-You will need to have link:https://www.docker.com/products/docker-desktop[Docker] installed on your system, as well as the most recent version of the CLI. You will also need to have a project with a valid `.circleci/config.yml` file in it.
+You will need to have link:https://www.docker.com/products/docker-desktop[Docker] installed on your system, as well as the most recent version of the CLI. You will also need to have a project that includes a valid `.circleci/config.yml` file.
 
 [#running-a-job]
 === Run a job
 
 . Navigate to the root of your project containing the `.circleci/config.yml` file.
 
-. Run the following command, specifying the job you would like to run:
-
-[,shell]
-----
-circleci local execute <job-name>
-----
-
-If your CircleCI configuration is set to version 2.1, you must first export your configuration to `process.yml`, and specify it when executing with the following commands:
-
+. Run the following command specifying the job you would like to run. If your CircleCI configuration is set to version 2.1, you must first export your configuration to `process.yml`, and specify it when executing with the following commands:
++
 [,shell]
 ----
 circleci config process .circleci/config.yml > process.yml
 circleci local execute -c process.yml <job-name>
+----
++
+If you are using `version: 2` configuration, you can simply run:
++
+[,shell]
+----
+circleci local execute <job-name>
 ----
 
 The commands above will run the job you specify by name. The CLI uses Docker to pull down the requirements for the build and then execute your CI steps locally.
@@ -299,7 +299,7 @@ The commands above will run the job you specify by name. The CLI uses Docker to 
 [#limitations-of-running-jobs-locally]
 === Limitations of running jobs locally
 
-Although running jobs locally with `circleci` is very helpful, there are some limitations.
+Although running jobs locally with `circleci` is helpful, there are some limitations.
 
 [#executors]
 ==== Executors
@@ -343,7 +343,7 @@ circleci build -e VAR1=FOO -e VAR2=BAR
 [#test-splitting]
 == Test splitting
 
-The CircleCI CLI is also used for some advanced features during job runs, for example xref:parallelism-faster-jobs#using-the-circleci-cli-to-split-tests[test splitting] for build time optimization.
+The CircleCI CLI is used for some advanced features during job runs, for example xref:parallelism-faster-jobs#using-the-circleci-cli-to-split-tests[test splitting] for build time optimization.
 
 [#context-management]
 == Context management
@@ -367,6 +367,69 @@ circleci context create --org-id <org-id> <context-name> [flags]
 Refer to the link:https://circleci-public.github.io/circleci-cli/circleci_context.html[CLI docs] for full details for each command. Many commands require that you include additional information as indicated by parameters delimited by `< >`. For example, when running `circleci context create`, you will need to provide a name for the context and your org ID.
 
 {% include snippets/find-organization-id.adoc %}
+
+[#config-policy-management]
+== Config policy management
+
+The CircleCI CLI can be used to manage config policies for your projects. Config policies allow you to enforce best practices and standards across your organization. With the CLI, you can execute several config policy-related commands:
+
+[NOTE]
+====
+**Using server?** When using the `circleci policy` commands with CircleCI server, you will need to use the `policy-base-url` flag to provide your CircleCI server domain. For example:
+[source,shell]
+----
+circleci policy settings --enabled=true --owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
+----
+====
+
+Config policies sub-commands are grouped under the `circleci policy` command.
+
+The following config policies sub-commands are supported within the CLI:
+
+* `diff` - shows the difference between local and remote policy bundles
+* `fetch` - fetches the policy bundle (or one policy, based on name) from remote
+* `push` - pushes the policy bundle (activate policy bundle)
++
+For example, running the following command activates a policy bundle stored at `./policy_bundle_dir_path`:
++
+[source,shell]
+----
+circleci policy push ./policy_bundle_dir_path --owner-id <your-organization-ID>
+----
+*  `settings` - used to modify config policies settings as required.
++
+When the `settings` sub-command is called without any flags, current settings are fetched and printed on console.
++
+[source,shell]
+----
+circleci policy settings --owner-id <your-organization-ID>
+----
++
+Example output:
++
+[source,shell]
+----
+{
+  "enabled": false
+}
+----
+* `test` - used to run tests on your policies.
++
+For example, running the following command runs all defined tests in the `policies` directory:
++
+[source,shell]
+----
+circleci policy test ./policies
+----
++
+Example output:
++
+[source,shell]
+----
+ok    policies    0.001s
+
+3/3 tests passed (0.001s)
+----
 
 [#next-steps]
 == Next steps


### PR DESCRIPTION
# Description
* Content refresh
* Add config policies use cases

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
