### PR TITLE
Improve linking for parallelism docs

### DIFF
--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -760,7 +760,11 @@ A map of environment variable names and values. For more information on defining
 
 This feature is used to optimize test steps. If `parallelism` is set to N > 1, then N independent executors will be set up and each will run the steps of that job in parallel.
 
-You can use the CircleCI CLI to split your test suite across parallel containers so the job completes in a shorter time. Learn more on the xref:parallelism-faster-jobs#[Test splitting and parallelism] page.
+You can use the CircleCI CLI to split your test suite across parallel containers so the job completes in a shorter time.
+
+* Read more about splitting tests across parallel execution environments on the xref:parallelism-faster-jobs#[Parallelism and test splitting] page.
+* Refer to the xref:use-the-circleci-cli-to-split-tests#[Use the CircleCI CLI to split tests] how-to guide.
+* Follow the xref:test-splitting-tutorial#[Test splitting tutorial].
 
 Example:
 

--- a/jekyll/_cci2/optimizations.adoc
+++ b/jekyll/_cci2/optimizations.adoc
@@ -36,7 +36,7 @@ To persist data from a job and make it available to downstream jobs via the xref
 * Read more on the xref:workspaces[Workspaces] page.
 
 [#speed]
-== Speed up pipelines
+== Reduce build time
 
 [#docker-image-choice]
 === Docker image choice
@@ -72,9 +72,18 @@ Workflows provide a means to define a collection of jobs and their run order. If
 [#parallelism]
 === Parallelism
 
-If your project has a large test suite, you can configure your build to use xref:configuration-reference#parallelism[`parallelism`] together with either xref:parallelism-faster-jobs#using-the-circleci-cli-to-split-tests[CircleCI's test splitting functionality], or a xref:parallelism-faster-jobs#other-ways-to-split-tests[third party application or library] to split your tests across multiple machines. CircleCI supports automatic test allocation across machines on a file-basis, however, you can also manually customize how tests are allocated.
+If your project has a large test suite, you can configure your build to use xref:configuration-reference#parallelism[`parallelism`] together with either xref:parallelism-faster-jobs#using-the-circleci-cli-to-split-tests[CircleCI's test splitting functionality], or a xref:parallelism-faster-jobs#other-ways-to-split-tests[third party application or library] to split your tests across multiple machines. CircleCI supports automatic test allocation across machines/containers on a file-basis You can also manually customize how tests are allocated.
 
-* Read more about splitting tests on the xref:parallelism-faster-jobs#[Parallelism] page.
+* Read more about splitting tests across parallel execution environments on the xref:parallelism-faster-jobs#[Parallelism and test splitting] page.
+* Refer to the xref:use-the-circleci-cli-to-split-tests#[Use the CircleCI CLI to split tests] how-to guide.
+* Follow the xref:test-splitting-tutorial#[Test splitting tutorial].
+
+[#rerun-failed-tests]
+=== Rerun failed tests
+
+Use the rerun failed tests feature to only rerun a subset of tests when a transient test failure arises, rather than rerunning the entire test suite.
+
+* For more information see the xref:rerun-failed-tests#[Rerun failed tests] page.
 
 [#resource-class]
 === Resource class

--- a/jekyll/_cci2/optimizations.adoc
+++ b/jekyll/_cci2/optimizations.adoc
@@ -72,7 +72,7 @@ Workflows provide a means to define a collection of jobs and their run order. If
 [#parallelism]
 === Parallelism
 
-If your project has a large test suite, you can configure your build to use xref:configuration-reference#parallelism[`parallelism`] together with either xref:parallelism-faster-jobs#using-the-circleci-cli-to-split-tests[CircleCI's test splitting functionality], or a xref:parallelism-faster-jobs#other-ways-to-split-tests[third party application or library] to split your tests across multiple machines. CircleCI supports automatic test allocation across machines/containers on a file-basis You can also manually customize how tests are allocated.
+If your project has a large test suite, you can configure your build to use xref:configuration-reference#parallelism[`parallelism`] together with either xref:parallelism-faster-jobs#using-the-circleci-cli-to-split-tests[CircleCI's test splitting functionality], or a xref:parallelism-faster-jobs#other-ways-to-split-tests[third party application or library] to split your tests across multiple machines. CircleCI supports automatic test allocation across machines/containers on a file-basis. You can also manually customize how tests are allocated.
 
 * Read more about splitting tests across parallel execution environments on the xref:parallelism-faster-jobs#[Parallelism and test splitting] page.
 * Refer to the xref:use-the-circleci-cli-to-split-tests#[Use the CircleCI CLI to split tests] how-to guide.


### PR DESCRIPTION
# Description
* Add links to all parallelism/test splitting resources to the optimization overview
* Add reference to rerun failed tests

# Reasons
Help people find the info

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
