### PR TITLE
Fix release marker typo

### DIFF
--- a/jekyll/_cci2/release/configure-release-markers.adoc
+++ b/jekyll/_cci2/release/configure-release-markers.adoc
@@ -32,7 +32,7 @@ Before adding a release marker step to your workflow, you will need to create a 
 
 == 2. Update configuration
 
-Next you will update your CircleCI configuration file. Add a `circleci run log release` command to your deployment job. This tells CircleCI to log the release marker in the Releases UI.
+Next you will update your CircleCI configuration file. Add a `circleci run release log` command to your deployment job. This tells CircleCI to log the release marker in the Releases UI.
 
 Add a `log release` step at the end of your _deployment_ job, for example:
 


### PR DESCRIPTION
# Description
Fix a typo in the release marker command.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
