### PR TITLE
docs: update env var (holder) for images based on Server version

### DIFF
--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-1-prerequisites.adoc
@@ -60,7 +60,7 @@ Download all images required for the release of CircleCI server to your local ma
 
 [source, bash]
 ----
-SERVER_4_2_IMAGE_LIST=`cat <<EOF
+SERVER_4_3_IMAGE_LIST=`cat <<EOF
 bitnami/postgresql:12.6.0
 cciserver.azurecr.io/api-gateway:0.1.31061-3f64088
 cciserver.azurecr.io/api-service:0.1.14854-4511416d
@@ -127,7 +127,7 @@ EOF
 
 [source, bash]
 ----
-echo $SERVER_4_2_IMAGE_LIST | while read -r image; do docker pull $image; done
+echo $SERVER_4_3_IMAGE_LIST | while read -r image; do docker pull $image; done
 ----
 
 [#copy-all-images]

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-1-prerequisites.adoc
@@ -61,7 +61,7 @@ Download all images required for the release of CircleCI server to your local ma
 
 [,bash]
 ----
-SERVER_4_2_IMAGE_LIST=`cat <<EOF
+SERVER_4_4_IMAGE_LIST=`cat <<EOF
 cciserver.azurecr.io/docker-agent:1.0.16422-f79384c
 cciserver.azurecr.io/picard:1.0.217358-0b5336a7
 cciserver.azurecr.io/machine-agent:1.0.68480-f0ce8c9d
@@ -132,7 +132,7 @@ EOF
 
 [source, bash]
 ----
-echo $SERVER_4_2_IMAGE_LIST | while read -r image; do docker pull $image; done
+echo $SERVER_4_4_IMAGE_LIST | while read -r image; do docker pull $image; done
 ----
 
 [#copy-all-images]

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-1-prerequisites.adoc
@@ -61,7 +61,7 @@ Download all images required for the release of CircleCI server to your local ma
 
 [,bash]
 ----
-SERVER_4_2_IMAGE_LIST=`cat <<EOF
+SERVER_4_5_IMAGE_LIST=`cat <<EOF
 cciserver.azurecr.io/docker-agent:1.0.16422-f79384c
 cciserver.azurecr.io/picard:1.0.234836-59bdf2c3
 cciserver.azurecr.io/machine-agent:1.0.70126-8f96354
@@ -135,7 +135,7 @@ EOF
 
 [source, bash]
 ----
-echo $SERVER_4_2_IMAGE_LIST | while read -r image; do docker pull $image; done
+echo $SERVER_4_5_IMAGE_LIST | while read -r image; do docker pull $image; done
 ----
 
 [#copy-all-images]


### PR DESCRIPTION
# Description
I changed the SERVER_4_x_IMAGE_LIST env var used in our example scripts to reflect the Server 4.x version correctly.

# Reasons
Server [4.1](https://circleci.com/docs/server/v4.1/air-gapped-installation/phase-1-prerequisites/#b-download-all-images-required-for-this-release) and [4.2](https://circleci.com/docs/server/v4.2/air-gapped-installation/phase-1-prerequisites/#b-download-all-images-required-for-this-release) were consistent;
From Server 4.3 onwards, this wasn't changed. Hence, this PR to clean up for clarity.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
