### PR TITLE
In android machine image doc, use working executor name and latest orb.

### DIFF
--- a/docs/guides/modules/execution-managed/pages/android-machine-image.adoc
+++ b/docs/guides/modules/execution-managed/pages/android-machine-image.adoc
@@ -8,7 +8,7 @@
 
 The Android machine image is accessed through the xref:reference:ROOT:configuration-reference.adoc#available-linux-machine-images-cloud[Linux machine executor], like other Linux machine images on CircleCI. The Android machine image supports nested virtualization and x86 Android emulators, so it can be used for Android UI testing. It also comes with the Android SDK pre-installed.
 
-[#using-the-android_machine-image]
+[#using-the-android-machine-image]
 == Using the Android machine image
 
 It is possible to configure the use of the Android image in your configuration with xref:orbs:use:orb-intro.adoc[orbs], as well as manually. The Android orb will simplify your configuration. More complex and custom configurations may benefit from manually configuring your usage instead of using the orb. This document will cover both use cases. Refer to the <<examples>> section below for more details.
@@ -16,7 +16,7 @@ It is possible to configure the use of the Android image in your configuration w
 [#pre-installed-software]
 == Pre-installed software
 
-View the quarterly update announcement on our link:https://discuss.circleci.com/t/android_machine-executor-images-2022-january-q1-update/42842/1[Discuss] page for a list of current pre-installed software.
+View the quarterly update announcement on our link:https://discuss.circleci.com/t/android-machine-executor-images-2022-january-q1-update/42842/1[Discuss] page for a list of current pre-installed software.
 
 [#examples]
 == Examples

--- a/docs/guides/modules/execution-managed/pages/android-machine-image.adoc
+++ b/docs/guides/modules/execution-managed/pages/android-machine-image.adoc
@@ -8,7 +8,7 @@
 
 The Android machine image is accessed through the xref:reference:ROOT:configuration-reference.adoc#available-linux-machine-images-cloud[Linux machine executor], like other Linux machine images on CircleCI. The Android machine image supports nested virtualization and x86 Android emulators, so it can be used for Android UI testing. It also comes with the Android SDK pre-installed.
 
-[#using-the-android-machine-image]
+[#using-the-android_machine-image]
 == Using the Android machine image
 
 It is possible to configure the use of the Android image in your configuration with xref:orbs:use:orb-intro.adoc[orbs], as well as manually. The Android orb will simplify your configuration. More complex and custom configurations may benefit from manually configuring your usage instead of using the orb. This document will cover both use cases. Refer to the <<examples>> section below for more details.
@@ -16,7 +16,7 @@ It is possible to configure the use of the Android image in your configuration w
 [#pre-installed-software]
 == Pre-installed software
 
-View the quarterly update announcement on our link:https://discuss.circleci.com/t/android-machine-executor-images-2022-january-q1-update/42842/1[Discuss] page for a list of current pre-installed software.
+View the quarterly update announcement on our link:https://discuss.circleci.com/t/android_machine-executor-images-2022-january-q1-update/42842/1[Discuss] page for a list of current pre-installed software.
 
 [#examples]
 == Examples
@@ -34,7 +34,7 @@ include::ROOT:partial$tips/add-version-number.adoc[]
 # .circleci/config.yaml
 version: 2.1
 orbs:
-  android: circleci/android@2.4.0
+  android: circleci/android@3.1.0
   # https://circleci.com/developer/orbs/orb/circleci/android for latest version
 workflows:
   test:
@@ -45,7 +45,7 @@ workflows:
           # to execute custom steps before and afer any of the built-in steps
           system-image: system-images;android-29;default;x86
           executor:
-            name: android/android-machine
+            name: android/android_machine
             resource-class: large
             tag: default
 ```
@@ -61,12 +61,12 @@ include::ROOT:partial$tips/add-version-number.adoc[]
 # .circleci/config.yml
 version: 2.1
 orbs:
-  android: circleci/android@2.4.0
+  android: circleci/android@3.1.0
   # https://circleci.com/developer/orbs/orb/circleci/android for latest version
 jobs:
   test:
     executor:
-      name: android/android-machine
+      name: android/android_machine
       resource-class: large
       tag: default
     steps:


### PR DESCRIPTION
# Description
Update android machine image documentation with:

* Working executor name
* Latest orb version.

# Reasons
Taking the documentation directly now, it was not working.


