### PR TITLE
clarify macOS limitations in ip-ranges.adoc

### DIFF
--- a/jekyll/_cci2/ip-ranges.adoc
+++ b/jekyll/_cci2/ip-ranges.adoc
@@ -182,10 +182,10 @@ In addition to AWS and GCP (see above), CircleCI's macOS cloud hosts jobs execut
 
 macOS builds are automatically restricted within the IP ranges listed here. In other words, you do not have to explicitly set `circleci_ip_ranges: true` for macOS builds. 
 
-*macOS IP ranges are not included in the machine-consumable lists maintained in DNS.* Please refer to the list above for the most up-to-date macOS IPs.
+*macOS IP ranges are not included in the machine-consumable lists maintained in DNS.* Refer to the list above for the most up-to-date macOS IPs.
 
 [#known-limitations]
 == Known limitations
 
-* There is currently no support for specifying IP ranges configuration syntax when using the link:{{site.baseurl}}/pipeline-variables/#pipeline-parameters-in-configuration[pipeline parameters feature]. Find more details in this https://discuss.circleci.com/t/ip-ranges-open-preview/40864/6[Discuss post].
+* Currently, the system does not have support for specifying IP ranges configuration syntax when using the link:{{site.baseurl}}/pipeline-variables/#pipeline-parameters-in-configuration[pipeline parameters feature]. Find more details in this https://discuss.circleci.com/t/ip-ranges-open-preview/40864/6[Discuss post].
 * IP ranges is currently available for the link:{{site.baseurl}}/configuration-reference/#machine[Docker executor], not including `remote_docker`. Jobs that attempt to use the IP ranges feature with a link:{{site.baseurl}}/configuration-reference/#machine[Machine executor], or with `setup_remote_docker`, will fail with an error. See this https://discuss.circleci.com/t/fyi-jobs-that-use-the-ip-ranges-feature-and-remote-docker-will-begin-to-fast-fail-this-week/44639[Discuss post] for details.


### PR DESCRIPTION
Add clarification the the macOS IP ranges are not included in the machine-readable lists in DNS eg: all.knownips.circleci.com.

# Description
Added a note to the macOS section directing customers to use this help article for finding current macOS IP ranges.

# Reasons
Prevent any confusion for users who want to automate setting allowed IP ranges.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
