### PR TITLE
format(server): fix small format issues for list of nomad options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ workflows:
       equal: [main, << pipeline.git.branch >>]
     jobs:
       - vale/lint:
-          reference_branch: server-4.8
+          reference_branch: main
           base_dir: docs
   build_validate_and_deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ workflows:
       equal: [main, << pipeline.git.branch >>]
     jobs:
       - vale/lint:
-          reference_branch: main
+          reference_branch: "server-4.8"
           base_dir: docs
   build_validate_and_deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ workflows:
       equal: [main, << pipeline.git.branch >>]
     jobs:
       - vale/lint:
-          reference_branch: "server-4.8"
+          reference_branch: server-4.8
           base_dir: docs
   build_validate_and_deploy:
     when:

--- a/docs/server-admin/modules/ROOT/partials/installation/phase-3.adoc
+++ b/docs/server-admin/modules/ROOT/partials/installation/phase-3.adoc
@@ -303,7 +303,9 @@ In the previous section you deployed your Nomad clients and have the IAM resourc
 
 [#where-to-deploy-nomad-servers]
 === a. Where to deploy nomad servers
+
 Nomad Servers are by default deployed within your CircleCI server cluster. However, Nomad Servers may be deployed externally. As with the Nomad clients, you can use the terraform module CircleCI provides to deploy your Nomad Servers or as a guide for how such a deployment might look.
+
 * If you wish to deploy your Nomad servers inside your CircleCI server cluster, continue to <<nomad-gossip-encryption-key>> below.
 * If you wish to deploy your Nomad servers externally, follow these steps:
 


### PR DESCRIPTION
# Description

Fixed a minor issue on server docs for the nomad installation options.

### Before

<img width="888" height="238" alt="Screenshot 2025-08-12 at 1 40 46 PM" src="https://github.com/user-attachments/assets/f4ed578c-52eb-4763-82df-efb06011fefb" />


### After

<img width="924" height="498" alt="Screenshot 2025-08-12 at 1 47 42 PM" src="https://github.com/user-attachments/assets/bfb1b77a-98f7-4d66-ad6c-5eb44845bdb7" />


# Reasons

It was broken. :-)
