### PR TITLE
fix spacing and breadcrumbs styling

### DIFF
--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -94,8 +94,9 @@
 
 /* Special case: Page title gets extra top margin on larger screens */
 @media screen and (min-width: 768px) {
-  .doc > h1.page:first-child {
-    margin-top: 2.5rem;
+  .doc h1.page {
+    margin-top: calc(40 / var(--rem-base) * 1rem); /* 40px */
+    margin-bottom: calc(32 / var(--rem-base) * 1rem); /* 32px */
   }
 }
 

--- a/ui/src/partials/breadcrumbs.hbs
+++ b/ui/src/partials/breadcrumbs.hbs
@@ -3,7 +3,7 @@
   <ul>
     {{#if site.homeUrl}}
     <li class="inline after:text-[#959595] after:content-['/'] after:px-2">
-      <a class="text-[#343434] font-normal" href="{{{relativize site.homeUrl}}}">Home</a>
+      <a class="text-link-on-light font-normal" href="{{{relativize site.homeUrl}}}">Home</a>
     </li>
     {{/if}}
     {{#with page.componentVersion}}
@@ -17,7 +17,7 @@
       {{#if (and ./url (eq ./urlType 'internal'))}}
         <a class="text-[#343434] font-normal" href="{{{relativize ./url}}}">{{{./content}}}</a>
               {{else}}
-          <span class="text-[#343434] font-normal">{{{./content}}}</span>
+          <span class="text-[#343434] font-normal cursor-default">{{{./content}}}</span>
         {{/if}}
     </li>
     {{/unless}}


### PR DESCRIPTION
# Description

* fix spacing between top elements on page and make it clear when the breadcrumbs are clickable

Before:
<img width="1300" height="580" alt="Screenshot 2025-10-13 at 13 45 00" src="https://github.com/user-attachments/assets/89dffff4-4474-475c-b3af-b3ded511a439" />

After:
<img width="1299" height="639" alt="Screenshot 2025-10-13 at 13 45 09" src="https://github.com/user-attachments/assets/48f4be87-1c3e-4ebc-93bd-6bd08b2716aa" />


# Reasons
Why did you make these changes?

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
