### PR TITLE
Update github-apps-integration.adoc

### DIFF
--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -237,7 +237,7 @@ The Only Build Pull Requests option (usually available in menu:Project Settings[
 [#github-status-updates]
 === GitHub Status Updates
 
-GitHub Status Updates is not currently supported for GitHub App Integrations. 
+xref:enable-checks#github-check-and-github-status-updates[GitHub status updates] are currently not supported for the GitHub App Integration.
 
 [#next-steps]
 == Next steps

--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -234,6 +234,11 @@ The xref:insights-snapshot-badge#[Insights snapshot badge] feature is not curren
 
 The Only Build Pull Requests option (usually available in menu:Project Settings[Advanced] or within trigger setup options) is not currently supported for GitHub App integrations
 
+[#github-status-updates]
+=== GitHub Status Updates
+
+GitHub Status Updates is not currently supported for GitHub App Integrations. 
+
 [#next-steps]
 == Next steps
 - xref:config-intro#[Configuration tutorial]


### PR DESCRIPTION
GitHub Status Updates is not supported on GitHub Apps Integration

# Description
GitHub Status Updates is not supported on GitHub Apps Integration 

# Reasons
Improving Customer comms that GitHub Status Updates is not supported for GitHub App Integration 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
