### PR TITLE
missing port and host for restore to ext mongo intructions

### DIFF
--- a/jekyll/_includes/snippets/server/migrate-internal-mongo-to-external.adoc
+++ b/jekyll/_includes/snippets/server/migrate-internal-mongo-to-external.adoc
@@ -70,7 +70,7 @@ Use the generated MongoDB backup to restore the data to your external MongoDB:
 
 [source,shell]
 ----
-kubectl -n "$namespace" exec "$MONGO_POD" -- mongorestore --drop -u "$MONGODB_USERNAME" -p "$MONGODB_PASSWORD" --authenticationDatabase admin /tmp/backups/circle_ghe;
+kubectl -n "$namespace" exec "$MONGO_POD" -- mongorestore --drop -u "$MONGODB_USERNAME" -p "$MONGODB_PASSWORD" --host <external-mongodb-host> --port <external-mongodb-port> --authenticationDatabase admin /tmp/backups/circle_ghe;
 ----
 
 Now your external MongoDB will have your CircleCI server data. In the next section you will update CircleCI server to point to your external MongoDB.


### PR DESCRIPTION
# Description
the migrate to external mongo docs in server have a typo in the mongo restore command. its missing the host and port tags to target the external mongo. Without this the command will just restore to the mongodb internal to the cluster.

# Reasons
https://circleci.atlassian.net/browse/ONPREM-62

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
