### PR TITLE
Fix typo in orbs doc

### DIFF
--- a/jekyll/_cci2/server/latest/operator/managing-orbs.adoc
+++ b/jekyll/_cci2/server/latest/operator/managing-orbs.adoc
@@ -22,7 +22,7 @@ Orbs are accessed via the xref:../../../local-cli#[CircleCI CLI]. Orbs require y
 
 Ensure that you are using a personal API token generated _after_ your user account is made an admin.
 
-Providing a local repository location using the `--host` option allows you to access your local server orbs, rather than public cloud orbs. For example, if your server installation is located at `\http://circleci.somehostname.com`, you can run orb commands local to that orb repository by passing `--host \http://cirlceci.somehostname.com`.
+Providing a local repository location using the `--host` option allows you to access your local server orbs, rather than public cloud orbs. For example, if your server installation is located at `\http://circleci.somehostname.com`, you can run orb commands local to that orb repository by passing `--host \http://circleci.somehostname.com`.
 
 [#list-available-orbs]
 == List available orbs


### PR DESCRIPTION
# Description

Fix typo in server installation URL.

# Reasons

There is a typo in the example for the case of using a server vs. the hosted service.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
