### PR TITLE
Clarifies that admin permissions are required to manage policies

### DIFF
--- a/jekyll/_cci2/config-policy-management-overview.adoc
+++ b/jekyll/_cci2/config-policy-management-overview.adoc
@@ -11,7 +11,7 @@ contentTags:
 :icons: font
 :experimental:
 
-NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI server v4.2.
+NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI server v4.2. You must be an organization admin in order to create and manage config policies.
 
 Use config policies to create organization-level policies to impose rules and scopes to govern which configuration elements are required, allowed, not allowed etc.
 

--- a/jekyll/_cci2/config-policy-reference.adoc
+++ b/jekyll/_cci2/config-policy-reference.adoc
@@ -11,7 +11,7 @@ contentTags:
 :icons: font
 :experimental:
 
-NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI server v4.2.
+NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI server v4.2. You must be an organization admin in order to create and manage config policies.
 
 This reference page lists a selection of _helpers_, or CircleCI-specific functions that are likely to be useful for you when you are writing your policies. These helpers will lead to _cleaner_ policies with less boilerplate.
 

--- a/jekyll/_cci2/create-and-manage-config-policies.adoc
+++ b/jekyll/_cci2/create-and-manage-config-policies.adoc
@@ -11,7 +11,7 @@ contentTags:
 :icons: font
 :experimental:
 
-NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI server v4.2.
+NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI server v4.2. You must be an organization admin in order to create and manage config policies.
 
 Follow the how-to guides on this page to manage, create, and use config policies.
 


### PR DESCRIPTION
Clarifies that users must be org admins to make changes to manage config policies

# Description
Adds a line clarifying that users must be org admins to manage config policies
Redo of #9125 

# Reasons
Previously, the only way users would know this is by trying and failing, or reading one of our blog posts.
This will reduce confusion about who can manage policies

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
