### PR TITLE
remove erroneous resource class token usage

### DIFF
--- a/jekyll/_cci2/runner-api.adoc
+++ b/jekyll/_cci2/runner-api.adoc
@@ -45,7 +45,7 @@ Ring-session sent through a cookie on the request. This authentication allows us
 [#resource-class-authentication-token]
 === Resource class token authentication
 
-This token is generated when creating a new resource class. This token is only displayed once when creating a resource class, and cannot be retrieved again.
+This token is generated when creating a new resource class. This token is only displayed once when creating a resource class, and cannot be retrieved again. This token is used exclusively by the self-hosted runner agents for claiming tasks.
 
 [#supported-methods]
 ==== Supported methods
@@ -74,7 +74,6 @@ Lists the available self-hosted runners based on the specified parameters. It is
 * Circle-Token (personal authentication)
 * Browser session authentication
 ** This allows the endpoint to be accessible on circleci.com/api/v3/runner for users that have already logged into circleci.com
-* Resource class token (generated when creating a resource class)
 
 [#get-api-v3-runner-request]
 ===== Request


### PR DESCRIPTION
# Description

* Remove a point that noted the resource class token could be used for authentication where it could not be. 
* Clarified the limitations of the resource class token

# Reasons
Customer reached out to CircleCI to note some confusion in the runner API docs about resource class token usage

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
