### PR TITLE
Update `Trigger pipelines with unversioned config` org and project setting docs

### DIFF
--- a/jekyll/_cci2/introduction-to-the-circleci-web-app.adoc
+++ b/jekyll/_cci2/introduction-to-the-circleci-web-app.adoc
@@ -179,6 +179,7 @@ The following settings are available in the project settings page. If you do not
 * Auto-cancel redundant workflows
 * Free and open source
 * Enable dynamic config using setup workflows.
+* xref:triggers-overview#trigger-a-pipeline-from-vs-code-with-unversioned-config[Trigger a pipeline with unversioned config] feature
 
 More information on these settings can be found on this page, as well as in our documentation.
 
@@ -191,8 +192,6 @@ More information on these settings can be found on this page, as well as in our 
 **LLMOps**: Set up integrations with LLMOps providers to streamline the process of configuring pipelines to build and test LLM-enabled applications.
 
 **Slack Integrations**: Authenticate Slack and set up the Slack orb in your config file to integrate Slack into your projects.
-
-**VS Code Integration**: Provides information and a link to organization settings to enable the xref:triggers-overview#trigger-a-pipeline-from-vs-code-with-unversioned-config[Trigger a pipeline with unversioned config] feature, which is currently in open-preview for some customers.
 
 **Status Badges**: A tool that allows you to generate a code snippet that will display your project's build status in a README or other document.
 

--- a/jekyll/_cci2/introduction-to-the-circleci-web-app.adoc
+++ b/jekyll/_cci2/introduction-to-the-circleci-web-app.adoc
@@ -179,7 +179,7 @@ The following settings are available in the project settings page. If you do not
 * Auto-cancel redundant workflows
 * Free and open source
 * Enable dynamic config using setup workflows.
-* xref:triggers-overview#trigger-a-pipeline-from-vs-code-with-unversioned-config[Trigger a pipeline with unversioned config] feature
+* xref:triggers-overview#trigger-a-pipeline-from-vs-code-with-unversioned-config[Trigger a pipeline with unversioned config].
 
 More information on these settings can be found on this page, as well as in our documentation.
 

--- a/jekyll/_cci2/vs-code-extension-overview.adoc
+++ b/jekyll/_cci2/vs-code-extension-overview.adoc
@@ -217,7 +217,7 @@ The ability to trigger pipelines from VS Code can be controlled **at the org lev
 
 * Organization level settings can be found under menu:Organization Settings[Advanced]. The setting default is **Off**. Toggle the "Trigger pipelines with unversioned config" option to **On** to opt-in. Organization level settings override project settings, and they can be changed only by organization admins.
 
-* Project level settings can be found under menu:Project Settings[VS Code integration]. The setting default is **On**. Toggle the "Trigger pipelines with unversioned config" option to **Off** to opt-out.
+* Project level settings can be found under menu:Project Settings[Advanced]. The setting default is **On**. Toggle the "Trigger pipelines with unversioned config" option to **Off** to opt-out.
 
 [#security-implications]
 === Security Implications


### PR DESCRIPTION
The setting has been enabled for standalone orgs, so it is available in org and project settings under the `Advanced` tab
