### PR TITLE
ONPREM-1276 | Added rabbitmq instruction in Server-4.2

### DIFF
--- a/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
@@ -54,8 +54,8 @@ kubectl -n <namespace> label secret/<secret-name> \
 
 . Check the link:https://circleci.com/server/changelog/[changelog] and make sure there are no actions you need to take before deploying a new version.
 
-. Export the "RabbitMQ" password as we are upgrading helm chart for the same as well.
-
+. Export the "RabbitMQ" password. We are also upgrading the RabbitMQ Helm chart during this upgrade.
++
 [source,shell]
 ----
 export RABBITMQ_PASSWORD=$(kubectl get secret --namespace <namespace> rabbitmq-key -o jsonpath="{.data.rabbitmq-password}" | base64 -d)

--- a/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.2/installation/upgrade-server.adoc
@@ -33,7 +33,6 @@ From server v4.2, CircleCI server auto-generates the following secrets if not pr
 
 - xref:../installation/phase-2-core-services#api-token[api-token]
 - xref:../installation/phase-2-core-services#session-cookie[session-cookie]
-- xref:../installation/phase-2-core-services#rabbitmq-configurations-and-auth-secrets[rabbitmq-key]
 - xref:../installation/phase-2-core-services#pusher-kubernetes-secret[pusher]
 - xref:../installation/phase-3-execution-environments#nomad-gossip-encryption-key[nomad-gossip-encryption-key]
 
@@ -54,6 +53,13 @@ kubectl -n <namespace> label secret/<secret-name> \
 == Upgrade steps
 
 . Check the link:https://circleci.com/server/changelog/[changelog] and make sure there are no actions you need to take before deploying a new version.
+
+. Export the "RabbitMQ" password as we are upgrading helm chart for the same as well.
+
+[source,shell]
+----
+export RABBITMQ_PASSWORD=$(kubectl get secret --namespace <namespace> rabbitmq-key -o jsonpath="{.data.rabbitmq-password}" | base64 -d)
+----
 
 . Optionally, confirm what the update is going to do using link:https://github.com/databus23/helm-diff[Helm Diff]:
 +


### PR DESCRIPTION
# Description
With Server 4.2 release, we are upgrading RabbitMQ helm chart which requires the Password to be present in env var `RABBITMQ_PASSWORD` when upgrade happens  

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
