### PR TITLE
add machine runner ssh dir config option

### DIFF
--- a/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
+++ b/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
@@ -195,7 +195,7 @@ runner:
 === `runner.use_home_ssh_dir_for_checkout_keys`
 `$USE_HOME_SSH_DIR_FOR_CHECKOUT_KEYS`
 
-This flag enables you to use the home directory of the user running the self-hosted runner instance for storing SSH checkout keys
+This flag enables you to use the home directory of the user running the self-hosted runner instance for storing SSH checkout keys.
 
 The possible values are:
 

--- a/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
+++ b/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
@@ -191,6 +191,26 @@ runner:
   cleanup_working_directory: true
 ```
 
+[#runner-use-ssh-dir-for-checkout-keys]
+=== `runner.use_home_ssh_dir_for_checkout_keys`
+`$USE_HOME_SSH_DIR_FOR_CHECKOUT_KEYS`
+
+This flag enables you to use the home directory of the user running the self-hosted runner instance for storing SSH checkout keys
+
+The possible values are:
+
+* `true`
+* `false`
+
+NOTE: The default value is `false`.
+
+Example:
+
+```yaml
+runner:
+   use_home_ssh_dir_for_checkout_keys: true
+```
+
 [#runner-mode]
 === `runner.mode`
 


### PR DESCRIPTION
# Description
Adding a new configuration option for machine runners in preparation for cutting a machine runner release.
# Reasons
A new feature for using the users ssh directory for checkout keys was added to machine runners. This PR advertises this option in our docs. Once the release is cut and this PR is approved it will be merged in.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
