### PR TITLE
Adds consistency information to the custom webhooks triggers overview

### DIFF
--- a/jekyll/_cci2/triggers-overview.adoc
+++ b/jekyll/_cci2/triggers-overview.adoc
@@ -185,7 +185,13 @@ curl -X POST -H "content-type: application/json" 'https://internal.circleci.com/
 
 For more information on using custom and outbound webhooks, see the xref:webhooks#[Use webhooks to integrate with services] page. Also, see our link:https://discuss.circleci.com/t/trigger-pipelines-from-anywhere-inbound-webhooks-now-in-preview/49864[community forum] for more details or how to use this functionality with a link:https://discuss.circleci.com/t/re-build-automatically-when-new-image-is-available-on-dockerhub/50350[3rd party service like DockerHub].
 
-+
+[NOTE]
+====
+When handling custom webhook requests, we use the "config branch" and "checkout branch" fields (`config_ref` and `checkout_ref` in the API) to determine which commits should be used for config and code checkout. This information is retrieved from link:https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit[GitHub's API].
+
+Since GitHub does not provide documented consistency guarantees for their API responses, there can be a brief delay (typically seconds) between when a commit is pushed and when the API returns the updated reference, especially with larger repositories. As a result, when fetching a branch reference, you may receive a slightly outdated commit rather than the most recent one.
+====
+
 NOTE: when handling custom webhook requests, we talk to 3rd party integrations via their APIs to fetch information such as what commit we should checkout, or where we should fetch the config file from. Integrations such as GitHub, do not have any consistency guarantees publicly documented and as such, there is a small posibility that we are given data that isn't fully up-to-date. 
 +
 

--- a/jekyll/_cci2/triggers-overview.adoc
+++ b/jekyll/_cci2/triggers-overview.adoc
@@ -192,9 +192,6 @@ When handling custom webhook requests, we use the "config branch" and "checkout 
 Since GitHub does not provide documented consistency guarantees for their API responses, there can be a brief delay (typically seconds) between when a commit is pushed and when the API returns the updated reference, especially with larger repositories. As a result, when fetching a branch reference, you may receive a slightly outdated commit rather than the most recent one.
 ====
 
-NOTE: when handling custom webhook requests, we talk to 3rd party integrations via their APIs to fetch information such as what commit we should checkout, or where we should fetch the config file from. Integrations such as GitHub, do not have any consistency guarantees publicly documented and as such, there is a small posibility that we are given data that isn't fully up-to-date. 
-+
-
 [#trigger-a-pipeline-from-vs-code-with-unversioned-config]
 == Trigger a pipeline from VS Code with unversioned config
 

--- a/jekyll/_cci2/triggers-overview.adoc
+++ b/jekyll/_cci2/triggers-overview.adoc
@@ -185,6 +185,10 @@ curl -X POST -H "content-type: application/json" 'https://internal.circleci.com/
 
 For more information on using custom and outbound webhooks, see the xref:webhooks#[Use webhooks to integrate with services] page. Also, see our link:https://discuss.circleci.com/t/trigger-pipelines-from-anywhere-inbound-webhooks-now-in-preview/49864[community forum] for more details or how to use this functionality with a link:https://discuss.circleci.com/t/re-build-automatically-when-new-image-is-available-on-dockerhub/50350[3rd party service like DockerHub].
 
++
+NOTE: when handling custom webhook requests, we talk to 3rd party integrations via their APIs to fetch information such as what commit we should checkout, or where we should fetch the config file from. Integrations such as GitHub, do not have any consistency guarantees publicly documented and as such, there is a small posibility that we are given data that isn't fully up-to-date. 
++
+
 [#trigger-a-pipeline-from-vs-code-with-unversioned-config]
 == Trigger a pipeline from VS Code with unversioned config
 


### PR DESCRIPTION
We've had issues where GitHub has changed how they respond to us such that the responses aren't fully consistent. This means there is a possibility that we are returned with data that is slightly stale when their system is processing write requests to their backend.

This note attempts to highlight to customers that this is the case and it's something we can point customers to if they experience any issues like this.

# Reasons
A link to a GitHub and/or JIRA issue (if applicable).
Otherwise, a brief sentence about why you made these changes.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
