### PR TITLE
Add note about naming files in parallel jobs

### DIFF
--- a/jekyll/_cci2/workspaces.adoc
+++ b/jekyll/_cci2/workspaces.adoc
@@ -34,6 +34,7 @@ Some notes about workspaces:
 * When attaching a workspace the "layer" from each upstream job is applied in the order the upstream jobs appear in the workflow graph. When two jobs run concurrently, the order in which their layers are applied is undefined.
 * If multiple concurrent jobs persist the same filename, then attaching the workspace will error.
 * If a workflow is re-run, it inherits the same workspace as the original workflow. When re-running failed jobs, only the re-run jobs will see the same workspace content as the jobs in the original workflow.
+* Workspaces don't fully work with parallelism, as environment variables like `$CIRCLE_NODE_INDEX` are not available in the `persist_to_workspace` step. Therefore, it's not possible to save files with non-conflicting names from the multiple parallel runs of the job.
 
 By default, on CircleCI cloud, workspace storage duration is set to 15 days. This can be customized on the link:https://app.circleci.com/[CircleCI web app] by navigating to menu:Plan[Usage Controls]. Currently, 15 days is also the maximum storage duration you can set.
 


### PR DESCRIPTION
# Description
Added a note about naming files in `persist_to_workspace` during parallel jobs - names are fixed, you cannot use parallelism environment variables to make the names of files unique and identifiable. 
Proven by this error message:
```
Error locating workspace root directory: stat /tmp/deploy_logs_$CIRCLE_NODE_INDEX: no such file or directory"
```

# Reasons
This behavior is not explained, so one has to figure it out by trial and error. 

Furthermore, there does not seem to be a way to achieve the goal at all - save files from multiple parallel runs of a job, and give them unique names that don't conflict with each other). 

Furthermore, the error message could be improved to help figure out the problem. Currently it says `The specified paths did not match any files in /tmp/deploy_logs` - it doesn't mention what paths were used: was it resolved to `deploy_logs_0` or is it literally `deploy_logs_$CIRCLE_NODE_INDEX`

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
