### PR TITLE
[ONPREM-2101] Update instructions on how to access the Nomad UI

### DIFF
--- a/jekyll/_cci2/server/latest/operator/introduction-to-nomad-cluster-operation.adoc
+++ b/jekyll/_cci2/server/latest/operator/introduction-to-nomad-cluster-operation.adoc
@@ -99,20 +99,11 @@ Complete the following steps to get logs from the allocation of the specified jo
 
 Nomad provides a web UI for inspecting your Nomad cluster. If you are using an internalized Nomad deployment, which is the default setup with CircleCI server, follow the instructions in this section to temporarily access the UI for troubleshooting purposes. For a more permanent solution, consider externalizing Nomad and consult the official Nomad documentation for setting up routing.
 
-. Nomad binds to its Pod IP. To port-forward to the Nomad service, you need to set up a lightweight tunneling mechanism within the cluster as follows:
+. In a terminal, run the following command to set up port forwarding:
 +
 [source,bash]
 ----
-export NOMAD_IP=$(kubectl get svc nomad-server -o jsonpath='{.spec.clusterIP}' -n <server-namespace>)
-
-kubectl run nomad-tunnel --rm -it --image=alpine --restart=Never -n <server-namespace> -- /bin/sh -c "apk add --no-cache socat && socat TCP-LISTEN:4646,fork,reuseaddr TCP:$NOMAD_IP:4646"
-----
-
-. In another terminal, run the following command to set up port forwarding:
-+
-[source,bash]
-----
-kubectl port-forward pod/nomad-tunnel 4646:4646 -n <server-namespace>
+kubectl port-forward svc/nomad-server 4646:4646 -n <server-namespace>
 ----
 
 . Navigate to `http://localhost:4646/ui` in your browser to access the Nomad UI. For more information on utilizing the Nomad UI, refer to the link:https://developer.hashicorp.com/nomad/tutorials/web-ui[Nomad documentation].


### PR DESCRIPTION
We made some changes to which address Nomad binds to that makes port-forwarding directly possible again

# Description
A brief description of the changes.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
