### PR TITLE
[ONPREM-2358] Add step when upgrading server 4.7 to enable RabbitMQ feature flags 

### DIFF
--- a/jekyll/_cci2/server/v4.7/installation/upgrade-server.adoc
+++ b/jekyll/_cci2/server/v4.7/installation/upgrade-server.adoc
@@ -29,7 +29,7 @@ To see some common upgrade path options, see link:https://support.circleci.com/h
 [#recommendations]
 == Recommendations
 
-We have moved away from Vault to Tink for encryption. The process for migration is link:https://github.com/CircleCI-Public/server-scripts/tree/main/vault-to-tink[documented here]. The migration includes a convenience script to move existing secrets. If you are using Vault, you should complete the migration to Tink on your v4.3.x installation before backing up your server installation in preparation for upgrading to v4.7. Customers that do not perform this step may have issues restoring Vault from backup in v4.7.
+We have moved away from Vault to Tink for encryption. The migration process is link:https://github.com/CircleCI-Public/server-scripts/tree/main/vault-to-tink[documented here]. The migration includes a convenience script to move existing secrets. If you use Vault, complete the migration to Tink on your v4.3.x installation first. Back up your server installation after the migration. Do this before upgrading to v4.7. Customers that skip this step may have issues restoring Vault from backup in v4.7.
 
 [#prerequisites]
 == Prerequisites
@@ -49,6 +49,13 @@ We have moved away from Vault to Tink for encryption. The process for migration 
 +
 [source,shell,subs=attributes+]
 helm diff upgrade circleci-server oci://cciserver.azurecr.io/circleci-server -n $namespace --version {serverversion47} -f <path-to-values.yaml> --username $USERNAME --password $PASSWORD
+
+. If using internalized RabbitMQ (the default on server), enable stable feature flags:
++
+[source,shell,subs=attributes+]
+kubectl exec -it rabbitmq-0 -n $namespace -- rabbitmqctl enable_feature_flag all
++
+link:https://www.rabbitmq.com/docs/feature-flags[The RabbitMQ docs] advise enabling stable feature flags as RabbitMQ is being upgraded. You only need to run this step once. Future server upgrades will not require it.
 
 . Perform the upgrade:
 +


### PR DESCRIPTION
# Description
RabbitMQ requires all stable feature flags to be enabled when upgrading. This adds a step to the server 4.7 upgrade docs on enabling those as we upgraded RabbitMQ this release.

# Reasons

https://circleci.atlassian.net/browse/ONPREM-2358

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.
