### PR TITLE
server: update date for 4.6 EOF

### DIFF
--- a/jekyll/_cci2/server/latest/operator/application-lifecycle.adoc
+++ b/jekyll/_cci2/server/latest/operator/application-lifecycle.adoc
@@ -40,8 +40,8 @@ CAUTION: Future dates listed here may change at any time.
 | Version | Released | End of Support
 
 |4.8.x
-|TBC
-|TBC
+|07/24/2025
+|07/24/2026*
 
 |4.7.x
 |11/07/2024
@@ -49,23 +49,23 @@ CAUTION: Future dates listed here may change at any time.
 
 |4.6.x
 |8/12/2024
-|8/12/2025*
+|07/24/2025
 
 |4.5.x
 |4/30/2024
-|4/30/2025*
+|4/30/2025
 
 |4.4.x
 |2/05/2024
-|2/28/2025*
+|2/28/2025
 
 |4.3.x
 |11/07/2023
-|11/30/2024*
+|11/30/2024
 
 |4.2.x
 |7/18/2023
-|7/31/2024*
+|7/31/2024
 
 |4.1.x
 |3/21/2023

--- a/jekyll/_cci2/server/v4.6/operator/application-lifecycle.adoc
+++ b/jekyll/_cci2/server/v4.6/operator/application-lifecycle.adoc
@@ -41,7 +41,7 @@ CAUTION: Future dates listed here may change at any time.
 
 |4.6.x
 |8/12/2024
-|8/12/2025*
+|07/24/2025
 
 |4.5.x
 |4/30/2024

--- a/jekyll/_cci2/server/v4.7/operator/application-lifecycle.adoc
+++ b/jekyll/_cci2/server/v4.7/operator/application-lifecycle.adoc
@@ -46,7 +46,7 @@ CAUTION: Future dates listed here may change at any time.
 
 |4.6.x
 |8/12/2024
-|8/12/2025*
+|07/24/2025
 
 |4.5.x
 |4/30/2024


### PR DESCRIPTION
# Description

With the release of [server 4.8](https://circleci.com/changelog/server-release-4-8-0/), the 4.6 version was now EOLed as per [our release cadence](https://circleci.com/changelog/server-releases-moving-to-twice-yearly/).

# Reasons

@vjpandian reminded us to do that [here](https://circleci.slack.com/archives/C016ZEHS3L5/p1751922107926539?thread_ts=1751921030.565419&cid=C016ZEHS3L5).

