### PR TITLE
Update ip-ranges.adoc show deprecation of macOS IPs

### DIFF
--- a/jekyll/_cci2/ip-ranges.adoc
+++ b/jekyll/_cci2/ip-ranges.adoc
@@ -164,6 +164,11 @@ CircleCI _does not recommend_ configuring an IP-based firewall based on the AWS 
 
 In addition to AWS and GCP (see above), CircleCI's macOS cloud hosts jobs executed by machines. The following IP address ranges are used by CircleCI macOS Cloud:
 
+[NOTE]
+====
+The macOS cloud IPs listed below are deprecated as of April 24, 2024. 
+====
+
 * 38.39.184.0/24
 * 38.39.185.0/24
 * 38.39.183.0/24


### PR DESCRIPTION
# Description
Add note to indicate deprecation of known macOS IPs.

# Reasons
macOS well-known IPs are no longer supported after April 24, 2024.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
