### PR TITLE
docs: correct agent.image.repository for container runner

### DIFF
--- a/jekyll/_cci2/container-runner.adoc
+++ b/jekyll/_cci2/container-runner.adoc
@@ -220,7 +220,7 @@ The following is for **Kubernetes object settings**. All settings prefixed with 
 
 | `agent.image.repository`
 | Agent image repository
-| `circleci/container-agent`
+| `circleci/runner-agent`
 
 | `agent.image.pullPolicy`
 | Agent image pull policy


### PR DESCRIPTION
# Description

This PR fixes the default value documented for the `agent.image.repository` setting on our Container Runner Helm chart.

# Reasons

As per our Container Runner Helm chart, this `agent.image.repository` now defaults to `circleci/runner-agent` .
(Ref: https://github.com/CircleCI-Public/container-runner-helm-chart/pull/7/files)

Specifically, we can also confirm that the `circleci/runner-agent:kubernetes-3` image-tag is available:
https://hub.docker.com/layers/circleci/runner-agent/kubernetes-3.0/images/sha256-ed37b242bcfb978fa66998989dcc0d523611d168527fb268d56a2f9ee027d823?context=explore

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
