### PR TITLE
Update secrets-masking.md

### DIFF
--- a/jekyll/_includes/snippets/secrets-masking.md
+++ b/jekyll/_includes/snippets/secrets-masking.md
@@ -13,5 +13,5 @@ The value of the environment variable or context will _not_ be masked in the job
 Secrets masking will only prevent values from appearing in your job output. Invoking a bash shell with the `-x` or `-o xtrace` options may inadvertently log unmasked secrets (please refer to [Using shell scripts]({{site.baseurl}}/using-shell-scripts)). If your secrets appear elsewhere, such as test results or artifacts, they will not be masked. Additionally, values are still accessible to users [debugging builds with SSH]({{site.baseurl}}/ssh-access-jobs).
 {: class="alert alert-warning"}
 
-The secrets masking feature exists as a preventative measure to catch unintentional display of secrets at the output. Best practice is to avoid printing secrets to the output. The are many ways that secrets masking could be bypassed, either accidentally or maliciously. For example, any process that reformats the output of a command or script could remove secrets masking.
+The secrets masking feature exists as a preventative measure to catch unintentional display of secrets at the output. Best practice is to avoid printing secrets to the output. There are many ways that secrets masking could be bypassed, either accidentally or maliciously. For example, any process that reformats the output of a command or script could remove secrets masking.
 {: class="alert alert-warning"}


### PR DESCRIPTION
fixed typo "the are" to "there are"

# Description
fixed typo "the are" to "there are"

# Reasons
Just saw a typo so I fixed it :) 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ x] Break up walls of text by adding paragraph breaks.
- [ x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ x] Keep the title between 20 and 70 characters.
- [x ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x ] Include relevant backlinks to other CircleCI docs/pages.
