### PR TITLE
Jrahme cci/update machine runner install docs

### DIFF
--- a/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-docker.adoc
@@ -116,4 +116,7 @@ To migrate from launch agent to machine runner 3.0 on Docker, stop and remove th
 [#additional-resources]
 == Additional resources
 
+- xref:install-machine-runner-3-on-linux.adoc[Machine runner 3.0 Linux package installation]
+- xref:install-machine-runner-3-on-macos.adoc[Machine runner 3.0 macOS Homebrew installation]
+- xref:install-machine-runner-3-on-windows.adoc[Machine runner 3.0 Windows installation]
 - xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]

--- a/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
@@ -36,6 +36,8 @@ To install machine runners and run jobs, you will need to have root access, and 
 
 * `rpmbuild` (link:https://www.redhat.com/en/enterprise-linux-8/details[RHEL 8] only)
 
+* link:https://gnupg.org/download/[GPG 2.1+]
+
 * The xref:local-cli#[CircleCI CLI] if you wish to install runners from the command line
 
 [#self-hosted-runner-terms-agreement]
@@ -57,6 +59,16 @@ To install machine runners and run jobs, you will need to have root access, and 
 [.tab.machine-runner-package-installation.rpm]
 --
 {% include snippets/runner/machine-runner-rpm-package-install.adoc %}
+--
+[.tab.machine-runner-manual-installation]
+--
+If you are unable to use the prebuilt packages to install your self-hosted runner the manual installation process may be used.
+
+CAUTION: We recommend installing and using machine runner 3.0 with the Linux packages on Linux.
+
+WARNING: If you follow the manual installation method, CricleCI machine runner 3.0 will not update or start automatically.
+
+xref:machine-runner-3-manual-installation.adoc[Machine Runner 3.0 manual installation process]
 --
 
 {% include snippets/machine-runner-example.adoc %}

--- a/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-linux.adoc
@@ -60,16 +60,6 @@ To install machine runners and run jobs, you will need to have root access, and 
 --
 {% include snippets/runner/machine-runner-rpm-package-install.adoc %}
 --
-[.tab.machine-runner-manual-installation]
---
-If you are unable to use the prebuilt packages to install your self-hosted runner the manual installation process may be used.
-
-CAUTION: We recommend installing and using machine runner 3.0 with the Linux packages on Linux.
-
-WARNING: If you follow the manual installation method, CricleCI machine runner 3.0 will not update or start automatically.
-
-xref:machine-runner-3-manual-installation.adoc[Machine Runner 3.0 manual installation process]
---
 
 {% include snippets/machine-runner-example.adoc %}
 
@@ -79,3 +69,12 @@ The job will then execute using your self-hosted runner when you push the `.circ
 == Troubleshooting
 
 Refer to the <<troubleshoot-self-hosted-runner#troubleshoot-machine-runner,Troubleshoot Machine Runner section>> of the Troubleshoot Self-hosted Runner guide if you encounter issues installing or running machine runner on Linux.
+
+[#additional-resources]
+== Additional resources
+
+- xref:install-machine-runner-3-on-macos.adoc[Machine runner 3.0 macOS Homebrew installation]
+- xref:install-machine-runner-3-on-windows.adoc[Machine runner 3.0 Windows installation]
+- xref:install-machine-runner-3-on-docker.adoc[Machine runner 3.0 Docker installation]
+- xref:machine-runner-3-manual-installation.adoc[Manual installation for machine runner 3.0]
+- xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]

--- a/jekyll/_cci2/install-machine-runner-3-on-macos.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-macos.adoc
@@ -205,4 +205,8 @@ The job will then execute using your self-hosted runner when you push the `.circ
 [#additional-resources]
 == Additional resources
 
--xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]
+- xref:machine-runner-3-manual-installation.adoc[Manual installation for machine runner 3.0]
+- xref:install-machine-runner-3-on-linux.adoc[Machine runner 3.0 Linux package installation]
+- xref:install-machine-runner-3-on-windows.adoc[Machine runner 3.0 Windows installation]
+- xref:install-machine-runner-3-on-docker.adoc[Machine runner 3.0 Docker installation]
+- xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]

--- a/jekyll/_cci2/install-machine-runner-3-on-windows.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-windows.adoc
@@ -99,3 +99,12 @@ A Windows machine runner *can* be run in `continuous` mode. However, doing so el
 == Troubleshooting
 
 Refer to the <<troubleshoot-self-hosted-runner#troubleshoot-machine-runner,Troubleshoot Machine Runner>> guide if you encounter issues installing or running machine runner on Windows.
+
+[#additional-resources]
+== Additional resources
+
+- xref:machine-runner-3-manual-installation-on-windows.adoc[Manual installation for machine runner 3.0 on Windows]
+- xref:install-machine-runner-3-on-linux.adoc[Machine runner 3.0 Linux package installation]
+- xref:install-machine-runner-3-on-macos.adoc[Machine runner 3.0 macOS Homebrew installation]
+- xref:install-machine-runner-3-on-docker.adoc[Machine runner 3.0 Docker installation]
+- xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]

--- a/jekyll/_cci2/machine-runner-3-manual-installation-on-windows.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation-on-windows.adoc
@@ -91,4 +91,8 @@ logging:
 [#additional-resources]
 == Additional resources
 
-xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]
+- xref:install-machine-runner-3-on-windows.adoc[Machine runner 3.0 Windows installation]
+- xref:install-machine-runner-3-on-linux.adoc[Machine runner 3.0 Linux package installation]
+- xref:install-machine-runner-3-on-macos.adoc[Machine runner 3.0 macOS Homebrew installation]
+- xref:install-machine-runner-3-on-docker.adoc[Machine runner 3.0 Docker installation]
+- xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]

--- a/jekyll/_cci2/machine-runner-3-manual-installation.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation.adoc
@@ -135,4 +135,8 @@ $HOME/circleci-runner machine --config $HOME/circleci-runner-config.yaml
 [#additional-resources]
 == Additional resources
 
-xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]
+- xref:install-machine-runner-3-on-linux.adoc[Machine runner 3.0 Linux package installation]
+- xref:install-machine-runner-3-on-macos.adoc[Machine runner 3.0 macOS Homebrew installation]
+- xref:install-machine-runner-3-on-docker.adoc[Machine runner 3.0 Docker installation]
+- xref:install-machine-runner-3-on-windows.adoc[Machine runner 3.0 Windows installation]
+- xref:machine-runner-3-configuration-reference.adoc[Machine runner 3.0 configuration reference]


### PR DESCRIPTION
# Description
* Add GPG dependency to the linux package installation for machine runner 3.0
* Cross link the installation documentation for other platforms on each machine runner 3.0 install page

# Reasons
Some support tickets arose around customers experiencing installation woes due to non-compatible GPG versions when trying to install runner via the linux package, so the GPG version has been added to the dependency. 

Some users were also not finding the manual installation instructions when they were unable to install the package due to incompatible GPG versions (AL2, and CentOS 7 in particular) so to improve visibility of these options the resources for installing runner on other platforms has been included as additional resources at the bottom of the installation doc pages. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
