### PR TITLE
Fix typo in security group section header

### DIFF
--- a/jekyll/_cci2/contexts.adoc
+++ b/jekyll/_cci2/contexts.adoc
@@ -159,7 +159,7 @@ If the context is restricted with a group other than `All members`, you must be 
 
 NOTE: If a _deleted_ context is used in a job, the job will fail and show an error.
 
-[#security-goup-restrictions]
+[#security-group-restrictions]
 == Security group restrictions
 
 [#restrict-a-context-to-a-security-group-or-groups]

--- a/jekyll/_cci2/github-apps-integration.adoc
+++ b/jekyll/_cci2/github-apps-integration.adoc
@@ -181,7 +181,7 @@ The following sections are features of CircleCI which are not currently supporte
 
 [#restrict-a-context-to-a-security-group]
 === Restrict a context to a security group
-The ability to xref:contexts#security-goup-restrictions[restrict a context to a security group] is not supported for GitHub App projects.
+The ability to xref:contexts#security-group-restrictions[restrict a context to a security group] is not supported for GitHub App projects.
 
 [#in-app-config-editor]
 === In-app config editor

--- a/jekyll/_cci2/version-control-system-integration-overview.adoc
+++ b/jekyll/_cci2/version-control-system-integration-overview.adoc
@@ -331,7 +331,7 @@ include::../_includes/partials/tips/check-github-type.adoc[Check your GitHub int
 | [.circle-green]#**Yes**#
 | [.circle-green]#**Yes**#
 
-| xref:contexts#security-goup-restrictions[Security group context restriction]
+| xref:contexts#security-group-restrictions[Security group context restriction]
 | [.circle-red]#**No**#
 | [.circle-red]#**No**#
 | [.circle-red]#**No**#

--- a/jekyll/_cci2/webhooks.adoc
+++ b/jekyll/_cci2/webhooks.adoc
@@ -43,7 +43,7 @@ curl -X POST -H "content-type: application/json" 'https://internal.circleci.com/
 
 See our link:https://discuss.circleci.com/t/trigger-pipelines-from-anywhere-inbound-webhooks-now-in-preview/49864[community forum] for more details or how to use this functionality with a link:https://discuss.circleci.com/t/re-build-automatically-when-new-image-is-available-on-dockerhub/50350[3rd party service like DockerHub].
 
-NOTE: Custom webhooks will not work with xref:contexts#security-goup-restrictions[security group restrictions].  Additionally, the configuration file that is used for pipelines triggered by a custom webhook will only be visible in the CircleCI web app if the configuration file path is `.circleci/config.yml`.
+NOTE: Custom webhooks will not work with xref:contexts#security-group-restrictions[security group restrictions].  Additionally, the configuration file that is used for pipelines triggered by a custom webhook will only be visible in the CircleCI web app if the configuration file path is `.circleci/config.yml`.
 
 === Example: Trigger one pipeline from another
 

--- a/jekyll/_cci2/workflows.adoc
+++ b/jekyll/_cci2/workflows.adoc
@@ -439,7 +439,7 @@ workflows:
 
 The `test1` and `test2` jobs have access to environment variables stored in the `org-global` context if the pipeline meets the restrictions set for the context, for example:
 
-* Was the pipeline triggered by a user who xref:contexts#security-goup-restrictions[has access] (is in the relevant org/security group etc.)?
+* Was the pipeline triggered by a user who xref:contexts#security-group-restrictions[has access] (is in the relevant org/security group etc.)?
 * Does the xref:contexts#project-restrictions[project have access] to the context? By default all projects in an organization have access to contexts set for that organization, but restrictions on project access can be configured.
 * Does the pipeline meet the requirements of any xref:contexts#expression-restrictions[expression restrictions] set up for the context?
 


### PR DESCRIPTION
# Description
Changed `#security-goup-restrictions` to `#security-group-restrictions`

# Reasons
Fix typo