### PR TITLE
docs: test llm lock to version 1 evals orb

### DIFF
--- a/jekyll/_cci2/testing-llm-enabled-applications-through-evaluations.adoc
+++ b/jekyll/_cci2/testing-llm-enabled-applications-through-evaluations.adoc
@@ -13,6 +13,11 @@ contentTags:
 
 This page describes common methods for testing applications powered by large language models (LLMs) through evaluations.
 
+[NOTE]
+====
+This documentation is only applicable for link:https://circleci.com/developer/orbs/orb/circleci/evals?version=1.0.8[CircleCI Evals Orb versions 1.x.x].
+====
+
 == Evaluations overview
 
 Evaluations, also known as evals, are a methodology for assessing the quality of AI software.

--- a/jekyll/_cci2/testing-llm-enabled-applications-through-evaluations.adoc
+++ b/jekyll/_cci2/testing-llm-enabled-applications-through-evaluations.adoc
@@ -46,7 +46,7 @@ Evaluations can cover many aspects of a model performance, including:
 
 Evaluations can be expressed as classic software tests, typically characterised by the "input, expected output, assertion" format, and as such they can be automated into CircleCI pipelines.
 
-There is two important differences between evals and classic software tests to keep in mind:
+Two important differences between evals and classic software tests to keep in mind:
 
 * LLMs are predominantly non-deterministic, leading to flaky evaluations, unlike deterministic software tests.
 * Evaluation results are subjective. Small regressions in a metric might not necessarily be a cause for concern, unlike failing tests in regular software testing.

--- a/jekyll/_cci2/testing-llm-enabled-applications-through-evaluations.adoc
+++ b/jekyll/_cci2/testing-llm-enabled-applications-through-evaluations.adoc
@@ -46,7 +46,7 @@ Evaluations can cover many aspects of a model performance, including:
 
 Evaluations can be expressed as classic software tests, typically characterised by the "input, expected output, assertion" format, and as such they can be automated into CircleCI pipelines.
 
-There are two important differences between evals and classic software tests to keep in mind:
+There is two important differences between evals and classic software tests to keep in mind:
 
 * LLMs are predominantly non-deterministic, leading to flaky evaluations, unlike deterministic software tests.
 * Evaluation results are subjective. Small regressions in a metric might not necessarily be a cause for concern, unlike failing tests in regular software testing.
@@ -70,7 +70,7 @@ Given the volatile nature of evaluations, evaluations orchestrated by the Circle
 
 Instead, a summary of the evaluation results is created and presented:
 
-* As a comment on the corresponding GitHub pull request (currently available only for projects integrated with xref:github-integration#[Github OAuth]):
+* As a comment on the corresponding GitHub pull request (currently available only for projects integrated with xref:github-integration#[GitHub OAuth]):
 +
 image::/docs/assets/img/docs/llmops/github-pr-comment.png[Jobs overview]
 


### PR DESCRIPTION
# Description
On Testing LLM docs, display a banner to notify the reader the documenation is only applicable for orb versions 1.x.x.

# Reasons
We are releasing orb version 2.0 and these docs only work for 1.x.x versions. We will be adding more docs at a later point in time. Till than this note will be kept.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
