### PR TITLE
ONPREM-1408 | updated the default s3 region details

### DIFF
--- a/jekyll/_cci2/server/v4.2/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.2/installation/installation-reference.adoc
@@ -51,7 +51,7 @@ object_storage:
   s3:
     enabled: true
     endpoint: "<aws-region-url>" # ex: https://s3.us-east-1.amazonaws.com
-    region: "<aws-region>"
+    region: "<aws-region>" # defaults to us-east-1, Update this value if you are using a different region
     irsaRole: "<arn-of-irsa-role>"
 
 github:

--- a/jekyll/_cci2/server/v4.3/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/installation-reference.adoc
@@ -51,7 +51,7 @@ object_storage:
   s3:
     enabled: true
     endpoint: "<aws-region-url>" # ex: https://s3.us-east-1.amazonaws.com
-    region: "<aws-region>"
+    region: "<aws-region>" # defaults to us-east-1, Update this value if you are using a different region
     irsaRole: "<arn-of-irsa-role>"
 
 github:

--- a/jekyll/_cci2/server/v4.4/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/installation-reference.adoc
@@ -51,7 +51,7 @@ object_storage:
   s3:
     enabled: true
     endpoint: "<aws-region-url>" # ex: https://s3.us-east-1.amazonaws.com
-    region: "<aws-region>"
+    region: "<aws-region>" # defaults to us-east-1, Update this value if you are using a different region
     irsaRole: "<arn-of-irsa-role>"
 
 github:

--- a/jekyll/_cci2/server/v4.5/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.5/installation/installation-reference.adoc
@@ -51,7 +51,7 @@ object_storage:
   s3:
     enabled: true
     endpoint: "<aws-region-url>" # ex: https://s3.us-east-1.amazonaws.com
-    region: "<aws-region>"
+    region: "<aws-region>"  # defaults to us-east-1, Update this value if you are using a different region
     irsaRole: "<arn-of-irsa-role>"
 
 github:


### PR DESCRIPTION
# Description
If AWS S3 Region is not defined, it defaults to `us-east-1` which clashes the `endpoint` value if set different

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
