### PR TITLE
Add missing colon in example workflow configuration

### DIFF
--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -2613,7 +2613,7 @@ workflows:
   my-workflow:
     jobs:
       - build
-      - test
+      - test:
           requires:
             - build
       - hold:


### PR DESCRIPTION
# Description
_A brief description of the changes._

See title.

PS: I also checked the Japanese translation and this particular bug does not exist there. (The example is slightly different.)

# Reasons
_A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes._

Customers deserve syntactically valid configuration examples.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.