### PR TITLE
Update roles-and-permissions tables

### DIFF
--- a/docs/guides/modules/permissions-authentication/pages/roles-and-permissions-overview.adoc
+++ b/docs/guides/modules/permissions-authentication/pages/roles-and-permissions-overview.adoc
@@ -20,7 +20,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 | *Organization*
 ^| *Admin*
@@ -106,7 +106,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 | *Insights*
 ^| *Admin*
@@ -122,7 +122,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 | *Runner*
 ^| *Admin*
@@ -143,7 +143,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 | *Projects*
 ^| *Admin*
@@ -169,7 +169,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 | *Contexts*
 ^| *Admin*
@@ -200,7 +200,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 | *Orbs*
 ^| *Admin*
@@ -231,7 +231,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 | *Webhooks*
 ^| *Admin*
@@ -262,7 +262,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 | *Schedule*
 ^| *Admin*
@@ -283,7 +283,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 |*Triggers*
 ^| *Admin*
@@ -309,7 +309,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 |*Pipelines*
 ^| *Admin*
@@ -330,7 +330,7 @@ The table below shows the permissions associated with each CircleCI organization
 [cols=4*, options="header"]
 |===
 | ACTIONS
-3+| ORGANIZATION ROLES
+3+^| ORGANIZATION ROLES
 
 |*Releases*
 ^| *Admin*


### PR DESCRIPTION

# Background
When looking at the tables on the[ roles-and-permissions-overview page](https://circleci.com/docs/guides/permissions-authentication/roles-and-permissions-overview/), the 'ORGANIZATION ROLES` header looks off. The header is left-aligned and although it looks center-aligned over the 'Admin' role,  it should be center-aligned above all 3 roles

Current table layout:
<img width="829" height="258" alt="image" src="https://github.com/user-attachments/assets/3f7e0580-49a0-44e5-8b66-1b0ea1ef848e" />

Proposed change:
<img width="829" height="258" alt="image" src="https://github.com/user-attachments/assets/a20e8e4b-50fc-43ff-90dc-a5865aa66cd5" />


# Reasons
The table doesn't look like it's formatted when the 'ORGANIZATION ROLES` is left aligned and the sub-headers are center aligned 

# How has it been tested?
No testing, but it's purely a formatting change, no content is getting changed. The changes were checked in an asciidoc editor before being applied in the branch

# What other systems will this impact?
None