### PR TITLE
redirect output to avoid arch variable contamination

### DIFF
--- a/jekyll/_cci2/machine-runner-3-manual-installation.adoc
+++ b/jekyll/_cci2/machine-runner-3-manual-installation.adoc
@@ -65,7 +65,7 @@ NOTE: The current CircleCI machine runner binary can always be found by using `c
 [,shell]
 ----
 export RUNNERVERSION='current'
-export CPUARCH=$(/usr/bin/arch | grep 'x86_64' && echo 'amd64' || echo 'arm64')
+export CPUARCH=$(/usr/bin/arch | grep 'x86_64' >/dev/null 2>/dev/null && echo 'amd64' || echo 'arm64')
 export OSTARGET=$(uname -s | tr '[:upper:]' '[:lower:]')
 curl -s -L "https://circleci-binary-releases.s3.amazonaws.com/circleci-runner/${RUNNERVERSION}/circleci-runner_${OSTARGET}_${CPUARCH}.tar.gz" -o $HOME/circleci-runner.tar.gz && tar -zxvf $HOME/circleci-runner.tar.gz
 ----


### PR DESCRIPTION
# Description
For the runner manual install some versions of grep caused extra output to enter the arch variable. This PR redirects the `/usr/bin/arch` stderr and stdout to avoid contaminating the variable with extra output. 

# Reasons
Issue was raised in an on-prem support workflow https://circleci.slack.com/archives/C05LH7BMR2A/p1713553512725209

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
