### PR TITLE
Separate left hand nav and article for separate scroll areas

### DIFF
--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -9,6 +9,7 @@ html {
   font-size: var(--body-font-size);
   height: 100%;
   scroll-behavior: smooth;
+  overscroll-behavior-y: none; /* Minimize rubber banding at page edges */
 }
 
 @media screen and (min-width: 1024px) {

--- a/ui/src/css/body.css
+++ b/ui/src/css/body.css
@@ -1,5 +1,26 @@
-@media screen and (min-width: 1024px) {
-  .body {
-    display: flex;
+/* Apply fixed navigation at 1200px+ where desktop layout is stable */
+@media screen and (min-width: 1200px) {
+  /* Make navigation fixed instead of sticky for independent scrolling */
+  [data-page-navigation] {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: 33.333%; /* lg:w-2/6 */
+    max-width: 420px;
+    min-width: 360px;
+    z-index: 1; /* Keep below header */
+  }
+
+  /* Make aside scrollable and account for header height */
+  [data-page-navigation] aside {
+    height: 100%;
+    overflow-y: auto;
+    padding-top: 180px; /* Add space for header */
+  }
+
+  /* Add padding to main content container to account for fixed nav */
+  body > div.flex > div.flex-col {
+    padding-left: clamp(360px, 33.333%, 420px);
   }
 }

--- a/ui/src/css/body.css
+++ b/ui/src/css/body.css
@@ -19,10 +19,11 @@
   }
 
   /* Make aside scrollable and account for header height */
+  /* Header height calculation: navbar + component nav + padding (~10rem total) */
   [data-page-navigation] aside {
     height: 100%;
     overflow-y: auto;
-    padding-top: 180px; /* Add space for header */
+    padding-top: calc(var(--navbar-height) + var(--toolbar-height) + 4rem);
   }
 
   /* Add padding to main content container to account for fixed nav */

--- a/ui/src/css/body.css
+++ b/ui/src/css/body.css
@@ -9,25 +9,22 @@
   /* Make navigation fixed instead of sticky for independent scrolling */
   [data-page-navigation] {
     position: fixed;
-    top: 0;
+    top: calc(var(--navbar-height) + var(--toolbar-height));
     left: 0;
-    height: 100vh;
-    width: 33.333%; /* lg:w-2/6 */
-    max-width: 420px;
-    min-width: 360px;
+    height: calc(100vh - var(--navbar-height) - var(--toolbar-height));
+    width: clamp(360px, 25%, 420px); /* Responsive width - stays at 420px until ~1680px */
     z-index: 1; /* Keep below header */
   }
 
-  /* Make aside scrollable and account for header height */
-  /* Header height calculation: navbar + component nav + padding (~10rem total) */
+  /* Make aside scrollable and add padding for remaining header space */
   [data-page-navigation] aside {
     height: 100%;
     overflow-y: auto;
-    padding-top: calc(var(--navbar-height) + var(--toolbar-height) + 5rem);
+    padding-top: 5rem; /* Space for component nav area */
   }
 
   /* Add padding to main content container to account for fixed nav */
   body > div.flex > div.flex-col {
-    padding-left: clamp(360px, 33.333%, 420px);
+    padding-left: clamp(360px, 25%, 420px); /* Match navigation width */
   }
 }

--- a/ui/src/css/body.css
+++ b/ui/src/css/body.css
@@ -23,7 +23,7 @@
   [data-page-navigation] aside {
     height: 100%;
     overflow-y: auto;
-    padding-top: calc(var(--navbar-height) + var(--toolbar-height) + 4rem);
+    padding-top: calc(var(--navbar-height) + var(--toolbar-height) + 5rem);
   }
 
   /* Add padding to main content container to account for fixed nav */

--- a/ui/src/css/body.css
+++ b/ui/src/css/body.css
@@ -1,3 +1,9 @@
+@media screen and (min-width: 1024px) {
+  .body {
+    display: flex;
+  }
+}
+
 /* Apply fixed navigation at 1200px+ where desktop layout is stable */
 @media screen and (min-width: 1200px) {
   /* Make navigation fixed instead of sticky for independent scrolling */


### PR DESCRIPTION
## Summary

  Fixed left-hand navigation scrolling issue where users could not access navigation items at the top when scrolled down in long articles.

### Problem

  The left navigation used position: sticky with height: 100vh, which meant:
  - When the page scrolled, the navigation stayed visually at the top (sticky behavior)
  - However, the navigation container scrolled WITH the page content
  - Users had to scroll the entire page back up to access top navigation items
  - Bottom navigation items were inaccessible without scrolling the page down

### Solution

  Changed navigation to position: fixed at desktop widths (1200px+), creating truly independent scroll areas.

### Changes Made

  File: ui/src/css/body.css
  - Added media query for min-width: 1200px
  - Navigation set to position: fixed with full viewport height
  - Navigation aside made scrollable with overflow-y: auto
  - Added padding-top: to account for sticky header
  - Added padding-left to main content container to prevent overlap with fixed navigation
