### PR TITLE
Remove base dir to lint files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,6 @@ workflows:
     jobs:
       - vale/lint:
           reference_branch: master
-          base_dir: /root/project/jekyll/_cci2
 
   build-deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ workflows:
     jobs:
       - vale/lint:
           reference_branch: master
-          base_dir: ~/project/jekyll/_cci2
+          base_dir: /root/project/jekyll/_cci2
 
   build-deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ workflows:
     jobs:
       - vale/lint:
           reference_branch: master
-          base_dir: ~/project/jekyll/_cci2/
+          base_dir: ~/project
 
   build-deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ workflows:
     jobs:
       - vale/lint:
           reference_branch: master
-          base_dir: ~/project
+          base_dir: ~/project/jekyll/_cci2
 
   build-deploy:
     when:

--- a/jekyll/_cci2/about-circleci.adoc
+++ b/jekyll/_cci2/about-circleci.adoc
@@ -47,7 +47,7 @@ CircleCI may be configured to deploy code to various environments, including (bu
 * Android
 * iOS
 
-The link:https://circleci.com/developer/orbs[orbs registry] contains packages of reusable configuration that can be used for common deployment targets. Orbs simplify and streamline your configuration.
+The link:https://circleci.com/developer/orbs[orbs registry] contains packages of reusable configuration for common deployment targets. Orbs simplify and streamline your configuration.
 
 Other cloud service deployments can be scripted using SSH, or by installing the API client of the service with your job configuration.
 


### PR DESCRIPTION
# Description
Base directory for linter is not working as expected so no files are currently being linted. Remove base dir until we work out a solution.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
