### PR TITLE
ruby: Update dependency rugged to version 1.6.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ group :jekyll_plugins do
 end
 
 group :test, :development do
+  # Remove when https://github.com/prontolabs/pronto/issues/447 is fixed.
+  gem 'rugged', '1.6.3'
   gem 'pronto'
   gem 'pronto-markdownlint'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     rouge (3.30.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    rugged (1.0.1)
+    rugged (1.6.3)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -206,6 +206,7 @@ DEPENDENCIES
   pronto
   pronto-markdownlint
   rake
+  rugged (= 1.6.3)
 
 RUBY VERSION
    ruby 3.1.3p185


### PR DESCRIPTION
# Description

Running `bundle install` on my machine fails because there is compilation error for rugged. Details collapsed below:

<details>
  <summary>Rugged compilation output</summary>
  <pre>
current directory: /Users/Marcos/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rugged-1.0.1/ext/rugged
/Users/Marcos/.rbenv/versions/3.1.3/bin/ruby -I /Users/Marcos/.rbenv/versions/3.1.3/lib/ruby/3.1.0 extconf.rb
checking for gmake... no
checking for make... yes
checking for cmake... yes
checking for pkg-config... yes
CMake Warning (dev) at CMakeLists.txt:14 (PROJECT):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- The C compiler identification is AppleClang 15.0.0.15000309
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Deprecation Warning at CMakeLists.txt:15 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Found PkgConfig: /opt/homebrew/bin/pkg-config (found version "2.3.0")
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Performing Test HAVE_STRUCT_STAT_ST_MTIM
-- Performing Test HAVE_STRUCT_STAT_ST_MTIM - Failed
-- Performing Test HAVE_STRUCT_STAT_ST_MTIMESPEC
-- Performing Test HAVE_STRUCT_STAT_ST_MTIMESPEC - Success
-- Performing Test HAVE_STRUCT_STAT_MTIME_NSEC
-- Performing Test HAVE_STRUCT_STAT_MTIME_NSEC - Failed
-- Performing Test HAVE_STRUCT_STAT_NSEC
-- Performing Test HAVE_STRUCT_STAT_NSEC - Success
-- Performing Test IS_WALL_SUPPORTED
-- Performing Test IS_WALL_SUPPORTED - Success
-- Performing Test IS_WEXTRA_SUPPORTED
-- Performing Test IS_WEXTRA_SUPPORTED - Success
-- Performing Test IS_WDOCUMENTATION_SUPPORTED
-- Performing Test IS_WDOCUMENTATION_SUPPORTED - Success
-- Performing Test IS_WNO_MISSING_FIELD_INITIALIZERS_SUPPORTED
-- Performing Test IS_WNO_MISSING_FIELD_INITIALIZERS_SUPPORTED - Success
-- Performing Test IS_WSTRICT_ALIASING_SUPPORTED
-- Performing Test IS_WSTRICT_ALIASING_SUPPORTED - Success
-- Performing Test IS_WSTRICT_PROTOTYPES_SUPPORTED
-- Performing Test IS_WSTRICT_PROTOTYPES_SUPPORTED - Success
-- Performing Test IS_WDECLARATION_AFTER_STATEMENT_SUPPORTED
-- Performing Test IS_WDECLARATION_AFTER_STATEMENT_SUPPORTED - Success
-- Performing Test IS_WSHIFT_COUNT_OVERFLOW_SUPPORTED
-- Performing Test IS_WSHIFT_COUNT_OVERFLOW_SUPPORTED - Success
-- Performing Test IS_WUNUSED_CONST_VARIABLE_SUPPORTED
-- Performing Test IS_WUNUSED_CONST_VARIABLE_SUPPORTED - Success
-- Performing Test IS_WUNUSED_FUNCTION_SUPPORTED
-- Performing Test IS_WUNUSED_FUNCTION_SUPPORTED - Success
-- Performing Test IS_WINT_CONVERSION_SUPPORTED
-- Performing Test IS_WINT_CONVERSION_SUPPORTED - Success
-- Performing Test IS_WFORMAT_SUPPORTED
-- Performing Test IS_WFORMAT_SUPPORTED - Success
-- Performing Test IS_WFORMAT_SECURITY_SUPPORTED
-- Performing Test IS_WFORMAT_SECURITY_SUPPORTED - Success
-- Performing Test IS_WNO_DOCUMENTATION_DEPRECATED_SYNC_SUPPORTED
-- Performing Test IS_WNO_DOCUMENTATION_DEPRECATED_SYNC_SUPPORTED - Success
-- Looking for futimens
-- Looking for futimens - found
-- Checking prototype qsort_r for HAVE_QSORT_R_BSD - True
-- Checking prototype qsort_r for HAVE_QSORT_R_GNU - False
-- Looking for qsort_s
-- Looking for qsort_s - not found
-- Looking for clock_gettime in rt
-- Looking for clock_gettime in rt - not found
-- Found OpenSSL: /opt/homebrew/Cellar/openssl@3/3.4.0/lib/libcrypto.dylib (found version "3.4.0")
-- Found Security /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/System/Library/Frameworks/Security.framework
-- Looking for SSLCreateContext in /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/System/Library/Frameworks/Security.framework
-- Looking for SSLCreateContext in /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/System/Library/Frameworks/Security.framework - found
-- Found CoreFoundation /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/System/Library/Frameworks/CoreFoundation.framework
-- Could NOT find PCRE (missing: PCRE_INCLUDE_DIR) 
-- Looking for dirent.h
-- Looking for dirent.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for inttypes.h
-- Looking for inttypes.h - found
-- Looking for sys/stat.h
-- Looking for sys/stat.h - found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Looking for windows.h
-- Looking for windows.h - not found
-- Looking for bcopy
-- Looking for bcopy - found
-- Looking for memmove
-- Looking for memmove - found
-- Looking for strerror
-- Looking for strerror - found
-- Looking for strtoll
-- Looking for strtoll - found
-- Looking for strtoq
-- Looking for strtoq - found
-- Looking for _strtoi64
-- Looking for _strtoi64 - not found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of long long
-- Check size of long long - done
-- Check size of unsigned long long
-- Check size of unsigned long long - done
-- Performing Test IS_WNO_UNUSED_FUNCTION_SUPPORTED
-- Performing Test IS_WNO_UNUSED_FUNCTION_SUPPORTED - Success
-- Performing Test IS_WNO_IMPLICIT_FALLTHROUGH_SUPPORTED
-- Performing Test IS_WNO_IMPLICIT_FALLTHROUGH_SUPPORTED - Success
-- http-parser version 2 was not found or disabled; using bundled 3rd-party sources.
-- Performing Test IS_WIMPLICIT_FALLTHROUGH_1_SUPPORTED
-- Performing Test IS_WIMPLICIT_FALLTHROUGH_1_SUPPORTED - Failed
-- Found ZLIB: /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/libz.tbd (found version "1.2.12")
-- Checking for module 'libssh2'
--   Found libssh2, version 1.11.1
--   Resolved libraries: /opt/homebrew/lib/libssh2.dylib
-- Looking for libssh2_userauth_publickey_frommemory in /opt/homebrew/lib/libssh2.dylib
-- Looking for libssh2_userauth_publickey_frommemory in /opt/homebrew/lib/libssh2.dylib - found
-- Checking for module 'heimdal-gssapi'
--   Package 'heimdal-gssapi' not found
-- Could NOT find GSSAPI (missing: GSSAPI_LIBRARIES) 
-- Found GSS.framework /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/System/Library/Frameworks/GSS.framework
-- Looking for iconv_open
-- Looking for iconv_open - not found
-- Found Iconv: -L/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib -liconv
-- Enabled features:
 * nanoseconds, whether to use sub-second file mtimes and ctimes
 * tracing, tracing support
 * threadsafe, threadsafe support
 * HTTPS, using SecureTransport
 * SHA, using CollisionDetection
 * regex, using bundled PCRE
 * http-parser, http-parser support (bundled)
 * zlib, using system zlib
 * SSH, SSH transport support
 * ntlmclient, NTLM authentication support for Unix
 * iconv, iconv encoding conversion support

-- Disabled features:
 * debugpool, debug pool allocator
 * SPNEGO, SPNEGO authentication support

-- Configuring done (8.7s)
-- Generating done (0.1s)
-- Build files have been written to: /Users/Marcos/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rugged-1.0.1/vendor/libgit2/build
 -- /usr/bin/make
checking for -lgit2... yes
checking for git2.h... yes
creating Makefile

current directory: /Users/Marcos/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rugged-1.0.1/ext/rugged
make DESTDIR\= sitearchdir\=./.gem.20241220-26548-t2qaxr sitelibdir\=./.gem.20241220-26548-t2qaxr clean

current directory: /Users/Marcos/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/rugged-1.0.1/ext/rugged
make DESTDIR\= sitearchdir\=./.gem.20241220-26548-t2qaxr sitelibdir\=./.gem.20241220-26548-t2qaxr
compiling rugged.c
rugged.c:296:2: warning: 'rb_iterate' is deprecated: by: rb_block_call since 1.9 [-Wdeprecated-declarations]
        rb_iterate(rb_each, rb_enum, &minimize_cb, (VALUE)shrt);
        ^
/Users/Marcos/.rbenv/versions/3.1.3/include/ruby-3.1.0/ruby/internal/iterator.h:269:1: note: 'rb_iterate' has been explicitly marked deprecated here
RBIMPL_ATTR_DEPRECATED(("by: rb_block_call since 1.9"))
^
/Users/Marcos/.rbenv/versions/3.1.3/include/ruby-3.1.0/ruby/internal/attr/deprecated.h:36:53: note: expanded from macro 'RBIMPL_ATTR_DEPRECATED'
# define RBIMPL_ATTR_DEPRECATED(msg) __attribute__((__deprecated__ msg))
                                                    ^
rugged.c:296:31: error: incompatible function pointer types passing 'VALUE (*)(VALUE, git_oid_shorten *)' (aka 'unsigned long (*)(unsigned long, struct git_oid_shorten *)') to parameter of type 'rb_block_call_func_t' (aka 'unsigned long (*)(unsigned long, unsigned long, int, const unsigned long *, unsigned long)') [-Wincompatible-function-pointer-types]
        rb_iterate(rb_each, rb_enum, &minimize_cb, (VALUE)shrt);
                                     ^~~~~~~~~~~~
/Users/Marcos/.rbenv/versions/3.1.3/include/ruby-3.1.0/ruby/internal/iterator.h:283:75: note: passing argument to parameter 'proc' here
VALUE rb_iterate(VALUE (*func1)(VALUE), VALUE data1, rb_block_call_func_t proc, VALUE data2);
                                                                          ^
rugged.c:308:3: warning: 'rb_iterate' is deprecated: by: rb_block_call since 1.9 [-Wdeprecated-declarations]
                rb_iterate(rb_each, rb_enum, &minimize_yield, (VALUE)yield_data);
                ^
/Users/Marcos/.rbenv/versions/3.1.3/include/ruby-3.1.0/ruby/internal/iterator.h:269:1: note: 'rb_iterate' has been explicitly marked deprecated here
RBIMPL_ATTR_DEPRECATED(("by: rb_block_call since 1.9"))
^
/Users/Marcos/.rbenv/versions/3.1.3/include/ruby-3.1.0/ruby/internal/attr/deprecated.h:36:53: note: expanded from macro 'RBIMPL_ATTR_DEPRECATED'
# define RBIMPL_ATTR_DEPRECATED(msg) __attribute__((__deprecated__ msg))
                                                    ^
rugged.c:308:32: error: incompatible function pointer types passing 'VALUE (*)(VALUE, VALUE *)' (aka 'unsigned long (*)(unsigned long, unsigned long *)') to parameter of type 'rb_block_call_func_t' (aka 'unsigned long (*)(unsigned long, unsigned long, int, const unsigned long *, unsigned long)') [-Wincompatible-function-pointer-types]
                rb_iterate(rb_each, rb_enum, &minimize_yield, (VALUE)yield_data);
                                             ^~~~~~~~~~~~~~~
/Users/Marcos/.rbenv/versions/3.1.3/include/ruby-3.1.0/ruby/internal/iterator.h:283:75: note: passing argument to parameter 'proc' here
VALUE rb_iterate(VALUE (*func1)(VALUE), VALUE data1, rb_block_call_func_t proc, VALUE data2);
                                                                          ^
2 warnings and 2 errors generated.
make: *** [rugged.o] Error 1

make failed, exit code 2
  </pre>
</details>

For reference, see https://github.com/prontolabs/pronto/issues/447.
