### PR TITLE
Fix scroll jumper to account for header correctly

### DIFF
--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -28,6 +28,7 @@
   hyphens: none;
   line-height: 1.3;
   margin: 1rem 0 0;
+  scroll-margin-top: calc(var(--navbar-height) + var(--toolbar-height) + 1rem); /* Account for sticky header height */
 }
 
 .doc > h1.page:first-child {

--- a/ui/src/js/03-fragment-jumper.js
+++ b/ui/src/js/03-fragment-jumper.js
@@ -3,7 +3,7 @@
 
   var article = document.querySelector('article.doc')
   if (!article) return
-  var toolbar = document.querySelector('.toolbar')
+  var toolbar = document.querySelector('header') || document.querySelector('.toolbar')
   var supportsScrollToOptions = 'scrollTo' in document.documentElement
 
   function decodeFragment (hash) {


### PR DESCRIPTION
Fix: Table of contents scroll positioning behind fixed header

## Problem

When users clicked on table of contents links, the target section would scroll to the top of the viewport but be hidden behind the sticky header, making the section title and content invisible.

## Solution

* Fixed JavaScript fragment jumper (ui/src/js/03-fragment-jumper.js):
* Updated to correctly reference the header element instead of non-existent .toolbar
* Added fallback for backward compatibility
* Added CSS scroll margins (ui/src/css/doc.css):
* Applied scroll-margin-top to all heading elements (h1-h6)
* Used calculated value based on existing CSS variables: calc(var(--navbar-height) + var(--toolbar-height) + 1rem)
Provides ~126px offset to account for sticky header height plus breathing room

## Impact

* Table of contents navigation now properly scrolls sections into view below the header
* Works for both desktop sidebar TOC and mobile/tablet embedded TOC
* Handles both JavaScript clicks and direct anchor link navigation
* Uses existing CSS architecture for maintainability