### PR TITLE
[ONPREM-1092] Add machine runner 3.0 docker docs

### DIFF
--- a/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
@@ -107,7 +107,9 @@ docker stop <container-name>; docker rm <container-name>;
 [#migrating-from-launch-agent]
 === Migrating from launch agent
 
-To migrate from launch agent to machine runner 3.0 on Docker simply requires stopping & removing the launch agent based containers and replacing them with the machine runner 3.0 based containers, as described above. The prefix of the name of environment variables has changed from `LAUNCH_AGENT_` to `CIRCLECI_RUNNER_`.
+NOTE: In machine runner 3.0, the environment variable name prefix has changed from `LAUNCH_AGENT_` to `CIRCLECI_RUNNER_`.
+
+To migrate from launch agent to machine runner 3.0 on Docker, stop and remove the launch agent containers and replace them with machine runner 3.0 containers, using the commands described above. 
 
 [#additional-resources]
 == Additional resources

--- a/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
@@ -13,7 +13,7 @@ contentTags:
 :machine:
 :docker:
 
-This page describes how to install CircleCI's machine runner 3.0 with the Docker executor on server. If you are looking to set up self-hosted runners in a private Kubernetes cluster, visit the <<container-runner-installation#,Container runner>> page.
+This page describes how to install CircleCI's machine runner 3.0 with the Docker executor. If you are looking to set up self-hosted runners in a private Kubernetes cluster, visit the <<container-runner-installation#,Container runner>> page.
 
 [#new-recommended-method-container-runner]
 == Recommended method for Docker installation (container runner)

--- a/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
@@ -15,10 +15,12 @@ contentTags:
 
 This page describes how to install CircleCI's machine runner 3.0 with the Docker executor. If you are looking to set up self-hosted runners in a private Kubernetes cluster, visit the <<container-runner-installation#,Container runner>> page.
 
-[#new-recommended-method-container-runner]
-== Recommended method for Docker installation (container runner)
+[NOTE]
+====
+xref:container-runner#[Container runner] is the **recommended method** for self-hosted runner Docker installation. The instructions on this page are for a simple Docker setup using machine runner 3.0.
 
-The <<container-runner#,container runner>> is the recommended approach for running containerized jobs on self-hosted runners. Container runner offers the ability to seamlessly define, publish, and use custom Docker images during job execution, as well as the ability to manage dependencies or libraries through custom Docker images instead of enumerating dependencies as part of `steps` in the `.circleci/config.yml` file.
+Container runner is the recommended approach for running containerized jobs on self-hosted runners. Container runner offers the ability to seamlessly define, publish, and use custom Docker images during job execution, as well as the ability to manage dependencies or libraries through custom Docker images instead of enumerating dependencies as part of `steps` in the `.circleci/config.yml` file.
+====
 
 [#machine-approach-with-docker]
 == Machine-based approach with Docker
@@ -28,8 +30,8 @@ The <<container-runner#,container runner>> is the recommended approach for runni
 
 * link:https://docs.docker.com/engine/install/[Docker]
 
-[#additional-prerequisites]
-==== Additional prerequisites with Docker
+[#resource-requirements]
+==== Resource requirements
 
 The host needs to have Docker installed. Once the `runner` container is started, the container will immediately attempt to start running jobs. The container will be reused to run more jobs indefinitely until it is stopped.
 
@@ -68,20 +70,23 @@ docker build --file ./Dockerfile.runner.extended .
 
 NOTE: The environment variable values are not available to the `docker` command, so these environment variables are not visible in `ps` output.
 
+[.tab.startContainer.Cloud]
+--
 ```shell
 CIRCLECI_RUNNER_NAME=<runner-name> CIRCLECI_RUNNER_API_AUTH_TOKEN=<runner-token> docker run --env CIRCLECI_RUNNER_NAME --env CIRCLECI_RUNNER_API_AUTH_TOKEN --name <container-name> <image-id-from-previous-step>
 ```
+--
 
-When the container starts, it will immediately attempt to start running jobs.
-
-[#start-the-docker-container-on-server]
-==== Start the Docker container on server
-
+[.tab.startContainer.Server]
+--
 When starting the Docker container on server, the `CIRCLECI_RUNNER_API_URL` environment variable will also need to be passed in using the `--env` flag.
 
 ```shell
 CIRCLECI_RUNNER_NAME=<runner-name> CIRCLECI_RUNNER_API_AUTH_TOKEN=<runner-token> CIRCLECI_RUNNER_API_URL=<server_host_name> docker run --env CIRCLECI_RUNNER_NAME --env CIRCLECI_RUNNER_API_AUTH_TOKEN --env CIRCLECI_RUNNER_API_URL --name <container-name> <image-id-from-previous-step>
 ```
+--
+
+When the container starts, it will immediately attempt to start running jobs.
 
 [#stopping-the-docker-container]
 === Stopping the Docker container

--- a/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
@@ -1,0 +1,110 @@
+---
+contentTags:
+  platform:
+  - Cloud
+  - Server v4.4+
+---
+= Install machine runner 3.0 on Docker
+:page-layout: classic-docs
+:page-liquid:
+:page-description: Instructions on how to install CircleCI's self-hosted machine runner (3.0) on Docker.
+:icons: font
+:experimental:
+:machine:
+:docker:
+
+This page describes how to install CircleCI's machine runner 3.0 with the Docker executor on server. If you are looking to set up self-hosted runners in a private Kubernetes cluster, visit the <<container-runner-installation#,Container runner>> page.
+
+[#new-recommended-method-container-runner]
+== Recommended method for Docker installation (container runner)
+
+The <<container-runner#,container runner>> is the recommended approach for running containerized jobs on self-hosted runners. Container runner offers the ability to seamlessly define, publish, and use custom Docker images during job execution, as well as the ability to manage dependencies or libraries through custom Docker images instead of enumerating dependencies as part of `steps` in the `.circleci/config.yml` file.
+
+[#machine-approach-with-docker]
+== Machine-based approach with Docker
+
+[#machine-runner-prerequsites]
+=== Prerequisites
+
+* link:https://docs.docker.com/engine/install/[Docker]
+
+[#additional-prerequisites]
+==== Additional prerequisites with Docker
+
+The host needs to have Docker installed. Once the `runner` container is started, the container will immediately attempt to start running jobs. The container will be reused to run more jobs indefinitely until it is stopped.
+
+The number of containers running in parallel on the host is constrained by the host's available resources and your jobs' performance requirements.
+
+[#self-hosted-runner-terms-agreement]
+=== Self-hosted runner terms agreement
+
+{% include snippets/runner/terms.adoc %}
+
+[#create-namespace-and-resource-class]
+=== 1. Create namespace and resource class
+
+{% include snippets/runner/install-with-cli-steps.adoc %}
+
+=== 2. Create a Dockerfile that extends the machine runner 3.0 image
+
+Create a `Dockerfile.runner.extended` file. In this example, Python 3 is installed on top of the base image.
+
+```dockerfile
+FROM circleci/runner-agent:machine-3
+RUN sudo apt-get update; \
+    sudo apt-get install --no-install-recommends -y \
+        python3
+```
+
+[#build-the-docker-image]
+=== 3. Build the Docker image
+
+```shell
+docker build --file ./Dockerfile.runner.extended .
+```
+
+[#start-the-docker-container]
+=== 4. Start the Docker container
+
+NOTE: The environment variable values are not available to the `docker` command, so these environment variables are not visible in `ps` output.
+
+```shell
+CIRCLECI_RUNNER_NAME=<runner-name> CIRCLECI_RUNNER_API_AUTH_TOKEN=<runner-token> docker run --env CIRCLECI_RUNNER_NAME --env CIRCLECI_RUNNER_API_AUTH_TOKEN --name <container-name> <image-id-from-previous-step>
+```
+
+When the container starts, it will immediately attempt to start running jobs.
+
+[#start-the-docker-container-on-server]
+==== Start the Docker container on server
+
+When starting the Docker container on server, the `CIRCLECI_RUNNER_API_URL` environment variable will also need to be passed in using the `--env` flag.
+
+```shell
+CIRCLECI_RUNNER_NAME=<runner-name> CIRCLECI_RUNNER_API_AUTH_TOKEN=<runner-token> CIRCLECI_RUNNER_API_URL=<server_host_name> docker run --env CIRCLECI_RUNNER_NAME --env CIRCLECI_RUNNER_API_AUTH_TOKEN --env CIRCLECI_RUNNER_API_URL --name <container-name> <image-id-from-previous-step>
+```
+
+[#stopping-the-docker-container]
+=== Stopping the Docker container
+
+```shell
+docker stop <container-name>
+```
+
+[#remove-the-docker-container]
+=== Remove the Docker container
+
+In some cases you might need to fully remove a stopped machine runner container from the system, such as when recreating a container using the same name.
+
+```shell
+docker stop <container-name>; docker rm <container-name>;
+```
+
+[#migrating-from-launch-agent]
+=== Migrating from launch agent
+
+To migrate from launch agent to machine runner 3.0 on Docker simply requires stopping & removing the launch agent based containers and replacing them with the machine runner 3.0 based containers, as described above. The prefix of the name of environment variables has changed from `LAUNCH_AGENT_` to `CIRCLECI_RUNNER_`.
+
+[#additional-resources]
+== Additional resources
+
+- xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]

--- a/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
@@ -111,6 +111,8 @@ NOTE: In machine runner 3.0, the environment variable name prefix has changed fr
 
 To migrate from launch agent to machine runner 3.0 on Docker, stop and remove the launch agent containers and replace them with machine runner 3.0 containers, using the commands described above. 
 
+{% include snippets/machine-runner-example.adoc %}
+
 [#additional-resources]
 == Additional resources
 

--- a/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
@@ -2,6 +2,7 @@
 contentTags:
   platform:
   - Cloud
+  - Server v4.4+
 ---
 = Install machine runner 3.0 on Linux
 :page-layout: classic-docs

--- a/jekyll/_cci2/install-machine-runner-3-on-macos.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-macos.adoc
@@ -2,6 +2,7 @@
 contentTags:
   platform:
   - Cloud
+  - Server v4.4+
 ---
 = Install machine runner 3.0 on macOS
 :page-layout: classic-docs

--- a/jekyll/_cci2/install-machine-runner-3-on-windows.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-windows.adoc
@@ -2,6 +2,7 @@
 contentTags:
   platform:
   - Cloud
+  - Server v4.4+
 ---
 = Install machine runner 3.0 on Windows
 :page-layout: classic-docs

--- a/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
+++ b/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
@@ -2,6 +2,7 @@
 contentTags:
   platform:
   - Cloud
+  - Server v4.4+
 ---
 = Machine runner 3.0 configuration reference - Open preview
 :page-layout: classic-docs

--- a/jekyll/_cci2/machine-runner-3-manual-installation-on-windows.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation-on-windows.adoc
@@ -2,6 +2,7 @@
 contentTags:
   platform:
   - Cloud
+  - Server v4.4+
 ---
 = Machine runner 3.0 manual installation for Windows
 :page-layout: classic-docs

--- a/jekyll/_cci2/machine-runner-3-manual-installation.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation.adoc
@@ -2,6 +2,7 @@
 contentTags:
   platform:
   - Cloud
+  - Server v4.4+
 ---
 = Machine runner 3.0 manual installation - Open preview
 :page-layout: classic-docs

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc
@@ -2,6 +2,7 @@
 contentTags:
   platform:
   - Cloud
+  - Server v4.4+
 ---
 = Migrate from launch agent to machine runner 3.0 on Linux
 :page-layout: classic-docs

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
@@ -2,6 +2,7 @@
 contentTags:
   platform:
   - Cloud
+  - Server v4.4+
 ---
 = Migrate from launch agent to machine runner 3.0 on Linux - Open preview
 :page-layout: classic-docs

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-windows.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-windows.adoc
@@ -2,6 +2,7 @@
 contentTags:
   platform:
   - Cloud
+  - Server v4.4+
 ---
 = Migrate from launch agent to machine runner 3.0 on Windows - Open preview
 :page-layout: classic-docs

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -34,7 +34,7 @@ image::runner-overview-diagram.png[CircleCI's machine runner architecture]
 [#circleci-launch-agent-1-1-deprecated]
 == Launch agent 1.1 deprecated
 
-Launch agent 1.1 has been deprecated. Machine Runner 3.0 is the recommended replacement. Launch agent 1.1 will cease to be supported as of July 31, 2024. 
+Launch agent 1.1 has been deprecated. Machine Runner 3.0 is the recommended replacement. Launch agent 1.1 will cease to be supported as of July 31, 2024.
 
 [#circleci-self-hosted-runner-operation]
 == CircleCI's self-hosted runner operation

--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -32,9 +32,9 @@ image::runner-overview-diagram.png[CircleCI's machine runner architecture]
 --
 
 [#circleci-launch-agent-1-1-deprecated]
-== Launch Agent 1.1 Deprecated
+== Launch agent 1.1 deprecated
 
-Launch Agent 1.1 has been deprecated. Machine Runner 3.0 is the recommended replacement. Launch Agent 1.1 will cease to be supported as of July 31, 2024. 
+Launch agent 1.1 has been deprecated. Machine Runner 3.0 is the recommended replacement. Launch agent 1.1 will cease to be supported as of July 31, 2024. 
 
 [#circleci-self-hosted-runner-operation]
 == CircleCI's self-hosted runner operation

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -278,6 +278,8 @@ en:
             link: install-machine-runner-3-on-macos
           - name: Install on Windows
             link: install-machine-runner-3-on-windows
+          - name: Install on Docker
+            link: install-machine-runner-3-on-docker
           - name: Manual install on Linux and macOS
             link: machine-runner-3-manual-installation
           - name: Manual install on Windows

--- a/styles/circleci-docs/CapitalizationDocs.yml
+++ b/styles/circleci-docs/CapitalizationDocs.yml
@@ -12,5 +12,5 @@ match: $sentence
 prefix: '^[a-z]\.\s'
 exceptions:
   - DEPRECATED
-  - Deprecated
+  - [Dd]eprecated
   - Open preview

--- a/styles/circleci-docs/CapitalizationDocs.yml
+++ b/styles/circleci-docs/CapitalizationDocs.yml
@@ -12,5 +12,6 @@ match: $sentence
 prefix: '^[a-z]\.\s'
 exceptions:
   - DEPRECATED
-  - [Dd]eprecated
+  - Deprecated
+  - deprecated
   - Open preview


### PR DESCRIPTION
# Description

Add docs for using the machine runner 3.0 docker image

# Reasons

We support running machine runner 3.0 in a docker image as we did for launch agent. We hadn't documented this though which had led some customers to assume this had been removed. This PR adds those docs

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
