### PR TITLE
[PIPE-4937] update requires docs to allow dependency on different statuses

### DIFF
--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -2629,22 +2629,13 @@ Jobs are run concurrently by default, so you must explicitly require any depende
 | N
 | List
 | A list of jobs that must succeed or attain a specified status for the job to start. Note: When jobs in the current workflow that are listed as dependencies are not executed (due to a filter function for example), their requirement as a dependency for other jobs will be ignored by the requires option. However, if all dependencies of a job are filtered, then that job will not be executed either.
-|===
 
-[.table.table-striped]
-[cols=3*, options="header", stripes=even]
-|===
-| Key | Type | Description
+ Possible values:
+ - Job name (a required job that must succeed for the job to start)
+ - Map of job name to status (a required job that must attain the specified status for the job to start)
+ - Map of job name to a list of statuses (a required job that must attain one of the specified status for the job to start)
 
-| `job_name`
-| Job Name
-| A required job that must `succeed` for the job to start.
-
-| `job_name`
-| Map
-| A map of job name to a status or list of statuses.
-
-  The job starts if the required dependency reaches one of the statuses. The possible status values are: `success`, `failed` and `canceled`.  
+ The possible status values are: `success`, `failed` and `canceled`.
 |===
 
 [,yml]

--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -2628,14 +2628,14 @@ Jobs are run concurrently by default, so you must explicitly require any depende
 | `requires`
 | N
 | List
-| A list of jobs that must succeed or attain a specified status for the job to start. Note: When jobs in the current workflow that are listed as dependencies are not executed (due to a filter function for example), their requirement as a dependency for other jobs will be ignored by the requires option. However, if all dependencies of a job are filtered, then that job will not be executed either.
+| A list of jobs that must succeed or attain a specified status for the job to start. *Note*: When jobs in the current workflow that are listed as dependencies are not executed (due to a filter function for example), their requirement as a dependency for other jobs will be ignored by the requires option. However, if all dependencies of a job are filtered, then that job will not be executed either.
 
- Possible values:
- - Job name (a required job that must succeed for the job to start)
- - Map of job name to status (a required job that must attain the specified status for the job to start)
- - Map of job name to a list of statuses (a required job that must attain one of the specified status for the job to start)
+ Possible types of `requires` items: + 
+ * Job name (a required job that must succeed for the job to start) +           
+ * Map of job name to status (a required job that must attain the specified status for the job to start) + 
+ * Map of job name to a list of statuses (a required job that must attain one of the specified status for the job to start)
 
- The possible status values are: `success`, `failed` and `canceled`.
+ The possible *status* values are: `success`, `failed` and `canceled`.
 |===
 
 [,yml]

--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -2628,8 +2628,48 @@ Jobs are run concurrently by default, so you must explicitly require any depende
 | `requires`
 | N
 | List
-| A list of jobs that must succeed for the job to start. Note: When jobs in the current workflow that are listed as dependencies are not executed (due to a filter function for example), their requirement as a dependency for other jobs will be ignored by the requires option. However, if all dependencies of a job are filtered, then that job will not be executed either.
+| A list of jobs that must succeed or attain a specified status for the job to start. Note: When jobs in the current workflow that are listed as dependencies are not executed (due to a filter function for example), their requirement as a dependency for other jobs will be ignored by the requires option. However, if all dependencies of a job are filtered, then that job will not be executed either.
 |===
+
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
+|===
+| Key | Type | Description
+
+| `job_name`
+| Job Name
+| A required job that must `succeed` for the job to start.
+
+| `job_name`
+| Map
+| A map of job name to a status or list of statuses.
+
+  The job starts if the required dependency reaches one of the statuses. The possible status values are: `success`, `failed` and `canceled`.  
+|===
+
+[,yml]
+----
+workflows:
+  my-workflow:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - deploy:
+          requires:
+            - build
+            - test
+     - notify-build-canceled:
+          requires:
+            - build: canceled
+      - cleanup:
+          requires:
+            - deploy:
+              - failed
+              - canceled
+      
+----
 
 '''
 

--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -2628,14 +2628,15 @@ Jobs are run concurrently by default, so you must explicitly require any depende
 | `requires`
 | N
 | List
-| A list of jobs that must succeed or attain a specified status for the job to start. *Note*: When jobs in the current workflow that are listed as dependencies are not executed (due to a filter function for example), their requirement as a dependency for other jobs will be ignored by the requires option. However, if all dependencies of a job are filtered, then that job will not be executed either.
+a| A list of jobs that must succeed or attain a specified status for the job to start. *Note*: When jobs in the current workflow that are listed as dependencies are not executed (due to a filter function for example), their requirement as a dependency for other jobs will be ignored by the requires option. However, if all dependencies of a job are filtered, then that job will not be executed either.
 
- Possible types of `requires` items: + 
- * Job name (a required job that must succeed for the job to start) +           
- * Map of job name to status (a required job that must attain the specified status for the job to start) + 
- * Map of job name to a list of statuses (a required job that must attain one of the specified status for the job to start)
+Possible types of `requires` items:
 
- The possible *status* values are: `success`, `failed` and `canceled`.
+* Job name (a required job that must succeed for the job to start) +
+* Map of job name to status (a required job that must attain the specified status for the job to start) +
+* Map of job name to a list of statuses (a required job that must attain one of the specified status for the job to start)
+
+The possible *status* values are: `success`, `failed` and `canceled`.
 |===
 
 [,yml]
@@ -2659,7 +2660,7 @@ workflows:
             - deploy:
               - failed
               - canceled
-      
+
 ----
 
 '''


### PR DESCRIPTION
# Description
Update documentation of `requires` job field. 


# Reasons
[Ticket.](https://circleci.atlassian.net/browse/PIPE-4937)
The new functionality allows users to define what statuses the upstream job dependency should have for the dependent job to start running.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
