### PR TITLE
Machine Runner support for Apple Silicon

### DIFF
--- a/jekyll/_cci2/runner-overview.adoc
+++ b/jekyll/_cci2/runner-overview.adoc
@@ -127,7 +127,7 @@ Using a supported platform, you get the following:
 
 **Machine runners:**
 
-* macOS X 11.2+ (Intel, Apple M1)
+* macOS X 11.2+ (Intel, Apple silicon)
 * Windows Server 2019, 2016 (x86_64)
 * Linux distributions - RHEL8, SUSE, Debian, etc (x86_64, ARM64, s390x, ppc64le)
 


### PR DESCRIPTION
Updates support wording from M1 to Apple Silicon for clarity that we support M2, M3, M4, etc.

# Description
Clarifies support for Apple Silicon for Machine Runner (rather than only M1).

# Reasons
Support ticket where customer was querying this:
https://circleci.zendesk.com/agent/tickets/157982

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
