### PR TITLE
Remove instruction to add an SSH key during project creation for GitHub App

### DIFF
--- a/jekyll/_cci2/first-steps.adoc
+++ b/jekyll/_cci2/first-steps.adoc
@@ -40,7 +40,7 @@ If you are new to CircleCI, you will create a CircleCI organization. A CircleCI 
 [start=4]
 . For GitHub, you will be taken to a screen to install the CircleCI GitHub App. In this step, you can specify exactly which repositories CircleCI can access, or opt to give CircleCI access to all repositories in your GitHub organization.
 
-. Next, in the Create New Project page, you will set up your first project and trigger your first pipeline in CircleCI. You need an SSH key. Add the private key on this page, and add the corresponding public key as a deploy key in GitHub. Follow the instructions on the page, or refer to the xref:create-project#[Creating a Project] guide for more details.
+. Next, in the Create New Project page, you will set up your first project and trigger your first pipeline in CircleCI. Follow the instructions on the page, or refer to the xref:create-project#[Creating a Project] guide for more details.
 +
 If you do not want to connect to your code at this time and only wish to continue with the email signup, click btn:[Cancel].
 

--- a/jekyll/_cci2/first-steps.adoc
+++ b/jekyll/_cci2/first-steps.adoc
@@ -115,7 +115,7 @@ Guides for integrating GitHub, Bitbucket, or GitLab projects are available as fo
 [#terms]
 == Terms
 
-By signing up, you are agreeing to our link:https://circleci.com/terms-of-service/[SaaS Agreement] and link:https://circleci.com/privacy/[Privacy Policy]. We ask for read/write access to make your experience seamless on CircleCI. If you are a GitHub user and aren’t ready to share access to your private projects, you can choose public repos instead. Protected by reCAPTCHA, Google link:https://policies.google.com/privacy?hl=en[Privacy Policy] and link:https://policies.google.com/terms?hl=en[Terms of Service] apply.
+By signing up, you are agreeing to our link:https://circleci.com/terms-of-service/[SaaS Agreement] and link:https://circleci.com/privacy/[Privacy Policy]. We ask for read/write access to make your experience seamless on CircleCI. If you are a GitHub user and aren’t ready to share access to your private projects, you can choose public repositories instead. Protected by reCAPTCHA, Google link:https://policies.google.com/privacy?hl=en[Privacy Policy] and link:https://policies.google.com/terms?hl=en[Terms of Service] apply.
 
 [#next-steps]
 == Next steps

--- a/jekyll/_cci2/getting-started.adoc
+++ b/jekyll/_cci2/getting-started.adoc
@@ -63,25 +63,14 @@ Don’t see these options? Use the org selector in the top left corner to find t
 
 
 {% capture content %}
-Check all the options are correct for your project, and follow the instructions to supply a private SSH key. CircleCI will use this to authenticate with GitHub and check out your code. Then click <b>Create Project</b>.
-{% endcapture %}
-
-{%- capture supply-ssh -%}
-  {{ site.baseurl }}/assets/img/docs/getting-started-guide-exp/create-project-gh-app.png
-{%- endcapture -%}
-
-{% include two-up.html title="2. Supply an SSH key" content=content imageURL=supply-ssh imageAlt="Supply private SSH key" %}
-
-
-{% capture content %}
-A <code>config.yml</code> file is generated for you based on the languages and frameworks used in your project.
+Give your project a name, check the options, then click <strong>Create Project</strong>. A <code>config.yml</code> file is generated for you based on the languages and frameworks used in your project.
 {% endcapture %}
 
 {%- capture configure-your-project -%}
   {{ site.baseurl }}/assets/img/docs/getting-started-guide-exp/generating-config.png
 {%- endcapture -%}
 
-{% include two-up.html title="3. Generate config" content=content imageURL=configure-your-project imageAlt="Config Editor" %}
+{% include two-up.html title="2. Generate config" content=content imageURL=configure-your-project imageAlt="Config Editor" %}
 
 
 {% capture content %}
@@ -92,7 +81,7 @@ Click <strong>Commit and Run</strong>. This will create a <code>.circleci/config
   {{ site.baseurl }}/assets/img/docs/getting-started-guide-exp/commit-run-github-app.png
 {%- endcapture -%}
 
-{% include two-up.html title="4. Commit and run your config" content=content imageURL=commit-run-github imageAlt="Commit a config" %}
+{% include two-up.html title="3. Commit and run your config" content=content imageURL=commit-run-github imageAlt="Commit a config" %}
 
 
 {% capture content %}
@@ -102,7 +91,7 @@ You should soon have a passing pipeline. If you are happy with this configuratio
   {{ site.baseurl }}/assets/img/docs/getting-started-guide-exp/pass-pipeline-gitlab.png
 {%- endcapture -%}
 
-{% include two-up.html title="5. Congratulations 🎉" content=content imageURL=congrats-first-green-pipeline imageAlt="Passing pipeline" %}
+{% include two-up.html title="4. Congratulations 🎉" content=content imageURL=congrats-first-green-pipeline imageAlt="Passing pipeline" %}
 ++++
 --
 

--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -51,7 +51,7 @@ NOTE: If you are new to CircleCI, you may wish to get started with our xref:gett
 
 When you choose the btn:[Commit and Run] option described in the section above, a pipeline is automatically triggered. You should see the pipeline running shortly after you are taken to the CircleCI dashboard.
 
-If you choose to review the configuration file in the config editor first, the pipeline is triggered after you save the `.circleci/config.yml` by clicking the btn:[Commit and Run] button..
+If you choose to review the configuration file in the config editor first, the pipeline is triggered after you save the `.circleci/config.yml` by clicking the btn:[Commit and Run] button.
 
 Each time you push changes to your GitHub repository, a new pipeline is triggered and you should see it running for the project within the CircleCI web app.
 
@@ -110,30 +110,6 @@ When the CircleCI GitHub App is installed for your organization, GitHub starts t
 - You can enable dynamic configuration using setup workflows in CircleCI. To learn about dynamic configuration, read the xref:dynamic-config#[Dynamic configuration] guide.
 - At this time, the **Free and Open Source** setting is not currently supported, but there are plans to make this available in the future.
 - At this time, auto-cancel redundant workflows is not supported. Refer to the xref:skip-build#auto-cancelling[Auto cancelling] section of the `skip` or `cancel` jobs and workflows page for more details.
-
-[#project-settings-ssh-keys]
-=== GitHub project SSH keys
-
-When creating a project in CircleCI, you will create and add SSH keys. At this time, only **Additional SSH Keys** are applicable to GitHub App integrations.
-
-[#create-ssh-key]
-==== Create an SSH key
-
-You will be guided through the SSH key generation process in the CircleCI web app on the **Create Project** page. The steps are as follows:
-
-. Create an SSH key-pair by using the following command. When prompted to enter a passphrase, do **not** enter one:
-+
-```shell
-  ssh-keygen -t ed25519 -C "your_email@example.com"
-```
-
-. Go to your GitHub repository menu:Settings[Security > Deploy Keys]. Copy and paste your public key here. We **do not** require write access. The title can be anything you want. Only a GitHub repository "admin" role is required (not GitHub organization owner), see link:https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization[GitHub's docs for more details].
-
-. In the CircleCI web app **Create Project** page, copy and paste your private key, including `---BEGIN RSA PRIVATE KEY---` and `---END RSA PRIVATE KEY---`, into the **GitHub personal SSH key** field.
-
-When you push to your GitHub repository from a job, CircleCI will use the SSH key you added.
-
-For more information on SSH keys, visit the xref:add-ssh-key#[Adding an SSH key to CircleCI] page.
 
 [#organization-settings]
 == Organization settings
@@ -233,7 +209,7 @@ The recommendation is to either:
 [#additional-ssh-keys-only]
 === Additional SSH keys only
 
-Deploy keys and user keys are not used by GitHub App integrations. All keys are stored in menu:Project Settings[ Additional SSH Keys]. Use the **Create Project** option to get a project set up. You will be guided through creating SSH keys for your project. If you are looking to set up an SSH key in order to check out code from additional repositories in GitHub, see xref:add-ssh-key#steps-to-add-additional-ssh-keys[Add additional SSH keys].
+Deploy keys and user keys are not used by GitHub App integrations. All keys are stored in menu:Project Settings[ Additional SSH Keys]. If you are looking to set up an SSH key in order to check out code from additional repositories in GitHub, see xref:add-ssh-key#steps-to-add-additional-ssh-keys[Add additional SSH keys].
 
 [#free-and-open-source-setting]
 === Free and open source setting

--- a/jekyll/_cci2/set-up-multiple-configuration-files-for-a-project.adoc
+++ b/jekyll/_cci2/set-up-multiple-configuration-files-for-a-project.adoc
@@ -60,7 +60,6 @@ Next, create a trigger for your new configuration source.
 . Click btn:[Next]
 . Complete the required form fields:
 ** Give your trigger a descriptive name
-** Add the private SSH key for your project in the SSH key field. This is the same key you used to create your project
 ** Select your project repository from the dropdown
 ** Choose your new configuration source from the "Choose config to run" menu
 

--- a/styles/config/vocabularies/Docs/accept.txt
+++ b/styles/config/vocabularies/Docs/accept.txt
@@ -146,6 +146,7 @@ Ruby
 [Rr]unner
 Sauce Labs
 Selenium
+[Ss]ignup
 SSH
 statsd
 stderr


### PR DESCRIPTION
# Description
Edit all pages that mentioned the add SSH key step for GitHub App to remove the requirement

Note: don't worry about the lint fail, it's to do with the experimental formatting on the quickstart quide

# Reasons
HTTPS checkouts mean SSH key no-longer required to set up a project and trigger

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
