### PR TITLE
Update pipeline-values.adoc

### DIFF
--- a/jekyll/_includes/snippets/pipeline-values.adoc
+++ b/jekyll/_includes/snippets/pipeline-values.adoc
@@ -36,6 +36,13 @@
 | icon:check[]
 | icon:check[]
 
+| `pipeline.project.slug`
+| GitHub, BitBucket, GitLab
+| String
+| Will provide the project's URL slug, for example, `vcs/org-name/project-name`
+| icon:check[]
+| icon:check[]
+
 | `pipeline.git.tag`
 | GitHub, Bitbucket, GitLab
 | String


### PR DESCRIPTION
Add pipeline parameter `pipeline.project.slug` to the available pipeline parameter docs

# Description
Added the `pipeline.project.slug` pipeline parameter to the available pipeline parameter docs.

# Reasons
Customer reached out to let us know that this parameter is recommended to be used with our [serial group](https://circleci.com/docs/configuration-reference/#serial-group) functionality, but is not present in our available pipeline parameter docs

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ X] Break up walls of text by adding paragraph breaks.
- [ X] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [X ] Keep the title between 20 and 70 characters.
- [ X] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ X] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ X] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ X] Include relevant backlinks to other CircleCI docs/pages.
