### PR TITLE
chore: remove google_analytics key from Antora playbook due to bot traffic

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -4,7 +4,6 @@ site:
   robots: allow
   keys:
     cookiebot: a28b71f3-4d2e-4eac-93bc-34929948dd7d
-    google_analytics: 'GTM-W9HDVK'
 content:
   sources:
   - url: .


### PR DESCRIPTION
Removes the site.keys.google_analytics entry from `antora-playbook.yml` to stop the spamming of our google analytics monitors again.