### PR TITLE
Only one workflow for setup config

### DIFF
--- a/jekyll/_cci2/dynamic-config.adoc
+++ b/jekyll/_cci2/dynamic-config.adoc
@@ -56,12 +56,12 @@ For some basic examples of using dynamic configuration, see the xref:using-dynam
 
 == Config continuation constraints
 
-Some constraints on continuing pipelines from a `setup` configuration are as follows:
+Some constraints on continuing pipelines from a `setup: true` configuration are as follows:
 
 - The `setup` configuration must be `version: 2.1`.
-- The `setup` configuration must only allow one continuation workflow to run in each pipeline. For example:
-** Have only one workflow that uses a call to the continuation API endpoint, either directly or using an orb.
-** Use logic conditions to ensure only one continuation is allowed at a time.
+- The `setup` configuration must only allow one workflow to run in each pipeline. For example:
+** Have only one workflow configured.
+** Use logic conditions to ensure only one is allowed for each pipeline.
 - A pipeline can only be continued once. A pipeline cannot be continued with another setup configuration. Workflow reruns will fail as part of this restriction. Rather than rerun a setup workflow you can trigger a new pipeline.
 - A pipeline can only be continued within six hours of its creation.
 - Pipeline parameters submitted at continuation time cannot overlap with pipeline parameters submitted at trigger (setup) time.


### PR DESCRIPTION
# Description
Simplify language. In last round of updates I mistakenly thought multiple workflows were allowed if only one was a continuation workflow. This isn't the case. Only one workflow is allowed.

# Reasons
Correction

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
