### PR TITLE
Add Where To Find MacOS IP Range Updates

### DIFF
--- a/jekyll/_cci2/ip-ranges.adoc
+++ b/jekyll/_cci2/ip-ranges.adoc
@@ -177,7 +177,7 @@ In addition to AWS and GCP (see above), CircleCI's macOS cloud hosts jobs execut
 
 macOS builds are automatically restricted within the IP ranges listed here. In other words, you do not have to explicitly set `circleci_ip_ranges: true` for macOS builds. 
 
-*macOS IP ranges are not included in the machine-consumable lists maintained in DNS.* Refer to the list above for the most up-to-date macOS IPs. Information about changes to macOS IP ranges will be included in the link:https://circleci.com/changelog/[changelog] and will be sent to the technical contact(s) listed on the Overview page under Organization Settings.
+*macOS IP ranges are not included in the machine-consumable lists maintained in DNS.* Refer to the list above for the most up-to-date macOS IPs. Information about changes to macOS IP ranges will be included in the link:https://circleci.com/changelog/[changelog] and will be sent to the technical contact(s) listed under menu:Organization Settings[Overview].
 
 [#known-limitations]
 == Known limitations

--- a/jekyll/_cci2/ip-ranges.adoc
+++ b/jekyll/_cci2/ip-ranges.adoc
@@ -177,7 +177,7 @@ In addition to AWS and GCP (see above), CircleCI's macOS cloud hosts jobs execut
 
 macOS builds are automatically restricted within the IP ranges listed here. In other words, you do not have to explicitly set `circleci_ip_ranges: true` for macOS builds. 
 
-*macOS IP ranges are not included in the machine-consumable lists maintained in DNS.* Refer to the list above for the most up-to-date macOS IPs.
+*macOS IP ranges are not included in the machine-consumable lists maintained in DNS.* Refer to the list above for the most up-to-date macOS IPs. Information about changes to macOS IP ranges will be included in the link:https://circleci.com/changelog/[changelog] and will be sent to the technical contact(s) listed on the Overview page under Organization Settings.
 
 [#known-limitations]
 == Known limitations


### PR DESCRIPTION
# Description
Adding information about the changelog and technical contacts to the MacOS IP Range section to better inform users about where to they can receive information about updates to the MacOS IP Range list.

# Reasons
This helps direct customers to multiple streams where they can receive updates so they don't feel like they have to monitor changes to the list in the docs.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
