### PR TITLE
recommend scaling down application before backups on server

### DIFF
--- a/docs/server-admin/modules/operator/pages/backup-and-restore.adoc
+++ b/docs/server-admin/modules/operator/pages/backup-and-restore.adoc
@@ -50,7 +50,7 @@ RANDOM_STR=$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-z0-9' | head -c 8)
 velero backup create "${K8S_NS}-${RANDOM_STR}" --include-namespaces "${K8S_NS}" --labels "chart--rev=${CHART}--${REV}"
 ----
 
-NOTE: If you had chosen to scale down your application before initiating your backup, you can restore your application state by running `helm upgrade` which would restore the application to the state you have specified in your `values.yaml`.
+NOTE: If you scaled down your application before initiating your backup, you can now restore your application state by running `helm upgrade`. Running this command restores your application to the state you have specified in your `values.yaml`.
 
 [#restoring-backups]
 == Restoring backups

--- a/docs/server-admin/modules/operator/pages/backup-and-restore.adoc
+++ b/docs/server-admin/modules/operator/pages/backup-and-restore.adoc
@@ -29,7 +29,7 @@ NOTE: CircleCI server makes use of Persistent Volumes for data storage. To inclu
 
 Now that Velero is installed on your cluster, you are ready to create your first backup.
 
-NOTE: For best results, we recommend that the backup be taken during a time when your CircleCI server instance is not in use. This is to ensure the data is not being altered while the backup is being genereated which limits the possibility of lost or corrupted data. You may use the following command to scale down the application's services so that no jobs are running during the backup. No Data is lost in this process, but the application will be unreachable. Alternatively you may choose to schedule your backups to be done during a time when your CircleCI server instance is not in use.
+NOTE: For best results, we recommend that the backup be taken during a time when your CircleCI server instance is not in use. This is to ensure the data is not being altered while the backup is being generated, which limits the possibility of lost or corrupted data. You may use the following command to scale down the application's services so that no jobs are running during the backup. No data is lost in this process, but the application will be unreachable. Alternatively you may choose to schedule your backups to be done during a time when your CircleCI server instance is not in use.
 
 [source,bash]
 ----

--- a/docs/server-admin/modules/operator/pages/backup-and-restore.adoc
+++ b/docs/server-admin/modules/operator/pages/backup-and-restore.adoc
@@ -29,6 +29,16 @@ NOTE: CircleCI server makes use of Persistent Volumes for data storage. To inclu
 
 Now that Velero is installed on your cluster, you are ready to create your first backup.
 
+NOTE: For best results, we recommend that the backup be taken during a time when your CircleCI server instance is not in use. This is to ensure the data is not being altered while the backup is being genereated which limits the possibility of lost or corrupted data. You may use the following command to scale down the application's services so that no jobs are running during the backup. No Data is lost in this process, but the application will be unreachable. Alternatively you may choose to schedule your backups to be done during a time when your CircleCI server instance is not in use.
+
+[source,bash]
+----
+namespace=<your-server-namespace>
+kubectl -n "$namespace" scale deploy -l "layer=application" --replicas="0"
+----
+
+Once you are ready, you may use the following command to create a backup of your CircleCI server instance.
+
 [source,bash]
 
 ----
@@ -39,6 +49,8 @@ RANDOM_STR=$(cat /dev/urandom | env LC_ALL=C tr -dc 'a-z0-9' | head -c 8)
 
 velero backup create "${K8S_NS}-${RANDOM_STR}" --include-namespaces "${K8S_NS}" --labels "chart--rev=${CHART}--${REV}"
 ----
+
+NOTE: If you had chosen to scale down your application before initiating your backup, you can restore your application state by running `helm upgrade` which would restore the application to the state you have specified in your `values.yaml`.
 
 [#restoring-backups]
 == Restoring backups


### PR DESCRIPTION
# Description
recommend scaling down application before taking backups on server. this will limit the possibility of data corruptions in the backups. Backups are suggested before performing upgrades

# Reasons
https://circleci.atlassian.net/browse/ONPREM-2508

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
