### PR TITLE
Update configuration-reference.adoc

### DIFF
--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -1820,7 +1820,7 @@ jobs:
     steps:
       # ... steps for building/testing app ...
       - setup_remote_docker:
-          version: 24.0.9
+          version: default
 ----
 
 [.table.table-striped]


### PR DESCRIPTION
we no longer support a docker version, instead you must use "default" , "current" or "edge". To use the current deprecated version, you can specify `20.10.24`

# Description
we no longer support a docker version, instead you must use "default" , "current" or "edge". To use the current deprecated version, you can specify `20.10.24`. Therefore, I updated the example config to use "default" as the version 

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
New supportedformat for default. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
