### PR TITLE
[MAC-2173] Add xcode 15.4 RC to Apple silicon documentation

### DIFF
--- a/jekyll/_includes/snippets/xcode-silicon-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.adoc
@@ -8,10 +8,10 @@
 | Release Notes
 
 | `15.4.0`
-| Xcode 15.4 Beta (15F5021i)
+| Xcode 15.4 RC (15F31c)
 | 14.3.1
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v14698/manifest.txt[Installed software]
-| link:https://discuss.circleci.com/t/xcode-15-4-beta-1-released/50862[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v14746/manifest.txt[Installed software]
+| link:https://discuss.circleci.com/t/xcode-15-4-release-candidate-rc-released/50890[Release Notes]
 
 | `15.3.0`
 | Xcode 15.3 (15E204a)


### PR DESCRIPTION
# Description
A brief description of the changes.

Xcode 15.4 Release Candidate (RC) is now available for use.

# Reasons

https://circleci.atlassian.net/browse/MAC-2173

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
