### PR TITLE
update auto-cancel docs

### DIFF
--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -108,7 +108,6 @@ When the CircleCI GitHub App is installed for your organization, GitHub starts t
 === Advanced
 
 - You can enable dynamic configuration using setup workflows in CircleCI. To learn about dynamic configuration, read the xref:dynamic-config#[Dynamic configuration] guide.
-- At this time, auto-cancel redundant workflows is not supported. Refer to the xref:skip-build#auto-cancelling[Auto cancelling] section of the `skip` or `cancel` jobs and workflows page for more details.
 
 [#organization-settings]
 == Organization settings
@@ -191,11 +190,6 @@ There is currently no method to manage the connection with GitHub outside of the
 === Scheduled pipelines
 
 The ability to xref:scheduled-pipelines#[schedule pipelines] is not currently supported for GitHub App projects. This feature is planned for a future release.
-
-[#auto-cancel-redundant-workflows]
-=== Auto-cancel redundant workflows
-
-Auto-cancel redundant workflows is not currently supported. It is often used to remove noise from the pipeline page and lower the time to feedback for a commit. Refer to the xref:skip-build#auto-cancelling[Skip or cancel jobs and workflows] page for more details.
 
 [#passing-secrets-to-forked-pull-requests]
 === Passing secrets to forked pull requests


### PR DESCRIPTION
no longer needed https://circleci.com/changelog/auto-cancel-redundant-workflows-for-github-app-projects/