### PR TITLE
[ONPREM-1242] Set aws_acm enable to true in server installation docs

### DIFF
--- a/jekyll/_cci2/server/latest/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/latest/installation/phase-2-core-services.adoc
@@ -501,7 +501,7 @@ nginx:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <acm-arn>
   aws_acm:
-    enabled: false
+    enabled: true
 ----
 
 [WARNING]
@@ -914,7 +914,7 @@ You need the IP address, or, if using AWS, the DNS name of the nginx load balanc
 
 [source,shell]
 ----
-kubectl get service circleci-proxy
+kubectl get service -l app=circleci-proxy
 ----
 
 [#validation]


### PR DESCRIPTION
# Description

Update a k8s template & update a kubectl query to be more reliable (the service name can differ but the label is stable)

# Reasons

ONPREM-1242

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
