### PR TITLE
Tweak instructions to stop triggering GitHub OAuth pipelines

### DIFF
--- a/docs/guides/modules/integration/pages/github-integration.adoc
+++ b/docs/guides/modules/integration/pages/github-integration.adoc
@@ -350,17 +350,7 @@ Key functionality enabled through the GitHub App integration includes the follow
 ### Installing GitHub App alongside the GitHub OAuth app
 
 ****
-Having both a GitHub App trigger *and* a GitHub OAuth trigger configured in the same project could result in duplicate builds. You can prevent this behavior by disabling the GitHub OAuth trigger. To do so, follow these steps:
-
-. Navigate to the GitHub repository associated with the project.
-. Go to menu:Settings[Webhooks].
-. Locate the CircleCI webhook (`https://circleci.com/hooks/github`) and select btn:[Delete].
-
-This action is reversible. To re-enable the OAuth trigger, follow these steps:
-
-. Go to menu:Project Settings[Overview]
-. Select "Stop building" at the bottom of the page
-. Then, select "Follow". This will create a new CircleCI webhook in your repository.
+Having both a GitHub App trigger *and* a GitHub OAuth trigger configured in the same project could result in duplicate builds. You can prevent this behavior by deleting the GitHub trigger associate with the GitHub OAuth pipeline, in menu:Project settings[Project setup]. This trigger can be re-created by selecting "click here" at the bottom of the GitHub OAuth pipeline card. 
 ****
 
 Installing the CircleCI GitHub App is a one-time action that enables all new features across the entire organization.


### PR DESCRIPTION
# Description
the instructions to stop triggering the OAuth pipeline for customers who want to use the GitHub App integration in their "classic" org

# Reasons
We now have a much simpler way to allow customers to stop building their OAuth pipeline.

When the OAuth trigger is present:
<img width="912" height="500" alt="Screenshot 2025-08-18 at 12 26 27" src="https://github.com/user-attachments/assets/9bd2043c-c48a-4816-8f13-25e5d9ac1773" />

When the Oauth trigger is not present:
<img width="908" height="404" alt="Screenshot 2025-08-18 at 12 26 58" src="https://github.com/user-attachments/assets/905cb325-f6cb-4298-9148-dd6122bf9735" />


# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
