### PR TITLE
Update reusing-config.md

### DIFF
--- a/jekyll/_cci2/reusing-config.md
+++ b/jekyll/_cci2/reusing-config.md
@@ -140,8 +140,8 @@ commands:
 
 Boolean parameter evaluation is based on the [values specified in YAML 1.1](https://yaml.org/type/bool.html):
 
-* True: `y` `yes` `true` `on`
-* False: `n` `no` `false` `off`
+* True: `yes` `true` `on`
+* False: `no` `false` `off`
 
 Capitalized and uppercase versions of the above values are also valid.
 


### PR DESCRIPTION
`y` and `n` are not supported for boolean params. Updating config

# Description
A brief description of the changes.

Updated resuable config docs to remove `y` and `n` as supported boolen params. 

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
https://circleci.atlassian.net/browse/CIRCLE-34676

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
