### PR TITLE
Update when always to when true

### DIFF
--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -1530,7 +1530,7 @@ NOTE: the `run` step replaces the deprecated `deploy` step. If your job has a pa
 | `when`
 | N
 | String
-| <<the-when-attribute,Specify when to enable or disable the step>>. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)
+| <<the-when-attribute,Specify when to enable or disable the step>>. Takes the following values: `true`, `on_success`, `on_fail` (default: `on_success`)
 |===
 
 Each `run` declaration represents a new shell. It is possible to specify a multi-line `command`, each line of which will be run in the same shell:
@@ -1654,7 +1654,7 @@ Adding the `when` attribute to a job step allows you to override this default be
 
 The default value of `on_success` means that the step will run only if all of the previous steps have been successful (returned exit code 0).
 
-A value of `always` means that the step will run regardless of the exit status of previous steps. This is useful if you have a task that you want to run regardless of whether the previous steps are successful or not. For example, you might have a job step that needs to upload logs or code-coverage data somewhere.
+A value of `true` means that the step will run regardless of the exit status of previous steps. This is useful if you have a task that you want to run regardless of whether the previous steps are successful or not. For example, you might have a job step that needs to upload logs or code-coverage data somewhere.
 
 A value of `on_fail` means that the step will run only if one of the preceding steps has failed (returns a non-zero exit code). It is common to use `on_fail` if you want to store some diagnostic data to help debug test failures, or to run custom notifications about the failure, such as sending emails or triggering alerts.
 
@@ -1665,7 +1665,7 @@ NOTE: Some steps, such as `store_artifacts` and `store_test_results` will always
 - run:
     name: Upload CodeCov.io Data
     command: bash <(curl -s https://codecov.io/bash) -F unittests
-    when: always # Uploads code coverage results, pass or fail
+    when: true # Uploads code coverage results, pass or fail
 ----
 
 '''
@@ -1872,7 +1872,7 @@ Cache retention can be customized on the link:https://app.circleci.com/[CircleCI
 | `when`
 | N
 | String
-| <<the-when-attribute,Specify when to enable or disable the step>>. Takes the following values: `always`, `on_success`, `on_fail` (default: `on_success`)
+| <<the-when-attribute,Specify when to enable or disable the step>>. Takes the following values: `true`, `on_success`, `on_fail` (default: `on_success`)
 |===
 
 The cache for a specific `key` is immutable and cannot be changed once written.


### PR DESCRIPTION
Based on the incoming change to when condition, this updates `when: always` references in `configuration-reference` to `when: true`.

# Description
Based on the incoming change to when condition, this updates `when: always` references in `configuration-reference` to `when: true`.

# Reasons
Internal customer feedback.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
