### PR TITLE
Added CIRCLE_PROJECT_ID, CIRCLE_ORGANIZATION_ID and CIRCLE_PIPELINE_ID

### DIFF
--- a/jekyll/_includes/snippets/built-in-env-vars.adoc
+++ b/jekyll/_includes/snippets/built-in-env-vars.adoc
@@ -78,6 +78,20 @@
 | icon:check[]
 | icon:times[]
 
+| `CIRCLE_ORGANIZATION_ID`
+| GitHub OAuth, GitHub App, Bitbucket, GitLab
+| String
+| A unique identifier for the CircleCI organization.
+| icon:check[]
+| icon:times[]
+
+| `CIRCLE_PIPELINE_ID`
+| GitHub OAuth, GitHub App, Bitbucket, GitLab
+| String
+| A unique identifier for the current pipeline.
+| icon:check[]
+| icon:times[]
+
 | `CIRCLE_PR_NUMBER`
 | GitHub OAuth, Bitbucket
 | Integer
@@ -105,6 +119,13 @@
 | The largest job number in a given branch that is less than the current job number. **Note**: The variable is not always set, and is not deterministic. It is also not set on runner executors. This variable is likely to be deprecated, and CircleCI recommends users to avoid using it.
 | icon:check[]
 | icon:check[]
+
+| `CIRCLE_PROJECT_ID`
+| GitHub OAuth, GitHub App, Bitbucket, GitLab
+| String
+| A unique identifier for the current project.
+| icon:check[]
+| icon:times[]
 
 | `CIRCLE_PROJECT_REPONAME`
 | GitHub OAuth, GitHub App, GitLab, Bitbucket


### PR DESCRIPTION
# Description
Added CIRCLE_PROJECT_ID, CIRCLE_ORGANIZATION_ID and CIRCLE_PIPELINE_ID

# Reasons
Recently CIRCLE_PROJECT_ID, CIRCLE_ORGANIZATION_ID and CIRCLE_PIPELINE_ID have been exposed as environment variables.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.


The only thing is for `CIRCLE_PIPELINE_ID` should we keep the same "value" as we have for `pipeline.id` which is `A globally unique id representing for the pipeline.` to keep things consistent.