### PR TITLE
[PIPE-4937] add space to example of requires

### DIFF
--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -2652,7 +2652,7 @@ workflows:
           requires:
             - build
             - test
-     - notify-build-canceled:
+      - notify-build-canceled:
           requires:
             - build: canceled
       - cleanup:


### PR DESCRIPTION
# Description
Follow-up for https://github.com/circleci/circleci-docs/pull/9097.

# Reasons
[Ticket.](https://circleci.atlassian.net/browse/PIPE-4937)
Fixes spacing in the config example

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
