### PR TITLE
link to docs and website homepages

### DIFF
--- a/ui/src/partials/component-explorer-nav.hbs
+++ b/ui/src/partials/component-explorer-nav.hbs
@@ -35,5 +35,11 @@
       </a>
       <img src="{{{uiRootPath}}}/img/link-arrow.svg" alt="Go to" class="md:hidden ml-2 inline-block w-[13px] h-[13px]">
     </li>
+    <li class="flex items-center">
+      <a href="https://circleci.com/" class="inline-block md:px-2 md:py-3">
+        CircleCI.com
+      </a>
+      <img src="{{{uiRootPath}}}/img/link-arrow.svg" alt="Go to" class="md:hidden ml-2 inline-block w-[13px] h-[13px]">
+    </li>
   </ul>
 </nav>

--- a/ui/src/partials/header-content.hbs
+++ b/ui/src/partials/header-content.hbs
@@ -2,7 +2,7 @@
   <div class="flex items-center justify-between mb-7">
     <!-- Logo + Title -->
     <div class="flex items-center space-x-2">
-      <a href="/">
+      <a href="{{{relativize '/'}}}">
         <img src="{{{uiRootPath}}}/img/logo.svg" alt="CircleCI Logo" class="h-[44px]">
       </a>
     </div>


### PR DESCRIPTION
# Description
The logo top left was linking to the website homepage which is not expected. I have made this link to the docs homepage. 
This change means there is no link to the website from the docs so I added that to the header. Not sure if we want this or not though 🤔 open to opinions:

<img width="1425" height="278" alt="Screenshot 2025-08-21 at 10 56 59" src="https://github.com/user-attachments/assets/ca5df5c5-dd7e-4a6c-9222-7cdb8720a126" />


# Reasons
Make link go to the place you expect

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
