### PR TITLE
Update anchor link on cache page

### DIFF
--- a/jekyll/_cci2/caching.adoc
+++ b/jekyll/_cci2/caching.adoc
@@ -368,7 +368,7 @@ During step execution, the templates above are replaced by runtime values and us
 | The number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC), also known as POSIX or UNIX epoch. This cache key is a good option if you need to ensure a new cache is always stored for each run.
 
 | {% raw %}`{{ arch }}`{% endraw %}
-| Captures OS and CPU (architecture, family, model) information. Useful when caching compiled binaries that depend on OS and CPU architecture, for example, `darwin-amd64-6_58` versus `linux-amd64-6_62`. See xref:faq#which-cpu-architectures-does-circleci-support[supported CPU architectures].
+| Captures OS and CPU (architecture, family, model) information. Useful when caching compiled binaries that depend on OS and CPU architecture, for example, `darwin-amd64-6_58` versus `linux-amd64-6_62`. See xref:faq#cpu-architecture-circleci-support[supported CPU architectures].
 |===
 
 [#further-notes-on-using-keys-and-templates]


### PR DESCRIPTION
Update the anchor tag to point to the correct section.

Section on this page where the bad link is: https://circleci.com/docs/caching/#using-keys-and-templates

# Description
The current link is pointing to the anchor tag `which-cpu-architectures-does-circleci-support` whereas the correct one is `cpu-architecture-circleci-support`.


# Reasons
To make the docs consistent, and take users to the correct section in the page.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
