### PR TITLE
Update scheduled-pipelines.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/scheduled-pipelines.adoc
+++ b/docs/guides/modules/orchestrate/pages/scheduled-pipelines.adoc
@@ -1,11 +1,11 @@
-= Scheduled pipelines
+= Schedule triggers
 :page-platform: Cloud
-:page-description: Learn about scheduled pipelines for your CircleCI projects.
+:page-description: Learn about schedule triggers for your CircleCI projects.
 :experimental:
 
-include::ROOT:partial$notes/standalone-unsupported.adoc[This feature is not supported for GitLab, GitHub App or Bitbucket Data Center]
+NOTE: This feature is not supported for GitLab or Bitbucket Data Center pipelines.
 
-Scheduled pipelines allow you to trigger pipelines periodically based on a schedule. Scheduled pipelines retain all the features of pipelines:
+Schedule triggers allow you to trigger pipelines periodically based on a schedule. Schedule triggers retain all the features of pipelines:
 
 - Control the actor (yourself, or the scheduling system) associated with the pipeline, which can enable the use of xref:security:contexts.adoc#project-restrictions[Restricted contexts].
 - Use xref:dynamic-config.adoc[Dynamic configuration] via setup workflows.
@@ -14,35 +14,35 @@ Scheduled pipelines allow you to trigger pipelines periodically based on a sched
 - Specify xref:pipeline-variables.adoc#pipeline-parameters-in-configuration[Pipeline parameters] associated with a schedule.
 - Manage common schedules, for example, across workflows.
 
-Scheduled pipelines are configured through the API, or through the project settings in the CircleCI web app.
+Schedule triggers are configured through the API, or through the project settings in the CircleCI web app.
 
-NOTE: A scheduled pipeline can only be configured for one branch. If you need to schedule for two branches, you would need to set up two schedules.
+NOTE: A schedule trigger can only be configured for one branch. If you need to schedule for two branches, you would need to set up two schedules.
 
 [#introduction]
 == Introduction
 
-Scheduled pipelines allow you to trigger pipelines periodically based on a schedule. Schedules can range from daily, weekly, monthly, or on a very specific timetable. To set up basic scheduled pipelines, you do not need any extra configuration in your `.circleci/config.yml` file. However, more advanced usage of the feature will require extra `.circleci/config.yml` configuration (for example, workflow filtering, or using parameters).
+Schedule triggers allow you to trigger pipelines periodically based on a schedule. Schedules can range from daily, weekly, monthly, or on a very specific timetable. To set up basic schedule triggers, you do not need any extra configuration in your `.circleci/config.yml` file. However, more advanced usage of the feature will require extra `.circleci/config.yml` configuration (for example, workflow filtering, or using parameters).
 
-Pipeline parameters are typed pipeline variables in the form of a string, integer, or boolean. Adding a parameter to a scheduled pipeline can be done in the web app in the triggers form while setting up a schedule. Any parameters set up in this manner must be added to your configuration file using the `parameters` key.
+Pipeline parameters are typed pipeline variables in the form of a string, integer, or boolean. Adding a parameter to a schedule trigger can be done in the web app in the triggers form while setting up a schedule. Any parameters set up in this manner must be added to your configuration file using the `parameters` key.
 
-Scheduled pipelines are set to run by an "actor", either the CircleCI scheduling system, or a specific user (for example, yourself). The scheduling actor is important to consider if making use of restricted contexts in workflows. If the user (actor) running the workflow does not have access to the context, the workflow will fail with the `Unauthorized` status.
+Schedule triggers are set to run by an "actor", either the CircleCI scheduling system, or a specific user (for example, yourself). The scheduling actor is important to consider if making use of restricted contexts in workflows. If the user (actor) running the workflow does not have access to the context, the workflow will fail with the `Unauthorized` status.
 
-You can find a basic how-to guide on the xref:set-a-nightly-scheduled-pipeline.adoc[Set a nightly scheduled pipeline] page, and more advanced examples on the xref:schedule-pipelines-with-multiple-workflows.adoc[Schedule pipelines with multiple workflows] pages.
+You can find a basic how-to guide on the xref:set-a-nightly-scheduled-pipeline.adoc[Set a nightly schedule trigger] page, and more advanced examples on the xref:schedule-pipelines-with-multiple-workflows.adoc[Schedule pipelines with multiple workflows] pages.
 
 [#get-started-with-scheduled-pipelines]
-== Get started with scheduled pipelines
+== Get started with schedule triggers
 
-To get started with scheduled pipelines, you have the option of using the API, or using the CircleCI web app. Both methods are described below.
+To get started with schedule triggers, you have the option of using the API, or using the CircleCI web app. Both methods are described below.
 
 [#use-project-settings]
 === Use project settings in the web app
 
-include::ROOT:partial$pipelines-and-triggers/scheduled-pipeline-setup.adoc[Setting up a scheduled pipeline using the CircleCI web app]
+include::ROOT:partial$pipelines-and-triggers/scheduled-pipeline-setup.adoc[Setting up a schedule trigger using the CircleCI web app]
 
 [#use-the-api]
 === Use the API
 
-If your project has no scheduled workflows, and you would like to try out scheduled pipelines:
+If your project has no scheduled workflows, and you would like to try out schedule triggers:
 
 . Have your CircleCI token ready, or create a new token by following the steps on the xref:toolkit:managing-api-tokens.adoc[Managing API tokens] page.
 . Create a new schedule link:https://circleci.com/docs/api/v2/index.html#operation/createSchedule[using the API]. For example:
@@ -72,27 +72,27 @@ include::ROOT:partial$tips/find-project-slug.adoc[]
 For additional information, refer to the **Schedule** section under the link:https://circleci.com/docs/api/v2/[API v2 docs]. Also see the xref:toolkit:api-developers-guide.adoc#getting-started-with-the-api[Getting started with the API] section of the API Developer's Guide for more guidance on making requests.
 
 [#migrate-scheduled-workflows-to-scheduled-pipelines]
-== Migrate scheduled workflows to scheduled pipelines
+== Migrate scheduled workflows to schedule triggers
 
-If you have existing scheduled workflows you need to migrate to scheduled pipelines, use the xref:migrate-scheduled-workflows-to-scheduled-pipelines.adoc[Scheduled pipelines migration] guide.
+If you have existing scheduled workflows you need to migrate to schedule triggers, use the xref:migrate-scheduled-workflows-to-scheduled-pipelines.adoc[Schedule triggers migration] guide.
 
 [#scheduled-pipelines-video-tutorial]
-== Scheduled pipelines video tutorial
+== Schedule triggers video tutorial
 
 The video offers a short tutorial for the following scenarios:
 
 - Set a schedule in the web app
 - Set a schedule with the API
-- Migrate from scheduled workflows to scheduled pipelines
+- Migrate from scheduled workflows to schedule triggers
 
 ++++
 <div class="video-wrapper">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/x3ruGpx6SEI" title="Scheduled pipelines tutorial" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/x3ruGpx6SEI" title="Schedule triggers tutorial" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </div>
 ++++
 
 For the documentation for these scenarios, visit the following pages:
-- xref:set-a-nightly-scheduled-pipeline.adoc[Set a nightly scheduled pipeline]
+- xref:set-a-nightly-scheduled-pipeline.adoc[Set a nightly schedule trigger]
 - xref:schedule-pipelines-with-multiple-workflows.adoc[Schedule pipelines with multiple workflows]
 
 [#scheduled-pipelines-faqs]
@@ -103,6 +103,6 @@ include::ROOT:partial$faq/scheduled-pipelines-faq-snip.adoc[]
 [#next-steps]
 == Next steps
 
-- xref:migrate-scheduled-workflows-to-scheduled-pipelines.adoc[Migrate scheduled workflows to scheduled pipelines]
+- xref:migrate-scheduled-workflows-to-scheduled-pipelines.adoc[Migrate scheduled workflows to schedule triggers]
 - xref:schedule-pipelines-with-multiple-workflows.adoc[Schedule pipelines with multiple workflows]
-- xref:set-a-nightly-scheduled-pipeline.adoc[Set a nightly scheduled pipeline]
+- xref:set-a-nightly-scheduled-pipeline.adoc[Set a nightly schedule trigger]


### PR DESCRIPTION
# Description

* Scheduled pipelines should be called "Schedule triggers" and be presented as **triggers**, not as an entity of their own
* GitHub App pipelines now support Schedule triggers

**Checklist of changes that still need to be made:**

- [ ] docs/guides/modules/orchestrate/pages/scheduled-pipelines.adoc should include a mention that "Schedule triggers" were previously called "Schedule pipelines"
- [ ] There is a lot of cross-referenced content that uses the `scheduled-pipeline` name, for example `migrate-scheduled-workflows-to-scheduled-pipelines.adoc`, `get-started-with-scheduled-pipelines` etc. It would be great if we could change all of these
- [ ] Can we rename the tab "Scheduled pipelines" into "Schedule triggers" here, and move it under "triggers"?
<img width="130" height="200" alt="Screenshot 2025-09-22 at 23 39 47" src="https://github.com/user-attachments/assets/ff820830-549b-4577-907e-a0a03f93c99c" />

- [ ] 

# Reasons
Why did you make these changes?

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
