### PR TITLE
update cci server version to match the documented version

### DIFF
--- a/jekyll/_cci2/server/v4.6/installation/phase-1-prerequisites.adoc
+++ b/jekyll/_cci2/server/v4.6/installation/phase-1-prerequisites.adoc
@@ -141,7 +141,7 @@ The application uses a large number of resources. Depending on your usage, your 
 | CircleCI Version
 | Kubernetes Version
 
-| 4.5.x
+| 4.6.x
 | 1.26 - 1.29
 |===
 

--- a/jekyll/_includes/server/latest/installation/phase-1.adoc
+++ b/jekyll/_includes/server/latest/installation/phase-1.adoc
@@ -126,7 +126,7 @@ The application uses a large number of resources. Depending on your usage, your 
 | CircleCI Version
 | Kubernetes Version
 
-| 4.5.x
+| 4.7.x
 | 1.26 - 1.29
 |===
 


### PR DESCRIPTION
# Description
CircleCI Server 4.7 and 4.6 were documented as being 4.5.x

# Reasons
Made this change so that customer wouldn't be confused and also matching with the right document version.

https://circleci.com/docs/server/latest/installation/phase-1-aws-prerequisites/#supported-kubernetes-versions
<img width="1291" alt="Screenshot 2024-11-11 at 9 29 12" src="https://github.com/user-attachments/assets/d2ee0cb7-7236-4cee-81e7-13c7e3c91a75">

https://circleci.com/docs/server/v4.6/installation/phase-1-prerequisites/#supported-kubernetes-versions
<img width="1294" alt="Screenshot 2024-11-11 at 9 28 49" src="https://github.com/user-attachments/assets/6bef364d-6f74-42bf-8f57-0918db87d7cb">


# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
