### PR TITLE
Specifying appropriate executor name for `deploy` job

### DIFF
--- a/jekyll/_cci2/language-python.md
+++ b/jekyll/_cci2/language-python.md
@@ -171,7 +171,7 @@ jobs:
             - .
 
   deploy: # this can be any name you choose
-    executor: python/default
+    executor: heroku/default
     steps:
       - attach_workspace:
           at: ~/project


### PR DESCRIPTION
# Description
Replacing the executor name `python/default` with `heroku/default`, in the [Full configuration file](https://circleci.com/docs/language-python/#full-configuration-file-new) example of the "Configure a Python application on CircleCI" tutorial.

# Reasons
The executor currently specified isn't the appropriate one.
- https://discuss.circleci.com/t/typo-in-configure-a-python-application-on-circleci-tutorial/52464
- https://circleci.atlassian.net/browse/DOCSS-1663