### PR TITLE
Tink is installed by default on server 4.2. +

### DIFF
--- a/jekyll/_cci2/server/v4.1/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/phase-2-core-services.adoc
@@ -786,9 +786,9 @@ proxy:
 
 === n. Encrypting Environment Variables
 
-All environment variables stored in contexts are encrypted using either https://www.vaultproject.io/[Hashicorp Vault] or  https://developers.google.com/tink[Google Tink]. By Default, CircleCI server 4.x will use Vault to generate and store encryption keys.
+All environment variables stored in contexts are encrypted using either https://developers.google.com/tink[Google Tink] or https://www.vaultproject.io/[Hashicorp Vault]. We recommend the use of Tink as Vault has been deprecated.
 
-==== Use Tink (optional)
+==== Use Tink
 
 The following steps cover using Tink as an alternative to Vault:
 
@@ -797,7 +797,7 @@ The following steps cover using Tink as an alternative to Vault:
 [source,yaml]
 ----
 tink:
-  enabled: false
+  enabled: true
   keyset: ""
 ----
 +

--- a/jekyll/_cci2/server/v4.2/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.2/installation/phase-2-core-services.adoc
@@ -799,9 +799,9 @@ proxy:
 
 === n. Encrypting Environment Variables
 
-All environment variables stored in contexts are encrypted using either https://www.vaultproject.io/[Hashicorp Vault] or  https://developers.google.com/tink[Google Tink]. By Default, CircleCI server 4.2 will use Vault to generate and store encryption keys.
+All environment variables stored in contexts are encrypted using either https://developers.google.com/tink[Google Tink] or https://www.vaultproject.io/[Hashicorp Vault]. We recommend the use of Tink as Vault has been deprecated.
 
-==== Use Tink (optional)
+==== Use Tink
 
 The following steps cover using Tink as an alternative to Vault:
 
@@ -810,7 +810,7 @@ The following steps cover using Tink as an alternative to Vault:
 [source,yaml]
 ----
 tink:
-  enabled: false
+  enabled: true
   keyset: ""
 ----
 +

--- a/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
@@ -65,3 +65,8 @@ helm diff upgrade circleci-server oci://cciserver.azurecr.io/circleci-server -n 
 helm upgrade circleci-server oci://cciserver.azurecr.io/circleci-server -n $namespace --version <version> -f <path-to-values.yaml> --username $USERNAME --password $PASSWORD
 
 . Deploy and run link:https://github.com/circleci/realitycheck[`reality check`] in your test environment to ensure your installation is fully operational.
+
+[#vault]
+=== Vault
+
+We have moved away from Vault to Tink for encryption. The process for migration is link:https://github.com/CircleCI-Public/server-scripts/tree/main/vault-to-tink[documented here], and includes a convenience script to move existing secrets. You should complete the migration to Tink on your v4.2.x installation after upgrading. Customers that do not perform this step may have issues restoring Vault from backup in v4.2.

--- a/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-2-core-services.adoc
@@ -806,9 +806,9 @@ proxy:
 
 === n. Encrypting Environment Variables
 
-All environment variables stored in contexts are encrypted using either https://www.vaultproject.io/[Hashicorp Vault] or  https://developers.google.com/tink[Google Tink]. By Default, CircleCI server v4.3 will use Vault to generate and store encryption keys.
+All environment variables stored in contexts are encrypted using either https://developers.google.com/tink[Google Tink] or https://www.vaultproject.io/[Hashicorp Vault]. We recommend the use of Tink as Vault has been deprecated.
 
-==== Use Tink (optional)
+==== Use Tink
 
 The following steps cover using Tink as an alternative to Vault:
 
@@ -817,7 +817,7 @@ The following steps cover using Tink as an alternative to Vault:
 [source,yaml]
 ----
 tink:
-  enabled: false
+  enabled: true
   keyset: ""
 ----
 +

--- a/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
@@ -806,9 +806,9 @@ proxy:
 
 === n. Encrypting Environment Variables
 
-All environment variables stored in contexts are encrypted using either https://www.vaultproject.io/[Hashicorp Vault] or  https://developers.google.com/tink[Google Tink]. By Default, CircleCI server v4.4 will use Vault to generate and store encryption keys.
+All environment variables stored in contexts are encrypted using either https://developers.google.com/tink[Google Tink] or https://www.vaultproject.io/[Hashicorp Vault]. We recommend the use of Tink as Vault has been deprecated.
 
-==== Use Tink (optional)
+==== Use Tink
 
 The following steps cover using Tink as an alternative to Vault:
 
@@ -817,7 +817,7 @@ The following steps cover using Tink as an alternative to Vault:
 [source,yaml]
 ----
 tink:
-  enabled: false
+  enabled: true
   keyset: ""
 ----
 +


### PR DESCRIPTION
# Description
We have effectively deprecated vault and now recommend that customers on 4.2+ use tink instead

# Reasons
https://circleci.atlassian.net/browse/ONPREM-676

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
