### PR TITLE
Update release agent warnings

### DIFF
--- a/jekyll/_cci2/release/update-the-kubernetes-release-agent.adoc
+++ b/jekyll/_cci2/release/update-the-kubernetes-release-agent.adoc
@@ -24,15 +24,6 @@ To update the Kubernetes release agent you need an operational CircleCI release 
 
 [CAUTION]
 ====
-We have made a small but significant change in the Helm installation command that you need to be aware of.
-
-**The argument name `manageNamespaces` is now `managedNamespaces`.**
-
-You must use `managedNamespaces` instead of `manageNamespaces` when installing or upgrading the CircleCI release agent. If you have any scripts or automation that includes the previous command, you will also need to update them to use `managedNamespaces`.
-====
-
-[WARNING]
-====
 If you were using the release agent prior to version `1.2.0` you were using `app` and `version` in place of `circleci.com/component-name` and `circleci.com/version`. While `app` and `version` are still supported, we recommend to migrate to the new labels as soon as possible.
 
 Support for the old labels will be dropped in one of the next releases. 


### PR DESCRIPTION
# Description
Remove an old warning and update another warning to CAUTION, instead of WARNING alert

# Reasons
The warning being removed is for a change made long enough ago that customers shouldn't face the issue anymore. The updated alert can be downgraded to CAUTION due to it not impacting customers who are just getting started (which is most customers at this point).

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
