### PR TITLE
docs(pipelines): remove redundant 'for example'

### DIFF
--- a/jekyll/_cci2/pipelines.adoc
+++ b/jekyll/_cci2/pipelines.adoc
@@ -12,7 +12,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 
-CircleCI pipelines are the highest-level unit of work, and they are described by a configuration file, for example, for example, `.circleci/config.yml`. _Triggers_ can be set up to automate when a pipeline will be triggered. Pipelines coordinate the execution of workflows and jobs to build, test, and deploy your code. Workflows can be conditional, based on xref:workflows#using-contexts-and-filtering-in-your-workflows[filters], xref:workflows#workflows-configuration-examples[job requirements], and xref:selecting-a-workflow-to-run-using-pipeline-parameters#[pipeline parameters].
+CircleCI pipelines are the highest-level unit of work, and they are described by a configuration file, for example, `.circleci/config.yml`. _Triggers_ can be set up to automate when a pipeline will be triggered. Pipelines coordinate the execution of workflows and jobs to build, test, and deploy your code. Workflows can be conditional, based on xref:workflows#using-contexts-and-filtering-in-your-workflows[filters], xref:workflows#workflows-configuration-examples[job requirements], and xref:selecting-a-workflow-to-run-using-pipeline-parameters#[pipeline parameters].
 
 Pipelines include your workflows, which coordinate your jobs. Pipelines have a fixed, linear lifecycle, and are associated with a specific actor. Pipelines trigger when a change is pushed to a project that has a CircleCI configuration file included, and can also be scheduled, triggered manually through the CircleCI app, or using the API.
 


### PR DESCRIPTION
# Description
Remove duplicate in sentence.
