### PR TITLE
REL-4233: Add warning about release agent compatibility in deploy markers docs

### DIFF
--- a/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
+++ b/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
@@ -78,6 +78,8 @@ This configuration would yield a value with the following format `12345`.
 
 === 1.2. Update the deploy status to running
 
+WARNING: The `circleci run release update` command is only for use with deploy markers. If you are using the CircleCI xref:release-agent-overview.adoc[release agent] for Kubernetes deployments, do NOT use the `update` commands. The release agent automatically handles status updates for you.
+
 After deploying your application, you can update the status of the deployment to `RUNNING` by running the `circleci run release update` command in a new step.
 
 [,yml]

--- a/docs/guides/modules/deploy/pages/configure-your-kubernetes-components.adoc
+++ b/docs/guides/modules/deploy/pages/configure-your-kubernetes-components.adoc
@@ -126,6 +126,8 @@ Substitute the placeholders above based on your application's details:
 +
 CAUTION: If you are using Argo Rollouts for a given component, be sure to set the `release-strategy` parameter to `progressive`.
 
+WARNING: The `circleci run release update` command is only for use with deploy markers. If you are using the CircleCI xref:release-agent-overview.adoc[release agent] for Kubernetes deployments, do NOT use the `update` commands. The release agent automatically handles status updates for you.
+
 . Define a new job to monitor the release, referencing the `release plan` created above as part of the _deployment_ job:
 +
 [,yaml]

--- a/docs/guides/modules/toolkit/pages/environment-cli-usage-guide.adoc
+++ b/docs/guides/modules/toolkit/pages/environment-cli-usage-guide.adoc
@@ -156,6 +156,8 @@ For more information on using the `circleci run release plan` command, see the x
 
 ===== Update
 
+WARNING: The `circleci run release update` command is only for use with deploy markers. If you are using the CircleCI xref:deploy:release-agent-overview.adoc[release agent] for Kubernetes deployments, do NOT use the `update` commands. The release agent automatically handles status updates for you.
+
 A subcommand of `release`. Use the `circleci run release update` command to update the status of the deployment.
 
 *Flags*


### PR DESCRIPTION
# Description
Added a warning to the deploy markers documentation to clarify that the `circleci run release update` command should only be used with deploy markers (agentless deployments) and not with the CircleCI release agent for Kubernetes deployments.

# Reasons
To prevent confusion and misuse of the `circleci run release update` command when users are working with different deployment methods. The release agent automatically handles status updates, so manual updates should not be used in that context.

# Content Checklist
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Include relevant backlinks to other CircleCI docs/pages.

REL-4233