### PR TITLE
[ONPREM-1242] Update aws_acm value to true

### DIFF
--- a/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-2-core-services.adoc
@@ -511,7 +511,7 @@ nginx:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <acm-arn>
   aws_acm:
-    enabled: false
+    enabled: true
 ----
 
 [WARNING]

--- a/jekyll/_cci2/server/v4.5/installation/phase-2-core-services.adoc
+++ b/jekyll/_cci2/server/v4.5/installation/phase-2-core-services.adoc
@@ -501,7 +501,7 @@ nginx:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <acm-arn>
   aws_acm:
-    enabled: false
+    enabled: true
 ----
 
 [WARNING]


### PR DESCRIPTION
# Description
A brief description of the changes.

# Reasons

ONPREM-1242

The `aws_acm` value should be set to true when enabling ACM managed ingress certs

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
