### PR TITLE
[NOTIFY-94] Indicate difference between OAuth and App Checks naming

### DIFF
--- a/jekyll/_cci2/enable-checks.md
+++ b/jekyll/_cci2/enable-checks.md
@@ -32,7 +32,7 @@ GitHub Checks should not be confused with GitHub status updates:
 
 * GitHub Checks are administered from the GitHub UI, and are reported in the GitHub UI per _workflow_.
   * GitHub Checks from OAuth integrations have the same name as the workflow.
-  * GitHub Checks from GitHub App integrations names are a combination of workflow name and the pipeline definition ID to prevent naming collisions. The pipeline definition ID is available in **Project Settings** > **Pipelines** page in the CircleCI app.
+  * GitHub Checks from GitHub App integrations names are a combination of workflow name and the first eight characters of the pipeline definition ID. The identifier is used to prevent naming collisions. The pipeline definition ID is available in **Project Settings** > **Pipelines** page in the CircleCI app.
 * GitHub status updates are the default way status updates from your builds are reported in the GitHub UI, and they are reported per _job_.
 
 If both these features are enabled, in a GitHub PR view the Checks tab will show **workflow status** and the Checks section in the PR conversation view will show **job status**.

--- a/jekyll/_cci2/enable-checks.md
+++ b/jekyll/_cci2/enable-checks.md
@@ -31,6 +31,8 @@ GitHub does not currently provide a granular way for you to rerun workflows. Whe
 GitHub Checks should not be confused with GitHub status updates:
 
 * GitHub Checks are administered from the GitHub UI, and are reported in the GitHub UI per _workflow_.
+  * GitHub Checks from OAuth integrations have the same name as the workflow.
+  * GitHub Checks from GitHub App integrations names are a combination of workflow name and the pipeline definition ID to prevent naming collisions. The pipeline definition ID is available in **Project Settings** > **Pipelines** page in the CircleCI app.
 * GitHub status updates are the default way status updates from your builds are reported in the GitHub UI, and they are reported per _job_.
 
 If both these features are enabled, in a GitHub PR view the Checks tab will show **workflow status** and the Checks section in the PR conversation view will show **job status**.

--- a/jekyll/_cci2/enable-checks.md
+++ b/jekyll/_cci2/enable-checks.md
@@ -31,8 +31,8 @@ GitHub does not currently provide a granular way for you to rerun workflows. Whe
 GitHub Checks should not be confused with GitHub status updates:
 
 * GitHub Checks are administered from the GitHub UI, and are reported in the GitHub UI per _workflow_.
-  * GitHub Checks from OAuth integrations have the same name as the workflow.
-  * GitHub Checks from GitHub App integrations names are a combination of workflow name and the first eight characters of the pipeline definition ID. The identifier is used to prevent naming collisions. The pipeline definition ID is available in **Project Settings** > **Pipelines** page in the CircleCI app.
+  * GitHub Checks from OAuth integrations have the same name as the associated workflow.
+  * GitHub Checks from GitHub App integrations are named using a combination of the workflow name and the first eight characters of the pipeline definition ID. The identifier is used to prevent naming collisions. The pipeline definition ID is available in the **Project Settings** > **Pipelines** page in the CircleCI web app.
 * GitHub status updates are the default way status updates from your builds are reported in the GitHub UI, and they are reported per _job_.
 
 If both these features are enabled, in a GitHub PR view the Checks tab will show **workflow status** and the Checks section in the PR conversation view will show **job status**.


### PR DESCRIPTION
# Description
Adding some context for checks naming between OAuth and App integrations

# Reasons
These are different enough that it could cause some customer confusion.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [X] Break up walls of text by adding paragraph breaks.
- [X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X] Keep the title between 20 and 70 characters.
- [X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [X] Include relevant backlinks to other CircleCI docs/pages.
