### PR TITLE
Splitting webhook integration content over separate pages

### DIFF
--- a/jekyll/_cci2/custom-webhooks.adoc
+++ b/jekyll/_cci2/custom-webhooks.adoc
@@ -1,0 +1,126 @@
+---
+contentTags:
+  platform:
+  - Cloud
+  - Server v4+
+---
+= Custom webhooks
+:page-layout: classic-docs
+:page-description: Use webhooks to integrate with third-party services and subscribe to CircleCI events
+:icons: font
+:experimental:
+
+Setting up an inbound webhook (as a **custom webhook** trigger) on CircleCI enables a third party service to trigger a CircleCI pipeline. Any service that can send a webhook or make a `curl` request can trigger a CircleCI pipeline.
+
+=== Introduction
+
+NOTE: Custom webhooks are available for projects integrated via the GitHub App. Custom webhooks are not available on CircleCI server.
+
+Use **custom webhooks** to trigger a pipeline from anywhere that can emit a webhook or run a curl command.
+
+TIP: Custom webhooks are inbound to CircleCI and are used to trigger pipelines from other services. If you are looking for a way to have a CircleCI pipeline trigger a service, use an <<outbound-webhooks,outbound webhook>>.
+
+This section presents some use cases for CircleCI custom webhooks.
+
+=== Quickstart
+
+Follow these steps to set up and test a custom webhook trigger. Trigger from anywhere that can emit a webhook or run a curl command:
+
+include::../_includes/partials/pipelines-and-triggers/custom-webhook-setup.adoc[]
+
+. You can now test your custom webhook trigger with `curl`. To trigger your pipeline, copy and paste the following sample request and replace `<your-URL>` and `<your-secret>` with the URL and secret that you generated in the previous step:
++
+NOTE: When triggering via `curl`, you must use a `POST` request with `content-type: application/json`.
++
+[,shell]
+----
+curl -X POST -H "content-type: application/json" '<your-URL>?secret=<your-secret>'
+----
+
+See our link:https://discuss.circleci.com/t/trigger-pipelines-from-anywhere-inbound-webhooks-now-in-preview/49864[community forum] for more details or how to use this functionality with a link:https://discuss.circleci.com/t/re-build-automatically-when-new-image-is-available-on-dockerhub/50350[3rd party service like DockerHub].
+
+NOTE: Custom webhooks will not work with xref:contexts#security-group-restrictions[security group restrictions].  Additionally, the configuration file that is used for pipelines triggered by a custom webhook will only be visible in the CircleCI web app if the configuration file path is `.circleci/config.yml`.
+
+=== Example: Trigger one pipeline from another
+
+Use a custom webhook to configure one pipeline to trigger a second pipeline. For example, you might need to run a set of integration tests on a repository after you have made a change to a separate repository.
+
+For this example, assume you have two projects in separate repositories:
+
+TIP: You can also use this method to trigger one pipeline from another within the _same_ project.
+
+* Project A
+* Project B
+
+When a change is made to Project A, we want the full Project A configuration to be run, and then the Project B pipeline should be triggered. To achieve this, follow these steps:
+
+==== 1. Set up a custom webhook for Project B
+
+Navigate to Project B in the CircleCI web app and set up a custom webhook by following these steps:
+
+include::../_includes/partials/pipelines-and-triggers/custom-webhook-setup.adoc[]
+
+==== 2. Configure Project A to trigger Project B
+
+Navigate to Project A in the CircleCI web app and set up an environment variable. The value of the environment variable will be the secret from the custom webhook you just set up for Project B.
+
+TIP: As an alternative, you can add an environment variable using a xref:contexts#[context].
+
+. In the link:https://app.circleci.com/[CircleCI web app] select your organization.
+. Select **Projects** in the sidebar.
+. Find your project in the list, select the ellipsis (icon:ellipsis-h[]), and select **Project Settings**.
+. Select **Environment Variables** from the sidebar.
+. Select btn:[Add Environment Variable].
+. Give your environment variable a name, for example, `WEBHOOK_SECRET`.
+. Update your Project A configuration file with a step that will trigger a pipeline for Project B, for example (lines 13-16):
++
+[,yaml]
+----
+version: 2.1
+
+jobs:
+  say-hello:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run:
+          name: example
+          command: echo "one step"
+
+      - run:
+          name: Kick off new pipeline
+          command: |
+              curl -X POST -H "content-type: application/json" "https://internal.circleci.com/private/soc/e/6ccfca1c-5ed6-4dcf-96ca-374969d6edcb?secret=${WEBHOOK_SECRET}"
+
+workflows:
+  say-hello-workflow:
+    jobs:
+      - say-hello
+----
+
+=== Example: Extract custom webhook payload data
+
+The custom webhook body is available by using the `pipeline.trigger_parameters.webhook.body` xref:variables#pipeline-values[pipeline value].
+
+The following example shows how you can use `jq` to extract values from the webhook payload into environment variables when you want to use them in your configuration.
+
+In this example the webhook body contains a property called `branch`. `jq` is installed and used to extract the `branch` value into an environment variable named `WEBHOOK_BRANCH`, which is then used in a GitHub clone command.
+
+TIP: The xref:configuration-reference#commands[command] configured in this example uses commands from the link:https://circleci.com/developer/orbs/orb/circleci/jq[jq] and link:https://circleci.com/developer/orbs/orb/circleci/github-cli[GitHub CLI] orbs.
+
+[,yaml]
+----
+commands:
+  shallow_clone:
+    description: Shallow Git Clone
+    steps:
+      - gh/setup:
+          token: "GITHUB_TOKEN"
+      - jq/install
+      - run:
+          name: Shallow Clone
+          command: |
+            WEBHOOK_BRANCH=$(echo '<< pipeline.trigger_parameters.webhook.body >>' | jq '.branch')
+            gh repo clone << pipeline.trigger_parameters.github_app.repo_url >> . -- --depth 10 --branch "$WEBHOOK_BRANCH"
+----

--- a/jekyll/_cci2/outbound-webhooks.adoc
+++ b/jekyll/_cci2/outbound-webhooks.adoc
@@ -4,9 +4,9 @@ contentTags:
   - Cloud
   - Server v4+
 ---
-= Webhook integration
+= Outbound webhooks
 :page-layout: classic-docs
-:page-description: Use webhooks to integrate with third-party services and subscribe to CircleCI events
+:page-description: Use outbound webhooks to integrate with third-party services and subscribe to CircleCI events
 :icons: font
 :experimental:
 
@@ -14,123 +14,7 @@ A webhook allows you to connect a platform (for example, CircleCI, an API you cr
 
 Setting up an **outbound webhook** on CircleCI enables your third party service to receive information (referred to as _events_) from CircleCI, as they happen. This can help you avoid polling the API or manually checking the CircleCI web application for desired information.
 
-Setting up an inbound webhook (as a **custom webhook** trigger) on CircleCI enables a third party service to trigger a CircleCI pipeline. Any service that can send a webhook or make a `curl` request can trigger a CircleCI pipeline.
-
-== Custom webhooks
-
-NOTE: Custom webhooks are available for projects integrated via the GitHub App. Custom webhooks are not available on CircleCI server.
-
-Use **custom webhooks** to trigger a pipeline from anywhere that can emit a webhook or run a curl command.
-
-TIP: Custom webhooks are inbound to CircleCI and are used to trigger pipelines from other services. If you are looking for a way to have a CircleCI pipeline trigger a service, use an <<outbound-webhooks,outbound webhook>>.
-
-This section presents some use cases for CircleCI custom webhooks.
-
-=== Quickstart
-
-Follow these steps to set up and test a custom webhook trigger. Trigger from anywhere that can emit a webhook or run a curl command:
-
-include::../_includes/partials/pipelines-and-triggers/custom-webhook-setup.adoc[]
-
-. You can now test your custom webhook trigger with `curl`. To trigger your pipeline, copy and paste the following sample request and replace `<your-URL>` and `<your-secret>` with the URL and secret that you generated in the previous step:
-+
-NOTE: When triggering via `curl`, you must use a `POST` request with `content-type: application/json`.
-+
-[,shell]
-----
-curl -X POST -H "content-type: application/json" '<your-URL>?secret=<your-secret>'
-----
-
-See our link:https://discuss.circleci.com/t/trigger-pipelines-from-anywhere-inbound-webhooks-now-in-preview/49864[community forum] for more details or how to use this functionality with a link:https://discuss.circleci.com/t/re-build-automatically-when-new-image-is-available-on-dockerhub/50350[3rd party service like DockerHub].
-
-NOTE: Custom webhooks will not work with xref:contexts#security-group-restrictions[security group restrictions].  Additionally, the configuration file that is used for pipelines triggered by a custom webhook will only be visible in the CircleCI web app if the configuration file path is `.circleci/config.yml`.
-
-=== Example: Trigger one pipeline from another
-
-Use a custom webhook to configure one pipeline to trigger a second pipeline. For example, you might need to run a set of integration tests on a repository after you have made a change to a separate repository.
-
-For this example, assume you have two projects in separate repositories:
-
-TIP: You can also use this method to trigger one pipeline from another within the _same_ project.
-
-* Project A
-* Project B
-
-When a change is made to Project A, we want the full Project A configuration to be run, and then the Project B pipeline should be triggered. To achieve this, follow these steps:
-
-==== 1. Set up a custom webhook for Project B
-
-Navigate to Project B in the CircleCI web app and set up a custom webhook by following these steps:
-
-include::../_includes/partials/pipelines-and-triggers/custom-webhook-setup.adoc[]
-
-==== 2. Configure Project A to trigger Project B
-
-Navigate to Project A in the CircleCI web app and set up an environment variable. The value of the environment variable will be the secret from the custom webhook you just set up for Project B.
-
-TIP: As an alternative, you can add an environment variable using a xref:contexts#[context].
-
-. In the link:https://app.circleci.com/[CircleCI web app] select your organization.
-. Select **Projects** in the sidebar.
-. Find your project in the list, select the ellipsis (icon:ellipsis-h[]), and select **Project Settings**.
-. Select **Environment Variables** from the sidebar.
-. Select btn:[Add Environment Variable].
-. Give your environment variable a name, for example, `WEBHOOK_SECRET`.
-. Update your Project A configuration file with a step that will trigger a pipeline for Project B, for example (lines 13-16):
-+
-[,yaml]
-----
-version: 2.1
-
-jobs:
-  say-hello:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run:
-          name: example
-          command: echo "one step"
-
-      - run:
-          name: Kick off new pipeline
-          command: |
-              curl -X POST -H "content-type: application/json" "https://internal.circleci.com/private/soc/e/6ccfca1c-5ed6-4dcf-96ca-374969d6edcb?secret=${WEBHOOK_SECRET}"
-
-workflows:
-  say-hello-workflow:
-    jobs:
-      - say-hello
-----
-
-=== Example: Extract custom webhook payload data
-
-The custom webhook body is available by using the `pipeline.trigger_parameters.webhook.body` xref:variables#pipeline-values[pipeline value].
-
-The following example shows how you can use `jq` to extract values from the webhook payload into environment variables when you want to use them in your configuration.
-
-In this example the webhook body contains a property called `branch`. `jq` is installed and used to extract the `branch` value into an environment variable named `WEBHOOK_BRANCH`, which is then used in a GitHub clone command.
-
-TIP: The xref:configuration-reference#commands[command] configured in this example uses commands from the link:https://circleci.com/developer/orbs/orb/circleci/jq[jq] and link:https://circleci.com/developer/orbs/orb/circleci/github-cli[GitHub CLI] orbs.
-
-[,yaml]
-----
-commands:
-  shallow_clone:
-    description: Shallow Git Clone
-    steps:
-      - gh/setup:
-          token: "GITHUB_TOKEN"
-      - jq/install
-      - run:
-          name: Shallow Clone
-          command: |
-            WEBHOOK_BRANCH=$(echo '<< pipeline.trigger_parameters.webhook.body >>' | jq '.branch')
-            gh repo clone << pipeline.trigger_parameters.github_app.repo_url >> . -- --depth 10 --branch "$WEBHOOK_BRANCH"
-----
-
-== Outbound webhooks
-
+=== Introduction
 Use outbound webhooks to integrate your CircleCI builds with external services.
 
 For example, you could use <<outbound-webhooks>> to:

--- a/jekyll/_data/sidenav.yml
+++ b/jekyll/_data/sidenav.yml
@@ -136,8 +136,8 @@ en:
             link: github-trigger-event-options
           - name: GitLab trigger options
             link: gitlab-trigger-options
-          - name: Webhook integration
-            link: webhooks
+          - name: Custom webhooks
+            link: custom-webhooks
       - name: Schedule
         children:
           - name: Scheduled pipelines
@@ -631,8 +631,8 @@ en:
     children:
       - name: Integration features
         children:
-          - name: Webhook integration
-            link: webhooks
+          - name: Outbound webhooks
+            link: outbound-webhooks
           - name: Notifications overview
             link: notifications
           - name: Build open source projects


### PR DESCRIPTION
# Description
Splitting webhook integration content over two separate pages:
- Custom webhooks (under "Orchestrate and trigger > Trigger")
- Outbound webhooks (under "Integration > Integration features")

# Reasons
Having both types of webhooks on the same page was confusing.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
