### PR TITLE
Update workspaces.adoc

### DIFF
--- a/jekyll/_cci2/workspaces.adoc
+++ b/jekyll/_cci2/workspaces.adoc
@@ -35,7 +35,7 @@ Some notes about workspaces:
 * If multiple concurrent jobs persist the same filename, then attaching the workspace will error.
 * If a workflow is re-run, it inherits the same workspace as the original workflow. When re-running failed jobs, only the re-run jobs will see the same workspace content as the jobs in the original workflow.
 
-By default, workspace storage duration is set to 15 days. This can be customized on the link:https://app.circleci.com/[CircleCI web app] by navigating to menu:Plan[Usage Controls]. Currently, 15 days is also the maximum storage duration you can set.
+By default, on CircleCI cloud, workspace storage duration is set to 15 days. This can be customized on the link:https://app.circleci.com/[CircleCI web app] by navigating to menu:Plan[Usage Controls]. Currently, 15 days is also the maximum storage duration you can set.
 
 image::/docs/assets/img/docs/workspaces.png[workspaces data flow]
 

--- a/jekyll/_cci2/workspaces.adoc
+++ b/jekyll/_cci2/workspaces.adoc
@@ -5,7 +5,7 @@ contentTags:
   - Server v4.x
   - Server v3.x
 ---
-= Using Workspaces to Share Data between Jobs
+= Using workspaces to share data between jobs
 :page-layout: classic-docs
 :page-description: This document describes how to use workspaces to share data to downstream jobs in your workflows.
 :page-liquid:


### PR DESCRIPTION
Clarifying that only CircleCI Cloud has a workspace retention period of 15 days.

# Description
A brief description of the changes.
Clarifying that only CircleCI cloud has a workspace retention period of 15 days by default. 

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.
Clarity for users. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
