### PR TITLE
Add note RE runner users need to enable ssh rerun feature

### DIFF
--- a/jekyll/_cci2/ssh-access-jobs.adoc
+++ b/jekyll/_cci2/ssh-access-jobs.adoc
@@ -27,6 +27,8 @@ Note that a _default_ CircleCI pipeline executes steps in a non-interactive shel
 
 NOTE: The steps described in this section apply to all CircleCI accounts. If you are using Bitbucket Cloud, or your account is integrated through the GitHub OAuth app, you can add an SSH key to your VCS account (https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/[GitHub] or https://confluence.atlassian.com/bitbucket/set-up-an-ssh-key-728138079.html[Bitbucket]) rather than in the CircleCI app under https://app.circleci.com/settings/user/job-ssh-keys[User Settings] if you prefer.
 
+NOTE: **Using self-hosted runners?** To use SSH reruns with CircleCI runners you will first need to enable the SSH rerun feature. Refer to the xref:machine-runner-3-configuration-reference#runner-ssh-advertise-addr[Machine runner 3.0] or xref:container-runner-installation#enable-rerun-job-with-ssh[Container runner] pages for steps.
+
 . If you have not already done so, add an SSH key to your link:https://app.circleci.com/settings/user/job-ssh-keys[User Settings]. This key will be used to connect to container or VM that is running your job.
 
 . Navigate to the job view for the job you want to rerun.


### PR DESCRIPTION
# Description
Adds a note to the Debug with SSH page to direct runner users to head to the runner docs for steps to enable the feature

# Reasons
Improved xrefs, get people to the steps they need

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
