### PR TITLE
adding docs for task agent caching

### DIFF
--- a/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
+++ b/jekyll/_cci2/machine-runner-3-configuration-reference.adoc
@@ -257,6 +257,20 @@ runner:
   mode: single-task
 ```
 
+[#cache-task-agent]
+=== `runner.cache_task_agent`
+
+`$CACHE_TASK_AGENT`
+
+When set to true, machine runner will not clear the task-agent cache when the agent shuts down. On startup the machine agent will check for an already downloaded task agent and will use that task-agent unless there is a newer version of task-agent available for download. This feature is off by default. This may be particularly useful for Windows which relies on `single-task` mode.
+
+Example:
+
+```yaml
+runner:
+  cache_task_agent: true
+```
+
 [#runner-max-run-time]
 === `runner.max_run_time`
 


### PR DESCRIPTION
# Description
We added the `cache-task-agent` flag to machine runner in 3.1.1 but did not add the documentation for it. This PR adds the missing docs.

# Reasons
https://circleci.atlassian.net/browse/ONPREM-1980

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
