### PR TITLE
List job naming restrictions

### DIFF
--- a/jekyll/_cci2/jobs-steps.adoc
+++ b/jekyll/_cci2/jobs-steps.adoc
@@ -27,7 +27,7 @@ The following diagram illustrates how data flows between jobs:
 
 image::/docs/assets/img/docs/jobs-overview.png[Jobs overview]
 
-The job names shown in this diagram are just examples. You can name your jobs whatever you want.
+The job names shown in this diagram are just examples. You can name your jobs whatever you want as long as they are alphanumeric, underscores and dashes.
 
 Jobs can be run in Docker containers, using the Docker executor, or in virtual machines using the `machine` executor, with Linux, macOS, or Windows images. Secondary containers or VMs can be configured to attach services, such as databases, to run alongside your jobs.
 


### PR DESCRIPTION
When naming a step with a . in the name, I get the following error message:

```console
ERROR IN CONFIG FILE:
[#/jobs/unit_quality_static_analysis_tests_php_8.2] string [unit_quality_static_analysis_tests_php_8.2] does not match pattern ^[A-Za-z][A-Za-z\s\d_-]*$
```

We can either document this in the docs here, possibly more elequently than I have, or change the implementation.

# Description

Add a sentence to dampen a users expectations of job naming

# Reasons

I want to add a . into the job name, I cannot, hence the documentation might require some adjusted.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

N.b. It is a Friday afternoon, my proposed sentence might not be fully coherent.

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
