### PR TITLE
docs(deploy): remove server tag from deploy overview and release agen…

### DIFF
--- a/docs/guides/modules/deploy/pages/deployment-overview.adoc
+++ b/docs/guides/modules/deploy/pages/deployment-overview.adoc
@@ -1,6 +1,6 @@
 = Deployment and deploy management overview
 :page-aliases: deploys-overview.adoc, deploy:deploy-to-amazon-sagemaker.adoc
-:page-platform: Cloud, Server v4+
+:page-platform: Cloud
 :page-description: Learn the basics of deployment and deploys management with CircleCI.
 :experimental:
 

--- a/docs/guides/modules/deploy/pages/release-agent-overview.adoc
+++ b/docs/guides/modules/deploy/pages/release-agent-overview.adoc
@@ -1,5 +1,5 @@
 = CircleCI release agent overview
-:page-platform: Cloud, Server v4+
+:page-platform: Cloud
 :page-description: Learn the basics of release management for your Kubernetes deployments with CircleCI.
 :experimental:
 


### PR DESCRIPTION
…t overview pages

# Description
What did you change?
Removed the Server v4+ tag from the deployment-overview.adoc and release-agent-overview.adoc pages
# Reasons
Why did you make these changes?
This change was made to address customer confusion regarding whether deploy management features are supported on CircleCI server v4.x. Removing the tag clarifies that these features are primarily for CircleCI Cloud.
# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Keep the title between 20 and 70 characters.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [x] Include relevant backlinks to other CircleCI docs/pages.
