### PR TITLE
Add `rabbitmq-key` to the list of secrets requiring migration in 4.2 [ONPREM-1276]

### DIFF
--- a/jekyll/_cci2/server/v4.2/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.2/installation/phase-2-core-services.adoc
@@ -290,7 +290,7 @@ mongodb:
 ----
 --
 
-[#rabbinmq-configurations-and-auth-secrets]
+[#rabbitmq-configurations-and-auth-secrets]
 === f. RabbitMQ configurations and auth Secrets
 
 The RabbitMQ installation requires two random alphanumeric strings. CircleCI will not be able to recover the values if lost. Based on how you prefer to manage Kubernetes Secrets there are two options.

--- a/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
@@ -33,7 +33,7 @@ From server v4.2, CircleCI server auto-generates the following secrets if not pr
 
 - xref:../installation/phase-2-core-services#api-token[api-token]
 - xref:../installation/phase-2-core-services#session-cookie[session-cookie]
-- xref:../installation/phase-2-core-services#rabbinmq-configurations-and-auth-secrets[rabbitmq-key]
+- xref:../installation/phase-2-core-services#rabbitmq-configurations-and-auth-secrets[rabbitmq-key]
 - xref:../installation/phase-2-core-services#pusher-kubernetes-secret[pusher]
 - xref:../installation/phase-3-execution-environments#nomad-gossip-encryption-key[nomad-gossip-encryption-key]
 

--- a/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
@@ -33,6 +33,7 @@ From server v4.2, CircleCI server auto-generates the following secrets if not pr
 
 - xref:../installation/phase-2-core-services#api-token[api-token]
 - xref:../installation/phase-2-core-services#session-cookie[session-cookie]
+- xref:../installation/phase-2-core-services#rabbinmq-configurations-and-auth-secrets[rabbitmq-key]
 - xref:../installation/phase-2-core-services#pusher-kubernetes-secret[pusher]
 - xref:../installation/phase-3-execution-environments#nomad-gossip-encryption-key[nomad-gossip-encryption-key]
 


### PR DESCRIPTION
# Description
A brief description of the changes.

The RabbitMQ secret requires an annotation if self-managed during a 4.1 -> 4.2 migration. However, it was missed on the list of secrets requiring intervention. This PR addresses that.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.atlassian.net/browse/ONPREM-1276

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
