### PR TITLE
fix css for code blocks in tables to fix migration pages

### DIFF
--- a/docs/guides/modules/migrate/pages/migrating-from-aws.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-aws.adoc
@@ -58,7 +58,7 @@ The AWS CodeBuild and CircleCI configurations will be different. It may be helpf
 
 include::ROOT:partial$notes/docker-auth.adoc[]
 
-[table-scroll]
+[.table-scroll]
 --
 [cols="1,1", options="header"]
 |===
@@ -67,7 +67,7 @@ include::ROOT:partial$notes/docker-auth.adoc[]
 2+| Define a job that executes a single build step.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 phases:
   build:
@@ -76,7 +76,7 @@ phases:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job1:
@@ -88,7 +88,7 @@ jobs:
 2+| Specify a Docker image to use for a job.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 phases:
   install:
@@ -97,7 +97,7 @@ phases:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job1:
@@ -108,7 +108,7 @@ jobs:
 2+| Define a multi-stage build pipeline. Job1 and Job2 run concurrently. Once they are done, Job3 runs. Once Job3 is done, Job4 runs. An AWS CodeBuild project runs all commands sequentially. If you are running concurrent commands, you are probably using CodePipeline and multiple CodeBuild projects.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 # CodePipeline Project 1
 phases:
@@ -136,7 +136,7 @@ phases:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 version: 2.1
 jobs:
@@ -170,7 +170,7 @@ workflows:
 2+| Execute jobs on multiple platforms. An AWS CodePipeline project can target a single platform only. If you are targeting multiple platforms, you’re probably using CodePipeline and multiple CodeBuild projects. CircleCI provides executors for Docker, Linux and macOS that can be combined in a single build definition.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 # Environments are selected in the CodeBuild
 # web console or defined in a project
@@ -191,7 +191,7 @@ a|
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   ubuntuJob:
@@ -214,7 +214,7 @@ jobs:
 2+| Cache dependencies.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 # If custom cache is enabled in the web
 # console, CLI or CloudFormation, cache
@@ -229,9 +229,8 @@ cache:
   paths:
     - 'node_modules/**/*'
 ----
-
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job1:
@@ -250,6 +249,7 @@ jobs:
 ----
 |===
 --
+
 
 For larger and more complex build files, we recommend moving over the build steps in phases until you get comfortable with the CircleCI platform. We recommend this order:
 

--- a/docs/guides/modules/migrate/pages/migrating-from-azuredevops.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-azuredevops.adoc
@@ -74,7 +74,7 @@ include::ROOT:partial$notes/docker-auth.adoc[]
 2+| Define a job that executes a single build step.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   - job: job1
@@ -84,7 +84,7 @@ jobs:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job1:
@@ -96,7 +96,7 @@ jobs:
 2+| Specify a Docker image to use for a job.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   - job: job1
@@ -105,7 +105,7 @@ jobs:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job1:
@@ -116,7 +116,7 @@ jobs:
 2+| Define a multi-stage build pipeline. Job1 and Job2 run in concurrently. Once they are done, Job3 runs. Once Job3 is done, Job4 runs.
 
 a|
-[source, yaml,role="no-numbers"]
+[source, yaml]
 ----
 stages:
   - stage: build
@@ -140,7 +140,7 @@ stages:
 ----
 
 a|
-[source, yaml,role="no-numbers"]
+[source, yaml]
 ----
 version: 2.1
 jobs:
@@ -174,7 +174,7 @@ workflows:
 2+| Execute jobs on multiple platforms. Azure DevOps uses pools and demands to identify build runners. CircleCI provides executors for Docker, Linux and macOS.
 
 a|
-[source, yaml,role="no-numbers"]
+[source, yaml]
 ----
 jobs:
   - job: ubuntuJob
@@ -192,7 +192,7 @@ jobs:
 ----
 
 a|
-[source, yaml,role="no-numbers"]
+[source, yaml]
 ----
 jobs:
   ubuntuJob:

--- a/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
@@ -67,14 +67,14 @@ include::ROOT:partial$notes/docker-auth.adoc[]
 2+| Define a job that executes a single build step.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 steps:
   - command: 'execute-script-for-job1.sh'
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job1:
@@ -86,7 +86,7 @@ jobs:
 2+| Specify a Docker image to use for a job.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 steps:
   - label: 'job1'
@@ -97,7 +97,7 @@ steps:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job1:
@@ -109,7 +109,7 @@ jobs:
 2+| Define a multi-stage build pipeline. Job1 and Job2 run concurrently. Once they are done, Job3 runs. Once Job3 is done, Job4 runs.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 steps:
   - label: 'job1'
@@ -130,7 +130,7 @@ steps:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 version: 2.1
 jobs:
@@ -164,7 +164,7 @@ workflows:
 2+| Execute jobs on multiple platforms. Buildkite uses tags to identify build agents. CircleCI provides executors for Docker, Linux and macOS.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 steps:
   - label: 'ubuntuJob'
@@ -180,7 +180,7 @@ steps:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   ubuntuJob:

--- a/docs/guides/modules/migrate/pages/migrating-from-github.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-github.adoc
@@ -24,7 +24,7 @@ CircleCI differs primarily in configuration syntax, setting up workflow and job 
 | GitHub | CircleCI
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 name: My GitHub Actions Workflow
 
@@ -43,7 +43,7 @@ jobs:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job_1:
@@ -99,7 +99,7 @@ include::ROOT:partial$notes/docker-auth.adoc[]
 `docker` is its https://circleci.com/docs/configuration-reference/#docker-machine-macos-windows-executor[own class of executor] in CircleCI.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 # Choosing an Operating System
 runs-on: ubuntu-latest # or windows, etc.
@@ -110,7 +110,7 @@ container:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 # Docker (container) Executor
 docker:
@@ -133,7 +133,7 @@ resource_class: windows.medium # can be medium, large, xlarge, 2xlarge
 2+| Specifying dependencies/services. All images specified after the first in CircleCI are treated https://circleci.com/docs/configuration-reference/#docker[as dependencies].
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   build:
@@ -154,7 +154,7 @@ jobs:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   build:
@@ -172,7 +172,7 @@ jobs:
 2+| Specifying steps to https://circleci.com/docs/configuration-reference/#run[run] in a job. Similar functionality, different syntax.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   build:
@@ -184,7 +184,7 @@ jobs:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   build:
@@ -200,7 +200,7 @@ jobs:
 and then https://circleci.com/docs/configuration-reference/#orbs[refer to them by name in config], similar in concept to Python or JavaScript imports.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   build:
@@ -218,7 +218,7 @@ jobs:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 orbs:
   slack-orb: circleci/slack@3.4.0
@@ -245,7 +245,7 @@ jobs:
 * Conditional, parameterized xref:orchestrate:workflows.adoc#use-conditional-logic-in-workflows[workflows].
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   build:
@@ -261,7 +261,7 @@ jobs:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   build:

--- a/docs/guides/modules/migrate/pages/migrating-from-gitlab.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-gitlab.adoc
@@ -40,14 +40,14 @@ include::ROOT:partial$notes/docker-auth.adoc[]
 
 2+| Defining a job that executes a single build step
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 job1:
   script: "execute-script-for-job1"
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job1:
@@ -59,14 +59,14 @@ jobs:
 2+| Specify a Docker image to use for a job.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 job1:
   image: node:10
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   job1:
@@ -77,7 +77,7 @@ jobs:
 2+| Define a multi-stage build pipeline. Job1 and Job2 run concurrently. Once they are done, Job3 runs. Once Job3 is done, Job4 runs.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 job1:
   stage: build
@@ -102,7 +102,7 @@ stages:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 version: 2.1
 jobs:
@@ -137,7 +137,7 @@ workflows:
 2+| Execute jobs on multiple platforms. GitLab uses tags to identify build runners. CircleCI provides all major OSes and Docker and must explicitly set in config. See our https://circleci.com/docs/executor-intro/#section=configuration[execution environments documentation] for more information.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 ubuntu job:
   tags:
@@ -153,7 +153,7 @@ osx job:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   ubuntu-job:
@@ -177,7 +177,7 @@ jobs:
 2+| Cache Dependencies.
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 image: node:latest
 
@@ -196,7 +196,7 @@ test_async:
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 jobs:
   test_async:

--- a/docs/guides/modules/migrate/pages/migrating-from-teamcity.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-teamcity.adoc
@@ -47,7 +47,7 @@ We have various other features that set our solution apart. https://circleci.com
 | TeamCity _settings.kts_ | Equivalent CircleCI _config.yml_
 
 a|
-[source,kotlin,role="no-numbers"]
+[source,kotlin]
 ----
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
@@ -69,7 +69,7 @@ object HelloWorld: BuildType({
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 version: 2.1
 workflows:
@@ -154,7 +154,7 @@ jobs:
 | TeamCity Build Chain | Equivalent CircleCI Workflow
 
 a|
-[source,kotlin,role="no-numbers"]
+[source,kotlin]
 ----
 project {
   sequence {
@@ -172,7 +172,7 @@ project {
 ----
 
 a|
-[source,yaml,role="no-numbers"]
+[source,yaml]
 ----
 version: 2.1
 workflows:

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -982,11 +982,6 @@
   box-sizing: border-box;
 }
 
-/* Hide line numbers for code blocks with role="no-numbers" */
-.doc .no-numbers .hljs-ln-numbers {
-  display: none !important;
-}
-
 /* Remove border from code block table cells when inside regular tables */
 .doc table.tableblock .hljs-ln td {
   border-bottom: none !important;

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -964,7 +964,6 @@
 }
 
 /* NEEDS REVIEW prevent pre in table from causing article to exceed bounds */
-.doc table.tableblock pre,
 .doc .listingblock.wrap pre {
   white-space: pre-wrap;
 }
@@ -1441,18 +1440,18 @@
   font-weight: var(--heading-font-weight);
 }
 
-/* Prevent code text from wrapping in table cells */
+/* Prevent inline code text from wrapping in table cells */
 td .pre,
 td .code,
-td code,
-td pre,
-td .tableblock code,
-td p code,
-.tableblock code {
+td code:not(pre code),
+.tableblock code:not(pre code) {
   white-space: nowrap !important;
 }
 
-/* Override nowrap for source code blocks in tables to preserve formatting */
-.tableblock .listingblock pre {
+/* Ensure code blocks in tables preserve formatting */
+.doc .tableblock .listingblock pre,
+.doc .tableblock .listingblock code,
+.doc td .listingblock pre,
+.doc td .listingblock code {
   white-space: pre !important;
 }

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -1443,8 +1443,10 @@
 /* Prevent inline code text from wrapping in table cells */
 td .pre,
 td .code,
-td code:not(pre code),
-.tableblock code:not(pre code) {
+td p code,
+td li code,
+.tableblock p code,
+.tableblock li code {
   white-space: nowrap !important;
 }
 

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -1451,3 +1451,15 @@ td p code,
 .tableblock code {
   white-space: nowrap !important;
 }
+
+/* Override nowrap for code blocks in tables to preserve formatting */
+.tableblock .listingblock pre,
+.tableblock .listingblock code,
+.tableblock .literalblock pre,
+.tableblock .literalblock code,
+td .listingblock pre,
+td .listingblock code,
+td .literalblock pre,
+td .literalblock code {
+  white-space: pre !important;
+}

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -1452,14 +1452,7 @@ td p code,
   white-space: nowrap !important;
 }
 
-/* Override nowrap for code blocks in tables to preserve formatting */
-.tableblock .listingblock pre,
-.tableblock .listingblock code,
-.tableblock .literalblock pre,
-.tableblock .literalblock code,
-td .listingblock pre,
-td .listingblock code,
-td .literalblock pre,
-td .literalblock code {
+/* Override nowrap for source code blocks in tables to preserve formatting */
+.tableblock .listingblock pre {
   white-space: pre !important;
 }


### PR DESCRIPTION
# Description

Our migration pages are (I think) the only pages where we have code blocks in a table.

Some fixes for other UI bugs have made the formatting break on these pages:

<img width="896" height="628" alt="image" src="https://github.com/user-attachments/assets/0b2fc19e-8747-49b8-943f-6b1465cf3b5f" />

## Fixes

- Remove nonumbers class, this is old, from a time when all code blocks had numbered lines

- apply table scroll class correctly

- CSS rule `.tableblock code { white-space: nowrap !important; }` was forcing all code elements in tables to collapse whitespace, removing indentation and line breaks

- target inline code contexts like `td p code`, `td li code`, `.tableblock p code`, and `.tableblock li code` for better reliability and browser support

- Created new CSS rule targeting `.listingblock` elements in tables with `white-space: pre !important` to preserve exact formatting for `[source,yaml]` code blocks

- Eliminated a rule that was forcing `pre-wrap` on all table pre elements, which was causing unwanted wrapping

- Removed duplicate selectors, redundant `.hljs-ln-code` rules, and optimized the CSS for better maintainability

### Result

<img width="855" height="510" alt="image" src="https://github.com/user-attachments/assets/45ce2ed5-78ac-44a8-97ea-d2c65928321e" />


# Reasons
Broken clode blocks in tables

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
