### PR TITLE
update dev orb info

### DIFF
--- a/jekyll/_cci2/orb-concepts.md
+++ b/jekyll/_cci2/orb-concepts.md
@@ -213,10 +213,10 @@ Production orbs are immutable and can be found on the [Orb Registry](https://cir
 
 Development orbs are temporary overwrite-able orb tag versions, useful for rapid development and testing prior to deploying a semver deployed production change.
 
+- A Development orb can only be published if the orb has an initial semver deployed production version
 - Development orbs are mutable, can be overwritten, and automatically expire 90 days after they are published
 - Version string must begin with `dev:` followed by any string, for example, `<namespace>/<orb>@dev:my-feature-branch`
 - Development orbs may be published by any member of the namespace organization
-- Will not appear on the Orb Registry
 - Open source, released under [MIT license](https://circleci.com/developer/orbs/licensing).
 - Available via CircleCI CLI (if the development tag name is known)
 


### PR DESCRIPTION
# Description
Updating the description of Development orbs to accurately reflect the process.

# Reasons
Currently the docs state that Development orbs do not appear in the registry but that is not true.

Development orbs do appear in the registry but do not properly publish unless the orb has had a production version published initially. The orb-tools workflow [includes a link to the Registry page](https://circleci.com/developer/orbs/orb/circleci/orb-tools#jobs-publish) when an creating a Development orb.

The CLI output bug [has been logged](https://circleci.atlassian.net/browse/LIFE-1124)

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
