### PR TITLE
Replace '@circleci/lifecycle' with '@circleci/webex'

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @circleci/docs @circleci/docs-friends @circleci/lifecycle @circleci/product-mgmt-product-experience
+* @circleci/docs @circleci/docs-friends @circleci/webex @circleci/product-mgmt-product-experience
 


### PR DESCRIPTION
This batch change replaces all occurrences of '@circleci/lifecycle' with '@circleci/webex' in the matched files.

[_Created by Sourcegraph batch change `kira-m/Webex-Codeowners`._](https://circleci.sourcegraphcloud.com/users/kira-m/batch-changes/Webex-Codeowners)