### PR TITLE
add reference to manual installation from runner migration docs

### DIFF
--- a/jekyll/_cci2/machine-runner-3-manual-installation.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation.adoc
@@ -120,7 +120,7 @@ api:
 api:
   auth_token: "your-auth-token"
   # On server, set url to the hostname of your server installation.
-  url: https://your.domain.here
+  url: https://runner.circleci.com
 ```
 
 [#start-machine-runner]

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc
@@ -68,3 +68,4 @@ sudo systemctl start circleci-runner
 == Additional resources
 
 - xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]
+- xref:machine-runner-3-manual-installation.adoc[Machine runner 3.0 manual installation reference]

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
@@ -37,3 +37,4 @@ Follow the instructions in xref:install-machine-runner-3-on-macos#install-circle
 == Additional resources
 
 - xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]
+- xref:machine-runner-3-manual-installation.adoc[Machine runner 3.0 manual installation reference]

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-windows.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-windows.adoc
@@ -64,3 +64,9 @@ The installation will be output into your PowerShell interface.
 After setup completes, the machine runner starts automatically and begins looking for jobs to process.
 
 {% include snippets/machine-runner-example.adoc %}
+
+[#additional-resources]
+== Additional resources
+
+- xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]
+- xref:machine-runner-3-manual-installation-on-windows.adoc[Machine runner 3.0 manual installation reference]


### PR DESCRIPTION
# Description
Adding a reference to the manual installation documentation for machine runner migration after some confusion was noted by a customer during a launch-agent migration. The configuration example for linux + macos manuall installation was also updated to be usable as copied on cloud with the correct URL specified. 

# Reasons
A customer was confused when migrating to Machine Runner 3.0 and trying to invoke it in a similar manner to how launch-agent was. This links in the manual installation documentation as an additional resource to make it easier to discover the documentation going over usage. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
