### PR TITLE
Add 98.80.165.0/24 to Mac IP Ranges documentation

### DIFF
--- a/jekyll/_cci2/ip-ranges.adoc
+++ b/jekyll/_cci2/ip-ranges.adoc
@@ -166,6 +166,7 @@ In addition to AWS and GCP (see above), CircleCI's macOS cloud hosts jobs execut
 
 * 100.27.248.128/25
 * 100.29.139.128/25
+* 98.80.165.0/24
 * 38.23.41.0/24
 * 38.23.42.0/24
 * 38.23.43.0/24


### PR DESCRIPTION
# Description
This PR adds `98.80.165.0/24` to the Mac IP ranges list.

# Reasons
This new range will be used for Mac executors on or after August 5th 2024

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
