### PR TITLE
Update server 4.3+ docs on DLC requiring S3 bucket versioning [ONPREM-1361]

### DIFF
--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -495,9 +495,19 @@ aws s3api create-bucket \
     --create-bucket-configuration LocationConstraint=<YOUR_REGION>
 ----
 
+==== b. Enable bucket versioning
+
+To use the https://circleci.com/docs/docker-layer-caching/[Docker layer caching] (DLC) feature in CircleCI, https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html[bucket versioning] needs to be enabled. Run the following command to do that on the bucket created in the previous step:
+[source,shell]
+----
+aws s3api put-bucket-versioning \
+    --bucket <YOUR_BUCKET_NAME> \
+    --region <YOUR_REGION> \
+    --versioning-configuration Status=Enabled
+----
 
 [#set-up-authentication-aws]
-==== b. Set up authentication
+==== c. Set up authentication
 
 There are two ways to authenticate CircleCI with S3: IAM Roles for Service Accounts (IRSA), and IAM access keys. IRSA is the recommended method.
 

--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -272,7 +272,7 @@ CAUTION: If GitHub Enterprise and CircleCI server are not on the same domain, th
 
 Registering and setting up a new GitHub OAuth app for CircleCI server allows for authorization control to your server installation using GitHub OAuth and for updates to GitHub projects/repos using build status information. The following steps apply for both GitHub.com and GitHub Enterprise.
 
-. In your browser, navigate to **your GitHub instance** > **User Settings** > **Developer Settings** > **OAuth Apps** and click the **New OAuth App** button.
+. In your browser, navigate to **your GitHub instance** > **User Settings** > **Developer Settings** > **OAuth Apps** and select the **New OAuth App** button.
 +
 .New GitHub OAuth App
 image::github-oauth-new.png[Screenshot showing setting up a new OAuth app]
@@ -302,7 +302,7 @@ ifndef::env-gcp[]
 === GCP - Reserve a static external IP address
 The link:https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#external-ip[Google Cloud docs] provide information on how reserve an IP address.
 
-Make note of the returned IPv4 address for use later in the values.yaml file.
+Make note of the returned IPv4 address for use later in the `values.yaml` file.
 
 endif::env-gcp[]
 
@@ -327,7 +327,7 @@ aws ec2 allocate-address
 #}
 ----
 
-Make note of each of the returned `AllocationId` values from the CLI for use in the values.yaml file.
+Make note of each of the returned `AllocationId` values from the CLI for use in the `values.yaml` file.
 
 endif::env-aws[]
 
@@ -482,7 +482,7 @@ NOTE: If you are installing behind a proxy, object storage should be behind this
 ifndef::env-gcp[]
 
 [#s3-storage]
-=== S3 Storage
+=== S3 storage
 
 [#create-aws-s3-bucket]
 ==== a. Create AWS S3 Bucket
@@ -509,7 +509,7 @@ aws s3api put-bucket-versioning \
 [#set-up-authentication-aws]
 ==== c. Set up authentication
 
-There are two ways to authenticate CircleCI with S3: IAM Roles for Service Accounts (IRSA), and IAM access keys. IRSA is the recommended method.
+Two ways to authenticate CircleCI with S3 are: IAM Roles for Service Accounts (IRSA), and IAM access keys. IRSA is the recommended method.
 
 [.tab.authentication.IRSA]
 --
@@ -517,7 +517,7 @@ There are two ways to authenticate CircleCI with S3: IAM Roles for Service Accou
 
 The following is a summary of link:https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[AWS's Documentation on IRSA] that is sufficient for installing CircleCI.
 
-. Create an IAM OIDC identity provider for your EKS Cluster.
+. Create an IAM OIDC Identity Provider for your EKS Cluster.
 +
 [source,shell]
 ----

--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -497,7 +497,7 @@ aws s3api create-bucket \
 
 ==== b. Enable bucket versioning
 
-To use the https://circleci.com/docs/docker-layer-caching/[Docker layer caching] (DLC) feature in CircleCI, https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html[bucket versioning] needs to be enabled. Run the following command to do that on the bucket created in the previous step:
+To use the link:https://circleci.com/docs/docker-layer-caching/[Docker layer caching] (DLC) feature in CircleCI, link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html[bucket versioning] needs to be enabled. Run the following command to enable bucket versioning on the bucket created in the previous step:
 [source,shell]
 ----
 aws s3api put-bucket-versioning \

--- a/jekyll/_cci2/server/v4.3/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/upgrade-server.adoc
@@ -36,6 +36,7 @@ Please note the following significant changes in server v4.3.
 * Old DLC volumes will not be carried over and need to be wiped manually
 * Projects that stop using DLC will not delete final DLC cache without manual intervention
 * DLC now runs through S3 and GCS instead of SSD Volumes
+* If AWS S3 is used for https://circleci.com/docs/server/v4.3/installation/phase-1-prerequisites/#s3-storage[object storage], DLC now requires https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html[versioning to be enabled] on the bucket.
 
 [#machine]
 === Machine jobs

--- a/jekyll/_cci2/server/v4.3/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/upgrade-server.adoc
@@ -36,7 +36,7 @@ Note the following significant changes in server v4.3.
 * Old DLC volumes will not be carried over and need to be wiped manually
 * Projects that stop using DLC will not delete final DLC cache without manual intervention
 * DLC now runs through S3 and GCS instead of SSD Volumes
-* If AWS S3 is used for https://circleci.com/docs/server/v4.3/installation/phase-1-prerequisites/#s3-storage[object storage], DLC now requires https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html[versioning to be enabled] on the bucket.
+* If AWS S3 is used for xref:phase-1-prerequisites#s3-storage[object storage], the use of Docker layer caching (DLC) requires link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html[versioning to be enabled] on the bucket.
 
 [#machine]
 === Machine jobs

--- a/jekyll/_cci2/server/v4.3/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/upgrade-server.adoc
@@ -28,10 +28,10 @@ To see some common upgrade path options, see link:https://support.circleci.com/h
 [#notes]
 == Notes on changes in v4.3
 
-Please note the following significant changes in server v4.3.
+Note the following significant changes in server v4.3.
 
 [#dlc]
-=== Docker layer caching (DLC)
+=== Docker layer caching (or DLC)
 
 * Old DLC volumes will not be carried over and need to be wiped manually
 * Projects that stop using DLC will not delete final DLC cache without manual intervention
@@ -65,7 +65,7 @@ Please note the following significant changes in server v4.3.
 [#workflows-conductor]
 === Workflows conductor
 
-* There is a `workflows-conductor` data migration that will run as a job in the background after your upgrade. The migration processes projects in batches of 1000 and sleeps for 60 seconds before starting another. Processing time for a batch depends on the MongoDB and PostgreSQL data stores, but in our production environment, a batch of 1000 projects took around 6 seconds.
+* A `workflows-conductor` data migration will run as a job in the background after your upgrade. The migration processes projects in batches of 1000 and sleeps for 60 seconds before starting another. Processing time for a batch depends on the MongoDB and PostgreSQL data stores, but in our production environment, a batch of 1000 projects took around 6 seconds.
 * Ensure that your CircleCI server v4.3 installation is left running until after the migration has completed. You can confirm that the migration has completed by checking the logs of `workflows-conductor-event-consumer`. There will be a `starting next-build-seq-migration` log message with `project_count=0`
 
 [#vault]
@@ -85,9 +85,9 @@ Please note the following significant changes in server v4.3.
 [#upgrade-steps]
 == Upgrade steps
 
-NOTE: This upgrade is a disruptive process and downtime is expected. Please do not attempt to run jobs during this upgrade.
+NOTE: This upgrade is a disruptive process and downtime is expected. Do not attempt to run jobs during this upgrade.
 
-. Ensure your cluster is running a compatible kubernetes version for this release (1.26 - 1.29).
+. Ensure your cluster is running a compatible Kubernetes version for this release (1.26 - 1.29).
 
 . Check the link:https://circleci.com/server/changelog/[changelog] and make sure there are no actions you need to take before deploying a new version.
 

--- a/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
@@ -510,7 +510,7 @@ aws s3api create-bucket \
 
 ==== b. Enable bucket versioning
 
-To use the https://circleci.com/docs/docker-layer-caching/[Docker layer caching] (DLC) feature in CircleCI, https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html[bucket versioning] needs to be enabled. Run the following command to do that on the bucket created in the previous step:
+To use the link:https://circleci.com/docs/docker-layer-caching/[Docker layer caching] (DLC) feature in CircleCI, link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html[bucket versioning] needs to be enabled. Run the following command to enable bucket versioning on the bucket created in the previous step:
 [source,shell]
 ----
 aws s3api put-bucket-versioning \

--- a/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
@@ -285,7 +285,7 @@ CAUTION: If GitHub Enterprise and CircleCI server are not on the same domain, th
 
 Registering and setting up a new GitHub OAuth app for CircleCI server allows for authorization control to your server installation using GitHub OAuth and for updates to GitHub projects/repos using build status information. The following steps apply for both GitHub.com and GitHub Enterprise.
 
-. In your browser, navigate to **your GitHub instance** > **User Settings** > **Developer Settings** > **OAuth Apps** and click the **New OAuth App** button.
+. In your browser, navigate to **your GitHub instance** > **User Settings** > **Developer Settings** > **OAuth Apps** and select the **New OAuth App** button.
 +
 .New GitHub OAuth App
 image::github-oauth-new.png[Screenshot showing setting up a new OAuth app]
@@ -315,7 +315,7 @@ ifndef::env-gcp[]
 === GCP: Reserve a static external IP address
 The link:https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#external-ip[Google Cloud docs] provide information on how reserve an IP address.
 
-Make note of the returned IPv4 address for use later in the values.yaml file.
+Make note of the returned IPv4 address for use later in the `values.yaml` file.
 
 endif::env-gcp[]
 
@@ -340,7 +340,7 @@ aws ec2 allocate-address
 #}
 ----
 
-Make note of each of the returned `AllocationId` values from the CLI for use in the values.yaml file.
+Make note of each of the returned `AllocationId` values from the CLI for use in the `values.yaml` file.
 
 endif::env-aws[]
 
@@ -522,7 +522,7 @@ aws s3api put-bucket-versioning \
 [#set-up-authentication-aws]
 ==== c. Set up authentication
 
-There are two ways to authenticate CircleCI with S3: IAM Roles for Service Accounts (IRSA), and IAM access keys. IRSA is the recommended method.
+Two ways to authenticate CircleCI with S3 are: IAM Roles for Service Accounts (IRSA), and IAM access keys. IRSA is the recommended method.
 
 [.tab.authentication.IRSA]
 --
@@ -530,7 +530,7 @@ There are two ways to authenticate CircleCI with S3: IAM Roles for Service Accou
 
 The following is a summary of link:https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html[AWS's Documentation on IRSA] that is sufficient for installing CircleCI.
 
-. Create an IAM OIDC identity provider for your EKS Cluster.
+. Create an IAM OIDC Identity Provider for your EKS Cluster.
 +
 [source,shell]
 ----

--- a/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
@@ -508,9 +508,19 @@ aws s3api create-bucket \
     --create-bucket-configuration LocationConstraint=<YOUR_REGION>
 ----
 
+==== b. Enable bucket versioning
+
+To use the https://circleci.com/docs/docker-layer-caching/[Docker layer caching] (DLC) feature in CircleCI, https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html[bucket versioning] needs to be enabled. Run the following command to do that on the bucket created in the previous step:
+[source,shell]
+----
+aws s3api put-bucket-versioning \
+    --bucket <YOUR_BUCKET_NAME> \
+    --region <YOUR_REGION> \
+    --versioning-configuration Status=Enabled
+----
 
 [#set-up-authentication-aws]
-==== b. Set up authentication
+==== c. Set up authentication
 
 There are two ways to authenticate CircleCI with S3: IAM Roles for Service Accounts (IRSA), and IAM access keys. IRSA is the recommended method.
 

--- a/jekyll/_cci2/server/v4.5/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.5/installation/phase-1-prerequisites.adoc
@@ -274,7 +274,7 @@ CAUTION: If GitHub Enterprise and CircleCI server are not on the same domain, th
 
 Registering and setting up a new GitHub OAuth app for CircleCI server allows for authorization control to your server installation using GitHub OAuth and for updates to GitHub projects/repos using build status information. The following steps apply for both GitHub.com and GitHub Enterprise.
 
-. In your browser, navigate to **your GitHub instance** > **User Settings** > **Developer Settings** > **OAuth Apps** and click the **New OAuth App** button.
+. In your browser, navigate to **your GitHub instance** > **User Settings** > **Developer Settings** > **OAuth Apps** and select the **New OAuth App** button.
 +
 .New GitHub OAuth App
 image::github-oauth-new.png[Screenshot showing setting up a new OAuth app]
@@ -524,7 +524,7 @@ aws s3api put-bucket-versioning \
 
 [#set-up-authentication-aws]
 ==== c. Set up authentication
-There are two ways to authenticate CircleCI with S3: IAM Roles for Service Accounts (IRSA), and IAM access keys. IRSA is the recommended method.
+Two ways to authenticate CircleCI with S3 are: IAM Roles for Service Accounts (IRSA), and IAM access keys. IRSA is the recommended method.
 
 [.tab.authentication.IRSA]
 --

--- a/jekyll/_cci2/server/v4.5/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.5/installation/phase-1-prerequisites.adoc
@@ -513,7 +513,7 @@ aws s3api create-bucket \
 
 ==== b. Enable bucket versioning
 
-To use the https://circleci.com/docs/docker-layer-caching/[Docker layer caching] (DLC) feature in CircleCI, https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html[bucket versioning] needs to be enabled. Run the following command to do that on the bucket created in the previous step:
+To use the link:https://circleci.com/docs/docker-layer-caching/[Docker layer caching] (DLC) feature in CircleCI, link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html[bucket versioning] needs to be enabled. Run the following command to enable bucket versioning on the bucket created in the previous step:
 [source,shell]
 ----
 aws s3api put-bucket-versioning \

--- a/jekyll/_cci2/server/v4.5/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.5/installation/phase-1-prerequisites.adoc
@@ -511,10 +511,19 @@ aws s3api create-bucket \
     --create-bucket-configuration LocationConstraint=<YOUR_REGION>
 ----
 
+==== b. Enable bucket versioning
+
+To use the https://circleci.com/docs/docker-layer-caching/[Docker layer caching] (DLC) feature in CircleCI, https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html[bucket versioning] needs to be enabled. Run the following command to do that on the bucket created in the previous step:
+[source,shell]
+----
+aws s3api put-bucket-versioning \
+    --bucket <YOUR_BUCKET_NAME> \
+    --region <YOUR_REGION> \
+    --versioning-configuration Status=Enabled
+----
 
 [#set-up-authentication-aws]
-==== b. Set up authentication
-
+==== c. Set up authentication
 There are two ways to authenticate CircleCI with S3: IAM Roles for Service Accounts (IRSA), and IAM access keys. IRSA is the recommended method.
 
 [.tab.authentication.IRSA]


### PR DESCRIPTION
# Description
A brief description of the changes.

- Update the 4.3+ prerequisite guides requiring S3 bucket versioning for DLC
- Add a note to the DLC upgrade guide for 4.3 specifically on this requirement

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

Jira: https://circleci.atlassian.net/browse/ONPREM-1361

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
