### PR TITLE
Update rexml for CVE-2024-35176

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,8 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.3.2)
+      strscan
     rouge (3.26.0)
     ruby2_keywords (0.0.4)
     rugged (1.0.1)
@@ -156,6 +157,7 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
+    strscan (3.1.0)
     terminal-table (3.0.1)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.1.0)


### PR DESCRIPTION
Vulnerability fixed in version 3.2.7, but we can update all the way to current without violating any version constraints in our other dependencies.