### PR TITLE
Update Xcode 15.4 Documentation for GA release

### DIFF
--- a/jekyll/_includes/snippets/xcode-silicon-vm.adoc
+++ b/jekyll/_includes/snippets/xcode-silicon-vm.adoc
@@ -8,10 +8,10 @@
 | Release Notes
 
 | `15.4.0`
-| Xcode 15.4 RC (15F31c)
+| Xcode 15.4 (15F31d)
 | 14.3.1
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v14746/manifest.txt[Installed software]
-| link:https://discuss.circleci.com/t/xcode-15-4-release-candidate-rc-released/50890[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v14775/manifest.txt[Installed software]
+| link:https://discuss.circleci.com/t/xcode-15-4-0-ga-released/50897[Release Notes]
 
 | `15.3.0`
 | Xcode 15.3 (15E204a)


### PR DESCRIPTION
# Description
Updating Xcode Image documentation for the 15.4 GA image, which is now available.

# Reasons
Xcode 15.4 GA has been [released](https://developer.apple.com/documentation/xcode-release-notes/xcode-15_4-release-notes)

# Content Checklist

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
