### PR TITLE
Remove redundant info from oauth page

### DIFF
--- a/docs/guides/modules/integration/pages/github-integration.adoc
+++ b/docs/guides/modules/integration/pages/github-integration.adoc
@@ -337,15 +337,6 @@ Until October 2024, the CircleCI GitHub App integration was available exclusivel
 
 The GitHub App and OAuth app can **co-exist side-by-side in the same organization**. You do not need to sacrifice functionality that is xref:version-control-system-integration-overview.adoc#feature-support-for-each-integration-type[not yet available to either integration], or migrate to a new organization.
 
-Key functionality enabled through the GitHub App integration includes the following:
-
-* The option to have **multiple pipelines in the same project**, each defined in its own YAML file.
-* The possibility to set up your pipelines so that the **config file and the application code are stored in different repositories**. Refer to the link:https://circleci.com/changelog/unlocking-any-cross-repo-pipeline-and-trigger-setups-including-central/[changelog entry] for more information.
-* A **more flexible trigger system**, with each pipeline having any number of VCS or non-VCS triggers. This includes:
-** **Non-repo based triggers**: xref:orchestrate:custom-webhooks.adoc[Custom webhooks] enable triggering builds from any system that can emit webhook events. Refer to our link:https://discuss.circleci.com/t/product-update-trigger-pipelines-from-anywhere-custom-webhooks/49864[community forum] for an example and known limitations.
-** **Cross-repo triggers**: Events in one repository can trigger builds on one or many other repositories.
-** **More GitHub events as triggers**: Pipelines can be set up to run on events other than "push", including pull request events, with more powerful customization of trigger conditions. For full details, see the xref:orchestrate:github-trigger-event-options.adoc[GitHub trigger event options] page.
-
 More information is available on the xref:guides:integration:using-the-circleci-github-app-in-an-oauth-org.adoc[Using the CircleCI GitHub App in an OAuth organization] page.
 
 [#next-steps]


### PR DESCRIPTION
# Description
remove a big block from the Github oauth page
# Reasons
Because that content is already present in https://circleci.com/docs/guides/integration/using-the-circleci-github-app-in-an-oauth-org/ 

I (@BeFunes ) will be out until September 30. This can be merged before then if it's considered ready! 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
