### PR TITLE
Update macos-resource-table.adoc

### DIFF
--- a/jekyll/_includes/snippets/macos-resource-table.adoc
+++ b/jekyll/_includes/snippets/macos-resource-table.adoc
@@ -3,9 +3,9 @@
 |===
 | Class | vCPUs | RAM | Cloud | Server
 
-| `macos.x86.medium.gen2*`
+| `macos.m1.medium.gen1.free`
 | 4 @ 3.2 GHz
-| 8GB
+| 6GB
 | icon:check[]
 | icon:times[]
 
@@ -21,12 +21,3 @@
 | icon:check[]
 | icon:times[]
 |===
-
-[WARNING]
-====
-*We are deprecating support for all Intel-based macOS resources.*
-
-The `macos.x86.medium.gen2` resource class is being deprecated on June 28, 2024.
-
-See our link:https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718[announcement] for more details.
-====


### PR DESCRIPTION
Replace gen2 medium with m1 medium for free plan.

# Description
Update the available resource class table for intel end-of-life.

# Reasons
Intel resources will be removed as of June 29. They are replaced with m1 medium.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
