### PR TITLE
Replace "workflow map" with "workflow graph"

### DIFF
--- a/jekyll/_cci2/sample-config.md
+++ b/jekyll/_cci2/sample-config.md
@@ -167,7 +167,7 @@ An approval job can have any name. In the example above the approval job is name
 
 The image below shows the workflow view for the following configuration example. This image has three parts to show:
 
-* The workflow map with the `hold` job paused
+* The workflow graph with the `hold` job paused
 * The "Needs Approval" popup that appears when you click on a hold job
 * The workflow view again once the `hold` job has been approved and the `deploy` job has run
 

--- a/jekyll/_cci2/workflows.adoc
+++ b/jekyll/_cci2/workflows.adoc
@@ -172,9 +172,9 @@ The following screenshot demonstrates:
 
 * A workflow that needs approval.
 * The approval popup.
-* The workflow map after approval.
+* The workflow graph after approval.
 
-image::/docs/assets/img/docs/approval-workflow-map.png[A three section image showing workflow map with "Needs approval" job, the approval popup, and the workflow map]
+image::/docs/assets/img/docs/approval-workflow-map.png[A three section image showing workflow graph with "Needs approval" job, the approval popup, and the workflow graph]
 
 By clicking on the `approval` job's name (`hold`, in the screenshot above), an approval dialog box appears. You can approve, cancel, or close the popup without approving.
 


### PR DESCRIPTION
# Description
_A brief description of the changes._

Replace some references to "workflow map" with the proper term.
# Reasons
_A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes._

Our documentation refers mostly to "workflow graph", which is the proper terminology. We should consolidate on that.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.