### PR TITLE
Correct missing comma after <SECURITY_GROUP_ID> in policy

### DIFF
--- a/jekyll/_cci2/server/v4.4/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/v4.4/installation/phase-3-execution-environments.adoc
@@ -813,7 +813,7 @@ Create a `policy.json` file with the following content. You should fill in the I
         "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:placement-group/*",
         "arn:aws:ec2:*:*:subnet/*",
-        "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>"
+        "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>",
         "arn:aws:ec2:*:*:volume/*"
       ]
     },

--- a/jekyll/_cci2/server/v4.5/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/v4.5/installation/phase-3-execution-environments.adoc
@@ -813,7 +813,7 @@ Create a `policy.json` file with the following content. You should fill in the I
         "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:placement-group/*",
         "arn:aws:ec2:*:*:subnet/*",
-        "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>"
+        "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>",
         "arn:aws:ec2:*:*:volume/*"
       ]
     },

--- a/jekyll/_cci2/server/v4.6/installation/phase-3-execution-environments.adoc
+++ b/jekyll/_cci2/server/v4.6/installation/phase-3-execution-environments.adoc
@@ -812,7 +812,7 @@ Create a `policy.json` file with the following content. You should fill in the I
         "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:placement-group/*",
         "arn:aws:ec2:*:*:subnet/*",
-        "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>"
+        "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>",
         "arn:aws:ec2:*:*:volume/*"
       ]
     },

--- a/jekyll/_includes/server/latest/installation/phase-3.adoc
+++ b/jekyll/_includes/server/latest/installation/phase-3.adoc
@@ -810,7 +810,7 @@ Create a `policy.json` file with the following content. You should fill in the I
         "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:placement-group/*",
         "arn:aws:ec2:*:*:subnet/*",
-        "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>"
+        "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>",
         "arn:aws:ec2:*:*:volume/*"
       ]
     },


### PR DESCRIPTION
…r policy

# Description
Correct Machine provisioner IAM policy to include the missing comma `,` after the `<SECURITY_GROUP_ID>` for 4.4/4.5/4.6/4.7 server installation docs

# Reasons
* Prevents confusion when the policy is copy/pasted, improves doc quality