### PR TITLE
Fixed typo in windows-resource-table.adoc

### DIFF
--- a/jekyll/_includes/snippets/windows-resource-table.adoc
+++ b/jekyll/_includes/snippets/windows-resource-table.adoc
@@ -10,7 +10,7 @@
 | icon:check[]
 | icon:check[]
 
-| `large `
+| `large`
 | 8
 | 30GB
 | 200 GB


### PR DESCRIPTION
# Description
Fixed a typo in the "large" resource class's name in windows-resource-table.adoc.

# Reasons
The large resource class name had an extra space and the formatting is not showing correctly on the docs:
https://circleci.com/docs/using-windows/#available-resource-classes

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ N/A ] Break up walls of text by adding paragraph breaks.
- [ N/A ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ N/A ] Keep the title between 20 and 70 characters.
- [ N/A ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ N/A ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ N/A ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ N/A ] Include relevant backlinks to other CircleCI docs/pages.
