### PR TITLE
[PIPE-4713] Updates [ci skip] docs

### DIFF
--- a/jekyll/_cci2/skip-build.md
+++ b/jekyll/_cci2/skip-build.md
@@ -14,7 +14,7 @@ This document describes how to skip or cancel work when triggering pipelines. Th
 ## Skip jobs
 {: #skip-jobs }
 
-By default, CircleCI automatically triggers a pipeline whenever you push changes to your project. You can override this behavior by adding a `[ci skip]` or `[skip ci]` tag within the first 250 characters of the body or title of the commit. This not only skips the marked commit, but also **all other commits** in the push.
+By default, CircleCI automatically triggers a pipeline whenever you push changes to your project. You can override this behavior by adding a `[ci skip]` or `[skip ci]` tag within the first 250 characters of the body or title of the **latest commit** you pushed. This will skip the pipeline execution for all the commits included in the push.
 
 ### Scope
 {: #scope }
@@ -22,7 +22,7 @@ By default, CircleCI automatically triggers a pipeline whenever you push changes
 A few points to note regarding the scope of the `ci skip` feature:
 
 * The pipeline and workflows will still exist for these commits but no jobs will be run.
-* If you push multiple commits at once, a single `[ci skip]` or `[skip ci]` will skip the build **for all commits**.
+* If you push multiple commits at once, and the latest commit includes a `[ci skip]` or `[skip ci]` tag, it will skip the pipeline execution for all commits in that push.
 * This feature is not supported for fork PRs. Scheduled workflows will run even if you push a commit with `[ci skip]` message. Changing the config file is the way to upgrade the current schedule.
 
 ### Example commit title


### PR DESCRIPTION
# Description
This change makes it clear that we will not execute the pipeline only when the skip tag is in the last commit.

# Reasons
In our docs, it says that in a multi-commit push, any commit that has the skip tag would make the whole push be skipped. However, that only applies if the last commit has the tag. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
