### PR TITLE
Clarify limitations linked to standalone orgs VS GitHub App pipelines

### DIFF
--- a/docs/guides/modules/integration/pages/github-apps-integration.adoc
+++ b/docs/guides/modules/integration/pages/github-apps-integration.adoc
@@ -172,16 +172,16 @@ The following sections are features of CircleCI which are not yet supported when
 
 [#restrict-a-context-to-a-security-group]
 === Restrict a context to a security group
-The ability to xref:security:contexts.adoc#security-group-restrictions[restrict a context to a security group] is supported for GitHub App pipelines only for organizations that have `/github/` (or `/gh/`) in the URL. It is not yet supported for organizations that have `/circleci/` in the URL. You can follow progress link:https://circleci.canny.io/cloud-feature-requests/p/ability-to-use-security-groups-for-contexts-used-by-github-app-type-pipelines[here].
+The ability to xref:security:contexts.adoc#security-group-restrictions[restrict a context to a security group] is supported for GitHub App pipelines only for organizations that have `/github/` (or `/gh/`) in the URL, no matter the pipeline integration type. It is not yet supported for organizations that have `/circleci/` in the URL. You can follow development progress link:https://circleci.canny.io/cloud-feature-requests/p/ability-to-use-security-groups-for-contexts-used-by-github-app-type-pipelines[here].
 
 [#in-app-config-editor]
 === In-app config editor
-The in-app config editor is not currently available for GitHub App pipeline, except during project creation.
+The in-app config editor is not currently available for GitHub App pipelines, except during project creation.
 
 [#account-integrations]
 === Account integrations
 
-Viewing menu:User settings[Account integrations] does not currently show a GitHub App integration. This page only shows GitHub OAuth app integrations.
+The page menu:User settings[Account integrations] does not currently list the GitHub App integration, even though your account may be correctly connected. This page only shows GitHub OAuth app integrations.
 
 [#build-forked-pull-requests]
 === Build forked pull requests


### PR DESCRIPTION
# Description
I changed some of the content of the "Currently not supported" section of the GitHub App integration page (https://circleci.com/docs/guides/integration/github-apps-integration/#currently-not-supported).

# Reasons
Often our docs conflate the limitations linked to "GitHub App pipelines" with those linked to standalone organizations. 
With an ever growing number of (paying) GitHub OAuth organizations adoption GitHub App pipelines, it's important to clarify which of these limitations apply to them and which don't. 
As a matter of fact, most of the limitations listed in the GitHub App integration page actually are not truly tied to the GitHub App integration, but rather to the organization type (= `/circleci/` instead of `/github/`).

I made these changes directly on the GitHub App integration page as a first urgent step, but I think we should consider organizing this content better and perhaps having a dedicated Org type disambiguation page. 

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.

<img width="759" height="1127" alt="Screenshot 2025-10-07 at 10 39 27" src="https://github.com/user-attachments/assets/a0589c63-4a10-4c7c-9b98-34b638671fab" />