### PR TITLE
Update Docker x86 to link to pricing page

### DIFF
--- a/jekyll/_includes/snippets/docker-resource-table.adoc
+++ b/jekyll/_includes/snippets/docker-resource-table.adoc
@@ -1,4 +1,4 @@
-NOTE: For credit and access information, see the link:https://circleci.com/pricing/[pricing page]. Resource class access is dependent on your xref:plan-overview#[Plan].
+NOTE: For credit and access information, see the link:https://circleci.com/product/features/resource-classes/[Resource classes page]. Resource class access is dependent on your xref:plan-overview#[Plan].
 
 [.table.table-striped]
 [cols=5*, options="header", stripes=even]


### PR DESCRIPTION
# Description
Updating the snippet in the x86 Docker page to link you to the pricing page like ARM.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
