### PR TITLE
Adding `override-with` key to config reference

### DIFF
--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -2679,7 +2679,7 @@ A job name that exists in your `config.yml`.
 [#override-with]
 ====== *`override-with`*
 
-The `override-with` key is used to override the job configuration with a job in the referenced orb.
+The `override-with` key is used to override the job configuration with a job from the referenced orb.
 
 [.table.table-striped]
 [cols=4*, options="header", stripes=even]
@@ -2689,7 +2689,7 @@ The `override-with` key is used to override the job configuration with a job in 
 | `override-with`
 | N
 | String
-| The orb job name to override the configuration with. (Both URL-based and registry orbs are supported)
+| The orb job name that will be used to override the existing job configuration. (Both URL-based and registry orbs are supported)
 |===
 
 *Example:*
@@ -2699,9 +2699,9 @@ The `override-with` key is used to override the job configuration with a job in 
 include::../_includes/snippets/orchestration-examples/override-with.yml[]
 ----
 
-In the example above, the _test_ job in the workflow is being overriden with the orb job _my-orb/my-test_. The _my-orb/my-test_ might be defined with a different resource class or execution steps. 
+In the example above, the `test` job in the workflow is being overriden with the orb job `my-orb/my-test`. The `my-orb/my-test` job might be defined with a different resource class or execution steps. 
 
-If the _my-orb/my-test_ job is not defined inside the orb, the _test_ job will compile using the local job definition.
+If the `my-orb/my-test` job is not defined inside the orb, the `test` job will compile using the local job definition.
 
 '''
 [#serial-group]

--- a/jekyll/_cci2/configuration-reference.adoc
+++ b/jekyll/_cci2/configuration-reference.adoc
@@ -2675,6 +2675,36 @@ A job can have the keys `requires`, `name`, `context`, `type`, and `filters`.
 A job name that exists in your `config.yml`.
 
 '''
+
+[#override-with]
+====== *`override-with`*
+
+The `override-with` key is used to override the job configuration with a job in the referenced orb.
+
+[.table.table-striped]
+[cols=4*, options="header", stripes=even]
+|===
+| Key | Required | Type | Description
+
+| `override-with`
+| N
+| String
+| The orb job name to override the configuration with. (Both URL-based and registry orbs are supported)
+|===
+
+*Example:*
+
+[,yml]
+----
+include::../_includes/snippets/orchestration-examples/override-with.yml[]
+----
+
+In the example above, the _test_ job in the workflow is being overriden with the orb job _my-orb/my-test_. The _my-orb/my-test_ might be defined with a different resource class or execution steps. 
+
+If the _my-orb/my-test_ job is not defined inside the orb, the _test_ job will compile using the local job definition.
+
+'''
+[#serial-group]
 ====== `serial-group`
 
 The `serial-group` key is used to add a property to a job to allow a group of jobs to run in series, rather than concurrently, across an organization. Serial groups control the orchestration of jobs across an organization, not just within projects and pipelines.

--- a/jekyll/_includes/snippets/orchestration-examples/override-with.yml
+++ b/jekyll/_includes/snippets/orchestration-examples/override-with.yml
@@ -1,0 +1,25 @@
+version: 2.1
+
+orbs:
+  my-orb: << url-ref >>
+
+jobs:
+  build:
+    steps: 
+      - run: task build
+  test:
+    steps:
+      - run: task test
+  deploy:
+    steps:
+      - run: ccc deploy
+
+workflows:
+  - build-test-deploy:
+      jobs:
+        - build:
+        - test:
+            override-with: my-orb/my-test
+            requires: build
+        - deploy:
+            requires: test


### PR DESCRIPTION
# Description
Adding a section for the `override-with` key to the configuration reference page.

# Reasons
The `override-with` key is new and needs to be documented.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
