### PR TITLE
prevent filefox flexbox from becoming too narrow

### DIFF
--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -145,3 +145,11 @@ object[type="image/svg+xml"]:not([width]) {
     background-color: var(--scrollbar_hover-thumb-color);
   }
 }
+
+/* Firefox-specific CSS to fix flexbox shrinking issue */
+@-moz-document url-prefix() {
+  main > .content .doc,
+  article.doc {
+    flex-shrink: 0; /* Prevent excessive shrinking in Firefox */
+  }
+}


### PR DESCRIPTION
# Description

The api docs homepage was bring shrink down to show just one character on each line on firefox

<img width="1701" height="837" alt="Screenshot 2025-08-19 at 14 57 00" src="https://github.com/user-attachments/assets/190ca8cd-e40c-4df8-b0c3-e246b45b0cb1" />

This fixes it by preventing the shrinking
<img width="1770" height="848" alt="Screenshot 2025-08-19 at 14 57 07" src="https://github.com/user-attachments/assets/966392e6-d8c0-4f77-b323-4807c6d65790" />


Why did you make these changes?

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
