### PR TITLE
[CIAMP-1281] add note about missing deploy/user keys

### DIFF
--- a/jekyll/_cci2/github-integration.adoc
+++ b/jekyll/_cci2/github-integration.adoc
@@ -116,6 +116,17 @@ Deploy keys and user keys are the only key types that GitHub supports. Deploy ke
 
 To achieve fine-grained access to more than one repository, consider creating what GitHub calls a <<#controlling-access-via-a-machine-user,machine user>>. Give this user exactly the permissions your build requires, and then associate its user key with your project on CircleCI.
 
+[NOTE]
+====
+If your deploy keys or user keys appear to have gone missing, it may be due to one of the following reasons:
+
+* GitHub will remove inactive keys if no one uses them for over a year.
+* If CircleCI creates keys through a user's OAuth integration with GitHub, and the user revokes or removes the integration, GitHub will also remove the associated keys.
+* In GitHub, if an organization owner restricts or disables deploy keys across all repositories, GitHub may disable or remove existing deploy keys.
+* If your CircleCI project has no followers, CircleCI will consider it disabled and remove the associated keys.
+* When you delete a CircleCI project, CircleCI will remove its associated keys.
+====
+
 [#create-additional-github-ssh-keys]
 === Create additional GitHub SSH keys
 


### PR DESCRIPTION
Ticket: https://circleci.atlassian.net/browse/CIAMP-1281

# Description
Making a note about why deploy/user may go missing. 

# Reasons
Deploy keys going missing has been a longstanding issues for customers. There was a somewhat recent investigation into the issue [here](https://circleci.atlassian.net/browse/CIAMP-730) and we have decided to add these notes to highlight why the keys may mysteriously disappear. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.
