### PR TITLE
Update Custom Webhook Example

### DIFF
--- a/jekyll/_cci2/webhooks.adoc
+++ b/jekyll/_cci2/webhooks.adoc
@@ -38,7 +38,7 @@ NOTE: When triggering via `curl`, you must use a `POST` request with `content-ty
 +
 [,shell]
 ----
-curl -X POST -H "content-type: application/json" 'https://internal.circleci.com/private/soc/e/<your-URL>?secret=<your-secret>'
+curl -X POST -H "content-type: application/json" '<your-URL>?secret=<your-secret>'
 ----
 
 See our link:https://discuss.circleci.com/t/trigger-pipelines-from-anywhere-inbound-webhooks-now-in-preview/49864[community forum] for more details or how to use this functionality with a link:https://discuss.circleci.com/t/re-build-automatically-when-new-image-is-available-on-dockerhub/50350[3rd party service like DockerHub].


### PR DESCRIPTION
# Description
The current custom webhook example includes an example URL with a variable asking for the user to enter the full URL at the end.

```bash
curl -X POST -H "content-type: application/json" 'https://internal.circleci.com/private/soc/e/<your-URL>?secret=<your-secret>'
```

Updated the example to remove the example URL and just have the variable

```bash
curl -X POST -H "content-type: application/json" '<your-URL>?secret=<your-secret>'
```

# Reasons
Clear up confusion
