### PR TITLE
Removed SSH re-run note about lack of container runner support

### DIFF
--- a/jekyll/_includes/snippets/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
+++ b/jekyll/_includes/snippets/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
@@ -152,4 +152,4 @@ Cancel the job and rerun it. If your job is still not running, file a link:https
 
 CircleCI's machine runners support rerunning a job with SSH for debugging purposes. Instructions on using this feature can be found at <<ssh-access-jobs#,Debugging with SSH>>.
 
-NOTE: The `Rerun job with SSH` feature is disabled by default. To enable this feature, see xref:runner-config-reference.adoc#runner-ssh-advertise_addr[Installing the CircleCI's Self-hosted Runner]. 
+NOTE: The `Rerun job with SSH` feature is disabled by default. To enable this feature, see the xref:jekyll/_cci2/machine-runner-3-configuration-reference.adoc#runner-ssh-advertise_addr[Machine Runner Instructions] or the xref:jekyll/_cci2/container-runner-installation.adoc#enable-rerun-job-with-ssh[Container Runner instructions].

--- a/jekyll/_includes/snippets/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
+++ b/jekyll/_includes/snippets/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
@@ -152,4 +152,4 @@ Cancel the job and rerun it. If your job is still not running, file a link:https
 
 CircleCI's machine runners support rerunning a job with SSH for debugging purposes. Instructions on using this feature can be found at <<ssh-access-jobs#,Debugging with SSH>>.
 
-NOTE: The `Rerun job with SSH` feature is disabled by default. To enable this feature, see the xref:jekyll/_cci2/machine-runner-3-configuration-reference.adoc#runner-ssh-advertise_addr[Machine Runner Instructions] or the xref:jekyll/_cci2/container-runner-installation.adoc#enable-rerun-job-with-ssh[Container Runner instructions].
+NOTE: The `Rerun job with SSH` feature is disabled by default. To enable this feature, see the xref:machine-runner-3-configuration-reference.adoc#runner-ssh-advertise_addr[machine runner configuration reference] or the xref:container-runner-installation.adoc#enable-rerun-job-with-ssh[container runner installation guide].

--- a/jekyll/_includes/snippets/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
+++ b/jekyll/_includes/snippets/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
@@ -152,4 +152,4 @@ Cancel the job and rerun it. If your job is still not running, file a link:https
 
 CircleCI's machine runners support rerunning a job with SSH for debugging purposes. Instructions on using this feature can be found at <<ssh-access-jobs#,Debugging with SSH>>.
 
-NOTE: The `Rerun job with SSH` feature is disabled by default. To enable this feature, see xref:runner-config-reference.adoc#runner-ssh-advertise_addr[Installing the CircleCI's Self-hosted Runner]. Rerun job with SSH is not currently available with container runner.
+NOTE: The `Rerun job with SSH` feature is disabled by default. To enable this feature, see xref:runner-config-reference.adoc#runner-ssh-advertise_addr[Installing the CircleCI's Self-hosted Runner]. 


### PR DESCRIPTION
This is supported on Container runner now:

- https://circleci.com/docs/container-runner-installation/#2-enable-the-rerun-job-with-ssh-feature
- Supported in Open Preview as of 3.0.15 (https://circleci.com/changelog/runner-3-0-15/)

# Description
Removed the note about no ssh rerun support on container runner in `self-hosted-runner-troubleshoot-snip.adoc`

# Reasons
This is now supported

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
