### PR TITLE
fix: Add server versions to page descriptions

### DIFF
--- a/jekyll/_cci2/server/latest/air-gapped-installation/additional-considerations.adoc
+++ b/jekyll/_cci2/server/latest/air-gapped-installation/additional-considerations.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Additional considerations
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This page presents some items that should be considered when starting an air-gapped installation of CircleCI server
+:page-description: This page presents some items that should be considered when starting an air-gapped installation of CircleCI server v4.6
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/air-gapped-installation/example-values.adoc
+++ b/jekyll/_cci2/server/latest/air-gapped-installation/example-values.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Example `values.yaml`
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This page presents an example values.yaml file to help with setting up an air-gapped installation of CircleCI server
+:page-description: This page presents an example values.yaml file to help with setting up an air-gapped installation of CircleCI server v4.6
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/air-gapped-installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/latest/air-gapped-installation/phase-1-prerequisites.adoc
@@ -8,7 +8,7 @@ contentTags:
 :page-layout: classic-docs
 :page-liquid:
 :experimental:
-:page-description: A guide to installing CircleCI server in an air-gapped environment. Requirements, images and Helm charts.
+:page-description: A guide to installing CircleCI server v4.6 in an air-gapped environment. Requirements, images and Helm charts.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/latest/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Phase 2 - Configure object storage
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to configure object storage through MinIO to run CircleCI server in an air-gapped environment.
+:page-description: How to configure object storage through MinIO to run CircleCI server v4.6 in an air-gapped environment.
 :icons: font
 :experimental:
 :toc: macro

--- a/jekyll/_cci2/server/latest/air-gapped-installation/phase-3-install-circleci-server.adoc
+++ b/jekyll/_cci2/server/latest/air-gapped-installation/phase-3-install-circleci-server.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Phase 3 - install CircleCI server
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to install the CircleCI server Helm deployment to an air-gapped environment.
+:page-description: How to install the CircleCI server v4.6 Helm deployment to an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/air-gapped-installation/phase-4-configure-nomad-clients.adoc
+++ b/jekyll/_cci2/server/latest/air-gapped-installation/phase-4-configure-nomad-clients.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Phase 4 - Configure Nomad clients
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to configure Nomad clients to run with CircleCI server in an air-gapped environment.
+:page-description: How to configure Nomad clients to run with CircleCI server v4.6 in an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/air-gapped-installation/phase-5-test-your-installation.adoc
+++ b/jekyll/_cci2/server/latest/air-gapped-installation/phase-5-test-your-installation.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Phase 5 - Test your installation
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to test your CircleCI server installation in an air-gapped environment.
+:page-description: How to test your CircleCI server v4.6 installation in an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/latest/installation/phase-1-prerequisites.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Phase 1 - Prerequisites
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server application.
+:page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server v4.6 application.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/installation/phase-4-post-installation.adoc
+++ b/jekyll/_cci2/server/latest/installation/phase-4-post-installation.adoc
@@ -6,7 +6,7 @@ contentTags:
 ---
 = Phase 4 - post installation
 :page-layout: classic-docs
-:page-description: CircleCI server post installation steps for v4.6
+:page-description: CircleCI server v4.6 post installation steps
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/operator/backup-and-restore.adoc
+++ b/jekyll/_cci2/server/latest/operator/backup-and-restore.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Backup and restore
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This document outlines recommendations for how to back up and restore your CircleCI server instance data and state.
+:page-description: This document outlines recommendations for how to back up and restore your CircleCI server v4.6 instance data and state.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/operator/manage-virtual-machines-with-machine-provisioner.adoc
+++ b/jekyll/_cci2/server/latest/operator/manage-virtual-machines-with-machine-provisioner.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Manage virtual machines with machine provisioner
 :page-layout: classic-docs
 :page-liquid:
-:page-description: CircleCI server’s machine provisioner service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
+:page-description: CircleCI server v4.6’s machine provisioner service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/operator/managing-user-accounts.adoc
+++ b/jekyll/_cci2/server/latest/operator/managing-user-accounts.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Managing user accounts
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This section provides information to help CircleCI server perators manage user accounts.
+:page-description: This section provides information to help CircleCI server v4.6 perators manage user accounts.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/latest/operator/operator-overview.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Operator overview
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server.
+:page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server v4.6.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/operator/upgrade-mongo.adoc
+++ b/jekyll/_cci2/server/latest/operator/upgrade-mongo.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Upgrade MongoDB
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn how to upgrade MongoDB up to v4.6.15 in an installation of CircleCI server.
+:page-description: Learn how to upgrade MongoDB up to v4.4.15 in an installation of CircleCI server.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/operator/upgrade-mongo.adoc
+++ b/jekyll/_cci2/server/latest/operator/upgrade-mongo.adoc
@@ -7,7 +7,7 @@ contentTags:
 = Upgrade MongoDB
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn how to upgrade MongoDB up to v4.4.15 in an installation of CircleCI server.
+:page-description: Learn how to upgrade MongoDB up to v4.4.15 in an installation of CircleCI server v4.6.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/latest/operator/user-authentication.adoc
+++ b/jekyll/_cci2/server/latest/operator/user-authentication.adoc
@@ -7,7 +7,7 @@ contentTags:
 = User authentication
 :page-layout: classic-docs
 :page-liquid:
-:page-description: CircleCI server currently supports OAuth through GitHub or GitHub Enterprise.
+:page-description: CircleCI server v4.6 currently supports OAuth through GitHub or GitHub Enterprise.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/additional-considerations.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/additional-considerations.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Additional considerations
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This page presents some items that should be considered when starting an air-gapped installation of CircleCI server
+:page-description: This page presents some items that should be considered when starting an air-gapped installation of CircleCI server v4.3
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/example-values.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/example-values.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Example `values.yaml`
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This page presents an example values.yaml file to help with setting up an air-gapped installation of CircleCI server
+:page-description: This page presents an example values.yaml file to help with setting up an air-gapped installation of CircleCI server v4.3
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-1-prerequisites.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 1 - Prerequisites
 :page-layout: classic-docs
 :page-liquid:
-:page-description: A guide to installing CircleCI server in an air-gapped environment. Requirements, images and Helm charts.
+:page-description: A guide to installing CircleCI server v4.3 in an air-gapped environment. Requirements, images and Helm charts.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 2 - Configure object storage
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to configure object storage through MinIO to run CircleCI server in an air-gapped environment.
+:page-description: How to configure object storage through MinIO to run CircleCI server v4.3 in an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-3-install-circleci-server.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-3-install-circleci-server.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 3 - install CircleCI server
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to install the CircleCI server Helm deployment to an air-gapped environment.
+:page-description: How to install the CircleCI server v4.3 Helm deployment to an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-4-configure-nomad-clients.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-4-configure-nomad-clients.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 4 - configure Nomad clients
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to configure Nomad clients to run with CircleCI server in an air-gapped environment.
+:page-description: How to configure Nomad clients to run with CircleCI server v4.3 in an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-5-test-your-installation.adoc
+++ b/jekyll/_cci2/server/v4.3/air-gapped-installation/phase-5-test-your-installation.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 5 - Test your installation
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to test your CircleCI server installation in an air-gapped environment.
+:page-description: How to test your CircleCI server v4.3 installation in an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-1-prerequisites.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 1 - Prerequisites
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server application.
+:page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server v4.3 application.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/installation/phase-4-post-installation.adoc
+++ b/jekyll/_cci2/server/v4.3/installation/phase-4-post-installation.adoc
@@ -7,7 +7,7 @@ noindex: true
 ---
 = Phase 4 - post installation
 :page-layout: classic-docs
-:page-description: CircleCI server post installation steps for v4.3
+:page-description: CircleCI server v4.3 post installation steps
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/operator/backup-and-restore.adoc
+++ b/jekyll/_cci2/server/v4.3/operator/backup-and-restore.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Backup and restore
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This document outlines recommendations for how to back up and restore your CircleCI server instance data and state.
+:page-description: This document outlines recommendations for how to back up and restore your CircleCI server v4.3 instance data and state.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/operator/manage-virtual-machines-with-machine-provisioner.adoc
+++ b/jekyll/_cci2/server/v4.3/operator/manage-virtual-machines-with-machine-provisioner.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Manage virtual machines with machine provisioner
 :page-layout: classic-docs
 :page-liquid:
-:page-description: CircleCI server’s machine provisioner service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
+:page-description: CircleCI server v4.3’s machine provisioner service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/v4.3/operator/operator-overview.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Operator overview
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server.
+:page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server v4.3.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/operator/upgrade-mongo.adoc
+++ b/jekyll/_cci2/server/v4.3/operator/upgrade-mongo.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Upgrade MongoDB
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn how to upgrade MongoDB up to v4.4.15 in an installation of CircleCI server.
+:page-description: Learn how to upgrade MongoDB up to v4.4.15 in an installation of CircleCI server v4.3.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.3/operator/user-authentication.adoc
+++ b/jekyll/_cci2/server/v4.3/operator/user-authentication.adoc
@@ -8,7 +8,7 @@ noindex: true
 = User authentication
 :page-layout: classic-docs
 :page-liquid:
-:page-description: CircleCI server currently supports OAuth through GitHub or GitHub Enterprise.
+:page-description: CircleCI server v4.3 currently supports OAuth through GitHub or GitHub Enterprise.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/additional-considerations.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/additional-considerations.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Additional considerations
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This page presents some items that should be considered when starting an air-gapped installation of CircleCI server
+:page-description: This page presents some items that should be considered when starting an air-gapped installation of CircleCI server v4.4
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/example-values.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/example-values.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Example `values.yaml`
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This page presents an example values.yaml file to help with setting up an air-gapped installation of CircleCI server
+:page-description: This page presents an example values.yaml file to help with setting up an air-gapped installation of CircleCI server v4.4
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-1-prerequisites.adoc
@@ -9,7 +9,7 @@ noindex: true
 :page-layout: classic-docs
 :page-liquid:
 :experimental:
-:page-description: A guide to installing CircleCI server in an air-gapped environment. Requirements, images and Helm charts.
+:page-description: A guide to installing CircleCI server v4.4 in an air-gapped environment. Requirements, images and Helm charts.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 2 - Configure object storage
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to configure object storage through MinIO to run CircleCI server in an air-gapped environment.
+:page-description: How to configure object storage through MinIO to run CircleCI server v4.4 in an air-gapped environment.
 :icons: font
 :experimental:
 :toc: macro

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-3-install-circleci-server.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-3-install-circleci-server.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 3 - install CircleCI server
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to install the CircleCI server Helm deployment to an air-gapped environment.
+:page-description: How to install the CircleCI server v4.4 Helm deployment to an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-4-configure-nomad-clients.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-4-configure-nomad-clients.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 4 - Configure Nomad clients
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to configure Nomad clients to run with CircleCI server in an air-gapped environment.
+:page-description: How to configure Nomad clients to run with CircleCI server v4.4 in an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-5-test-your-installation.adoc
+++ b/jekyll/_cci2/server/v4.4/air-gapped-installation/phase-5-test-your-installation.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 5 - Test your installation
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to test your CircleCI server installation in an air-gapped environment.
+:page-description: How to test your CircleCI server v4.4 installation in an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-1-prerequisites.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 1 - Prerequisites
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server application.
+:page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server v4.4 application.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/installation/phase-4-post-installation.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-4-post-installation.adoc
@@ -7,7 +7,7 @@ noindex: true
 ---
 = Phase 4 - post installation
 :page-layout: classic-docs
-:page-description: CircleCI server post installation steps for v4.4
+:page-description: CircleCI server v4.4 post installation steps
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/operator/backup-and-restore.adoc
+++ b/jekyll/_cci2/server/v4.4/operator/backup-and-restore.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Backup and restore
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This document outlines recommendations for how to back up and restore your CircleCI server instance data and state.
+:page-description: This document outlines recommendations for how to back up and restore your CircleCI server v4.4 instance data and state.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/operator/manage-virtual-machines-with-machine-provisioner.adoc
+++ b/jekyll/_cci2/server/v4.4/operator/manage-virtual-machines-with-machine-provisioner.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Manage virtual machines with machine provisioner
 :page-layout: classic-docs
 :page-liquid:
-:page-description: CircleCI server’s machine provisioner service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
+:page-description: CircleCI server v4.4’s machine provisioner service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/v4.4/operator/operator-overview.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Operator overview
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server.
+:page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server v4.4.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/operator/upgrade-mongo.adoc
+++ b/jekyll/_cci2/server/v4.4/operator/upgrade-mongo.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Upgrade MongoDB
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn how to upgrade MongoDB up to v4.4.15 in an installation of CircleCI server.
+:page-description: Learn how to upgrade MongoDB up to v4.4.15 in an installation of CircleCI server v4.4.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.4/operator/user-authentication.adoc
+++ b/jekyll/_cci2/server/v4.4/operator/user-authentication.adoc
@@ -8,7 +8,7 @@ noindex: true
 = User authentication
 :page-layout: classic-docs
 :page-liquid:
-:page-description: CircleCI server currently supports OAuth through GitHub or GitHub Enterprise.
+:page-description: CircleCI server v4.4 currently supports OAuth through GitHub or GitHub Enterprise.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/additional-considerations.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/additional-considerations.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Additional considerations
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This page presents some items that should be considered when starting an air-gapped installation of CircleCI server
+:page-description: This page presents some items that should be considered when starting an air-gapped installation of CircleCI server v4.5
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/example-values.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/example-values.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Example `values.yaml`
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This page presents an example values.yaml file to help with setting up an air-gapped installation of CircleCI server
+:page-description: This page presents an example values.yaml file to help with setting up an air-gapped installation of CircleCI server v4.5
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-1-prerequisites.adoc
@@ -9,7 +9,7 @@ noindex: true
 :page-layout: classic-docs
 :page-liquid:
 :experimental:
-:page-description: A guide to installing CircleCI server in an air-gapped environment. Requirements, images and Helm charts.
+:page-description: A guide to installing CircleCI server v4.5 in an air-gapped environment. Requirements, images and Helm charts.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-2-configure-object-storage.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 2 - Configure object storage
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to configure object storage through MinIO to run CircleCI server in an air-gapped environment.
+:page-description: How to configure object storage through MinIO to run CircleCI server v4.5 in an air-gapped environment.
 :icons: font
 :experimental:
 :toc: macro

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-3-install-circleci-server.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-3-install-circleci-server.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 3 - install CircleCI server
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to install the CircleCI server Helm deployment to an air-gapped environment.
+:page-description: How to install the CircleCI server v4.5 Helm deployment to an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-4-configure-nomad-clients.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-4-configure-nomad-clients.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 4 - Configure Nomad clients
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to configure Nomad clients to run with CircleCI server in an air-gapped environment.
+:page-description: How to configure Nomad clients to run with CircleCI server v4.5 in an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-5-test-your-installation.adoc
+++ b/jekyll/_cci2/server/v4.5/air-gapped-installation/phase-5-test-your-installation.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 5 - Test your installation
 :page-layout: classic-docs
 :page-liquid:
-:page-description: How to test your CircleCI server installation in an air-gapped environment.
+:page-description: How to test your CircleCI server v4.5 installation in an air-gapped environment.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.5/installation/phase-1-prerequisites.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Phase 1 - Prerequisites
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server application.
+:page-description: Find the general and infrastructure-specific requirements that are needed in order to configure the CircleCI server v4.5 application.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/installation/phase-4-post-installation.adoc
+++ b/jekyll/_cci2/server/v4.5/installation/phase-4-post-installation.adoc
@@ -7,7 +7,7 @@ noindex: true
 ---
 = Phase 4 - post installation
 :page-layout: classic-docs
-:page-description: CircleCI server post installation steps for v4.5
+:page-description: CircleCI server v4.5 post installation steps
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/operator/backup-and-restore.adoc
+++ b/jekyll/_cci2/server/v4.5/operator/backup-and-restore.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Backup and restore
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This document outlines recommendations for how to back up and restore your CircleCI server instance data and state.
+:page-description: This document outlines recommendations for how to back up and restore your CircleCI server v4.5 instance data and state.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/operator/manage-virtual-machines-with-machine-provisioner.adoc
+++ b/jekyll/_cci2/server/v4.5/operator/manage-virtual-machines-with-machine-provisioner.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Manage virtual machines with machine provisioner
 :page-layout: classic-docs
 :page-liquid:
-:page-description: CircleCI server’s machine provisioner service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
+:page-description: CircleCI server v4.5’s machine provisioner service controls how machine executor (Linux and Windows images) and Remote Docker jobs are run.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/operator/managing-user-accounts.adoc
+++ b/jekyll/_cci2/server/v4.5/operator/managing-user-accounts.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Managing user accounts
 :page-layout: classic-docs
 :page-liquid:
-:page-description: This section provides information to help CircleCI server perators manage user accounts.
+:page-description: This section provides information to help CircleCI server v4.5 perators manage user accounts.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/operator/operator-overview.adoc
+++ b/jekyll/_cci2/server/v4.5/operator/operator-overview.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Operator overview
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server.
+:page-description: Learn about the various tasks and tools involved in administering an installation of CircleCI server v4.5.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/operator/upgrade-mongo.adoc
+++ b/jekyll/_cci2/server/v4.5/operator/upgrade-mongo.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Upgrade MongoDB
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn how to upgrade MongoDB up to v4.5.15 in an installation of CircleCI server v4.5.
+:page-description: Learn how to upgrade MongoDB up to v4.4.15 in an installation of CircleCI server v4.5.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/operator/upgrade-mongo.adoc
+++ b/jekyll/_cci2/server/v4.5/operator/upgrade-mongo.adoc
@@ -8,7 +8,7 @@ noindex: true
 = Upgrade MongoDB
 :page-layout: classic-docs
 :page-liquid:
-:page-description: Learn how to upgrade MongoDB up to v4.5.15 in an installation of CircleCI server.
+:page-description: Learn how to upgrade MongoDB up to v4.5.15 in an installation of CircleCI server v4.5.
 :icons: font
 :toc: macro
 :toc-title:

--- a/jekyll/_cci2/server/v4.5/operator/user-authentication.adoc
+++ b/jekyll/_cci2/server/v4.5/operator/user-authentication.adoc
@@ -8,7 +8,7 @@ noindex: true
 = User authentication
 :page-layout: classic-docs
 :page-liquid:
-:page-description: CircleCI server currently supports OAuth through GitHub or GitHub Enterprise.
+:page-description: CircleCI server v4.5 currently supports OAuth through GitHub or GitHub Enterprise.
 :icons: font
 :toc: macro
 :toc-title:


### PR DESCRIPTION
Added server versions to the titles that were missing them. I did a simple regex so it's _very_ likely I missed some.

These were the settings I had when I did the replace:
![image](https://github.com/user-attachments/assets/40563c79-fd17-46f9-a733-e12fbf0b073e)

I manually removed the duplicate version in the title from the post-installation docs and fixed the Mongo versions that were seemingly replaced by accident in 4.5/4.6 (which makes sense - I'm sure we just did a `sed 's|v4\.4|v4.5|g` and then 4.5->4.6 on them).