### PR TITLE
Update migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc

### DIFF
--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-macos.adoc
@@ -4,7 +4,7 @@ contentTags:
   - Cloud
   - Server v4.4+
 ---
-= Migrate from launch agent to machine runner 3.0 on Linux - Open preview
+= Migrate from launch agent to machine runner 3.0 on macOS
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Steps to migrate from using launch agent to the machine runner 3.0 preview


### PR DESCRIPTION
# Description
Updated the title in the document to include `macOS` rather than `Linux`
removed Open Preview

# Reasons
It had `Linux - Open preview` in title for the macOS document. Despite the link showing macos in sidebar

![image](https://github.com/circleci/circleci-docs/assets/104026596/d21f4299-c777-41d2-8845-a079468225a5)


# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
