### PR TITLE
Specify last compatible CLI version for server 4.2 [ONPREM-237]

### DIFF
--- a/jekyll/_cci2/server/v4.2/overview/release-notes.adoc
+++ b/jekyll/_cci2/server/v4.2/overview/release-notes.adoc
@@ -18,6 +18,8 @@ noindex: true
 
 The v4.2 release introduces the config policies feature to CircleCI server. Use config policies to create organization-level policies to impose rules and scopes to govern which configuration elements are required, allowed, not allowed etc. For more information see the xref:../../../config-policy-management-overview#[Config policies overview]. To use config policies CLI commands with server, append all commands shown in the docs with `--policy-base-url https://<CIRCLECI-SERVER-DOMAIN>.com`
 
+WARNING: The last fully compatible CircleCI CLI version for v4.2 is link:https://github.com/CircleCI-Public/circleci-cli/releases/tag/v0.1.30549[v0.1.30549], specifically for operations on self-hosted runners.
+
 [#upgrade]
 == Upgrade
 For upgrade steps see the xref:../installation/upgrade-server#[Upgrade server v4.2 guide].


### PR DESCRIPTION
# Description
A brief description of the changes.

The CLI is being updated to use the _runner_ API v3 (https://github.com/CircleCI-Public/circleci-cli/pull/1065), which is only supported on 4.3+. While 4.2 is now unsupported with the release of 4.6, this is just a courtesy for users still on 4.2.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

https://circleci.atlassian.net/browse/ONPREM-237

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
