### PR TITLE
docs: add missing instructions for required files in Minio

### DIFF
--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -130,7 +130,7 @@ Follow the steps in this section to copy the required files into MinIO within yo
 
 [#copy-canary-txt-file]
 === a. Copy canary.txt file
-Download the canary.txt file required by distributor.
+Download the `canary.txt` file required by distributor.
 
 [,bash]
 ----

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -126,7 +126,7 @@ image::./minio/minio_upload_cci_agent.png[Uploading the CircleCI agent]
 
 [#copy-other-miscellaneous-files]
 == 3. Copy other miscellaneous files
-Follow the steps in this section to copy the following files into MinIO within your air-gapped environment.
+Follow the steps in this section to copy the required files into MinIO within your air-gapped environment.
 
 [#copy-canary-txt-file]
 === a. Copy canary.txt file

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -138,7 +138,7 @@ Download the `canary.txt` file required by distributor.
 curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/canary.txt
 ----
 
-Copy this canary.txt file to the root directory of the `circleci-data` bucket.
+Copy this `canary.txt` file to the root directory of the `circleci-data` bucket.
 
 [#copy-candidate-txt-file]
 === b. Copy candidate.txt file

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -142,7 +142,7 @@ Copy this canary.txt file to the root directory of the `circleci-data` bucket.
 
 [#copy-candidate-txt-file]
 === a. Copy candidate.txt file
-Download the candidate.txt file required by runner_admin.
+Download the `candidate.txt` file required by `runner_admin`.
 
 [,bash]
 ----

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -141,7 +141,7 @@ curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/canary.
 Copy this canary.txt file to the root directory of the `circleci-data` bucket.
 
 [#copy-candidate-txt-file]
-=== a. Copy candidate.txt file
+=== b. Copy candidate.txt file
 Download the `candidate.txt` file required by `runner_admin`.
 
 [,bash]

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -124,6 +124,34 @@ CIRCLE_AGENT_VERSION/
 
 image::./minio/minio_upload_cci_agent.png[Uploading the CircleCI agent]
 
+[#copy-other-miscellaneous-files]
+== 3. Copy other miscellaneous files
+Follow the steps in this section to copy the following files into MinIO within your air-gapped environment.
+
+[#copy-canary-txt-file]
+=== a. Copy canary.txt file
+Download the canary.txt file required by distributor.
+
+[,bash]
+----
+# Download canary.txt
+curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/canary.txt
+----
+
+Copy this canary.txt file to the root directory of the `circleci-data` bucket.
+
+[#copy-candidate-txt-file]
+=== a. Copy candidate.txt file
+Download the candidate.txt file required by runner_admin.
+
+[,bash]
+----
+# Download candidate.txt
+curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent/candidate.txt
+----
+
+Copy this candidate.txt file to the root directory of the `circleci-data` bucket.
+
 [#next-steps]
 == Next steps
 

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -150,7 +150,7 @@ Download the `candidate.txt` file required by `runner_admin`.
 curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent/candidate.txt
 ----
 
-Copy this candidate.txt file to the root directory of the `circleci-data` bucket.
+Copy this `candidate.txt` file to the root directory of the `circleci-data` bucket.
 
 [#next-steps]
 == Next steps

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-3-install-circleci-server.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-3-install-circleci-server.adoc
@@ -92,6 +92,15 @@ distributor:
   launch_agent_base_url: http://<minio-internal-hostname>:9000/circleci-data/
 ----
 
+Similarly, update the runner_admin section of the `values.yaml` file to point `external.launch_agent_base_url` to the `circleci-data` bucket.
+
+[source, yaml]
+----
+runner_admin:
+  external:
+    launch_agent_base_url: http://<minio-internal-hostname>:9000/circleci-data/
+----
+
 NOTE: Port 9000 is referenced here as that is a default for MinIO. If your MinIO instance is configured differently, this port will need to be updated.
 
 NOTE: Update the protocol to `http` or `https` depending on your MinIO installation.

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-3-install-circleci-server.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-3-install-circleci-server.adoc
@@ -134,8 +134,8 @@ machine_provisioner:
 ----
 
 [#add-additional-nginx-annotations]
-=== g. Add additional NGINX annotations
-Add any additional NGINX annotations as necessary depending on your installation to provision a load balancer. In this example, MetalLB is used. For more information, see the xref:additional-considerations/#service-type-load-balancers-k3s[Service Type Load Balancers in K3s] section on the Additional considerations page.
+=== g. Add additional nginx annotations
+Add any additional nginx annotations as necessary depending on your installation to provision a load balancer. In this example, MetalLB is used. For more information, see the xref:additional-considerations/#service-type-load-balancers-k3s[Service Type Load Balancers in K3s] section on the Additional considerations page.
 
 [source, yaml]
 ----

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-3-install-circleci-server.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-3-install-circleci-server.adoc
@@ -92,7 +92,7 @@ distributor:
   launch_agent_base_url: http://<minio-internal-hostname>:9000/circleci-data/
 ----
 
-Similarly, update the runner_admin section of the `values.yaml` file to point `external.launch_agent_base_url` to the `circleci-data` bucket.
+Update the runner_admin section of the `values.yaml` file to point `external.launch_agent_base_url` to the `circleci-data` bucket.
 
 [source, yaml]
 ----


### PR DESCRIPTION
# Description

This PR adds the missing steps to 1. include files into the Minio bucket, as required by certain services, 2. update the runner_admin.external.launch_agent_base_url to also point to the Minio bucket.

# Reasons

While working on the air-gapped installation with a customer, we noted the distributor-internal-xxxx and radm-external-xxxx pods would end up in a CrashLoopBackOff state.
After looking at the logs, it appears that:

- distributor-internal-xxxx pod was trying to look up the canary.txt file in the `circleci-data` Minio bucket.
- radm-external-xxxx pod was trying to look up the candidate.txt file in the `circleci-data` Minio bucket.

Based on the default  Helm values for `distributor.agent_base_url` and `runner_admin.external.launch_agent_base_url`, I noted these .txt files can be copied from the base URLs:

```shell
$ curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-agent/canary.txt

$ curl -O https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent/can
didate.txt
```

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
