### PR TITLE
Update macos-resource-table.adoc

### DIFF
--- a/jekyll/_includes/snippets/macos-resource-table.adoc
+++ b/jekyll/_includes/snippets/macos-resource-table.adoc
@@ -14,14 +14,12 @@
 | 12GB
 | icon:check[]
 | icon:times[]
-|
 
 | `m2pro.medium`
 | 4 @ 3.49 GHz
 | 8GB
 | icon:check[]
 | icon:times[]
-|
 
 | `m2pro.large`
 | 4 @ 3.49 GHz


### PR DESCRIPTION
# Description
Fix table formatting for macOS resource class reference

# Reasons
There's a couple of accidental extra rows in the table which are messing up formatting.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
