### PR TITLE
fix banner titles

### DIFF
--- a/jekyll/_cci2/faq.adoc
+++ b/jekyll/_cci2/faq.adoc
@@ -9,6 +9,7 @@ contentTags:
 :categories: ["migration"]
 :description: Frequently asked questions about CircleCI
 :experimental:
+:icons: font
 :page-layout: classic-docs
 :short-title: FAQ
 

--- a/jekyll/_cci2/getting-started.adoc
+++ b/jekyll/_cci2/getting-started.adoc
@@ -5,6 +5,7 @@ contentTags:
 ---
 = Quickstart guide
 :page-layout: classic-docs
+:icons: font
 :page-description: A quickstart guide for adding a project to CircleCI and exploring some features
 :page-liquid:
 

--- a/jekyll/_cci2/optimizations.adoc
+++ b/jekyll/_cci2/optimizations.adoc
@@ -8,6 +8,7 @@ contentTags:
 = Optimization reference
 :page-layout: classic-docs
 :page-description: Learn about ways to optimize your CircleCI pipelines
+:icons: font
 :page-liquid:
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/orb-author-faq.adoc
+++ b/jekyll/_cci2/orb-author-faq.adoc
@@ -8,6 +8,7 @@ contentTags:
 = Orb author FAQ
 :page-layout: classic-docs
 :page-liquid:
+:icons: font
 :page-description: This page answers the most frequently asked questions by orb authors.
 :experimental:
 

--- a/jekyll/_cci2/orb-development-kit.adoc
+++ b/jekyll/_cci2/orb-development-kit.adoc
@@ -1,13 +1,16 @@
 ---
-layout: classic-docs
-title: Orb development kit
-description: How to use CircleCI's orb development kit
 contentTags:
   platform:
   - Cloud
   - Server v4.x
   - Server v3.x
 ---
+= Orb development kit
+:page-layout: classic-docs
+:page-liquid:
+:icons: font
+:page-description: How to use CircleCI's orb development kit.
+:experimental:
 
 [#orb-development-kit]
 == Overview

--- a/jekyll/_cci2/runner-config-reference.adoc
+++ b/jekyll/_cci2/runner-config-reference.adoc
@@ -8,7 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :icons: font
-:experimental:ß
+:experimental:
 
 [#self-hosted-runner-configuration-reference]
 == Machine runner configuration reference

--- a/jekyll/_cci2/runner-faqs.adoc
+++ b/jekyll/_cci2/runner-faqs.adoc
@@ -10,7 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: This page answers the most frequently asked questions for the CircleCI's self-hosted runner product.
 :icons: font
-:experimental:ß
+:experimental:
 
 This page answers frequently asked questions for CircleCI's self-hosted container and machine runners.
 

--- a/jekyll/_cci2/sumo-logic-integration.adoc
+++ b/jekyll/_cci2/sumo-logic-integration.adoc
@@ -10,7 +10,7 @@ contentTags:
 :page-liquid:
 :page-description: This document describes how to track and visualize analytical data across all of your jobs on CircleCI with Sumo Logic.
 :icons: font
-:toc: macro
+:experimental:
 
 This page describes how to connect Insights data with link:https://www.sumologic.com/[Sumo Logic].
 


### PR DESCRIPTION
# Description
Some banners were displaying a title incorrectly. This was due to a missing attribute in asciidoc files: `:icons: font`

For example:
Before
![Screenshot 2024-03-26 at 16 25 52](https://github.com/circleci/circleci-docs/assets/24589403/c3a8d1e2-f7e8-47d9-bc34-deea9af28324)

After
![Screenshot 2024-03-26 at 16 26 00](https://github.com/circleci/circleci-docs/assets/24589403/9b5ec48f-f150-4422-93b8-4f985294bf23)


# Reasons
Looked bad!

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
