### PR TITLE
YAML aliases are resolved before logic steps

### DIFF
--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -3302,11 +3302,6 @@ includes:
 | is truthy
 | `true`/`42`/`"a string"`
 
-| YAML alias
-| None
-| resolves to a truthy value
-| *my-alias
-
 | xref:guides:orchestrate:pipeline-variables.adoc#pipeline-values[Pipeline Value]
 | None
 | resolves to a truthy value


### PR DESCRIPTION
At the point of validation they have already resolved to one of the other logic types.

# Reasons
I am working on a new config processor and found this as I was reading the docs.

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs) 😸:

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Is there a "Next steps" section at the end of the page giving the reader a clear path to what to read next?
- [ ] Include relevant backlinks to other CircleCI docs/pages.