### PR TITLE
fix: Use "AND" instead of "OR" for MP IAM

### DIFF
--- a/docs/server-admin-4.3/modules/installation/pages/phase-3-execution-environments.adoc
+++ b/docs/server-admin-4.3/modules/installation/pages/phase-3-execution-environments.adoc
@@ -685,21 +685,6 @@ aws iam create-policy --policy-name circleci-vm --policy-document file://<POLICY
     },
     {
       "Action": [
-        "ec2:CreateTags",
-        "ec2:StartInstances",
-        "ec2:StopInstances",
-        "ec2:TerminateInstances"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:*/*",
-      "Condition": {
-        "StringEquals": {
-          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
-        }
-      }
-    },
-    {
-      "Action": [
         "ec2:RunInstances",
         "ec2:StartInstances",
         "ec2:StopInstances",
@@ -709,7 +694,8 @@ aws iam create-policy --policy-name circleci-vm --policy-document file://<POLICY
       "Resource": "arn:aws:ec2:*:*:subnet/*",
       "Condition": {
         "StringEquals": {
-          "ec2:Vpc": "<VPC_ID>"
+          "ec2:Vpc": "<VPC_ID>",
+          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
         }
       }
     }
@@ -817,21 +803,6 @@ Create a `policy.json` file with the following content. You should fill in the I
     },
     {
       "Action": [
-        "ec2:CreateTags",
-        "ec2:StartInstances",
-        "ec2:StopInstances",
-        "ec2:TerminateInstances"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:*/*",
-      "Condition": {
-        "StringEquals": {
-          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
-        }
-      }
-    },
-    {
-      "Action": [
         "ec2:RunInstances",
         "ec2:StartInstances",
         "ec2:StopInstances",
@@ -841,7 +812,8 @@ Create a `policy.json` file with the following content. You should fill in the I
       "Resource": "arn:aws:ec2:*:*:subnet/*",
       "Condition": {
         "StringEquals": {
-          "ec2:Vpc": "<VPC_ID>"
+          "ec2:Vpc": "<VPC_ID>",
+          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
         }
       }
     }

--- a/docs/server-admin-4.7/modules/ROOT/partials/installation/phase-3.adoc
+++ b/docs/server-admin-4.7/modules/ROOT/partials/installation/phase-3.adoc
@@ -742,21 +742,6 @@ aws iam create-policy --policy-name circleci-vm --policy-document file://<POLICY
     },
     {
       "Action": [
-        "ec2:CreateTags",
-        "ec2:StartInstances",
-        "ec2:StopInstances",
-        "ec2:TerminateInstances"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:*/*",
-      "Condition": {
-        "StringEquals": {
-          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
-        }
-      }
-    },
-    {
-      "Action": [
         "ec2:RunInstances",
         "ec2:StartInstances",
         "ec2:StopInstances",
@@ -770,6 +755,9 @@ aws iam create-policy --policy-name circleci-vm --policy-document file://<POLICY
             "arn:aws:ec2:*:*:subnet/<SUBNET_ID_1>",
             "arn:aws:ec2:*:*:subnet/<SUBNET_ID_2>"
           ]
+        },
+        "StringEquals": {
+          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
         }
       }
     }
@@ -884,21 +872,6 @@ Create a `policy.json` file with the following content. You should fill in the I
     },
     {
       "Action": [
-        "ec2:CreateTags",
-        "ec2:StartInstances",
-        "ec2:StopInstances",
-        "ec2:TerminateInstances"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:*/*",
-      "Condition": {
-        "StringEquals": {
-          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
-        }
-      }
-    },
-    {
-      "Action": [
         "ec2:RunInstances",
         "ec2:StartInstances",
         "ec2:StopInstances",
@@ -912,6 +885,9 @@ Create a `policy.json` file with the following content. You should fill in the I
             "arn:aws:ec2:*:*:subnet/<SUBNET_ID_1>",
             "arn:aws:ec2:*:*:subnet/<SUBNET_ID_2>"
           ]
+        },
+        "StringEquals": {
+          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
         }
       }
     }

--- a/docs/server-admin-4.8/modules/ROOT/partials/installation/phase-3.adoc
+++ b/docs/server-admin-4.8/modules/ROOT/partials/installation/phase-3.adoc
@@ -776,21 +776,6 @@ aws iam create-policy --policy-name circleci-vm --policy-document file://<POLICY
     },
     {
       "Action": [
-        "ec2:CreateTags",
-        "ec2:StartInstances",
-        "ec2:StopInstances",
-        "ec2:TerminateInstances"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:*/*",
-      "Condition": {
-        "StringEquals": {
-          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
-        }
-      }
-    },
-    {
-      "Action": [
         "ec2:RunInstances",
         "ec2:StartInstances",
         "ec2:StopInstances",
@@ -804,6 +789,9 @@ aws iam create-policy --policy-name circleci-vm --policy-document file://<POLICY
             "arn:aws:ec2:*:*:subnet/<SUBNET_ID_1>",
             "arn:aws:ec2:*:*:subnet/<SUBNET_ID_2>"
           ]
+        },
+        "StringEquals": {
+          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
         }
       }
     }
@@ -918,21 +906,6 @@ Create a `policy.json` file with the following content. You should fill in the I
     },
     {
       "Action": [
-        "ec2:CreateTags",
-        "ec2:StartInstances",
-        "ec2:StopInstances",
-        "ec2:TerminateInstances"
-      ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:*/*",
-      "Condition": {
-        "StringEquals": {
-          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
-        }
-      }
-    },
-    {
-      "Action": [
         "ec2:RunInstances",
         "ec2:StartInstances",
         "ec2:StopInstances",
@@ -946,6 +919,9 @@ Create a `policy.json` file with the following content. You should fill in the I
             "arn:aws:ec2:*:*:subnet/<SUBNET_ID_1>",
             "arn:aws:ec2:*:*:subnet/<SUBNET_ID_2>"
           ]
+        },
+        "StringEquals": {
+          "ec2:ResourceTag/ManagedBy": "circleci-machine-provisioner"
         }
       }
     }


### PR DESCRIPTION
IAM role had an "OR" but it should be an "AND"

Only doing this for 4.3, 4.7, and 4.8 (read: supported versions + 4.3)