### PR TITLE
PIPE-4728 Add is default branch pipeline value

### DIFF
--- a/jekyll/_includes/snippets/pipeline-values.adoc
+++ b/jekyll/_includes/snippets/pipeline-values.adoc
@@ -50,6 +50,13 @@
 | icon:check[]
 | icon:check[]
 
+| `pipeline.git.branch.is_default`
+| GitHub App, GitHub OAuth, Bitbucket, GitLab
+| Boolean
+| Whether the branch the pipeline was triggered on is the default branch.
+| icon:check[]
+| icon:check[] (>= v4.6)
+
 | `pipeline.git.revision`
 | GitHub App, GitHub OAuth, Bitbucket, GitLab
 | String


### PR DESCRIPTION
# Description

A new pipeline value that represents whether the branch the pipeline was triggered on is the default, following the below criteria:

- `true` when it is the default branch.
- `false` when it isn’t the default branch.
- `false` when it is any other push (e.g. tag push).
- omitted when it is not a VCS-triggered pipeline.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.atlassian.net/browse/PIPE-4728

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
