### PR TITLE
Remove old deployment trigger annotation references

### DIFF
--- a/jekyll/_cci2/release/configure-your-kubernetes-components.adoc
+++ b/jekyll/_cci2/release/configure-your-kubernetes-components.adoc
@@ -266,9 +266,6 @@ metadata:
     circleci.com/helm-revision-number: "1"
     circleci.com/job-number: "1"
     circleci.com/operation-timeout: 30m
-    circleci.com/pipeline-id: 88dfee99-0348-407f-b113-dbf270cad093
-    circleci.com/project-id: 9da0c100-3295-49a4-827f-7892f3e8dc83
-    circleci.com/workflow-id: 5b8c4de8-fd5f-4be2-80a4-3d0c03fc138c
   labels:
     circleci.com/component-name: example-deployment
     circleci.com/version: 1.0.0

--- a/jekyll/_cci2/release/releases-overview.adoc
+++ b/jekyll/_cci2/release/releases-overview.adoc
@@ -206,21 +206,6 @@ The following table shows a complete list of labels and annotations either requi
 | Yes
 
 |`Metadata.Annotations`
-|`circleci.com/job-number`
-|`CIRCLE_BUILD_NUM` xref:../variables#built-in-environment-variables[environment variable]
-| No. Used to enable linking between deploy job and release
-
-|`Metadata.Annotations`
-|`circleci.com/pipeline-id`
-|`pipeline.id` xref:../variables#pipeline-values[pipeline value]
-| No. Used to enable linking between deploy job and release
-
-|`Metadata.Annotations`
-|`circleci.com/workflow-id`
-|`CIRCLE_WORKFLOW_ID` xref:../variables#built-in-environment-variables[environment variable]
-| No. Used to enable linking between deploy job and release
-
-|`Metadata.Annotations`
 |`circleci.com/project-id`
 |Project ID for the CircleCI project associated with the job that deploys your component
 |Yes


### PR DESCRIPTION
# Description
Release jobs is now the recommended approach for linking CI workflows to releases, rather than using kubernetes annotations.

# Reasons
We are removing references to the old annotations to avoid confusion.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
