### PR TITLE
Use trailing slashes on all relativised URLs

### DIFF
--- a/ui/src/partials/landing.hbs
+++ b/ui/src/partials/landing.hbs
@@ -9,13 +9,13 @@
     </p>
     <ol class="list-decimal list-inside text-link-on-light">
       <li>
-        <a href="{{{relativize '/guides/getting-started/first-steps'}}}">Connect your code</a>
+        <a href="{{{relativize '/guides/getting-started/first-steps/'}}}">Connect your code</a>
       </li>
       <li>
-        <a href="{{{relativize '/guides/getting-started/create-project'}}}">Set up a project</a>
+        <a href="{{{relativize '/guides/getting-started/create-project/'}}}">Set up a project</a>
       </li>
       <li>
-        <a href="{{{relativize '/guides/getting-started/invite-your-team'}}}">Invite your team</a>
+        <a href="{{{relativize '/guides/getting-started/invite-your-team/'}}}">Invite your team</a>
       </li>
     </ol>
   </div>
@@ -29,7 +29,7 @@
     </p>
 
     <div class="flex flex-col md:flex-row gap-8 md:justify-between">
-      <a href="{{{relativize '/guides/getting-started/getting-started'}}}" class="group flex-1 rounded-2xl border border-vapor p-8 hover:bg-inline-grey flex flex-col justify-between items-start">
+      <a href="{{{relativize '/guides/getting-started/getting-started/'}}}" class="group flex-1 rounded-2xl border border-vapor p-8 hover:bg-inline-grey flex flex-col justify-between items-start">
         <img src="{{{uiRootPath}}}/img/deployment.svg" alt="Quick Start Rocket" class="h-[48px]">
         <p class="flex items-center justify-between font-medium text-[20px] lg:text-[24px] md:flex-col lg:flex-row lg:items-center md:items-start mt-4">
           Quickstart guide
@@ -38,7 +38,7 @@
           </svg>
         </p>
       </a>
-      <a href="{{{relativize '/guides/getting-started/hello-world'}}}" class="group flex-1 rounded-2xl border border-vapor p-8 hover:bg-inline-grey flex flex-col justify-between items-start">
+      <a href="{{{relativize '/guides/getting-started/hello-world/'}}}" class="group flex-1 rounded-2xl border border-vapor p-8 hover:bg-inline-grey flex flex-col justify-between items-start">
         <img src="{{{uiRootPath}}}/img/insights.svg" alt="Idea - Hello world" class="h-[48px]">
         <p class="flex items-center justify-between font-medium text-[20px] lg:text-[24px] md:flex-col lg:flex-row lg:items-center md:items-start mt-4">
           Hello world
@@ -47,7 +47,7 @@
           </svg>
         </p>
       </a>
-      <a href="{{{relativize '/guides/getting-started/slack-orb-tutorial'}}}" class="group flex-1 rounded-2xl border border-vapor p-8 hover:bg-inline-grey flex flex-col justify-between items-start">
+      <a href="{{{relativize '/guides/getting-started/slack-orb-tutorial/'}}}" class="group flex-1 rounded-2xl border border-vapor p-8 hover:bg-inline-grey flex flex-col justify-between items-start">
         <img src="{{{uiRootPath}}}/img/chat-with-us.svg" alt="Chat Notifications" class="h-[48px]">
         <p class="flex items-center justify-between font-medium text-[20px] lg:text-[24px] md:flex-col lg:flex-row lg:items-center md:items-start mt-4">
           Slack Notifications
@@ -66,7 +66,7 @@
           <img src="{{{uiRootPath}}}/img/stack.svg" alt="Execution Environments" class="h-7 w-7 p-0.5">
         </div>
         <div>
-          <a href="{{{relativize '/guides/execution-managed/executor-intro'}}}" class="text-link-on-light">
+          <a href="{{{relativize '/guides/execution-managed/executor-intro/'}}}" class="text-link-on-light">
             <h5 class="font-medium text-[20px]">
               Execution Environments
             </h5>
@@ -81,7 +81,7 @@
           <img src="{{{uiRootPath}}}/img/pipeline.svg" alt="Pipelines" class="h-7 w-7 p-0.5">
         </div>
         <div>
-          <a href="{{{relativize '/guides/orchestrate/pipelines'}}}" class="text-link-on-light">
+          <a href="{{{relativize '/guides/orchestrate/pipelines/'}}}" class="text-link-on-light">
             <h5 class="font-medium text-[20px]">
               Pipelines
             </h5>
@@ -96,7 +96,7 @@
           <img src="{{{uiRootPath}}}/img/job.svg" alt="Jobs Deployment Examples" class="h-7 w-7 p-0.5">
         </div>
         <div>
-          <a href="{{{relativize '/guides/deploy/deployment-overview'}}}" class="text-link-on-light">
+          <a href="{{{relativize '/guides/deploy/deployment-overview/'}}}" class="text-link-on-light">
             <h5 class="font-medium text-[20px]">
               Deployment Examples
             </h5>
@@ -111,7 +111,7 @@
           <img src="{{{uiRootPath}}}/img/container.svg" alt="Docker Container"  class="h-7 w-7 p-0.5">
         </div>
         <div>
-          <a href="{{{relativize '/guides/execution-managed/using-docker'}}}" class="text-link-on-light">
+          <a href="{{{relativize '/guides/execution-managed/using-docker/'}}}" class="text-link-on-light">
             <h5 class="font-medium text-[20px]">
               Using Docker
             </h5>
@@ -127,7 +127,7 @@
           <img src="{{{uiRootPath}}}/img/orbs.svg" alt="Orbs"  class="h-7 w-7 p-0.5">
         </div>
         <div>
-          <a href="{{{relativize '/orbs/use/orb-intro'}}}" class="text-link-on-light">
+          <a href="{{{relativize '/orbs/use/orb-intro/'}}}" class="text-link-on-light">
             <h5 class="font-medium text-[20px]">
               Third Party Integrations
             </h5>
@@ -143,7 +143,7 @@
           <img src="{{{uiRootPath}}}/img/security.svg" alt="Security"  class="h-7 w-7 p-0.5">
         </div>
         <div>
-          <a href="{{{relativize '/guides/security/contexts'}}}" class="text-link-on-light">
+          <a href="{{{relativize '/guides/security/contexts/'}}}" class="text-link-on-light">
             <h5 class="font-medium text-[20px]">
               Security
             </h5>
@@ -164,7 +164,7 @@
       <p class="text-left lg:text-justify max-w-[400px]">
         View and manage your deployments from a single dashboard. Gain immediate visibility into org wide deployments. No infra access required.
       </p>
-      <a href="{{{relativize '/guides/deploy/deploys-overview'}}}" class="flex items-center gap-2 mt-4">
+      <a href="{{{relativize '/guides/deploy/deploys-overview/'}}}" class="flex items-center gap-2 mt-4">
         <p class="font-medium text-[18px] underline underline-offset-3 decoration-2">
           Get started with deploys
         </p>
@@ -180,13 +180,13 @@
       <h4 class="font-medium text-[20px] md:text-[24px] mb-6">Samples</h4>
       <ul class="text-link-on-light flex flex-col gap-2">
         <li>
-          <a href="{{{relativize '/guides/toolkit/sample-config'}}}">Sample config.yml Files</a>
+          <a href="{{{relativize '/guides/toolkit/sample-config/'}}}">Sample config.yml Files</a>
         </li>
         <li>
-          <a href="{{{relativize '/guides/toolkit/postgres-config'}}}">Database Config Examples</a>
+          <a href="{{{relativize '/guides/toolkit/postgres-config/'}}}">Database Config Examples</a>
         </li>
         <li>
-          <a href="{{{relativize '/guides/security/set-environment-variable'}}}">Using Environment Variables</a>
+          <a href="{{{relativize '/guides/security/set-environment-variable/'}}}">Using Environment Variables</a>
         </li>
       </ul>
     </div>
@@ -194,16 +194,16 @@
       <h4 class="font-medium text-[20px] md:text-[24px] mb-6">Tools</h4>
       <ul class="text-link-on-light flex flex-col gap-2">
         <li>
-          <a href="{{{relativize '/reference/configuration-reference'}}}">Configuration Reference</a>
+          <a href="{{{relativize '/reference/configuration-reference/'}}}">Configuration Reference</a>
         </li>
         <li>
-          <a href="{{{relativize '/guides/integration/outbound-webhooks'}}}">Outbound webhooks</a>
+          <a href="{{{relativize '/guides/integration/outbound-webhooks/'}}}">Outbound webhooks</a>
         </li>
         <li>
-          <a href="{{{relativize '/api/v2'}}}">API v2 Reference</a>
+          <a href="{{{relativize '/api/v2/'}}}">API v2 Reference</a>
         </li>
         <li>
-          <a href="{{{relativize '/api/v1'}}}">API v1 Reference</a>
+          <a href="{{{relativize '/api/v1/'}}}">API v1 Reference</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
- This will avoid needless status `302` redirects in production, and also allow these links to work in the CI preview.