### PR TITLE
Clarify no options to select GitHub App pipeline in scheduled form

### DIFF
--- a/jekyll/_cci2/scheduled-pipelines.adoc
+++ b/jekyll/_cci2/scheduled-pipelines.adoc
@@ -30,7 +30,7 @@ NOTE: A scheduled pipeline can only be configured for one branch. If you need to
 [#introduction]
 == Introduction
 
-Scheduled pipelines allow you to trigger pipelines periodically based on a schedule, from either the CircleCI web app or API. Schedules can range from daily, weekly, monthly, or on a very specific timetable. To set up basic scheduled pipelines, you do not need any extra configuration in your `.circleci/config.yml` file. However, more advanced usage of the feature will require extra `.circleci/config.yml` configuration (for example, workflow filtering, or using parameters).
+Scheduled pipelines allow you to trigger pipelines periodically based on a schedule. Schedules can range from daily, weekly, monthly, or on a very specific timetable. To set up basic scheduled pipelines, you do not need any extra configuration in your `.circleci/config.yml` file. However, more advanced usage of the feature will require extra `.circleci/config.yml` configuration (for example, workflow filtering, or using parameters).
 
 Pipeline parameters are typed pipeline variables in the form of a string, integer, or boolean. Adding a parameter to a scheduled pipeline can be done in the web app in the triggers form while setting up a schedule. Any parameters set up in this manner must be added to your configuration file using the `parameters` key.
 

--- a/jekyll/_includes/partials/pipelines-and-triggers/scheduled-pipeline-setup.adoc
+++ b/jekyll/_includes/partials/pipelines-and-triggers/scheduled-pipeline-setup.adoc
@@ -1,8 +1,18 @@
-. In the link:https://app.circleci.com/[CircleCI web app] select **Projects** in the sidebar
-. Find your project in the list, select the ellipsis (icon:ellipsis-h[]) next to it and choose **Project Settings**.
+include::../app-navigation/steps-to-project-settings.adoc[]
 . Select **Triggers** in the sidebar.
 . Select btn:[Add Trigger].
++
+NOTE: The "Pipeline to run" menu only shows the OAuth pipelines, you cannot schedule GitHub App, GitLab or Bitbucket Data Center pipelines.
++
+** Give your trigger a descriptive name.
+** Enter an optional trigger description.
+** Select the pipeline to run.
+** Select a release frequencies (weekly/monthly, which days/months/time etc.).
+** Enter a branch or tag name to determine when to trigger the pipeline.
+** Optionally, enter pipeline parameters. If you declare pipeline parameters in the form, you need to make sure they are configured in your project's `.circleci/config.yml`. See the xref:pipeline-variables#pipeline-parameters-in-configuration[Pipeline values and parameters] page for more information.
+** Select an actor to initiate the trigger.
 . Define the new schedule by filling out the form, then select **Save Trigger**.
+
 
 The form also provides the option of adding xref:pipeline-variables#[pipeline parameters], which are typed pipeline variables that you declare at the top level of a configuration.
 

--- a/jekyll/_includes/snippets/faq/scheduled-pipelines-faq-snip.adoc
+++ b/jekyll/_includes/snippets/faq/scheduled-pipelines-faq-snip.adoc
@@ -46,6 +46,6 @@ However, subsequent runs of the scheduled pipeline will always be run on the sam
 
 Not currently. Scheduled pipelines require highly deterministic inputs such as a commit SHA, branch, or tag (fully qualified, no regex) included in the webhook, API call, or schedule.
 
-=== Why can I not see my pipeline in the scheduled pipelines to run menu?
+=== Why can I not see my pipeline in the scheduled pipeline to run menu?
 
-If you do not see your pipeline in the "Pipeline to run" dropdown menu, it may be that you are trying to access an unsupported pipeline. Only OAuth pipelines are supported for scheduling, so GitHub App, GitLab, and Bitbucket Data Center pipelines will not appear in the list.
+If you do not see your pipeline in the "Pipeline to run" dropdown menu, it may be that you are trying to access an unsupported pipeline type. Only OAuth pipelines are supported for scheduling, so GitHub App, GitLab, and Bitbucket Data Center pipelines will not appear in the list. You can see the pipeline type by looking at your pipeline list (menu:Project Settings[Pipelines]) and inspecting the pipeline labels.

--- a/jekyll/_includes/snippets/faq/scheduled-pipelines-faq-snip.adoc
+++ b/jekyll/_includes/snippets/faq/scheduled-pipelines-faq-snip.adoc
@@ -45,3 +45,7 @@ However, subsequent runs of the scheduled pipeline will always be run on the sam
 === Do you support regex?
 
 Not currently. Scheduled pipelines require highly deterministic inputs such as a commit SHA, branch, or tag (fully qualified, no regex) included in the webhook, API call, or schedule.
+
+=== Why can I not see my pipeline in the scheduled pipelines to run menu?
+
+If you do not see your pipeline in the "Pipeline to run" dropdown menu, it may be that you are trying to access an unsupported pipeline. Only OAuth pipelines are supported for scheduling, so GitHub App, GitLab, and Bitbucket Data Center pipelines will not appear in the list.


### PR DESCRIPTION
# Description
* Add notes to trigger setup steps to say GitHub App pipelines won't appear in the menu when setting up scheduled 
pipelines
* Add FAQ to help Kapa
* expand on existing steps

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
