### PR TITLE
Document organization deletion feature

### DIFF
--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -252,6 +252,7 @@
 *** xref:security:rotate-project-ssh-keys.adoc[Rotate project SSH keys]
 *** xref:security:stop-building-a-project-on-circleci.adoc[Stop building a project on CircleCI]
 *** xref:security:rename-organizations-and-repositories.adoc[Rename organizations and repositories]
+*** xref:security:delete-organizations-and-projects.adoc[Delete organizations and projects]
 
 * Manage config policies
 ** xref:config-policies:config-policy-management-overview.adoc[Config policy management overview]

--- a/docs/guides/modules/security/pages/delete-organizations-and-projects.adoc
+++ b/docs/guides/modules/security/pages/delete-organizations-and-projects.adoc
@@ -1,0 +1,107 @@
+= Delete organizations and projects
+:page-platform: Cloud
+:page-description: Learn how to delete organizations and projects in CircleCI.
+:experimental:
+
+This page details everything you need to know about deleting organizations and projects connected to CircleCI.
+
+[cols="1,^1,^1,2", options="header"]
+|===
+| VCS integration | Delete organization | Delete project | Notes
+
+| GitHub App
+| [.circle-green]#Yes#
+| [.circle-green]#Yes#
+| Lore ipsum dolor sit amet.
+
+| GitLab
+| [.circle-green]#Yes#
+| [.circle-green]#Yes#
+| Lore ipsum dolor sit amet.
+
+| Bitbucket Data Center
+| [.circle-green]#Yes#
+| [.circle-green]#Yes#
+| Lore ipsum dolor sit amet.
+
+| GitHub OAuth app
+| [.circle-green]#Yes#
+| [.circle-green]#Yes#
+| Lore ipsum dolor sit amet.
+
+| Bitbucket Cloud
+| [.circle-green]#Yes#
+| [.circle-green]#Yes#
+| Lore ipsum dolor sit amet.
+
+|===
+
+
+[#delete-an-organization]
+== Delete an organization
+
+NOTE: You can only delete an organization when both the below conditions are met:
+
+- The organization has a Free plan.
+- The user performing the action has an admin role in the organization.
+
+You can delete your organization from the CircleCI web app or via the CircleCI API:
+
+[tabs]
+====
+CircleCI web app::
++
+--
+. Select the organization you want to remove.
+. Select **Organization Settings** in the sidebar.
+. Scroll to the bottom of the Overview page and select btn:[Delete Organization].
+. Confirm your choice by entering the organization and selecting the btn:[Permanently Delete Organization] in the popup.
+--
+API::
++
+--
+. Set up your API authentication. Steps are available in the xref:toolkit:api-developers-guide.adoc#add-an-api-token[API developers guide].
+. You can use the link:https://circleci.com/docs/api/v2/#tag/Organization/operation/deleteOrganization[Delete an organization] endpoint with either your oprganization ID or your organization slug. Both can be retrieved from the CircleCI web app under menu:Organization Settings[Overview].
++
+[,shell]
+----
+curl --request DELETE \
+  --url https://circleci.com/api/v2/organization/<org-slug-or-id> \
+  --header "Circle-Token: ${CIRCLE_TOKEN}"
+----
+--
+====
+
+[#delete-a-project]
+== Delete a project
+
+NOTE: Only organization admins and project admins can delete projects.
+
+If you want to remove a project from your CircleCI account, follow the steps below. Deleting a project will remove the complete build history. 
+
+[tabs]
+====
+CircleCI web app::
++
+--
+. Select the organization associated with the project you want to remove.
+. Select the project you want to remove from the project cards. If you do not see your project, select **Projects** in the sidebar and find it in the list.
+. Select **Project Settings** (or the ellipsis next to your project image:guides:ROOT:icons/more.svg[more icon, role="no-border"] and then select **Project Settings**).
+. Scroll to the bottom of the Overview page and select **Delete Project** and confirm your choice in the popup.
+--
+API::
++
+--
+. Set up your API authentication. Steps are available in the xref:toolkit:api-developers-guide.adoc#add-an-api-token[API developers guide].
+. You will need the project slug to use the link:https://circleci.com/docs/api/v2/#tag/Project/operation/deleteProjectBySlug[Delete a project] endpoint. You can retrieve the project slug from the CircleCI web app under menu:Project Settings[Overview].
++
+[,shell]
+----
+curl --request DELETE \
+  --url https://circleci.com/api/v2/project/<project-slug> \
+  --header "Circle-Token: ${CIRCLE_TOKEN}"
+----
+--
+====
+
+If you encounter an error, open a new link:https://support.circleci.com/hc/en-us/requests/new[support request] with details of the project that you wish to remove. Choose the "Build Failure/Configuration Help/Service Issue" option when opening the request. For more information on submitting support requests, see this https://support.circleci.com/hc/en-us/articles/27162205043995-How-to-submit-a-support-ticket[support article].

--- a/docs/guides/modules/security/pages/delete-organizations-and-projects.adoc
+++ b/docs/guides/modules/security/pages/delete-organizations-and-projects.adoc
@@ -40,11 +40,13 @@ This page details everything you need to know about deleting organizations and p
 [#delete-an-organization]
 == Delete an organization
 
-NOTE: You can only delete an organization when both the below conditions are met:
+[NOTE]
+====
+You can only delete an organization when both the below conditions are met:
 
 - The organization has a Free plan.
 - The user performing the action has an admin role in the organization.
-
+====
 You can delete your organization from the CircleCI web app or via the CircleCI API:
 
 [tabs]
@@ -87,7 +89,7 @@ CircleCI web app::
 . Select the organization associated with the project you want to remove.
 . Select the project you want to remove from the project cards. If you do not see your project, select **Projects** in the sidebar and find it in the list.
 . Select **Project Settings** (or the ellipsis next to your project image:guides:ROOT:icons/more.svg[more icon, role="no-border"] and then select **Project Settings**).
-. Scroll to the bottom of the Overview page and select **Delete Project** and confirm your choice in the popup.
+. Scroll to the bottom of the Overview page, select **Delete Project**, and confirm your choice in the popup.
 --
 API::
 +

--- a/docs/guides/modules/security/pages/stop-building-a-project-on-circleci.adoc
+++ b/docs/guides/modules/security/pages/stop-building-a-project-on-circleci.adoc
@@ -10,7 +10,7 @@ This page outlines how to stop builds for a project on CircleCI, and how to dele
 [#stop-building-a-project]
 == Stop building a project
 
-CAUTION: The **Stop Building** option will not automatically remove all project data from the CircleCI databases. To remove all project data from CircleCI you need to contact CircleCI support, as detailed in the <<remove-a-project-from-circleci>> section.
+CAUTION: The **Stop Building** option will not automatically remove all project data from the CircleCI databases. To remove all project data from CircleCI, see the xref:security:delete-organizations-and-projects.adoc#delete-a-project[Delete a project] documentation.
 
 include::ROOT:partial$notes/standalone-unsupported.adoc[This feature is not supported for GitLab, GitHub App or Bitbucket Data Center]
 
@@ -20,16 +20,3 @@ If you are using the GitHub OAuth App or Bitbucket Cloud, to stop building one o
 . Scroll to the bottom of the Overview page and select **Stop Building**. You will need to reconfirm your choice in the popup.
 
 NOTE: If you want to start building this project again, just go to the **Projects** page in the web app and select **Set Up Project** and follow the set up steps.
-
-[#remove-a-project-from-circleci]
-== Delete a project from CircleCI
-
-If you want to remove a project from your CircleCI account, follow the steps below. Deleting a project will remove the complete build history. Only organization admins and project admins can delete projects.
-
-. In the link:https://app.circleci.com/home/[CircleCI web app], select the organization associated with the project you want to remove.
-. Select the project you want to remove from the project cards. If you do not see your project, select **Projects** in the sidebar and find it in the list.
-. Select **Project Settings** (or the ellipsis next to your project image:guides:ROOT:icons/more.svg[more icon, role="no-border"] and then select **Project Settings**).
-. Scroll to the bottom of the Overview page and select **Delete Project** and reconfirm your choice in the popup.
-
-
-If you encounter an error, open a new link:https://support.circleci.com/hc/en-us/requests/new[support request] with details of the project that you wish to remove. Choose the "Build Failure/Configuration Help/Service Issue" option when opening the request. For more information on submitting support requests, see this https://support.circleci.com/hc/en-us/articles/27162205043995-How-to-submit-a-support-ticket[support article].


### PR DESCRIPTION
# Description
- Added a new page to document organization deletion.
- Moved project deletion content from the [Stop building a project on CircleCI](https://circleci.com/docs/guides/security/stop-building-a-project-on-circleci) page to the newly created page.
- Updated note on the "Stop building a project on CircleCI" page with an `xref` to the new location of the project deletion content.
- Added navigation item (under"Manage security and secrets" > "How-to guides") pointing to the new content.

# Reasons
- Organization deletion is available but is not documented. 
- Regrouping deletion-related content on a single page makes more sense (up for debate 😅 )

# Left to do
- Update the [Roles and permissions matrix](https://circleci.com/docs/roles-and-permissions-overview/#organization-role-permissions-matrix) to include organization and project deletion.
- Fix the column title alignment in all tables of the aforementioned matrix.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
