### PR TITLE
Update use-the-circleci-cli-to-split-tests.adoc

### DIFF
--- a/jekyll/_cci2/use-the-circleci-cli-to-split-tests.adoc
+++ b/jekyll/_cci2/use-the-circleci-cli-to-split-tests.adoc
@@ -301,7 +301,7 @@ jobs:
     resource_class: large
     steps:
       - run:
-          command: go list ./... | circleci tests run --command "xargs gotestsum --junitfile junit.xml --format testname --" --split-by=timings --timings-type=name
+          command: go list ./... | circleci tests run --command "xargs gotestsum --junitfile junit.xml --format testname --" --split-by=timings --timings-type=classname
 
       - store_test_results:
           path: junit.xml


### PR DESCRIPTION
# Description
Update --timings-type=name to --timings-type=classname

# Reasons
"name" is not supported and it errors if used

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [x] Include relevant backlinks to other CircleCI docs/pages.

# Next Steps
Merge PR. Enjoy correct documentation