### PR TITLE
Add documentation about the project slug

### DIFF
--- a/jekyll/_includes/partials/pipelines-and-triggers/pipeline-values.adoc
+++ b/jekyll/_includes/partials/pipelines-and-triggers/pipeline-values.adoc
@@ -29,6 +29,13 @@
 | icon:check[]
 | icon:check[]
 
+| `pipeline.project.slug`
+| GitHub, Bitbucket, GitLab
+| String
+| The unique URL slug for the project. For example, `gh/circleci/circleci-docs`.
+| icon:check[]
+| icon:check[]
+
 | `pipeline.project.type`
 | GitHub, Bitbucket, GitLab
 | String


### PR DESCRIPTION
# Description
Add documentation about the existing `pipeline.project.slug` pipeline value.

# Reasons

We refer to this elsewhere in documentation, cf snippets/orchestration-examples/serial-group.yml#L10. It makes sense to document it in this list of pipeline values.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.