### PR TITLE
Removes reference to multiple instances on one machine.

### DIFF
--- a/jekyll/_cci2/runner-config-reference.adoc
+++ b/jekyll/_cci2/runner-config-reference.adoc
@@ -108,7 +108,7 @@ runner:
 === `runner.working_directory`
 `$LAUNCH_AGENT_RUNNER_WORK_DIR`
 
-This directory takes a fully qualified path and allows you to control the default working directory used by each job. If the directory already exists, the task-agent will need permissions to write to the directory. If the directory does not exist, then the task-agent will need permissions to create the directory. If installing multiple launch-agents on the same machine, each launch-agent will need a unique working directory.
+This directory takes a fully qualified path and allows you to control the default working directory used by each job. If the directory already exists, the task-agent will need permissions to write to the directory. If the directory does not exist, then the task-agent will need permissions to create the directory.
 
 NOTE: These directories will not automatically be removed, see `cleanup_working_directory` to configure cleanup of directory.
 


### PR DESCRIPTION
Only one instance per environment is supported.

# Description
Removes reference to multiple instances of Machine Runner on a single machine.

# Reasons
This is not officially supported.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
