### PR TITLE
Adding docs for disabling presigned URLs in server 4.3+

### DIFF
--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -556,7 +556,7 @@ aws iam create-role --role-name circleci-s3 --assume-role-policy-document file:/
 }
 ----
 +
-NOTE: If you wish to store artifacts which are larger than 5GB, you will need to enable non-presigned URLs. To do this you will need your IRSA role to assume itself. Replace your trust policy above with the contents below.
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to enable non-presigned URLs. To do this you will need your IRSA role to be able to assume itself. Replace your trust policy above with the contents below.
 +
 [source, json]
 ----

--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -568,15 +568,19 @@ NOTE: If you wish to store artifacts which are larger than 5GB, you will need to
       "Principal": {
         "Federated": "<OIDC_PROVIDER_ARN>"
       },
-      "Action": [
-        "sts:AssumeRoleWithWebIdentity",
-        "sts:AssumeRole"
-      ],
+      "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
           "<OIDC_PROVIDER_URL>:sub": "system:serviceaccount:<K8S_NAMESPACE>:object-storage"
         }
       }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "<ROLE_ARN>"
+      },
+      "Action": "sts:AssumeRole"
     }
   ]
 }

--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -703,7 +703,7 @@ aws iam attach-role-policy --role-name <OBJECT_STORAGE_ROLE_NAME> --policy-arn=<
 --
 **Option 2:** IAM access keys
 
-NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned mode which requires an AWS role. We recommend you follow the instructions for creating an IRSA role in this case.
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned mode which requires an AWS role. Disabling presigned mode will enable the use of muli-part uploads to S3 which can support larger files and potentially faster transfers. We recommend you follow the instructions for creating an IRSA role in this case.
 
 . Create an IAM user for CircleCI server.
 +

--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -555,6 +555,32 @@ aws iam create-role --role-name circleci-s3 --assume-role-policy-document file:/
   ]
 }
 ----
++
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to enable non-presigned URLs. To do this you will need your IRSA role to assume itself. Replace your trust policy above with the contents below.
++
+[source, json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "<OIDC_PROVIDER_ARN>"
+      },
+      "Action": [
+        "sts:AssumeRoleWithWebIdentity",
+        "sts:AssumeRole"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "<OIDC_PROVIDER_URL>:sub": "system:serviceaccount:<K8S_NAMESPACE>:object-storage"
+        }
+      }
+    }
+  ]
+}
+----
 
 . Create the policy using the command and template below. Fill in the bucket name and the role ARN.
 +
@@ -672,6 +698,8 @@ aws iam attach-role-policy --role-name <OBJECT_STORAGE_ROLE_NAME> --policy-arn=<
 [.tab.authentication.IAM_access_keys]
 --
 **Option 2:** IAM access keys
+
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned URLs which requires an AWS role. We recommend you follow the instructions for creating an IRSA role in this case.
 
 . Create an IAM user for CircleCI server.
 +

--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -556,7 +556,7 @@ aws iam create-role --role-name circleci-s3 --assume-role-policy-document file:/
 }
 ----
 +
-NOTE: If you wish to store artifacts which are larger than 5GB, you will need to enable non-presigned URLs. To do this you will need your IRSA role to be able to assume itself. Replace your trust policy above with the contents below.
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned mode. To do this you will need your IRSA role to be able to assume itself. Replace your trust policy above with the contents below.
 +
 [source, json]
 ----

--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -703,7 +703,7 @@ aws iam attach-role-policy --role-name <OBJECT_STORAGE_ROLE_NAME> --policy-arn=<
 --
 **Option 2:** IAM access keys
 
-NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned URLs which requires an AWS role. We recommend you follow the instructions for creating an IRSA role in this case.
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned mode which requires an AWS role. We recommend you follow the instructions for creating an IRSA role in this case.
 
 . Create an IAM user for CircleCI server.
 +

--- a/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
@@ -678,7 +678,7 @@ object_storage:
     irsaRole: "<irsa-arn>"
 ----
 
-**Non-presigned URLs (Optional)**
+**Non-presigned Mode (Optional)**
 If you wish to store artifacts larger than 5GB, you will need to disable presigned URLS. Add the following to the `object_storage.s3` section:
 [source,yaml]
 ----

--- a/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
@@ -678,7 +678,7 @@ object_storage:
     irsaRole: "<irsa-arn>"
 ----
 
-**Non-presigned Mode (Optional)**
+**Disable Presigned Mode (Optional)**
 If you wish to store artifacts larger than 5GB, you will need to link:https://circleci.com/docs/server/v4.3/installation/phase-1-prerequisites/#s3-storage[update your trust policy for your IRSA role]. Then disable presigned mode by adding the following to the `object_storage.s3` section:
 [source,yaml]
 ----

--- a/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
@@ -679,7 +679,7 @@ object_storage:
 ----
 
 **Non-presigned Mode (Optional)**
-If you wish to store artifacts larger than 5GB, you will need to disable presigned URLS. Add the following to the `object_storage.s3` section:
+If you wish to store artifacts larger than 5GB, you will need to link:https://circleci.com/docs/server/v4.3/installation/phase-1-prerequisites/#s3-storage[update your trust policy for your IRSA role]. Then disable presigned mode by adding the following to the `object_storage.s3` section:
 [source,yaml]
 ----
 object_storage:

--- a/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
@@ -647,8 +647,6 @@ Under `object_storage.s3`, you may provide the `accessKey` and `secretKey`, the 
 --
 **Option 1:** Use IAM keys.
 
-NOTE: This option is not recommended if your pipelines store artifacts greater than 5GB. A limitation with the MinIO backend causes S3 uploads with objects greater than 5GB to fail when using IAM keys. For 5GB+ object support, use IRSA (documented below).
-
 Add the following to the `object_storage.s3` section:
 
 [source,yaml]
@@ -679,6 +677,18 @@ object_storage:
     region: "<role-region>"
     irsaRole: "<irsa-arn>"
 ----
+
+**Non-presigned URLs (Optional)**
+If you wish to store artifacts larger than 5GB, you will need to disable presigned URLS. Add the following to the `object_storage.s3` section:
+[source,yaml]
+----
+object_storage:
+  ...
+  s3:
+    ...
+    presigned: false
+    storageRole: "<irsa-arn>"
+----
 --
 
 [.tab.s3compatible.You_create_Secret]
@@ -695,7 +705,7 @@ kubectl -n <namespace> create secret generic object-storage-secret \
 ----
 --
 
-CircleCI server will use the role provided to authenticate to S3.
+CircleCI server will use the credentials provided to authenticate to S3.
 
 
 // Stop hiding from GCP PDF:

--- a/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
@@ -716,7 +716,7 @@ aws iam attach-role-policy --role-name <OBJECT_STORAGE_ROLE_NAME> --policy-arn=<
 --
 **Option 2:** IAM access keys
 
-NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned mode which requires an AWS role. We recommend you follow the instructions for creating an IRSA role in this case.
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned mode which requires an AWS role. Disabling presigned mode will enable the use of muli-part uploads to S3 which can support larger files and potentially faster transfers. We recommend you follow the instructions for creating an IRSA role in this case.
 
 . Create an IAM user for CircleCI server.
 +

--- a/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
@@ -569,7 +569,7 @@ aws iam create-role --role-name circleci-s3 --assume-role-policy-document file:/
 }
 ----
 +
-NOTE: If you wish to store artifacts which are larger than 5GB, you will need to enable non-presigned URLs. To do this you will need your IRSA role to assume itself. Replace your trust policy above with the contents below.
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned mode. To do this you will need your IRSA role to assume itself. Replace your trust policy above with the contents below.
 +
 [source, json]
 ----

--- a/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
@@ -716,7 +716,7 @@ aws iam attach-role-policy --role-name <OBJECT_STORAGE_ROLE_NAME> --policy-arn=<
 --
 **Option 2:** IAM access keys
 
-NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned URLs which requires an AWS role. We recommend you follow the instructions for creating an IRSA role in this case.
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned mode which requires an AWS role. We recommend you follow the instructions for creating an IRSA role in this case.
 
 . Create an IAM user for CircleCI server.
 +

--- a/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
@@ -581,15 +581,19 @@ NOTE: If you wish to store artifacts which are larger than 5GB, you will need to
       "Principal": {
         "Federated": "<OIDC_PROVIDER_ARN>"
       },
-      "Action": [
-        "sts:AssumeRoleWithWebIdentity",
-        "sts:AssumeRole"
-      ],
+      "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
           "<OIDC_PROVIDER_URL>:sub": "system:serviceaccount:<K8S_NAMESPACE>:object-storage"
         }
       }
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "<ROLE_ARN>"
+      },
+      "Action": "sts:AssumeRole"
     }
   ]
 }

--- a/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
@@ -568,6 +568,32 @@ aws iam create-role --role-name circleci-s3 --assume-role-policy-document file:/
   ]
 }
 ----
++
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to enable non-presigned URLs. To do this you will need your IRSA role to assume itself. Replace your trust policy above with the contents below.
++
+[source, json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "<OIDC_PROVIDER_ARN>"
+      },
+      "Action": [
+        "sts:AssumeRoleWithWebIdentity",
+        "sts:AssumeRole"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "<OIDC_PROVIDER_URL>:sub": "system:serviceaccount:<K8S_NAMESPACE>:object-storage"
+        }
+      }
+    }
+  ]
+}
+----
 
 . Create the policy using the command and template below. Fill in the bucket name and the role ARN.
 +
@@ -685,6 +711,8 @@ aws iam attach-role-policy --role-name <OBJECT_STORAGE_ROLE_NAME> --policy-arn=<
 [.tab.authentication.IAM_access_keys]
 --
 **Option 2:** IAM access keys
+
+NOTE: If you wish to store artifacts which are larger than 5GB, you will need to disable presigned URLs which requires an AWS role. We recommend you follow the instructions for creating an IRSA role in this case.
 
 . Create an IAM user for CircleCI server.
 +

--- a/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
@@ -678,7 +678,7 @@ object_storage:
     irsaRole: "<irsa-arn>"
 ----
 
-**Non-presigned URLs (Optional)**
+**Disable Presigned Mode (Optional)**
 If you wish to store artifacts larger than 5GB, you will need to link:https://circleci.com/docs/server/v4.4/installation/phase-1-prerequisites/#s3-storage[update your trust policy for your IRSA role]. Then disable presigned mode by adding the following to the `object_storage.s3` section:
 [source,yaml]
 ----

--- a/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
@@ -679,7 +679,7 @@ object_storage:
 ----
 
 **Non-presigned URLs (Optional)**
-If you wish to store artifacts larger than 5GB, you will need to disable presigned URLS. Add the following to the `object_storage.s3` section:
+If you wish to store artifacts larger than 5GB, you will need to link:https://circleci.com/docs/server/v4.4/installation/phase-1-prerequisites/#s3-storage[update your trust policy for your IRSA role]. Then disable presigned mode by adding the following to the `object_storage.s3` section:
 [source,yaml]
 ----
 object_storage:

--- a/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
@@ -647,8 +647,6 @@ Under `object_storage.s3`, you may provide the `accessKey` and `secretKey`, the 
 --
 **Option 1:** Use IAM keys.
 
-NOTE: This option is not recommended if your pipelines store artifacts greater than 5GB. A limitation with the MinIO backend causes S3 uploads with objects greater than 5GB to fail when using IAM keys. For 5GB+ object support, use IRSA (documented below).
-
 Add the following to the `object_storage.s3` section:
 
 [source,yaml]
@@ -679,6 +677,18 @@ object_storage:
     region: "<role-region>"
     irsaRole: "<irsa-arn>"
 ----
+
+**Non-presigned URLs (Optional)**
+If you wish to store artifacts larger than 5GB, you will need to disable presigned URLS. Add the following to the `object_storage.s3` section:
+[source,yaml]
+----
+object_storage:
+  ...
+  s3:
+    ...
+    presigned: false
+    storageRole: "<irsa-arn>"
+----
 --
 
 [.tab.s3compatible.You_create_Secret]
@@ -695,7 +705,7 @@ kubectl -n <namespace> create secret generic object-storage-secret \
 ----
 --
 
-CircleCI server will use the role provided to authenticate to S3.
+CircleCI server will use the credentials provided to authenticate to S3.
 
 
 // Stop hiding from GCP PDF:


### PR DESCRIPTION
# Description
As of server 4.3, customers are able to disable presigned URLs to allow for larger artifact uploads but this has not been documented. This PR adds these instrutions

# Reasons
https://circleci.atlassian.net/browse/ONPREM-908

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
