### PR TITLE
Convert from liquid to adoc syntax

### DIFF
--- a/jekyll/_cci2/android-machine-image.adoc
+++ b/jekyll/_cci2/android-machine-image.adoc
@@ -6,7 +6,6 @@ contentTags:
 ---
 = Android images with the machine executor
 :page-layout: classic-docs
-:page-liquid:
 :page-description: Using the Android image on the machine executor
 :icons: font
 :experimental:
@@ -36,7 +35,7 @@ Below you will find several examples demonstrating the use of the Android machin
 
 The below sample uses the Android orb to run a single job.
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 # .circleci/config.yaml
@@ -63,7 +62,7 @@ workflows:
 
 This example shows how you can use more granular orb commands to achieve what the link:https://circleci.com/developer/orbs/orb/circleci/android#commands-start-emulator-and-run-tests[start-emulator-and-run-tests] command does.
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 # .circleci/config.yml
@@ -110,8 +109,6 @@ workflows:
 
 The following is an example of using the Android machine image, _without_ using the `circleci/android` link:https://circleci.com/developer/orbs/orb/circleci/android[orb]. These steps are similar to what is run when you use the link:https://circleci.com/developer/orbs/orb/circleci/android#jobs-run-ui-tests[`run-ui-tests` job] of the orb.
 
-
-{% raw %}
 ```yaml
 # .circleci/config.yml
 version: 2.1
@@ -186,7 +183,6 @@ workflows:
     jobs:
       - build
 ```
-{% endraw %}
 
 [#using-the-android-image-on-server-v3x]
 === Using the Android image on server
@@ -210,7 +206,7 @@ It is also possible to use the Android orb, as shown above, for cloud. Your serv
 
 This example shows how you can use granular orb commands to achieve what the link:https://circleci.com/developer/orbs/orb/circleci/android#commands-start-emulator-and-run-tests[start-emulator-and-run-tests] command does.
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 # .circleci/config.yml

--- a/jekyll/_cci2/artifacts.adoc
+++ b/jekyll/_cci2/artifacts.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 This document describes how to work with artifacts on CircleCI. Use artifacts to persist data after a job or pipeline has completed. For example building documents or other assets, or saving test results for further inspection.
 
@@ -20,15 +19,15 @@ Artifacts persist data after a job is completed and may be used for storage of t
 
 For example, when a Java build/test process finishes, the output of the process is saved as a `.jar` file. CircleCI can store this file as an artifact, keeping it available after the process has finished.
 
-image::{{site.baseurl}}/assets/img/docs/Diagram-v3-Artifact.png[Artifacts data flow]
+image::Diagram-v3-Artifact.png[Artifacts data flow]
 
 Another example of an artifact is a project that is packaged as an Android app where the `.apk` file is uploaded to Google Play.
 
 If a job produces persistent artifacts such as screenshots, coverage reports, core files, or deployment tarballs, CircleCI can automatically save and link them for you.
 
-Navigate to a pipeline's *Job* page on the link:https://app.circleci.com/[CircleCI web app] to find the *Artifacts* tab. Artifacts are stored on Amazon S3 and are protected with your CircleCI account for private projects. There is a 3GB `curl` file size limit.
+Navigate to a pipeline's *Job* page on the link:https://app.circleci.com/[CircleCI web app] to find the *Artifacts* tab. Artifacts are stored on Amazon S3 and are protected with your CircleCI account for private projects. cURL file size is limited o 3GB.
 
-image::{{site.baseurl}}/assets/img/docs/artifacts.png[Artifacts tab screenshot]
+image::artifacts.png[Artifacts tab screenshot]
 
 By default, artifact storage duration is set to 30 days. This can be customized on the link:https://app.circleci.com/[CircleCI web app] by navigating to menu:Plan[Usage Controls]. Currently, 30 days is also the maximum storage duration you can set.
 
@@ -43,7 +42,7 @@ If you need to restrict the connections allowed in your jobs, consider enabling 
 
 To upload artifacts created during builds, use the following example:
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yaml]
 ----
@@ -70,7 +69,7 @@ jobs:
           path: /tmp/artifacts
 ----
 
-The `store_artifacts` step uploads two build artifacts: a file (`/tmp/artifact-1`) and a directory (`/tmp/artifacts`). After the artifacts successfully upload, view them in the *Artifacts* tab of the *Job* page in your browser. If you are uploading hundreds of artifacts, then consider link:https://support.circleci.com/hc/en-us/articles/360024275534?input_string=store_artifacts+step[compressing and uploading as a single compressed file] to accelerate this step. There is no limit on the number of `store_artifacts` steps a job can run.
+The `store_artifacts` step uploads two build artifacts: a file (`/tmp/artifact-1`) and a directory (`/tmp/artifacts`). After the artifacts successfully upload, view them in the *Artifacts* tab of the *Job* page in your browser. If you are uploading hundreds of artifacts, then consider link:https://support.circleci.com/hc/en-us/articles/360024275534?input_string=store_artifacts+step[compressing and uploading as a single compressed file] to accelerate this step. `store_artifacts` steps for a job are unlimited.
 
 Currently, `store_artifacts` has two keys: `path` and `destination`.
 
@@ -133,7 +132,7 @@ The `ulimit -c unlimited` removes the file size limit on core dump files. With t
 
 Finally, the core dump files are stored to the artifacts service with `store_artifacts` in the `/tmp/core_dumps` directory.
 
-image::{{ site.baseurl }}/assets/img/docs/core_dumps.png[Core dump file in Artifacts page]
+image::core_dumps.png[Core dump file in Artifacts page]
 
 When CircleCI runs a job, a link to the core dump file appears in the *Artifacts* tab of the *Job* page.
 
@@ -215,11 +214,11 @@ You can read more about using CircleCI's API to interact with artifacts in our l
 [#artifacts-and-self-hosted-runner]
 == Artifact storage customization
 
-When using self-hosted runners, there is a network and storage usage limit included in your plan. There are certain actions related to artifacts that will accrue network and storage usage. Once your usage exceeds your limit, charges will apply.
+When using self-hosted runners, there is a network and storage usage limit included in your plan. Some actions related to artifacts that will accrue network and storage usage. Once your usage exceeds your limit, charges will apply.
 
 Retaining an artifact for a long period of time will have storage cost implications, therefore, it is best to determine why you are retaining artifacts. One benefit of retaining an artifact might be so you can use it to troubleshoot why a build is failing. Once the build passes, the artifact is likely not needed. Setting a low storage retention for artifacts is recommended if this suits your needs.
 
-You can customize storage usage retention periods for artifacts on the https://app.circleci.com/[CircleCI web app] by navigating to menu:Plan[Usage Controls]. For information on managing network and storage usage, see the link:{{site.baseurl}}/persist-data/#managing-network-and-storage-usage[Persisting Data] page.
+You can customize storage usage retention periods for artifacts on the https://app.circleci.com/[CircleCI web app] by navigating to menu:Plan[Usage Controls]. For information on managing network and storage usage, see the xref:persist-data#managing-network-and-storage-usage[Persisting Data] page.
 
 [#artifacts-optimization]
 == Artifacts optimization

--- a/jekyll/_cci2/browser-testing.adoc
+++ b/jekyll/_cci2/browser-testing.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 This page describes common methods for running and debugging browser testing in your CircleCI config.
 
@@ -41,7 +40,7 @@ WebDriver can operate in two modes, local, or remote:
 
 If Selenium is not included in your primary Docker image, install, and run Selenium as shown below:
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yaml]
 ----

--- a/jekyll/_cci2/building-docker-images.adoc
+++ b/jekyll/_cci2/building-docker-images.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 Use the remote Docker environment to build Docker images within the Docker execution environment.
 
@@ -22,7 +21,7 @@ NOTE: The _remote_ in "remote Docker" is a legacy term from when remote Docker u
 
 To build Docker images (for example, using `docker` or `docker compose` commands) when using the Docker execution environment, you must use the `setup_remote_docker` key in your job:
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yaml]
 ----
@@ -39,7 +38,7 @@ Using `setup_remote_docker` for a job means that all Docker commands execute loc
 
 In the CircleCI web app, jobs that run in the remote Docker environment have the **Remote Docker** label, as follows:
 
-image::{{ site.baseurl }}/assets/img/docs/remote-docker-label.png[Remote Docker label]
+image::remote-docker-label.png[Remote Docker label]
 
 CAUTION: Only use `setup_remote_docker` key for jobs where your primary executor _is_ a Docker container. If your job uses a VM rather than a container (for example, your executor is `machine`) you do *not* need to use the `setup_remote_docker` key. For an example, see <<run-docker-commands-using-the-machine-executor,Run Docker commands using the `machine` executor>>.
 
@@ -129,7 +128,7 @@ To optionally specify a Docker version, you can set it as a `version` attribute 
           version: edge
 ----
 
-CircleCI supports the tags listed below for remote Docker, as per our link:{{site.baseurl}}/remote-docker-images-support-policy/#tagging[Remote Docker tagging policy].
+CircleCI supports the tags listed below for remote Docker, as per our xref:remote-docker-images-support-policy#tagging[Remote Docker tagging policy].
 
 For *x86* and *Arm* architecture, the following tags are available:
 

--- a/jekyll/_cci2/caching.adoc
+++ b/jekyll/_cci2/caching.adoc
@@ -9,11 +9,10 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 Caching is one of the most effective ways to make jobs faster on CircleCI. By reusing the data from previous jobs, you also reduce the cost of fetch operations. After an initial job run, subsequent instances of the job run faster, as you are not redoing work.
 
-image::/docs/assets/img/docs/caching-dependencies-overview.png[caching data flow]
+image::caching-dependencies-overview.png[caching data flow]
 
 Caching is useful with *package dependency managers* such as Yarn, Bundler, or Pip. With dependencies restored from a cache, commands like `yarn install` need only download new or updated dependencies, rather than downloading everything on each build.
 
@@ -73,8 +72,6 @@ CircleCI restores caches in the order of keys listed in the `restore_cache` step
 
 In the example below, two keys are provided:
 
-{% raw %}
-
 [,yaml]
 ----
     steps:
@@ -87,11 +84,9 @@ In the example below, two keys are provided:
             - v1-npm-deps-
 ----
 
-{% endraw %}
-
 Because the second key is less specific than the first, it is more likely there will be differences between the current state and the most recently generated cache. When a dependency tool runs, it would discover outdated dependencies and update them. This is referred to as a *partial cache restore*.
 
-Each line in the `keys:` list manages _one cache_ (each line does *not* correspond to its own cache). The list of keys {% raw %}(`v1-npm-deps-{{ checksum "package-lock.json" }}`{% endraw %} and `v1-npm-deps-`), in this example, represent a *single* cache. When it is time to restore the cache, CircleCI first validates the cache based on the first (and most specific) key, and then steps through the other keys looking for any other cache key changes.
+Each line in the `keys:` list manages _one cache_ (each line does *not* correspond to its own cache). The list of keys (`v1-npm-deps-{{ checksum "package-lock.json" }}` and `v1-npm-deps-`), in this example, represent a *single* cache. When it is time to restore the cache, CircleCI first validates the cache based on the first (and most specific) key, and then steps through the other keys looking for any other cache key changes.
 
 The first key concatenates the checksum of `package-lock.json` file into the string `v1-npm-deps-`. If this file changed in your commit, CircleCI would see a new cache key.
 
@@ -105,8 +100,6 @@ link:https://yarnpkg.com/[Yarn] is an open-source package manager for JavaScript
 NOTE: Yarn 2.x comes with the ability to do link:https://yarnpkg.com/features/zero-installs[Zero Installs]. If you are using Zero Installs, you should not need to do any special caching within CircleCI.
 
 If you are using Yarn 2.x _without_ Zero Installs, you can do something like the following:
-
-{% raw %}
 
 [,yaml]
 ----
@@ -126,11 +119,7 @@ If you are using Yarn 2.x _without_ Zero Installs, you can do something like the
             - .yarn/unplugged
 ----
 
-{% endraw %}
-
 If you are using Yarn 1.x, you can do something like the following:
-
-{% raw %}
 
 [,yaml]
 ----
@@ -148,8 +137,6 @@ If you are using Yarn 1.x, you can do something like the following:
           paths:
             - ~/.cache/yarn
 ----
-
-{% endraw %}
 
 [#caching-and-open-source]
 == Caching and open source
@@ -173,8 +160,6 @@ We recommend that you verify that the dependencies installation step succeeds be
 
 Example of caching `pip` dependencies:
 
-{% raw %}
-
 [,yaml]
 ----
 version: 2.1
@@ -197,8 +182,6 @@ jobs:
           paths:
             - "venv"
 ----
-
-{% endraw %}
 
 Make note of the use of a `checksum` in the cache `key`. This is used to calculate when a specific dependency-management file (such as a `package.json` or `requirements.txt` in this case) _changes_, and so the cache will be updated accordingly. In the above example, the
 xref:configuration-reference#restorecache[`restore_cache`] example uses interpolation to put dynamic values into the cache-key, allowing more control in what exactly constitutes the need to update a cache.
@@ -224,7 +207,7 @@ You can make this workflow deterministic by changing the job dependencies. For e
 [#caching-race-condition-example-2]
 === Caching race condition example 2
 
-A more complex caching example could be using a dynamic key, for example, {% raw %}`node-cache-{{ checksum "package-lock.json" }}`{% endraw %} and restoring using a partial key match, for example, `node-cache-`.
+A more complex caching example could be using a dynamic key, for example, `node-cache-{{ checksum "package-lock.json" }}` and restoring using a partial key match, for example, `node-cache-`.
 
 A race condition is still possible, but the details may change. For instance, the downstream job uses the cache from the upstream job that ran last.
 
@@ -240,8 +223,6 @@ The following example is one approach to managing a shared cache based on multip
 
 . Add custom command to config:
 +
-{% raw %}
-+
 [,yaml]
 ----
 commands:
@@ -256,12 +237,8 @@ commands:
           command: npx lerna la -a | awk -F packages '{printf "\"packages%s/package-lock.json\" ", $2}' | xargs cat > << parameters.filename >>
 
 ----
-+
-{% endraw %}
 
 . Use custom command in build to generate the concatenated `package-lock` file:
-+
-{% raw %}
 +
 [,yaml]
 ----
@@ -275,8 +252,7 @@ commands:
             - v3-deps-{{ checksum "package-lock.json" }}-{{ checksum "combined-package-lock.txt" }}
             - v3-deps
 ----
-+
-{% endraw %}
+
 
 [#managing-caches]
 == Managing caches
@@ -317,7 +293,7 @@ A cache key is a _user-defined_ string that corresponds to a data cache. A cache
 
 [,shell]
 ----
-{% raw %}myapp-{{ checksum "package-lock.json" }}{% endraw %}
+myapp-{{ checksum "package-lock.json" }}
 ----
 
 The above example outputs a unique string to represent this key. The example is using a link:https://en.wikipedia.org/wiki/Checksum[checksum] to create a unique string that represents the contents of a `package-lock.json` file.
@@ -337,9 +313,9 @@ The first step is to decide when a cache will be saved or restored by using a ke
 
 The following are examples of caching strategies for different goals:
 
-* {% raw %}`myapp-{{ checksum "package-lock.json" }}`{% endraw %} - Cache is regenerated every time something is changed in `package-lock.json` file. Different branches of this project generate the same cache key.
-* {% raw %}`myapp-{{ .Branch }}-{{ checksum "package-lock.json" }}`{% endraw %} - Cache is regenerated every time something is changed in `package-lock.json` file. Different branches of this project generate separate cache keys.
-* {% raw %}`myapp-{{ epoch }}`{% endraw %} - Every build generates separate cache keys.
+* `myapp-{{ checksum "package-lock.json" }}` - Cache is regenerated every time something is changed in `package-lock.json` file. Different branches of this project generate the same cache key.
+* `myapp-{{ .Branch }}-{{ checksum "package-lock.json" }}` - Cache is regenerated every time something is changed in `package-lock.json` file. Different branches of this project generate separate cache keys.
+* `myapp-{{ epoch }}` - Every build generates separate cache keys.
 
 During step execution, the templates above are replaced by runtime values and use the resultant string as the `key`. The following table describes the available cache `key` templates:
 
@@ -348,25 +324,25 @@ During step execution, the templates above are replaced by runtime values and us
 |===
 | Template | Description
 
-| {% raw %}`{{ checksum "filename" }}`{% endraw %}
+| `{{ checksum "filename" }}`
 | A base64 encoded SHA256 hash of a given filename, so that a new cache key is generated if the file changes. This should be a file committed in your repository. Consider using dependency manifests, such as `package-lock.json`, `pom.xml` or `project.clj`. The important factor is that the file does not change between `restore_cache` and `save_cache`, otherwise the cache is saved under a cache key that is different from the file used at `restore_cache` time.
 
-| {% raw %}`{{ .Branch }}`{% endraw %}
+| `{{ .Branch }}`
 | The VCS branch currently being built.
 
-| {% raw %}`{{ .BuildNum }}`{% endraw %}
+| `{{ .BuildNum }}`
 | The CircleCI job number for this build.
 
-| {% raw %}`{{ .Revision }}`{% endraw %}
+| `{{ .Revision }}`
 | The VCS revision currently being built.
 
-| {% raw %}`{{ .Environment.variableName }}`{% endraw %}
+| `{{ .Environment.variableName }}`
 | The environment variable `variableName` (supports any environment variable xref:env-vars#[exported by CircleCI] or added to a specific xref:contexts#[Context], not any arbitrary environment variable).
 
-| {% raw %}`{{ epoch }}`{% endraw %}
+| `{{ epoch }}`
 | The number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC), also known as POSIX or UNIX epoch. This cache key is a good option if you need to ensure a new cache is always stored for each run.
 
-| {% raw %}`{{ arch }}`{% endraw %}
+| `{{ arch }}`
 | Captures OS and CPU (architecture, family, model) information. Useful when caching compiled binaries that depend on OS and CPU architecture, for example, `darwin-amd64-6_58` versus `linux-amd64-6_62`. See xref:faq#cpu-architecture-circleci-support[supported CPU architectures].
 |===
 
@@ -374,8 +350,8 @@ During step execution, the templates above are replaced by runtime values and us
 === Further notes on using keys and templates
 
 * A 900 character limit is imposed on each cache key. Be sure your key is shorter than this, otherwise your cache will not save.
-* When defining a unique identifier for the cache, be careful about overusing template keys that are highly specific such as {% raw %}`{{ epoch }}`{% endraw %}. If you use less specific template keys such as {% raw %}`{{ .Branch }}`{% endraw %} or {% raw %}`{{ checksum "filename" }}`{% endraw %}, you increase the chance of the cache being used.
-* Cache variables can also accept xref:reusing-config#using-parameters-in-executors[parameters], if your build makes use of them. For example: {% raw %}`v1-deps-<< parameters.varname >>`{% endraw %}.
+* When defining a unique identifier for the cache, be careful about overusing template keys that are highly specific such as `{{ epoch }}`. If you use less specific template keys such as `{{ .Branch }}`or `{{ checksum "filename" }}`, you increase the chance of the cache being used.
+* Cache variables can also accept xref:reusing-config#using-parameters-in-executors[parameters], if your build makes use of them. For example: `v1-deps-<< parameters.varname >>`.
 * You do not have to use dynamic templates for your cache key. You can use a static string, and "bump" (change) its name to force a cache invalidation.
 
 [#full-example-of-saving-and-restoring-cache]
@@ -386,7 +362,7 @@ The following example demonstrates how to use `restore_cache` and `save_cache`, 
 CAUTION: This example uses a _very_ specific cache key. Making your caching key more specific gives you greater control over which branch or commit dependencies are saved to a cache. However, it is important to be aware that this can *significantly increase* your storage usage. For tips on optimizing your caching strategy, see the xref:caching-strategy#[Caching Strategies] page.
 This example is only a _potential_ solution and might be unsuitable for your specific needs, and increase storage costs.
 
-{% raw %}
+
 
 [,yaml]
 ----
@@ -448,16 +424,15 @@ jobs:
       - run: bundle exec cucumber
 ----
 
-{% endraw %}
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [#source-caching]
 == Source caching
 
 It is possible and often beneficial to cache your git repository to save time in your `checkout` step, especially for larger projects. Here is an example of source caching:
 
-{% raw %}
+
 
 [,yaml]
 ----
@@ -476,8 +451,6 @@ It is possible and often beneficial to cache your git repository to save time in
             - ".git"
 ----
 
-{% endraw %}
-
 In this example, `restore_cache` looks for a cache hit in the following order:
 
 * From the current git revision
@@ -488,7 +461,7 @@ When CircleCI encounters a list of `keys`, the cache is restored from the first 
 
 If your source code changes frequently, we recommend using fewer, more specific keys. This produces a more granular source cache that updates more often as the current branch and git revision change.
 
-Even with the narrowest `restore_cache` option ({% raw %}`source-v1-{{ .Branch }}-{{ .Revision }}`{% endraw %}), source caching can be greatly beneficial, for example:
+Even with the narrowest `restore_cache` option (`source-v1-{{ .Branch }}-{{ .Revision }}`), source caching can be greatly beneficial, for example:
 
 * Running repeated builds against the same git revision (for example, with link:https://circleci.com/docs/api/v1/#trigger-a-new-build-by-project-preview[API-triggered builds])
 * When using workflows, where you might otherwise need to `checkout` the same repository once per workflow job.

--- a/jekyll/_cci2/circleci-images.adoc
+++ b/jekyll/_cci2/circleci-images.adoc
@@ -63,7 +63,7 @@ jobs:
       - image: cimg/base:2021.04
 ----
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 `cimg/base:2021.04` is a Ubuntu-based image designed to install the bare minimum. The
 next-generation convenience images are based on this image.

--- a/jekyll/_cci2/code-coverage.adoc
+++ b/jekyll/_cci2/code-coverage.adoc
@@ -3,14 +3,12 @@ contentTags:
   platform:
   - Cloud
   - Server v4+
-
 ---
 = Generate code coverage metrics
 :page-description: Generate code coverage metrics for different languages.
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 [#introduction]
 == Introduction
@@ -22,12 +20,12 @@ CircleCI provides different options for code coverage reporting using built-in C
 
 You can upload your code coverage reports directly to CircleCI. First, add a coverage library to your project and configure your build to write the coverage report to CircleCI's artifacts directory. Code coverage reports are stored as build artifacts where they can be viewed or downloaded. See our xref:artifacts#[build artifacts] guide for more information on downloading coverage reports stored in your artifacts.
 
-image::{{site.baseurl}}/assets/img/docs/artifacts.png[Artifacts tab in the web app]
+image::artifacts.png[Artifacts tab in the web app]
 
 [#language-specific-code-coverage-options]
 == Language-specific code coverage options
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [#ruby]
 === Ruby

--- a/jekyll/_cci2/concepts.adoc
+++ b/jekyll/_cci2/concepts.adoc
@@ -3,14 +3,12 @@ contentTags:
   platform:
   - Cloud
   - Server v4+
-
 ---
 = Concepts
 :description: CircleCI concepts
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 [#introduction]
 == Introduction
@@ -48,7 +46,7 @@ Your CircleCI configuration can be adapted to fit many different needs of your p
 
 The following illustration uses an link:https://github.com/CircleCI-Public/circleci-demo-java-spring/tree/2.1-config[example Java application] to show the various configuration elements:
 
-image::{{site.baseurl}}/assets/img/docs/config-elements.png[configuration elements]
+image::config-elements.png[configuration elements]
 
 CircleCI configurations use YAML. See the xref:introduction-to-yaml-configurations#[Introduction to YAML configurations] page for basic guidance. For a full overview of what is possible in a configuration file, see the xref:configuration-reference#[Configuration reference] page.
 
@@ -57,7 +55,7 @@ CircleCI configurations use YAML. See the xref:introduction-to-yaml-configuratio
 
 Contexts provide a mechanism for securing and sharing environment variables across projects. The environment variables are defined as name/value pairs and are injected at runtime. After a context has been created, you can use the `context` key in the workflows section of a project's `.circleci/config.yml` file to give any job(s) access to the environment variables associated with the context.
 
-image::{{site.baseurl}}/assets/img/docs/contexts_cloud.png[Contexts Overview]
+image::contexts_cloud.png[Contexts Overview]
 
 See the xref:contexts#[Using contexts] page for more information.
 
@@ -66,7 +64,7 @@ See the xref:contexts#[Using contexts] page for more information.
 
 Persist data to move data between jobs and speed up your build. There are three main methods for persisting data in CircleCI: artifacts, caches, and workspaces.
 
-image::{{site.baseurl}}/assets/img/docs/workspaces.png[workflow illustration]
+image::workspaces.png[workflow illustration]
 
 Note the following distinctions between artifacts, caches and workspaces:
 
@@ -95,8 +93,6 @@ Note the following distinctions between artifacts, caches and workspaces:
 === Artifacts
 
 Artifacts persist data after a workflow is completed and may be used for longer-term storage of the outputs of your build process.
-
-{% raw %}
 
 [,yaml]
 ----
@@ -144,8 +140,6 @@ workflows:
             - build2
 ----
 
-{% endraw %}
-
 See the xref:artifacts#[Storing build artifacts] page for more information.
 
 [#caches]
@@ -154,8 +148,6 @@ See the xref:artifacts#[Storing build artifacts] page for more information.
 A cache stores a file or directory of files such as dependencies or source code in object storage. To speed up the build, each job may contain special steps for caching dependencies from previous jobs.
 
 If you need to clear your cache, refer to the xref:caching#clearing-cache[Caching dependencies] page for more information.
-
-{% raw %}
 
 [,yaml]
 ----
@@ -194,8 +186,6 @@ workflows:
           requires:
             - build1
 ----
-
-{% endraw %}
 
 For more information see the xref:caching#[Caching dependencies] and xref:caching-strategy#[Caching strategies] pages.
 
@@ -250,11 +240,11 @@ See the xref:dynamic-config#[Dynamic configuration] page for more information.
 
 Each separate job defined within your configuration runs in a unique execution environment, known as executors. An executor can be a Docker container, or a virtual machine running Linux, Windows, or macOS. In some of these instances, you can set up an environment using GPU, or Arm. CircleCI also provides a machine-based and container-based self-hosted runner solution.
 
-image::{{site.baseurl}}/assets/img/docs/executor_types.png[Illustration of a CircleCI job]
+image::executor_types.png[Illustration of a CircleCI job]
 
 An _image_ is a packaged system that includes instructions for creating a running container or virtual machine, and you can define an image for each executor. CircleCI provides a range of images for use with the Docker executor, called _convenience images_ (details in the <<images,images>> section).
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [.tab.executors.Cloud]
 [,yaml]
@@ -348,7 +338,7 @@ An image is a packaged system that includes instructions for creating a running 
 
 The *Docker executor* spins up a container with a Docker image. CircleCI maintains xref:circleci-images#[convenience images] for popular languages on Docker Hub.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 The *machine executor* spins up a complete Ubuntu virtual machine image, giving you full access to OS resources and complete control over the job environment. For more information, see the xref:configuration-reference#machine[Using machine] page.
 
@@ -401,7 +391,7 @@ See the xref:circleci-images#[Images] page for more information.
 
 Jobs are the building blocks of your configuration. Jobs are collections of <<steps,steps>>, which run commands/scripts as required. Each job must declare an executor that is either `docker`, `machine`, `windows`, or `macos`. For `docker` you must xref:executor-intro#docker[specify an image] to use for the primary container. For `macos` you must specify an xref:executor-intro#macos[Xcode version]. For `windows` you must use the xref:executor-intro#windows[Windows orb].
 
-image::{{site.baseurl}}/assets/img/docs/job.png[Illustration of a CircleCI job]
+image::job.png[Illustration of a CircleCI job]
 
 See the xref:jobs-steps#[Jobs and steps] page for more information.
 
@@ -414,7 +404,7 @@ The illustration in the <<configuration,Configuration>> section showing an examp
 
 // Turn this into a config snippet
 
-image::{{site.baseurl}}/assets/img/docs/config-elements-orbs.png[Configuration using Maven orb]
+image::config-elements-orbs.png[Configuration using Maven orb]
 
 See xref:orb-concepts#[Using orbs] for details on how to use orbs in your configuration and an introduction to orb design. Visit the link:https://circleci.com/developer/orbs[Orbs registry] to search for orbs to help simplify your configuration.
 
@@ -439,7 +429,7 @@ jobs:
       - run: go list ./... | circleci tests run --command "xargs gotestsum --junitfile junit.xml --format testname --" --split-by=timings --timings-type=name
 ----
 
-image::{{site.baseurl}}/assets/img/docs/executor_types_plus_parallelism.png[Executor types with parallelism]
+image::executor_types_plus_parallelism.png[Executor types with parallelism]
 
 See xref:parallelism-faster-jobs#[Test splitting and parallelism] page for more information.
 
@@ -450,7 +440,7 @@ A CircleCI pipeline is the full set of processes you run when you trigger work o
 
 Pipelines represent methods for interacting with your configuration:
 
-{% include snippets/pipelines-benefits.adoc %}
+include::../_includes/snippets/pipelines-benefits.adoc[]
 
 See the xref:pipelines#[Pipelines overview] page for more information.
 
@@ -480,7 +470,7 @@ Select *Projects* in the CircleCI web app sidebar to enter the projects dashboar
 * _Set Up_ or _Create_ any project that you are the owner of in your VCS.
 * _Follow_ any project in your organization to gain access to its pipelines and to subscribe to link:/docs/notifications/[email notifications] for the project's status.
 
-image::{{site.baseurl}}/assets/img/docs/CircleCI-2.0-setup-project-circle101_cloud.png[Project dashboard]
+image::CircleCI-2.0-setup-project-circle101_cloud.png[Project dashboard]
 
 [#resource-class]
 == Resource class
@@ -578,9 +568,7 @@ image::/docs/assets/img/docs/workflow_detail_newui.png[Workflows illustration cl
 
 The following configuration example shows a workflow called `build_and_test` in which the job `build1` runs and then jobs `build2` and `build3` run concurrently:
 
-{% include snippets/docker-auth.adoc %}
-
-{% raw %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yaml]
 ----
@@ -632,8 +620,6 @@ workflows:
            - build1 # wait for build1 job to complete successfully before starting
            # run build2 and build3 concurrently to save time.
 ----
-
-{% endraw %}
 
 See the xref:workflows#[Using workflows] page for more information.
 

--- a/jekyll/_cci2/concurrency.adoc
+++ b/jekyll/_cci2/concurrency.adoc
@@ -3,11 +3,9 @@ contentTags:
   platform:
   - Cloud
   - Server v4+
-
 ---
 = Concurrency
 :page-layout: classic-docs
-:page-liquid:
 :page-description: This page summarizes concurrency, and suggests ways to use concurrency to your advantage.
 :icons: font
 :experimental:
@@ -39,7 +37,7 @@ To run a set of concurrent jobs, you will need to add a `workflows` section to y
 
 The simple example below shows the default workflow orchestration with two concurrent jobs. The `workflows` key needs to have a unique name. In this example, the unique name is `build_and_test`. The `jobs` key is nested under the uniquely named workflow, and contains the list of job names. Since the jobs have no dependencies, they will run concurrently.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/config-intro.adoc
+++ b/jekyll/_cci2/config-intro.adoc
@@ -6,7 +6,6 @@ contentTags:
 ---
 = Configuration introduction
 :page-layout: classic-docs
-:page-liquid:
 :page-description: "Learn how to get started with the CircleCI config.yml file."
 :icons: font
 :experimental:
@@ -36,7 +35,7 @@ CircleCI provides an on-demand shell to run commands. In this first example, you
 . If you have not done so already, <<first-steps#,sign up with CircleCI>> and then either create or set up a new project. You can follow the steps to connect a code repository in our xref:getting-started#[Quickstart guide].
 . Once you have created or set up your project in CircleCI, go to the `.circleci/config.yml` file and replace its contents with the following code:
 +
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 +
 [source,yaml]
 ----
@@ -335,7 +334,7 @@ If you use VS Code, you might find the official xref:vs-code-extension-overview#
 
 The extension provides real-time syntax highlighting and validation, assisted navigation through go-to-definition and go-to-reference commands, usage hints, and autocomplete suggestions.
 
-image::{{site.baseurl}}/assets/img/docs/vs_code_extension_config_helper_go-to-definition-optimised.gif[Screenshot showing the definition available on hover]
+image::vs_code_extension_config_helper_go-to-definition-optimised.gif[Screenshot showing the definition available on hover]
 
 The CircleCI VS Code extension is available to download on the link:https://marketplace.visualstudio.com/items?itemName=circleci.circleci[VS Code marketplace.]
 

--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -1278,7 +1278,7 @@ include::../_includes/snippets/docker-arm-resource-table.adoc[]
 [#linuxvm-execution-environment]
 ===== LinuxVM execution environment
 
-includ::../_includes/snippets/machine-resource-table.adoc[]
+include::../_includes/snippets/machine-resource-table.adoc[]
 
 Example:
 

--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -423,7 +423,6 @@ suggested:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 This document is a reference for the CircleCI 2.x configuration keys that are used in the `.circleci/config.yml` file.
 
@@ -1265,21 +1264,21 @@ jobs:
 [#x86]
 ====== x86
 
-{% include snippets/docker-resource-table.adoc %}
+include::../_includes/snippets/docker-resource-table.adoc[]
 
 [#arm]
 ====== Arm
 
 *Arm on Docker* For pricing information, and a list of CircleCI Docker convenience images that support Arm resource classes, see the link:https://circleci.com/product/features/resource-classes/[Resource classes page].
 
-{% include snippets/docker-arm-resource-table.adoc %}
+include::../_includes/snippets/docker-arm-resource-table.adoc[]
 
 '''
 
 [#linuxvm-execution-environment]
 ===== LinuxVM execution environment
 
-{% include snippets/machine-resource-table.adoc %}
+includ::../_includes/snippets/machine-resource-table.adoc[]
 
 Example:
 
@@ -1315,7 +1314,7 @@ jobs:
 [#macos-execution-environment]
 ===== macOS execution environment
 
-{% include snippets/macos-resource-table.adoc %}
+include::../_includes/snippets/macos-resource-table.adoc[]
 
 *Example*
 
@@ -1342,7 +1341,7 @@ If you are working on CircleCI server v3.1 and up, you can access the macOS exec
 [#windows-execution-environment]
 ===== Windows execution environment
 
-{% include snippets/windows-resource-table.adoc %}
+include::../_includes/snippets/windows-resource-table.adoc[]
 
 Example:
 
@@ -1387,7 +1386,7 @@ jobs:
 [#gpu-execution-environment-linux]
 ===== GPU execution environment (Linux)
 
-{% include snippets/gpu-linux-resource-table.adoc %}
+include::../_includes/snippets/gpu-linux-resource-table.adoc[]
 
 Example:
 
@@ -1412,7 +1411,7 @@ See the <<available-linux-gpu-images,Available Linux GPU images>> section for th
 [#gpu-execution-environment-windows]
 ===== GPU execution-environment (Windows)
 
-{% include snippets/gpu-windows-resource-table.adoc %}
+include::../_includes/snippets/gpu-windows-resource-table.adoc[]
 
 Example:
 
@@ -1437,7 +1436,7 @@ jobs:
 [#arm-execution-environment-linux]
 ===== Arm VM execution-environment
 
-{% include snippets/arm-resource-table.adoc %}
+include::../_includes/snippets/arm-resource-table.adoc[]
 
 Example:
 
@@ -1659,7 +1658,7 @@ If you want to avoid this behaviour, you can specify `set +o pipefail` in the co
 
 In general, we recommend using the default options (`-eo pipefail`) because they show errors in intermediate commands and simplify debugging job failures. For convenience, the UI displays the used shell and all active options for each `run` step.
 
-For more information, see the link:{{ site.baseurl }}/using-shell-scripts/[Using Shell Scripts] document.
+For more information, see the xref:using-shell-scripts#[Using Shell Scripts] document.
 
 '''
 
@@ -1940,28 +1939,28 @@ When storing a new cache, the `key` value may contain special, templated, values
 |===
 | Template | Description
 
-| {% raw %}`{{ .Branch }}`{% endraw %}
+| `{{ .Branch }}`
 | The VCS branch currently being built.
 
-| {% raw %}`{{ .BuildNum }}`{% endraw %}
+| `{{ .BuildNum }}`
 | The CircleCI build number for this build.
 
-| {% raw %}`{{ .Revision }}`{% endraw %}
+| `{{ .Revision }}`
 | The VCS revision currently being built.
 
-| {% raw %}`{{ .CheckoutKey }}`{% endraw %}
+| `{{ .CheckoutKey }}`
 | The SSH key used to checkout the repository.
 
-| {% raw %}`{{ .Environment.variableName }}`{% endraw %}
+| `{{ .Environment.variableName }}`
 | The environment variable `variableName` (supports any environment variable xref:env-vars#[exported by CircleCI] or added to a specific xref:contexts#[context]--not any arbitrary environment variable).
 
-| {% raw %}`{{ checksum "filename" }}`{% endraw %}
+| `{{ checksum "filename" }}`
 | A base64 encoded SHA256 hash of the given filename's contents. This should be a file committed in your repository and may also be referenced as a path that is absolute or relative from the current working directory. Good candidates are dependency manifests, such as `package-lock.json`, `pom.xml` or `project.clj`. It is important that this file does not change between `restore_cache` and `save_cache`, otherwise the cache will be saved under a cache key different than the one used at `restore_cache` time.
 
-| {% raw %}`{{ epoch }}`{% endraw %}
+| `{{ epoch }}`
 | The current time in seconds since the UNIX epoch.
 
-| {% raw %}`{{ arch }}`{% endraw %}
+| `{{ arch }}`
 | The OS and CPU information.  Useful when caching compiled binaries that depend on OS and CPU architecture, for example, `darwin amd64` versus `linux i386/32-bit`.
 |===
 
@@ -1969,9 +1968,9 @@ During step execution, the templates above will be replaced by runtime values an
 
 Template examples:
 
-* {% raw %}`myapp-{{ checksum "package-lock.json" }}`{% endraw %} - cache will be regenerated every time something is changed in `package-lock.json` file, different branches of this project will generate the same cache key.
-* {% raw %}`myapp-{{ .Branch }}-{{ checksum "package-lock.json" }}`{% endraw %} - same as the previous one, but each branch will generate separate cache
-* {% raw %}`myapp-{{ epoch }}`{% endraw %} - every run of a job will generate a separate cache
+* `myapp-{{ checksum "package-lock.json" }}` - cache will be regenerated every time something is changed in `package-lock.json` file, different branches of this project will generate the same cache key.
+* `myapp-{{ .Branch }}-{{ checksum "package-lock.json" }}` - same as the previous one, but each branch will generate separate cache
+* `myapp-{{ epoch }}` - every run of a job will generate a separate cache
 
 While choosing suitable templates for your cache `key`, keep in mind that cache saving is not a free operation, because it will take some time to upload the cache to our storage. Best practice is to have a `key` that generates a new cache only if something actually changed and avoid generating a new one every time a job is run.
 
@@ -1979,7 +1978,7 @@ NOTE: Given the immutability of caches, it might be helpful to start all your ca
 
 Example:
 
-{% raw %}
+
 
 [,yml]
 ----
@@ -1989,9 +1988,9 @@ Example:
       - /home/ubuntu/.m2
 ----
 
-{% endraw %}
 
-{% raw %}
+
+
 
 [,yml]
 ----
@@ -2002,7 +2001,7 @@ Example:
       - node_modules/workspace-c
 ----
 
-{% endraw %}
+
 
 [NOTE]
 ====
@@ -2075,7 +2074,7 @@ A path is not required here because the cache will be restored to the location f
 
 Example:
 
-{% raw %}
+
 
 [,yml]
 ----
@@ -2094,7 +2093,7 @@ Example:
       - /foo
 ----
 
-{% endraw %}
+
 
 '''
 
@@ -2273,7 +2272,7 @@ NOTE: Everything must be relative to the work space root directory.
 [#attachworkspace]
 ===== *`attach_workspace`*
 
-Special step used to attach the workflow's workspace to the current container. The full contents of the workspace are downloaded and copied into the directory the workspace is being attached at. For more information on using workspaces, see the link:{{site.baseurl}}/workspaces/[Using workspaces] page.
+Special step used to attach the workflow's workspace to the current container. The full contents of the workspace are downloaded and copied into the directory the workspace is being attached at. For more information on using workspaces, see the xref:workspaces#[Using workspaces] page.
 
 [.table.table-striped]
 [cols=4*, options="header", stripes=even]
@@ -2727,7 +2726,7 @@ The `name` key can be used to invoke reusable jobs across any number of workflow
 [#context]
 ====== *`context`*
 
-Jobs may be configured to use global environment variables set for an organization, see the link:{{ site.baseurl }}/contexts[Contexts] document for adding a context in the application settings.
+Jobs may be configured to use global environment variables set for an organization, see the xref:contexts#[Contexts] document for adding a context in the application settings.
 
 [.table.table-striped]
 [cols=4*, options="header", stripes=even]
@@ -3267,12 +3266,12 @@ includes:
 | resolves to a truthy value
 | *my-alias
 
-| link:{{site.baseurl}}/pipeline-variables/#pipeline-values[Pipeline Value]
+| xref:pipeline-variables#pipeline-values[Pipeline Value]
 | None
 | resolves to a truthy value
 | `<< pipeline.git.branch >>`
 
-| link:{{site.baseurl}}/pipeline-variables/#pipeline-parameters-in-configuration[Pipeline Parameter]
+| xref:pipeline-variables#pipeline-parameters-in-configuration[Pipeline Parameter]
 | None
 | resolves to a truthy value
 | `<< pipeline.parameters.my-parameter >>`
@@ -3397,9 +3396,9 @@ workflows:
 [#example-full-configuration]
 == Example full configuration
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
-{% raw %}
+
 
 [,yaml]
 ----
@@ -3514,4 +3513,4 @@ workflows:
               only: main
 ----
 
-{% endraw %}
+

--- a/jekyll/_cci2/custom-images.adoc
+++ b/jekyll/_cci2/custom-images.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 This page describes how to create and use custom Docker images with CircleCI.
 
@@ -196,7 +195,7 @@ jobs:
       - image: circleci/cci-demo-docker-primary:0.0.1
 ----
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 If you have any questions, head over to our https://discuss.circleci.com/[community forum].
 

--- a/jekyll/_cci2/databases.adoc
+++ b/jekyll/_cci2/databases.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 This page describes how to use the official CircleCI pre-built Docker container images for a database service in CircleCI.
 
@@ -34,7 +33,7 @@ In the primary image, the config defines an environment variable with the `envir
 
 Set the `POSTGRES_USER` environment variable in your CircleCI config to `postgres` to add the role to the image as follows:
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yml]
 ----
@@ -42,8 +41,6 @@ Set the `POSTGRES_USER` environment variable in your CircleCI config to `postgre
         environment:
           POSTGRES_USER: postgres
 ----
-
-{% raw %}
 
 [,yml]
 ----
@@ -78,15 +75,13 @@ jobs:
           -c "INSERT INTO test VALUES ('John'), ('Joanna'), ('Jennifer');"
 ----
 
-{% endraw %}
-
 The `steps` run `checkout` first, then install the PostgreSQL client tools. The `cimg/postgres:14.0` image doesn't install any client-specific database adapters. For example, for Python, you might install link:https://www.psycopg.org/[`psycopg2`] so that you can interface with the PostgreSQL database.
 
 In this example, the config installs the PostgreSQL client tools, `postgresql-client` via `apt-get`, to get access to `psql`. Installing packages in images requires administrator privileges, therefore `sudo` is used - a password is not required.
 
 Two commands follow the `postgresql-client` installation that interact with the database service. These are SQL commands that create a table called test and insert a value into that table. After committing changes and pushing them, the build is automatically triggered on CircleCI and spins up the primary container.
 
-NOTE: CircleCI injects a number of convenience environment variables into the primary container that you can use in conditionals throughout the rest of your build. For example, CIRCLE_NODE_INDEX and CIRCLE_NODE_TOTAL are related to concurrent execution environments. See the link:{{site.baseurl}}/variables#built-in-environment-variables[Project values and variables] document for details.
+NOTE: CircleCI injects a number of convenience environment variables into the primary container that you can use in conditionals throughout the rest of your build. For example, CIRCLE_NODE_INDEX and CIRCLE_NODE_TOTAL are related to concurrent execution environments. See the xref:variables#built-in-environment-variables[Project values and variables] document for details.
 
 When the database service spins up, it automatically creates the database `circle_test` and the `postgres` role that you can use to log in and run your tests. Then the database tests run to create a table and insert a value into it.
 

--- a/jekyll/_cci2/deploy-to-artifactory.adoc
+++ b/jekyll/_cci2/deploy-to-artifactory.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 In this how-to guide, you will learn how to upload artifacts to Artifactory in CircleCI.
 
@@ -103,7 +102,7 @@ command: |
 
 The full `.circleci/config.yml` file would look something like the following:
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yml]
 ----

--- a/jekyll/_cci2/deploy-to-aws.adoc
+++ b/jekyll/_cci2/deploy-to-aws.adoc
@@ -1,13 +1,12 @@
 ---
-description: This is document provides examples of deploying to Amazon Web Services.
 contentTags:
   platform:
   - Cloud
   - Server v4+
 ---
 = Deploy to AWS
+:page-description: This is document provides examples of deploying to Amazon Web Services.
 :page-layout: classic-docs
-:page-liquid:
 :icons: font
 :experimental:
 
@@ -47,7 +46,7 @@ Add your link:https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.h
 
 Use the orb's `sync` command to deploy. Note the use of workflows to deploy only if the `build` job passes and the current branch is `main`.
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 version: 2.1
@@ -113,7 +112,7 @@ Install `awscli` in your primary container by following the link:https://docs.aw
 
 link:https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-using.html[Use the AWS CLI] to deploy your application to S3 or perform other AWS operations. Note the use of workflows to deploy only if the build job passes and the current branch is `main`.
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 version: 2.1
@@ -155,7 +154,7 @@ The AWS ECR orb enables you to log into AWS, build, and then push a Docker image
 
 Using the `build_and_push_image` job (shown below) requires the following environment variables to be set: `AWS_ECR_ACCOUNT_URL`, `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`.
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 version: 2.1
@@ -185,7 +184,7 @@ Use the link:https://circleci.com/developer/orbs/orb/circleci/aws-ecr[AWS ECR] a
 
 Using the `build-and-push-image` job (shown below) requires the following environment variables to be set: `OIDC-USER`, `AWS__DEFAULT_REGION`, `MY_APP_PREFIX`.
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 version: '2.1'

--- a/jekyll/_cci2/deploy-to-azure-container-registry.adoc
+++ b/jekyll/_cci2/deploy-to-azure-container-registry.adoc
@@ -1,13 +1,12 @@
 ---
-description: This is document provides examples of deploying to Azure Container Registry.
 contentTags:
   platform:
   - Cloud
   - Server v4+
 ---
 = Deploy to Azure Container Registry
+:page-description: This is document provides examples of deploying to Azure Container Registry.
 :page-layout: classic-docs
-:page-liquid:
 :icons: font
 :experimental:
 
@@ -18,7 +17,7 @@ In this how-to guide, you will learn how to configure CircleCI to deploy to Azur
 
 This page describes a simple deployment to the Azure Container Registry (ACR) using the CircleCI ACR orb and `version 2.1` configuration.
 
-{% include snippets/env-var-or-context.adoc %}
+include::../_includes/snippets/env-var-or-context.adoc[]
 
 In addition to the orb described below, CircleCI has created an Azure convenience image focusing on link:https://circleci.com/developer/images/image/cimg/azure[deployment: `cimg/azure`].
 
@@ -45,7 +44,7 @@ For service principal logins use:
 
 Use the orb's `build-and-push-image` job to build your image and deploy it to ACR. Note the use of workflows to deploy only if the current branch is `main`.
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 version: 2.1 # Use version 2.1 config to get access to orbs, pipelines

--- a/jekyll/_cci2/deploy-to-google-cloud-platform.adoc
+++ b/jekyll/_cci2/deploy-to-google-cloud-platform.adoc
@@ -1,13 +1,12 @@
 ---
-description: This is document provides examples of deploying to Google Cloud Platform.
 contentTags:
   platform:
   - Cloud
   - Server v4+
 ---
 =  Deploy to Google Cloud Platform
+:page-description: This is document provides examples of deploying to Google Cloud Platform.
 :page-layout: classic-docs
-:page-liquid:
 :icons: font
 :experimental:
 
@@ -25,7 +24,7 @@ In addition to the orbs described below, CircleCI has created an GCP convenience
 
 Several Google Cloud orbs are available in the link:https://circleci.com/developer/orbs[CircleCI Orbs Registry]. Use the orbs to simplify your deployments. For example, the link:https://circleci.com/developer/orbs/orb/circleci/gcp-gke#usage-publish-and-rollout-image[Google Kubernetes Engine (GKE) orb] has a pre-built job to build and publish a Docker image, and roll the image out to a GKE cluster, as follows:
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/deploy-to-heroku.adoc
+++ b/jekyll/_cci2/deploy-to-heroku.adoc
@@ -1,13 +1,12 @@
 ---
-description: This is document provides examples of deploying to Heroku.
 contentTags:
   platform:
   - Cloud
   - Server v4+
 ---
 = Deploy to Heroku
+:page-description: This is document provides examples of deploying to Heroku.
 :page-layout: classic-docs
-:page-liquid:
 :icons: font
 :experimental:
 
@@ -28,14 +27,16 @@ Create a Heroku account and follow the link:https://devcenter.heroku.com/start[G
 [#create-env-vars]
 === 2. Create environment variables
 
-Add the name of your Heroku application and your Heroku API key as environment variables as `HEROKU_APP_NAME` and `HEROKU_API_KEY`, respectively. {% include snippets/env-var-or-context.adoc %}
+Add the name of your Heroku application and your Heroku API key as environment variables as `HEROKU_APP_NAME` and `HEROKU_API_KEY`, respectively.
+
+include::../_includes/snippets/env-var-or-context.adoc[]
 
 [#deploy-with-orb]
 === 3. Deploy with the Heroku orb
 
 Use the link:https://circleci.com/developer/orbs/orb/circleci/heroku[Heroku orb] to keep your configuration simple. The `deploy-via-git` installs the Heroku CLI in the primary container, runs any pre deployment steps you define, deploys your application, then runs any post-deployment steps you define. See the Heroku orb page in the link:https://circleci.com/developer/orbs/orb/circleci/heroku[orbs registry] for full details of parameters and options:
 
-{% include snippets/add-version-number.adoc %}
+include::../_includes/snippets/add-version-number.adoc[]
 
 ```yaml
 version: 2.1
@@ -64,7 +65,9 @@ Create a Heroku account and follow the link:https://devcenter.heroku.com/start[G
 [#create-env-vars-2]
 === 2. Create environment variables
 
-Add the name of your Heroku application and your Heroku API key as environment variables as `HEROKU_APP_NAME` and `HEROKU_API_KEY`, respectively. {% include snippets/env-var-or-context.adoc %}
+Add the name of your Heroku application and your Heroku API key as environment variables as `HEROKU_APP_NAME` and `HEROKU_API_KEY`, respectively.
+
+include::../_includes/snippets/env-var-or-context.adoc[]
 
 [#create-deploy-job]
 === 3. Create deploy job

--- a/jekyll/_cci2/hello-world.adoc
+++ b/jekyll/_cci2/hello-world.adoc
@@ -15,9 +15,9 @@ sectionTags:
 ---
 = Hello world
 :page-layout: classic-docs
-:page-liquid:
 :page-description: Get started with CircleCI by printing Hello World in any execution environment.
 :icons: font
+:experimental:
 
 This page provides configuration examples to get started with a basic pipeline using any execution environment.
 
@@ -28,7 +28,7 @@ This page provides configuration examples to get started with a basic pipeline u
 * A code repository you want to build on CircleCI.
 * Follow the xref:create-project#[Create a Project] guide to connect your repository to CircleCI. You can then use the examples below to configure a basic pipeline using any execution environment.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [#echo-hello-world-cloud]
 == Echo hello world

--- a/jekyll/_cci2/introduction-to-yaml-configurations.adoc
+++ b/jekyll/_cci2/introduction-to-yaml-configurations.adoc
@@ -7,7 +7,6 @@ contentTags:
 ---
 = Introduction to YAML configuration
 :page-layout: classic-docs
-:page-liquid:
 :page-description: "Overview of CircleCI configuration written in YAML"
 :icons: font
 :experimental:
@@ -43,7 +42,7 @@ Some limitations exist depending on the execution environment in your configurat
 
 In the `.circleci/config.yml` file, we will add a Docker execution environment to our job `build`.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 ```yaml
 # CircleCI configuration file
@@ -135,7 +134,7 @@ If you use VS Code, you might find the official xref:vs-code-extension-overview#
 
 The extension provides real-time syntax highlighting and validation, improved navigation through go-to-definition and go-to-reference commands, usage hints and autocomplete suggestions.
 
-image::{{site.baseurl}}/assets/img/docs/vs_code_extension_config_helper_go-to-definition-optimised.gif[Screenshot showing the definition available on hover]
+image::vs_code_extension_config_helper_go-to-definition-optimised.gif[Screenshot showing the definition available on hover]
 
 Authenticating the extension with your CircleCI account will also allow you to visualize and manage your CircleCI pipelines directly from VS Code, and be notified of workflow status changes.
 The CircleCI VS Code extension is available to download on the link:https://marketplace.visualstudio.com/items?itemName=circleci.circleci[VS Code marketplace.]
@@ -148,7 +147,7 @@ Below are some fun examples of other YAML syntax that might become handy as you 
 [#multi-line-strings]
 === Multi-line strings
 
-If the value is a multi-line string, use the `>` character, followed by any number of lines. This is especially useful for lengthy commands.
+If the value is a multi-line string, use the `>` character, followed by any number of lines. This method is especially useful for lengthy commands.
 
 ```yaml
 haiku: >

--- a/jekyll/_cci2/jobs-steps.adoc
+++ b/jekyll/_cci2/jobs-steps.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 This page provides an overview of CircleCI jobs and steps.
 
@@ -84,7 +83,7 @@ image::/docs/assets/img/docs/pipelines-job-step-test-artifact.png[Job tab option
 
 Using parameters allows you to run a single job multiple times for different scenarios, such as different package versions or execution environments. An extension of this functionality is xref:configuration-reference#matrix[matrix jobs]. Below is a basic example of passing a parameter to a job when it is run.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yml]
 ----

--- a/jekyll/_cci2/migrating-from-aws.adoc
+++ b/jekyll/_cci2/migrating-from-aws.adoc
@@ -6,7 +6,6 @@ contentTags:
 ---
 = Migrate from AWS
 :page-layout: classic-docs
-:page-liquid:
 :page-description: This overview provides instructions for installing CircleCI Server on Amazon Web Services (AWS) with Terraform.
 :icons: font
 :experimental:
@@ -64,7 +63,7 @@ The AWS CodeBuild and CircleCI configurations will be different. It may be helpf
 [#configuration-comparison]
 == Configuration comparison
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [.table.table-striped.table-migrating-page]
 [cols=2*, options="header,unbreakable,autowidth", stripes=even]

--- a/jekyll/_cci2/migrating-from-azuredevops.adoc
+++ b/jekyll/_cci2/migrating-from-azuredevops.adoc
@@ -6,7 +6,6 @@ contentTags:
 ---
 = Migrate from Azure DevOps
 :page-layout: classic-docs
-:page-liquid:
 :page-description: An overview of how to migrate from Azure DevOps to CircleCI.
 :icons: font
 :experimental:
@@ -71,7 +70,7 @@ The Azure DevOps Pipelines and CircleCI configurations will be different. It may
 [#configuration-comparison]
 == Configuration comparison
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [.table.table-striped.table-migrating-page]
 [cols=2*, options="header,unbreakable,autowidth", stripes=even]

--- a/jekyll/_cci2/migrating-from-buildkite.adoc
+++ b/jekyll/_cci2/migrating-from-buildkite.adoc
@@ -6,7 +6,6 @@ contentTags:
 ---
 = Migrate from Buildkite
 :page-layout: classic-docs
-:page-liquid:
 :page-description: An overview of how to migrate from Buildkite to CircleCI.
 :icons: font
 :experimental:
@@ -64,7 +63,7 @@ The Buildkite and CircleCI configurations will be different. It may be helpful t
 [#configuration-comparison]
 == Configuration comparison
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [.table.table-striped.table-migrating-page]
 [cols=2*, options="header,unbreakable,autowidth", stripes=even]

--- a/jekyll/_cci2/migrating-from-github.adoc
+++ b/jekyll/_cci2/migrating-from-github.adoc
@@ -6,7 +6,6 @@ contentTags:
 ---
 = Migrate from GitHub Actions
 :page-layout: classic-docs
-:page-liquid:
 :page-description: An overview of how to migrate from GitHub Actions to CircleCI.
 :icons: font
 :experimental:
@@ -94,7 +93,7 @@ See the table in the next section to compare configuration.
 [#configuration-comparison]
 == Configuration comparison
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [.table.table-striped.table-migrating-page]
 [cols=2*, options="header,unbreakable,autowidth", stripes=even]

--- a/jekyll/_cci2/migrating-from-gitlab.adoc
+++ b/jekyll/_cci2/migrating-from-gitlab.adoc
@@ -6,7 +6,6 @@ contentTags:
 ---
 = Migrate from GitLab
 :page-layout: classic-docs
-:page-liquid:
 :page-description: An overview of how to migrate from GitLab to CircleCI.
 :icons: font
 :experimental:
@@ -38,7 +37,7 @@ The GitLab and CircleCI configurations will be different. It may be helpful to h
 [#configuration-comparison]
 == Configuration comparison
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [.table.table-striped.table-migrating-page]
 [cols=2*, options="header,unbreakable,autowidth", stripes=even]
@@ -207,7 +206,6 @@ test_async:
 a|
 [source, yaml]
 ----
-{% raw %}
 jobs:
   test_async:
     steps:
@@ -220,7 +218,6 @@ jobs:
           paths:
             - node_modules
       - run: node ./specs/start.js
-{% endraw %}
 ----
 |===
 

--- a/jekyll/_cci2/migrating-from-teamcity.adoc
+++ b/jekyll/_cci2/migrating-from-teamcity.adoc
@@ -6,7 +6,6 @@ contentTags:
 ---
 = Migrate from TeamCity
 :page-layout: classic-docs
-:page-liquid:
 :description: An overview of how to migrate from TeamCity to CircleCI.
 :source-highlighter: pygments.rb
 :icons: font
@@ -296,7 +295,7 @@ In TeamCity, build steps are chosen from a list of defined Runner Types (for exa
 
 Subsequently, this flexibility allows steps to be adapted to any language, framework, and tool. For example, a https://circleci.com/docs/language-ruby/[Rails project] may use a Ruby container and run `bundler` commands. A https://circleci.com/docs/language-javascript/[Node.js project] may use a Node container and `npm` commands. Visit our <<examples-and-guides-overview#,Examples and Guides Overview>> for various language and framework examples.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [.table.table-striped.table-migrating-page.table-no-background]
 [cols=2*, options="header,unbreakable,autowidth", stripes=even]

--- a/jekyll/_cci2/publish-packages-to-packagecloud.adoc
+++ b/jekyll/_cci2/publish-packages-to-packagecloud.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 In this how-to guide, you will learn how to configure CircleCI to publish packages to Packagecloud.
 
@@ -58,7 +57,7 @@ The build processes for package types will vary, but pushing them into a package
 
 The following is a full example `.circleci/config.yml` that will checkout a git repository, run a `make` task (this command can be anything configured to build your package), then deploy the package to a packagecloud repo.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yaml]
 ----

--- a/jekyll/_cci2/reusing-config.adoc
+++ b/jekyll/_cci2/reusing-config.adoc
@@ -9,11 +9,10 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 This guide describes how to get started with reusable commands, jobs, executors and orbs. This guide also covers the use of parameters for creating parameterized reusable elements.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [#notes-on-reusable-configuration]
 == Notes on reusable configuration
@@ -210,8 +209,6 @@ commands:
 
 The following `enum` type declaration is invalid because the default is not declared in the enum list.
 
-{% raw %}
-
 [,yaml]
 ----
 version: 2.1
@@ -224,8 +221,6 @@ commands:
         default: "windows" #invalid declaration of default that does not appear in the comma-separated enum list
         enum: ["darwin", "linux"]
 ----
-
-{% endraw %}
 
 [#executor]
 ==== Executor
@@ -241,8 +236,6 @@ The following example uses parameters:
  ** An enum parameter is used to choose a xref:configuration-reference#linuxvm-execution-environment[resource class].
 * For the `xenial` executor:
  ** A string parameter is used to set an environment variable.
-
-{% raw %}
 
 [,yaml]
 ----
@@ -307,14 +300,10 @@ workflows:
             image: ubuntu-2404:edge # Set the image to use
 ----
 
-{% endraw %}
-
 [#steps]
 ==== Steps
 
 Steps are used when you have a job or command that needs to mix predefined and user-defined steps. When passed in to a command or job invocation, the steps passed as parameters are always defined as a sequence, even if only one step is provided.
-
-{% raw %}
 
 [,yaml]
 ----
@@ -333,11 +322,7 @@ commands:
       - run: make test
 ----
 
-{% endraw %}
-
 The following example demonstrates that steps passed as parameters are given as the value of a `steps` declaration under the job's `steps`.
-
-{% raw %}
 
 [,yaml]
 ----
@@ -366,11 +351,7 @@ jobs:
             - run: echo "And now I'm going to run the tests"
 ----
 
-{% endraw %}
-
 The above will resolve to the following:
-
-{% raw %}
 
 [,yaml]
 ----
@@ -382,16 +363,12 @@ steps:
   - run: make test
 ----
 
-{% endraw %}
-
 [#environment-variable-name]
 ==== Environment variable name
 
 The environment variable name (`env_var_name`) parameter is a string that must match a POSIX_NAME regular expression (for example, there can be no spaces or special characters). The `env_var_name` parameter is a more meaningful parameter type that enables CircleCI to check that the string that has been passed can be used as an environment variable name. For more information on environment variables, see the guide to xref:env-vars#[Environment Variables].
 
 The example below shows you how to use the `env_var_name` parameter type for deploying to AWS S3 with a reusable `build` job. This example uses the `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables with the `access-key` and `secret-key` parameters. If you have a deploy job that runs the `s3cmd`, it is possible to create a reusable command that uses the needed authentication, but deploys to a custom bucket.
-
-{% raw %}
 
 Original `config.yml` file:
 
@@ -447,8 +424,6 @@ workflows:
           secret-key: BIN_BAZ
           command: ls s3://some/where
 ----
-
-{% endraw %}
 
 [#authoring-reusable-commands]
 == Authoring reusable commands
@@ -898,8 +873,6 @@ It is possible to invoke the same job more than once in the workflows stanza of 
 
 Example of defining and invoking a parameterized job in a `config.yml`:
 
-{% raw %}
-
 [,yaml]
 ----
 version: 2.1
@@ -923,8 +896,6 @@ workflows:
       - sayhello: # invokes the parameterized job
           saywhat: Everyone
 ----
-
-{% endraw %}
 
 When invoking the same job multiple times with parameters across any number of workflows, the build name will be changed (for example, `sayhello-1`, `sayhello-2`, etc.). To ensure build numbers are not appended, utilize the `name` key. The name you assign needs to be unique, otherwise the numbers will still be appended to the job name. As an example:
 

--- a/jekyll/_cci2/sample-config.adoc
+++ b/jekyll/_cci2/sample-config.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 This document provides sample `.circleci/config.yml` files that you can use as a starting point when setting up projects, or to better understand different ways to orchestrate jobs using workflows and filters. For information on all configuration elements available to you, see the xref:configuration-reference#[Configuration reference] page.
 
@@ -30,7 +29,7 @@ The CircleCI VS Code extension is available to download on the link:https://mark
 [#simple-configuration-examples]
 == Simple configuration examples
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [#concurrent-workflow]
 === Concurrent workflow
@@ -42,7 +41,7 @@ The configuration example below shows a concurrent workflow in which the `build`
 
 This image shows the workflow view for the following configuration example:
 
-image::{{ site.baseurl }}/assets/img/docs/concurrent-workflow-map.png[Concurrent Workflow Graph]
+image::concurrent-workflow-map.png[Concurrent Workflow Graph]
 
 [,yaml]
 ----
@@ -81,7 +80,7 @@ The configuration example below shows a sequential workflow where the `build` jo
 
 This image shows the workflow view for the following configuration example, in which jobs run sequentially (one after the other):
 
-image::{{ site.baseurl }}/assets/img/docs/sequential-workflow-map.png[Sequential Workflow Graph]
+image::sequential-workflow-map.png[Sequential Workflow Graph]
 
 [,yaml]
 ----
@@ -175,7 +174,7 @@ The image below shows the workflow view for the following configuration example.
 * The "Needs Approval" popup that appears when you click on a hold job
 * The workflow view again once the `hold` job has been approved and the `deploy` job has run
 
-image::{{ site.baseurl }}/assets/img/docs/approval-workflow-map.png[Approval Workflow Graph]
+image::approval-workflow-map.png[Approval Workflow Graph]
 
 * Refer to the xref:workflows#[Workflows] document for complete details about orchestrating job runs with concurrent, sequential, and manual approval workflows.
 * Refer to the link:https://circleci.com/developer/images?imageType=docker[developer hub convenience images] page to find out about available Docker images for running your jobs.
@@ -303,9 +302,7 @@ This example shows a sequential workflow with the `test` job configured to run o
 
 Below are two sample configurations for a Fan-in/Fan-out workflow.
 
-image::{{ site.baseurl }}/assets/img/docs/fan-in-out-example.png[Fan-in-out]
-
-{% raw %}
+image::fan-in-out-example.png[Fan-in-out]
 
 [,yaml]
 ----
@@ -441,8 +438,6 @@ workflows:
                       - build-docker-image
                       - test
 ----
-
-{% endraw %}
 
 NOTE: A job can only run when its dependencies are satisfied therefore it requires the dependencies of all upstream jobs. This means only the immediate upstream dependencies need to be specified in the `requires:` blocks.
 
@@ -720,8 +715,6 @@ workflows:
             branches:
               only: main
 ----
-
-{% raw %}
 --
 
 [tab.multiple-executors.Example_2]
@@ -779,8 +772,6 @@ workflows:
       - danger
       - build-and-test
 ----
-
-{% endraw %}
 --
 
 [#see-also]

--- a/jekyll/_cci2/set-environment-variable.adoc
+++ b/jekyll/_cci2/set-environment-variable.adoc
@@ -6,14 +6,13 @@ contentTags:
 ---
 = Set an environment variable
 :page-layout: classic-docs
-:page-liquid:
 :page-description: How to set environment variables for use in your CircleCI pipelines.
 :icons: font
 :experimental:
 
 Environment variables can be stored and configured for use in CircleCI jobs in several ways to provide variety in scope and authorization level.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [#set-an-environment-variable-in-a-shell-command]
 == Set an environment variable in a shell command

--- a/jekyll/_cci2/test-splitting-tutorial.adoc
+++ b/jekyll/_cci2/test-splitting-tutorial.adoc
@@ -6,7 +6,6 @@ contentTags:
 ---
 = Test splitting to speed up your pipelines
 :page-layout: classic-docs
-:page-liquid:
 :page-description: Learn to split and run tests in parallel in CircleCI.
 :icons: font
 :experimental:
@@ -46,7 +45,7 @@ When you set up the project in CircleCI later in this tutorial, you'll select th
 
 The following is a copy of the `.circleci/config.yml` template that you will *edit* later.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [source,yaml]
 ----

--- a/jekyll/_cci2/test.adoc
+++ b/jekyll/_cci2/test.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 [#introduction]
 == Introduction
@@ -25,7 +24,7 @@ To automatically run your test suites in a project pipeline, you will add config
 
 A pipeline might consist of a single workflow, with a single job defined that includes a step to execute a suite of tests within an execution environment.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yaml]
 ----
@@ -100,7 +99,7 @@ For more detailed examples of storing test data with different testing framework
 
 When xref:parallelism-faster-jobs#[parallelism and test splitting] are enabled, CircleCI provides a bird's-eye view into the timing of each parallel run in the *Timing* tab in the *Job Details* UI.
 
-image::{{site.baseurl}}/assets/img/docs/parallel-runs-timing-tests.png[Timing tab, parallel runs]
+image::parallel-runs-timing-tests.png[Timing tab, parallel runs]
 
 The Timing tab lets you identify which steps are taking the longest amount of time in a given parallel run so that you can make targeted improvements to reduce overall runtime.
 

--- a/jekyll/_cci2/using-branch-filters.adoc
+++ b/jekyll/_cci2/using-branch-filters.adoc
@@ -9,7 +9,6 @@ document-type:
 ---
 = Using branch filters
 :page-layout: classic-docs
-:page-liquid:
 :icons: font
 :experimental:
 
@@ -20,7 +19,7 @@ Branch filtering has previously only been available for workflows, but with comp
 
 The following example shows using the <<pipeline-variables#pipeline-values,pipeline value>> `pipeline.git.branch` to control `when` a step should run. In this case the step `run: echo "I am on main"` only runs when the commit is on the main branch:
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 ```yaml
 version: 2.1

--- a/jekyll/_cci2/using-docker.adoc
+++ b/jekyll/_cci2/using-docker.adoc
@@ -9,7 +9,6 @@ contentTags:
 :experimental:
 :icons: font
 :page-layout: classic-docs
-:page-liquid:
 
 CAUTION: *Legacy images with the prefix `circleci/`` were link:https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034[deprecated]* on December 31, 2021. For faster builds, upgrade your projects with link:https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/[next-generation convenience images].
 
@@ -17,7 +16,7 @@ You can use the Docker execution environment to run your xref:jobs-steps#[jobs] 
 
 Specify a Docker image in your xref:configuration-reference#[`.circleci/config.yml`] file to spin up a container. All steps in your job will be run in this container.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [,yaml]
 ----
@@ -92,19 +91,19 @@ jobs:
 
 For the Docker execution environment, the following resources classes are available for the x86 architecture:
 
-{% include snippets/docker-resource-table.adoc %}
+include::../_includes/snippets/docker-resource-table.adoc[]
 
 [#arm]
 === Arm
 
 The following resource classes are available for Arm with Docker:
 
-{% include snippets/docker-arm-resource-table.adoc %}
+include::../_includes/snippets/docker-arm-resource-table.adoc[]
 
 [#view-resource-usage]
 === View resource usage
 
-{% include snippets/resource-class-view.adoc %}
+include::../_includes/snippets/resource-class-view.adoc[]
 
 [#docker-benefits-and-limitations]
 == Docker benefits and limitations

--- a/jekyll/_cci2/using-matrix-jobs.adoc
+++ b/jekyll/_cci2/using-matrix-jobs.adoc
@@ -1,5 +1,4 @@
 ---
-description: "A how to guide for using matrix jobs to simplify your CircleCI configuration."
 contentTags:
   platform:
   - Cloud
@@ -8,8 +7,8 @@ document-type:
 - How-to
 ---
 = Using matrix jobs
+:page-description: "A how to guide for using matrix jobs to simplify your CircleCI configuration."
 :page-layout: classic-docs
-:page-liquid:
 :icons: font
 :experimental:
 
@@ -20,7 +19,7 @@ Matrix jobs provide a way to run a job multiple times with arguments. Arguments 
 
 In the following example, the `test` job is run across a Linux Docker container, Linux VM, and macOS environments, using two different versions of Node.js. On each run of the `test` job, different parameters are passed to set both the OS and the Node.js version:
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [source,yaml]
 ----

--- a/jekyll/_cci2/workflows.adoc
+++ b/jekyll/_cci2/workflows.adoc
@@ -7,7 +7,6 @@ contentTags:
 = Workflow orchestration
 :page-description: Learn about using CircleCI workflows to orchestrate jobs
 :page-layout: classic-docs
-:page-liquid:
 :icons: font
 :experimental:
 
@@ -40,7 +39,7 @@ The example in this section shows the default workflow orchestration model of co
 * Name the workflow, in this case, `build_and_test`.
 * Nest the `jobs` key with a list of job names that are defined in the configuration file. In this example the jobs have no dependencies defined, so they run concurrently.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [source,yaml]
 ----

--- a/jekyll/_cci2/workspaces.adoc
+++ b/jekyll/_cci2/workspaces.adoc
@@ -7,7 +7,6 @@ contentTags:
 = Using workspaces to share data between jobs
 :page-layout: classic-docs
 :page-description: This document describes how to use workspaces to share data to downstream jobs in your workflows.
-:page-liquid:
 :icons: font
 :experimental:
 
@@ -47,7 +46,7 @@ If you have custom storage settings, `persist_to_workspace` will default to the 
 
 Configure a job to get saved data by configuring the `attach_workspace` key. The following `.circleci/config.yml` file defines two jobs where the `downstream` job uses the artifact of the `flow` job. The workflow configuration is sequential, so that `downstream` requires `flow` to finish before it can start.
 
-{% include snippets/docker-auth.adoc %}
+include::../_includes/snippets/docker-auth.adoc[]
 
 [source,yaml]
 ----

--- a/jekyll/_includes/snippets/resource-class-view.adoc
+++ b/jekyll/_includes/snippets/resource-class-view.adoc
@@ -9,4 +9,4 @@ To view the compute resource usage for the duration of a job in the CircleCI web
 
 You can use these insights to decide whether to make changes to the job's configured resource class. You can also access xref:resource-class-overview#resource-class-insights[resource class Insights].
 
-image::{{site.baseurl}}/assets/img/docs/view-resource-usage.png[Resources tab]
+image::view-resource-usage.png[Resources tab]


### PR DESCRIPTION
# Description
Convert pages from liquid include syntax to asciidoctor include

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
