### PR TITLE
Revise install steps for macOS machine runner 3.0 [ONPREM-1225]

### DIFF
--- a/jekyll/_cci2/install-machine-runner-3-on-macos.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-macos.adoc
@@ -150,11 +150,10 @@ sudo xattr -r -d com.apple.quarantine "$(brew --prefix)/bin/circleci-runner"
 
 To start the macOS machine runner 3.0 for the first time, you will need to bootstrap the service. Depending on whether you are using a GUI or non-GUI session (for example, when remotely tunneling into the machine), the commands to bootstrap the service will differ:
 
-[.tab.domain.GUI]
+[.tab.startdomain.GUI_domain]
 --
-*GUI domain*
 
-1. For running the agent in a GUI session, you can bootstrap the provided `.plist` file and enable the service by running the following commands:
+. For running the agent in a GUI session, you can bootstrap the provided `.plist` file and enable the service by running the following commands:
 +
 [source,shell]
 ----
@@ -162,7 +161,7 @@ launchctl bootstrap gui/$(id -u) $HOME/Library/LaunchAgents/com.circleci.runner.
 launchctl enable gui/$(id -u)/com.circleci.runner
 launchctl kickstart -k gui/$(id -u)/com.circleci.runner
 ----
-2. Finally, you can check the service is running by invoking the following command:
+. Finally, you can check the service is running by invoking the following command:
 +
 [source,shell]
 ----
@@ -170,9 +169,8 @@ launchctl print gui/$(id -u)/com.circleci.runner
 ----
 --
 
-[.tab.domain.User]
+[.tab.startdomain.User_domain]
 --
-*User domain*
 
 1. When using a non-GUI (or headless) session, the provided `.plist` file should be moved to `/Library/LaunchAgents`. This location is for per-user agents configured by the administrator, which allows the service to load after a reboot. Run the following command to do this:
 +
@@ -201,17 +199,17 @@ launchctl print user/$(id -u)/com.circleci.runner
 
 To stop the machine runner service, run the following command to disable the machine runner service, depending on the service target used in the previous step:
 
-[.tab.domain.GUI]
+[.tab.stopdomain.GUI_domain]
 --
-Targeting the GUI domain:
+
 [source,shell]
 ----
 launchctl disable gui/$(id -u)/com.circleci.runner
 ----
 --
-[.tab.domain.User]
+[.tab.stopdomain.User_domain]
 --
-Targeting the user domain:
+
 [source,shell]
 ----
 launchctl disable user/$(id -u)/com.circleci.runner
@@ -220,11 +218,11 @@ launchctl disable user/$(id -u)/com.circleci.runner
 
 [#uninstall-machine-runner-macos]
 == Uninstall machine runner 3.0 on macOS
-To uninstall machine runner from your macOS device, follow these steps.
+To uninstall machine runner 3.0 from your macOS device, follow these steps.
 
 . Stop the machine runner service by using the following command to disable it, depending on the service target used during installation:
 +
-[.tab.domain.GUI]
+[.tab.uninstalldomain.GUI_domain]
 --
 Targeting the GUI domain:
 [source,shell]
@@ -233,7 +231,7 @@ launchctl bootout gui/$(id -u)/com.circleci.runner
 ----
 --
 +
-[.tab.domain.User]
+[.tab.uninstalldomain.User_domain]
 --
 Targeting the user domain:
 [source,shell]
@@ -256,7 +254,7 @@ brew uninstall --cask circleci-public/homebrew-circleci/circleci-runner
 [.tab.machine-runner-uninstall-macos.Purge_logs_and_configuration]
 --
 
-This command will *purge all logs and configuration files*.
+CAUTION: This command will *purge all logs and configuration files*.
 
 To uninstall and purge all logs and configuration files, run the following command.
 

--- a/jekyll/_cci2/install-machine-runner-3-on-macos.adoc
+++ b/jekyll/_cci2/install-machine-runner-3-on-macos.adoc
@@ -82,18 +82,20 @@ Replace `api.auth_token` with the token generated in the steps above, and choose
 
 . If you are using CircleCI server you will need to provide the URL for your install. You can do this by either setting the `CIRCLECI_RUNNER_API_URL` environment variable:
 +
-```shell
+[source,shell]
+----
 export CIRCLECI_RUNNER_API_URL="your server domain"
-```
+----
 +
 Or by adding the URL to `$HOME/Library/Preferences/com.circleci.runner/config.yaml` using text editor of your choice.
 +
-```yaml
+[source,yaml]
+----
 api:
   auth_token: "your-auth-token"
   # On server, set url to the hostname of your server installation.
   url: https://your.domain.here
-```
+----
 
 [#migrate-existing-configuration-files]
 === Migrate existing configuration files
@@ -122,60 +124,133 @@ The binary must be approved to run on your macOS system because the self-hosted 
 
 . Verify the signature and notarization with this command:
 +
-```shell
+[source,shell]
+----
 spctl -a -vvv -t install "$(brew --prefix)/bin/circleci-runner"
-```
+----
 +
 It should return an output that looks like this:
 +
-```shell
+[source,shell]
+----
 /opt/homebrew/bin/circleci-runner: accepted
 source=Notarized Developer ID
 origin=Developer ID Application: Circle Internet Services Inc.
-```
+----
 
 . When ready, run the command to accept the notarization. You will need to enter the macOS system password.
 +
-```shell
+[source,shell]
+----
 sudo xattr -r -d com.apple.quarantine "$(brew --prefix)/bin/circleci-runner"
-```
+----
 
 [#start-macos-machine-runner]
 == 4. Start macOS machine runner 3.0
 
-To start the macOS machine runner 3.0 for the first time, run the following commands to bootstrap and load the `plist` file:
+To start the macOS machine runner 3.0 for the first time, you will need to bootstrap the service. Depending on whether you are using a GUI or non-GUI session (for example, when remotely tunneling into the machine), the commands to bootstrap the service will differ:
 
-```shell
-launchctl bootstrap gui/`stat -f %u` $HOME/Library/LaunchAgents/com.circleci.runner.plist
-launchctl load $HOME/Library/LaunchAgents/com.circleci.runner.plist
-```
+[.tab.domain.GUI]
+--
+*GUI domain*
+
+1. For running the agent in a GUI session, you can bootstrap the provided `.plist` file and enable the service by running the following commands:
++
+[source,shell]
+----
+launchctl bootstrap gui/$(id -u) $HOME/Library/LaunchAgents/com.circleci.runner.plist
+launchctl enable gui/$(id -u)/com.circleci.runner
+launchctl kickstart -k gui/$(id -u)/com.circleci.runner
+----
+2. Finally, you can check the service is running by invoking the following command:
++
+[source,shell]
+----
+launchctl print gui/$(id -u)/com.circleci.runner
+----
+--
+
+[.tab.domain.User]
+--
+*User domain*
+
+1. When using a non-GUI (or headless) session, the provided `.plist` file should be moved to `/Library/LaunchAgents`. This location is for per-user agents configured by the administrator, which allows the service to load after a reboot. Run the following command to do this:
++
+[source,shell]
+----
+sudo mv $HOME/Library/LaunchAgents/com.circleci.runner.plist /Library/LaunchAgents/
+----
+2. Now you can bootstrap the `.plist` file and enable the service by running the following commands:
++
+[source,shell]
+----
+launchctl bootstrap user/$(id -u) /Library/LaunchAgents/com.circleci.runner.plist
+launchctl enable user/$(id -u)/com.circleci.runner
+launchctl kickstart -k user/$(id -u)/com.circleci.runner
+----
+3. Finally, you can check the service is running by invoking the following command:
++
+[source,shell]
+----
+launchctl print user/$(id -u)/com.circleci.runner
+----
+--
 
 [#stop-macos-machine-runner]
 == 5. Stop macOS machine runner 3.0
 
-To stop the machine runner service, run the following command to unload the `plist` file:
-```shell
-launchctl unload $HOME/Library/LaunchAgents/com.circleci.runner.plist
-```
+To stop the machine runner service, run the following command to disable the machine runner service, depending on the service target used in the previous step:
+
+[.tab.domain.GUI]
+--
+Targeting the GUI domain:
+[source,shell]
+----
+launchctl disable gui/$(id -u)/com.circleci.runner
+----
+--
+[.tab.domain.User]
+--
+Targeting the user domain:
+[source,shell]
+----
+launchctl disable user/$(id -u)/com.circleci.runner
+----
+--
 
 [#uninstall-machine-runner-macos]
 == Uninstall machine runner 3.0 on macOS
 To uninstall machine runner from your macOS device, follow these steps.
 
-. Stop the machine runner service by using the following command to unload the `plist` file:
+. Stop the machine runner service by using the following command to disable it, depending on the service target used during installation:
 +
-```shell
-launchctl unload $HOME/Library/LaunchAgents/com.circleci.runner.plist
-```
+[.tab.domain.GUI]
+--
+Targeting the GUI domain:
+[source,shell]
+----
+launchctl bootout gui/$(id -u)/com.circleci.runner
+----
+--
++
+[.tab.domain.User]
+--
+Targeting the user domain:
+[source,shell]
+----
+launchctl bootout user/$(id -u)/com.circleci.runner
+----
+--
 . Uninstall machine runner:
 +
 [.tab.machine-runner-uninstall-macos.Keep_logs_and_configuration]
 --
 To uninstall without purging logs and configuration files, run the following command.
 
-```shell
+[source,shell]
+----
 brew uninstall --cask circleci-public/homebrew-circleci/circleci-runner
-```
+----
 --
 +
 [.tab.machine-runner-uninstall-macos.Purge_logs_and_configuration]
@@ -185,18 +260,20 @@ This command will *purge all logs and configuration files*.
 
 To uninstall and purge all logs and configuration files, run the following command.
 
-```shell
+[source,shell]
+----
 brew uninstall --cask --zap circleci-public/homebrew-circleci/circleci-runner
-```
+----
 --
 
 [#access-runner-logs]
 == Access runner logs
 On your macOS machine, logs from `circleci-runner` are located in the following directory by default.
 
-```shell
+[source,shell]
+----
 $HOME/Library/Logs/com.circleci.runner/runner.log
-```
+----
 
 {% include snippets/machine-runner-example.adoc %}
 


### PR DESCRIPTION
# Description

Addressed issues encountered when installing machine runner 3.0 on macOS, especially for non-GUI sessions.

Applied changes are based on the corresponding updates made in https://github.com/CircleCI-Public/homebrew-circleci/pull/93

# Reasons

https://circleci.atlassian.net/browse/ONPREM-1225

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
