### PR TITLE
Updating documentation for releases with the new labels to be used to onboard components

### DIFF
--- a/jekyll/_cci2/release/configure-your-kubernetes-components.adoc
+++ b/jekyll/_cci2/release/configure-your-kubernetes-components.adoc
@@ -27,8 +27,8 @@ Before following the steps below, ensure the release environment is set up. Refe
 
 To enable your release to show up on the releases UI in the CircleCI web app, add the following labels and annotation to your Kubernetes Deployment or Argo Rollout:
 
-* Specify the `app` and `version` label in the Kubernetes object `Metadata.Labels`
-* Specify the `app` and `version` label in the Kubernetes object `Spec.Template.Metadata.Labels`
+* Specify the `circleci.com/component-name` and `circleci.com/version` label in the Kubernetes object `Metadata.Labels`
+* Specify the `circleci.com/component-name` and `circleci.com/version` label in the Kubernetes object `Spec.Template.Metadata.Labels`
 * Add the `circleci.com/project-id` annotation with the value set to your project ID
 +
 [NOTE]
@@ -52,22 +52,32 @@ metadata:
   annotations:
     circleci.com/project-id: <your-project-ID>
   labels:
-    app: example-deployment
-    version: 1.0.0
+    circleci.com/component-name: example-deployment
+    circleci.com/version: 1.0.0
   name: example-deployment
   namespace: default
 spec:
   selector:
     matchLabels:
-      app: example-deployment
+      ...     
   template:
     metadata:
       labels:
-        app: example-deployment
-        version: 1.0.0
+        ...     
+        circleci.com/component-name: example-deployment
+        circleci.com/version: 1.0.0
 ----
 
-NOTE: Do not add `version` to the selector labels. These labels can not be changed later, and `version` changes frequently.
+NOTE: Do not add `circleci.com/version` and `circleci.com/component-name` to the selector labels. These labels can not be changed later, and `circleci.com//version` should change for every new release.
+
+[WARNING]
+====
+If you were using the release agent prior to version `1.2.0` you were using `app` and `version` in place of `circleci.com/component-name` and `circleci.com/version`. While `app` and `version` are still supported, we recommend to migrate to the new labels as soon as possible.
+
+Support for the old labels will be dropped in one of the next releases. 
+
+After migrating to the new labels, rolling back to versions that used the old labels will be supported only for deployments and rollouts managed through Helm.
+====
 
 Once you have updated your Deployment or Rollout, check the CircleCI releases dashboard and you should see your release in the timeline view.
 
@@ -188,8 +198,8 @@ metadata:
     circleci.com/scale-component-enabled: "true"
     circleci.com/workflow-id: 5b8c4de8-fd5f-4be2-80a4-3d0c03fc138c
   labels:
-    app: example-deployment
-    version: 1.0.0
+    circleci.com/component-name: example-deployment
+    circleci.com/version: 1.0.0
   name: example-deployment
   namespace: default
 spec:
@@ -201,7 +211,8 @@ spec:
     metadata:
       labels:
         app: example-deployment
-        version: 1.0.0
+        circleci.com/component-name: example-deployment
+        circleci.com/version: 1.0.0
     spec:
       containers:
         - name: example-deployment

--- a/jekyll/_cci2/release/releases-overview.adoc
+++ b/jekyll/_cci2/release/releases-overview.adoc
@@ -57,7 +57,7 @@ The sections below explain some key software delivery concepts. Understanding th
 [#component]
 === Component
 
-A _component_ in CircleCI is a collection of code and configuration that is deployed and released as a single unit. In Kubernetes terms, this would be a Deployment or Rollout object along with the related objects such as Pods, ReplicaSets, etc. that share a common `app` label.
+A _component_ in CircleCI is a collection of code and configuration that is deployed and released as a single unit. In Kubernetes terms, this would be a Deployment or Rollout object along with the related objects such as Pods, ReplicaSets, etc. that share a common `circleci.com/component-name` label.
 
 [#delivery]
 === Delivery

--- a/jekyll/_cci2/release/update-the-kubernetes-release-agent.adoc
+++ b/jekyll/_cci2/release/update-the-kubernetes-release-agent.adoc
@@ -31,6 +31,15 @@ We have made a small but significant change in the Helm installation command tha
 You must use `managedNamespaces` instead of `manageNamespaces` when installing or upgrading the CircleCI release agent. If you have any scripts or automation that includes the previous command, you will also need to update them to use `managedNamespaces`.
 ====
 
+[WARNING]
+====
+If you were using the release agent prior to version `1.2.0` you were using `app` and `version` in place of `circleci.com/component-name` and `circleci.com/version`. While `app` and `version` are still supported, we recommend to migrate to the new labels as soon as possible.
+
+Support for the old labels will be dropped in one of the next releases. 
+
+After migrating to the new labels, rolling back to versions that used the old labels will be supported only for deployments and rollouts managed through Helm.
+====
+
 [#update-steps]
 == Update steps
 


### PR DESCRIPTION
# Description
The release agent has been updated to use `circleci.com/component-name` and `circleci.com/version` in place of `app` and `version` for detecting new components on the cluster. Old labels are still supported for the time being

# Reasons
https://circleci.atlassian.net/browse/REL-2978

Thsi will be merged only after the new release agent version has been released.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
