### PR TITLE
Fix syntax for Config Policy helpers

### DIFF
--- a/jekyll/_cci2/manage-contexts-with-config-policies.adoc
+++ b/jekyll/_cci2/manage-contexts-with-config-policies.adoc
@@ -113,10 +113,10 @@ import data.circleci.config
 policy_name["contexts_allowed_by_project"]
 
 # Declare a rule
-rule_contexts_allowed_by_project_ids = config.contexts_allowed_by_project_ids{
+rule_contexts_allowed_by_project_ids = config.contexts_allowed_by_project_ids(
     ["<project-ID>"],
     ["<context-1>","<context-2>"]
-}
+)
 
 # Enable the rule and choose the hard_fail enforcement level
 enable_hard["rule_contexts_allowed_by_project_ids"]
@@ -231,10 +231,10 @@ import data.circleci.config
 policy_name["contexts_allowed_by_sample_project"]
 
 # Declare a rule
-rule_contexts_allowed_by_project_ids = config.contexts_allowed_by_project_ids{
+rule_contexts_allowed_by_project_ids = config.contexts_allowed_by_project_ids(
     Front_end_applications,
     Front_end_application_contexts
-}
+)
 
 # Enable the rule and choose the hard_fail enforcement level
 enable_hard["rule_contexts_allowed_by_project_ids"]
@@ -273,10 +273,10 @@ import data.circleci.config
 policy_name["contexts_blocked_by_sample_project"]
 
 # Declare a rule
-rule_contexts_blocked_by_project_ids = config.contexts_blocked_by_project_ids{
+rule_contexts_blocked_by_project_ids = config.contexts_blocked_by_project_ids(
     ["<project-ID>"],
     ["<context-1>","<context-2>"]
-}
+)
 
 # Enable the rule and choose the hard_fail enforcement level
 enable_hard["rule_contexts_blocked_by_project_ids"]
@@ -370,10 +370,10 @@ import data.circleci.config
 policy_name["reserved_contexts"]
 
 # Declare a rule
-rule_reserve_contexts = config.contexts_reserved_by_project_ids{
+rule_reserve_contexts = config.contexts_reserved_by_project_ids(
     ["<project-ID-1>","<project-ID-1>"],
     ["<context-1>","<context-2>"]
-}
+)
 
 # Enable the rule and choose the hard_fail enforcement level
 enable_hard["rule_reserve_contexts"]
@@ -465,9 +465,9 @@ import data.circleci.config
 policy_name["prod_context_protection"]
 
 # Declare a rule
-use_prod_context_on_main = config.contexts_reserved_by_branches{["main"],
+use_prod_context_on_main = config.contexts_reserved_by_branches(["main"],
     ["<context-1>","<context-2>"]
-}
+)
 
 # This rule will apply to all projects subscribed in project_groups.rego under policy_restrict_context_access
 enable_rule["use_prod_context_on_main"]{


### PR DESCRIPTION
# Description

The Config Policy helpers are incorrect and should use `()` around their arguments instead of `{}`.

I have tested this locally to verify they work.

# Reasons

[Incorrect syntax highlighted internally](https://circleci.slack.com/archives/C06JL6KC4TV/p1714591318698049)

# Content Checklist

- [X] Break up walls of text by adding paragraph breaks.
  - N/A
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
  - N/A
- [X] Keep the title between 20 and 70 characters.
  - N/A
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
  - N/A
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
  - N/A
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
  - N/A
- [X] Include relevant backlinks to other CircleCI docs/pages.
  - N/A