### PR TITLE
Removing `Open Preview` Titles on Runner docs

### DIFF
--- a/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
+++ b/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
@@ -4,7 +4,7 @@ contentTags:
   - Cloud
   - Server v4.4+
 ---
-= Machine runner 3.0 configuration reference - Open preview
+= Machine runner 3.0 configuration reference
 :page-layout: classic-docs
 :page-liquid:
 :icons: font

--- a/jekyll/_cci2/machine-runner-3-manual-installation.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation.adoc
@@ -4,7 +4,7 @@ contentTags:
   - Cloud
   - Server v4.4+
 ---
-= Machine runner 3.0 manual installation - Open preview
+= Machine runner 3.0 manual installation
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Instructions on how to manually start CircleCI's self-hosted machine runner 3.0 on macOS and Linux.

--- a/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-windows.adoc
+++ b/jekyll/_cci2/migrate-from-launch-agent-to-machine-runner-3-on-windows.adoc
@@ -4,7 +4,7 @@ contentTags:
   - Cloud
   - Server v4.4+
 ---
-= Migrate from launch agent to machine runner 3.0 on Windows - Open preview
+= Migrate from launch agent to machine runner 3.0 on Windows
 :page-layout: classic-docs
 :page-liquid:
 :page-description: Steps to migrate from using launch agent to the machine runner 3.0 preview on Windows


### PR DESCRIPTION
# Description
There were a few runner documentation pages with ` - Open Preview` suffixed in the titles - this PR is to remove those on 3 remaining pages where I located this discrepancy

# Reasons
Runner 3.0 is GA as of Nov 2023
> https://discuss.circleci.com/t/machine-runner-3-0-ga-now-w-support-for-macos-and-windows/49812

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
