### PR TITLE
fix(server/typo): fix small typo in server homepage docs

### DIFF
--- a/archive/server 4.1/server-admin/modules/ROOT/pages/index.adoc
+++ b/archive/server 4.1/server-admin/modules/ROOT/pages/index.adoc
@@ -3,4 +3,4 @@
 :page-layout: subsection
 :page-description: CircleCI server documentation for installing, configuring, and managing CircleCI server.
 
-CircleCI server is the on-premisis CircleCI platform. In this section you will find the documentation for installing, configuring, and managing CircleCI server.
+CircleCI server is the on-premises CircleCI platform. In this section you will find the documentation for installing, configuring, and managing CircleCI server.

--- a/docs/server-admin-4.3/modules/ROOT/pages/index.adoc
+++ b/docs/server-admin-4.3/modules/ROOT/pages/index.adoc
@@ -3,4 +3,4 @@
 :page-layout: subsection
 :page-description: CircleCI server documentation for installing, configuring, and managing CircleCI server.
 
-CircleCI server is the on-premisis CircleCI platform. In this section you will find the documentation for installing, configuring, and managing CircleCI server.
+CircleCI server is the on-premises CircleCI platform. In this section you will find the documentation for installing, configuring, and managing CircleCI server.

--- a/docs/server-admin-4.4/modules/ROOT/pages/index.adoc
+++ b/docs/server-admin-4.4/modules/ROOT/pages/index.adoc
@@ -3,4 +3,4 @@
 :page-layout: subsection
 :page-description: CircleCI server documentation for installing, configuring, and managing CircleCI server.
 
-CircleCI server is the on-premisis CircleCI platform. In this section you will find the documentation for installing, configuring, and managing CircleCI server.
+CircleCI server is the on-premises CircleCI platform. In this section you will find the documentation for installing, configuring, and managing CircleCI server.

--- a/docs/server-admin-4.8/modules/ROOT/pages/index.adoc
+++ b/docs/server-admin-4.8/modules/ROOT/pages/index.adoc
@@ -2,4 +2,4 @@
 :page-layout: subsection
 :page-description: CircleCI server documentation for installing, configuring, and managing CircleCI server.
 
-CircleCI server is the on-premisis CircleCI platform. In this section you will find the documentation for installing, configuring, and managing CircleCI server.
+CircleCI server is the on-premises CircleCI platform. In this section you will find the documentation for installing, configuring, and managing CircleCI server.


### PR DESCRIPTION
# Description

Fixed small typo (`on-premisis` -> `on-premises`) in server home page docs. Interestingly enought, this was correct for a few server versions. 🤔 

# Reasons

I like tacos but I don't like typos.

# Content Checklist

Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

