### PR TITLE
more specific

### DIFF
--- a/jekyll/_cci2/roles-and-permissions-overview.adoc
+++ b/jekyll/_cci2/roles-and-permissions-overview.adoc
@@ -261,7 +261,7 @@ The table below shows the permissions associated with each CircleCI organization
 ^| icon:check-circle[]
 ^| icon:check-circle[]
 
-^| Trigger build
+^| Trigger re-run via the CircleCI web app
 ^| icon:check-circle[]
 ^| icon:check-circle[]
 ^|


### PR DESCRIPTION
anyone with push access to a repo can trigger a build so this is wrong. gitlab/github app triggers cant be run via the CCI UI or API today. so im making this more specific to say "reruns"

https://circleci.slack.com/archives/C055HTSAN8K/p1714667491334609