### PR TITLE
Restore CODEOWNERS now that Renovate does not require this workaround

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,2 @@
 * @circleci/docs @circleci/docs-friends @circleci/lifecycle @circleci/product-mgmt-product-experience
 
-# removed owners to allow Renovate auto-merge
-Gemfile
-src-api/Gemfile
-.circleci/config.yml
-docker-compose-yml
-Dockerfile
-package.json
-src-api/package.json
-.ruby-version


### PR DESCRIPTION
Renovate used to require that we remove CODEOWNERS for files in order to auto-merge PRs. It no longer requires this, so let's remove this workaround. 

By _not_ having CODEOWNERS those of us who use GitHub notificatinos don't get pinged for Renovate PRs that touch only the affected files.

cf https://circleci.slack.com/archives/C06BR4CLXAT/p1747045241350629?thread_ts=1747045174.500279&cid=C06BR4CLXAT

NB. It is the owner's responsibility to merge this PR.

[_Created by Sourcegraph batch change `stig/restore-codeowners`._](https://circleci.sourcegraphcloud.com/users/stig/batch-changes/restore-codeowners)