### PR TITLE
ONPREM-2481 | SERVER | Update AWS Machine Provisioner policy with explicit subnets

### DIFF
--- a/docs/server-admin/modules/ROOT/partials/installation/phase-3.adoc
+++ b/docs/server-admin/modules/ROOT/partials/installation/phase-3.adoc
@@ -726,9 +726,16 @@ aws iam create-policy --policy-name circleci-vm --policy-document file://<POLICY
         "arn:aws:ec2:*:*:launch-template/*",
         "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:placement-group/*",
-        "arn:aws:ec2:*:*:subnet/*",
         "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>",
         "arn:aws:ec2:*:*:volume/*"
+      ]
+    },
+    {
+      "Action": "ec2:RunInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:ec2:*:*:subnet/<SUBNET_ID_1>",
+        "arn:aws:ec2:*:*:subnet/<SUBNET_ID_2>"
       ]
     },
     {
@@ -756,7 +763,7 @@ aws iam create-policy --policy-name circleci-vm --policy-document file://<POLICY
       "Resource": "arn:aws:ec2:*:*:*/*",
       "Condition": {
         "StringEquals": {
-          "ec2:CreateAction" : "RunInstances"
+          "ec2:CreateAction": "RunInstances"
         }
       }
     },
@@ -783,10 +790,13 @@ aws iam create-policy --policy-name circleci-vm --policy-document file://<POLICY
         "ec2:TerminateInstances"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:subnet/*",
+      "Resource": "arn:aws:ec2:*:*:instance/*",
       "Condition": {
-        "StringEquals": {
-          "ec2:Vpc": "<VPC_ID>"
+        "StringLike": {
+          "ec2:Subnet": [
+            "arn:aws:ec2:*:*:subnet/<SUBNET_ID_1>",
+            "arn:aws:ec2:*:*:subnet/<SUBNET_ID_2>"
+          ]
         }
       }
     }
@@ -858,9 +868,16 @@ Create a `policy.json` file with the following content. You should fill in the I
         "arn:aws:ec2:*:*:launch-template/*",
         "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:placement-group/*",
-        "arn:aws:ec2:*:*:subnet/*",
         "arn:aws:ec2:*:*:security-group/<SECURITY_GROUP_ID>"
         "arn:aws:ec2:*:*:volume/*"
+      ]
+    },
+    {
+      "Action": "ec2:RunInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:ec2:*:*:subnet/<SUBNET_ID_1>",
+        "arn:aws:ec2:*:*:subnet/<SUBNET_ID_2>"
       ]
     },
     {
@@ -915,10 +932,13 @@ Create a `policy.json` file with the following content. You should fill in the I
         "ec2:TerminateInstances"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:subnet/*",
+      "Resource": "arn:aws:ec2:*:*:instance/*",
       "Condition": {
-        "StringEquals": {
-          "ec2:Vpc": "<VPC_ID>"
+        "StringLike": {
+          "ec2:Subnet": [
+            "arn:aws:ec2:*:*:subnet/<SUBNET_ID_1>",
+            "arn:aws:ec2:*:*:subnet/<SUBNET_ID_2>"
+          ]
         }
       }
     }


### PR DESCRIPTION
# Description
Updated AWS MP policy with the explicit subnet input in Server 4.8

# Reasons
This will allow us to have multiple AWS MP Policies controlling different subnets, also, enable the multiple "server" install within the same aws infrastructure. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
