### PR TITLE
Correct some server links

### DIFF
--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -973,7 +973,7 @@ The machine executor is configured using the `machine` key, which takes a map:
 | `image`
 | Y
 | String
-| The virtual machine image to use. View https://circleci.com/developer/images?imageType=machine[available images]. *Note:* This key is *not* supported for Linux VMs on installations of CircleCI server. For information about customizing `machine` executor images on CircleCI installed on your servers, see our xref:./server/v4.4/operator/manage-virtual-machines-with-machine-provisioner#[Machine provisioner documentation].
+| The virtual machine image to use. View https://circleci.com/developer/images?imageType=machine[available images]. *Note:* This key is *not* supported for Linux VMs on installations of CircleCI server. For information about customizing `machine` executor images on CircleCI installed on your servers, see our xref:./server/latest/operator/manage-virtual-machines-with-machine-provisioner#[Machine provisioner documentation].
 
 | `docker_layer_caching`
 | N

--- a/jekyll/_cci2/dynamic-config.adoc
+++ b/jekyll/_cci2/dynamic-config.adoc
@@ -33,7 +33,7 @@ NOTE: Projects created **after** December 1st 2023 have dynamic config enabled b
 To enable dynamic configuration in CircleCI:
 
 . In the CircleCI web app, select **Projects** in the sidebar
-. Click the icon:ellipsis-h[ellipsis] next to your project and select **Project Settings**
+. Select the icon:ellipsis-h[ellipsis] next to your project and select **Project Settings**
 . From the sidebar, select *Advanced*.
 . Scroll to the *Enable dynamic config using setup workflows* setting, and toggle it to the "on" position, as shown below:
 +
@@ -56,7 +56,7 @@ For some basic examples of using dynamic configuration, see the xref:using-dynam
 
 == Config continuation constraints
 
-There are some constraints on continuing pipelines from a `setup` configuration, as follows:
+Some constraints on continuing pipelines from a `setup` configuration are as follows:
 
 - The `setup` configuration must be `version: 2.1`.
 - The `setup` configuration must only allow one continuation workflow to run in each pipeline. For example:
@@ -119,7 +119,7 @@ For an example of config splitting, see the xref:using-dynamic-configuration#pac
 
 == Using dynamic configuration on CircleCI server
 
-TIP: For more information on managing orbs in a server installation see the xref:/server/v4.5/operator/managing-orbs#[Managing orbs] page.
+TIP: For more information on managing orbs in a server installation see the xref:/server/latest/operator/managing-orbs#[Managing orbs] page.
 
 If you are using CircleCI server there are a few extra steps you will need to take to use the dynamic configuration orbs.
 

--- a/jekyll/_cci2/server/latest/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/latest/installation/installation-reference.adoc
@@ -1135,7 +1135,7 @@ this value is '`15672`' else port of external rabbitmq instance
 
 |redis.master.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/latest/operator/expanding-internal-database-volumes
 
 |redis.master.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |
@@ -1150,7 +1150,7 @@ https://circleci.com/docs/server/operator/expanding-internal-database-volumes
 
 |redis.slave.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/latest/operator/expanding-internal-database-volumes
 
 |redis.slave.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |

--- a/jekyll/_cci2/server/latest/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/latest/operator/operator-overview.adoc
@@ -40,7 +40,7 @@ See the link:https://www.nomadproject.io/docs/install/production/requirements#re
 NOTE: The maximum machine size for a Nomad client is 128GB RAM/64 CPUs. Contact your CircleCI account representative to request use of larger machines for Nomad clients.
 
 For more information on Nomad port requirements, see the
-https://circleci.com/docs/server/installation/hardening-your-cluster/[Hardening Your Cluster]
+xref:../installation/hardening-your-cluster/[Hardening Your Cluster]
 guide.
 
 [#github]

--- a/jekyll/_cci2/server/v4.1/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.1/installation/installation-reference.adoc
@@ -331,11 +331,11 @@ pass:[<!-- vale off -->]
 | redis.cluster.slaveCount | int | `1` |  |
 | redis.fullnameOverride | string | `"redis"` |  |
 | redis.image.tag | string | `"6.2.1-debian-10-r13"` |  |
-| redis.master.persistence.size | string | `"8Gi"` | To increase PVC size, follow this guide: https://circleci.com/docs/server/operator/expanding-internal-database-volumes |
+| redis.master.persistence.size | string | `"8Gi"` | To increase PVC size, follow this guide: https://circleci.com/docs/server/v4.1/operator/expanding-internal-database-volumes |
 | redis.master.podAnnotations."backup.velero.io/backup-volumes" | string | `"redis-data"` |  |
 | redis.podLabels.app | string | `"redis"` |  |
 | redis.podLabels.layer | string | `"data"` |  |
-| redis.slave.persistence.size | string | `"8Gi"` | To increase PVC size, follow this guide: https://circleci.com/docs/server/operator/expanding-internal-database-volumes |
+| redis.slave.persistence.size | string | `"8Gi"` | To increase PVC size, follow this guide: https://circleci.com/docs/server/v4.1/operator/expanding-internal-database-volumes |
 | redis.slave.podAnnotations."backup.velero.io/backup-volumes" | string | `"redis-data"` |  |
 | redis.statefulset.labels.app | string | `"redis"` |  |
 | redis.statefulset.labels.layer | string | `"data"` |  |

--- a/jekyll/_cci2/server/v4.1/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/v4.1/operator/operator-overview.adoc
@@ -40,7 +40,7 @@ See the link:https://www.nomadproject.io/docs/install/production/requirements#re
 NOTE: The maximum machine size for a Nomad client is 128GB RAM/64 CPUs. Contact your CircleCI account representative to request use of larger machines for Nomad clients.
 
 For more information on Nomad port requirements, see the
-https://circleci.com/docs/server/installation/hardening-your-cluster/[Hardening Your Cluster]
+xref:../installation/hardening-your-cluster/[Hardening Your Cluster]
 guide.
 
 [#github]

--- a/jekyll/_cci2/server/v4.2/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.2/installation/installation-reference.adoc
@@ -686,7 +686,7 @@ secret name for existingPasswordSecret
 
 |redis.master.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/v4.2/operator/expanding-internal-database-volumes
 
 |redis.master.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |
@@ -697,7 +697,7 @@ https://circleci.com/docs/server/operator/expanding-internal-database-volumes
 
 |redis.slave.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/v4.2/operator/expanding-internal-database-volumes
 
 |redis.slave.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |

--- a/jekyll/_cci2/server/v4.2/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/v4.2/operator/operator-overview.adoc
@@ -41,7 +41,7 @@ See the link:https://www.nomadproject.io/docs/install/production/requirements#re
 NOTE: The maximum machine size for a Nomad client is 128GB RAM/64 CPUs. Contact your CircleCI account representative to request use of larger machines for Nomad clients.
 
 For more information on Nomad port requirements, see the
-https://circleci.com/docs/server/installation/hardening-your-cluster/[Hardening Your Cluster]
+xref:../installation/hardening-your-cluster/[Hardening Your Cluster]
 guide.
 
 [#github]

--- a/jekyll/_cci2/server/v4.3/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/installation-reference.adoc
@@ -1068,7 +1068,7 @@ this value is '`15672`' else port of external rabbitmq instance
 
 |redis.master.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/v4.3/operator/expanding-internal-database-volumes
 
 |redis.master.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |
@@ -1083,7 +1083,7 @@ https://circleci.com/docs/server/operator/expanding-internal-database-volumes
 
 |redis.slave.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/v4.3/operator/expanding-internal-database-volumes
 
 |redis.slave.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |

--- a/jekyll/_cci2/server/v4.3/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/v4.3/operator/operator-overview.adoc
@@ -41,7 +41,7 @@ See the link:https://www.nomadproject.io/docs/install/production/requirements#re
 NOTE: The maximum machine size for a Nomad client is 128GB RAM/64 CPUs. Contact your CircleCI account representative to request use of larger machines for Nomad clients.
 
 For more information on Nomad port requirements, see the
-https://circleci.com/docs/server/installation/hardening-your-cluster/[Hardening Your Cluster]
+xref:../installation/hardening-your-cluster/[Hardening Your Cluster]
 guide.
 
 [#github]

--- a/jekyll/_cci2/server/v4.4/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/installation-reference.adoc
@@ -1069,7 +1069,7 @@ this value is '`15672`' else port of external rabbitmq instance
 
 |redis.master.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/v4.4/operator/expanding-internal-database-volumes
 
 |redis.master.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |
@@ -1084,7 +1084,7 @@ https://circleci.com/docs/server/operator/expanding-internal-database-volumes
 
 |redis.slave.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/v4.4/operator/expanding-internal-database-volumes
 
 |redis.slave.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |

--- a/jekyll/_cci2/server/v4.4/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/v4.4/operator/operator-overview.adoc
@@ -41,7 +41,7 @@ See the link:https://www.nomadproject.io/docs/install/production/requirements#re
 NOTE: The maximum machine size for a Nomad client is 128GB RAM/64 CPUs. Contact your CircleCI account representative to request use of larger machines for Nomad clients.
 
 For more information on Nomad port requirements, see the
-https://circleci.com/docs/server/installation/hardening-your-cluster/[Hardening Your Cluster]
+xref:../installation/hardening-your-cluster/[Hardening Your Cluster]
 guide.
 
 [#github]

--- a/jekyll/_cci2/server/v4.5/installation/installation-reference.adoc
+++ b/jekyll/_cci2/server/v4.5/installation/installation-reference.adoc
@@ -1126,7 +1126,7 @@ this value is '`15672`' else port of external rabbitmq instance
 
 |redis.master.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/v4.5/operator/expanding-internal-database-volumes
 
 |redis.master.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |
@@ -1141,7 +1141,7 @@ https://circleci.com/docs/server/operator/expanding-internal-database-volumes
 
 |redis.slave.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+https://circleci.com/docs/server/v4.5/operator/expanding-internal-database-volumes
 
 |redis.slave.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |

--- a/jekyll/_cci2/server/v4.5/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/v4.5/operator/operator-overview.adoc
@@ -41,7 +41,7 @@ See the link:https://www.nomadproject.io/docs/install/production/requirements#re
 NOTE: The maximum machine size for a Nomad client is 128GB RAM/64 CPUs. Contact your CircleCI account representative to request use of larger machines for Nomad clients.
 
 For more information on Nomad port requirements, see the
-https://circleci.com/docs/server/installation/hardening-your-cluster/[Hardening Your Cluster]
+xref:../installation/hardening-your-cluster/[Hardening Your Cluster]
 guide.
 
 [#github]


### PR DESCRIPTION
# Description
Update server links to point to correct set of server docs

# Reasons
Links from main dev docs were going to older versions of server docs. Should always point to /latest/. Also links between server docs within a version should use cross references to link to the correct version page.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
