### PR TITLE
fix: Air-gap should use :start to download assets

### DIFF
--- a/jekyll/_cci2/server/v4.1/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/troubleshooting-and-support.adoc
@@ -109,7 +109,7 @@ If you are in an air-gapped environment, you will first need to download the `le
 
 [source,bash]
 ----
-docker run -it clojure lein repl :connect 6005
+docker run -it clojure lein repl :start
 docker commit $(docker ps -aq | head -1) <your-private-registry>/clojure
 ----
 

--- a/jekyll/_cci2/server/v4.2/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/v4.2/operator/troubleshooting-and-support.adoc
@@ -112,7 +112,7 @@ If you are in an air-gapped environment, you will first need to download the `le
 
 [source,bash]
 ----
-docker run -it clojure lein repl :connect 6005
+docker run -it clojure lein repl :start
 docker commit $(docker ps -aq | head -1) <your-private-registry>/clojure
 ----
 

--- a/jekyll/_cci2/server/v4.3/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/v4.3/operator/troubleshooting-and-support.adoc
@@ -112,7 +112,7 @@ If you are in an air-gapped environment, you will first need to download the `le
 
 [source,bash]
 ----
-docker run -it clojure lein repl :connect 6005
+docker run -it clojure lein repl :start
 docker commit $(docker ps -aq | head -1) <your-private-registry>/clojure
 ----
 

--- a/jekyll/_cci2/server/v4.4/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/v4.4/operator/troubleshooting-and-support.adoc
@@ -112,7 +112,7 @@ If you are in an air-gapped environment, you will first need to download the `le
 
 [source,bash]
 ----
-docker run -it clojure lein repl :connect 6005
+docker run -it clojure lein repl :start
 docker commit $(docker ps -aq | head -1) <your-private-registry>/clojure
 ----
 

--- a/jekyll/_cci2/server/v4.5/operator/troubleshooting-and-support.adoc
+++ b/jekyll/_cci2/server/v4.5/operator/troubleshooting-and-support.adoc
@@ -112,7 +112,7 @@ If you are in an air-gapped environment, you will first need to download the `le
 
 [source,bash]
 ----
-docker run -it clojure lein repl :connect 6005
+docker run -it clojure lein repl :start
 docker commit $(docker ps -aq | head -1) <your-private-registry>/clojure
 ----
 


### PR DESCRIPTION
The :start command was failing when there is no REPL to connect to. Using :start allows the shell to download assets to be committed via Docker and then utilized within an air-gap environment.