### PR TITLE
Add documentation for new OIDC claims

### DIFF
--- a/docs/guides/modules/permissions-authentication/pages/openid-connect-tokens.adoc
+++ b/docs/guides/modules/permissions-authentication/pages/openid-connect-tokens.adoc
@@ -78,6 +78,12 @@ The OpenID Connect ID tokens also contain some https://openid.net/specs/openid-c
 | `oidc.circleci.com/project-id`
 | The ID of the project in which the job is running. Its value is a string containing a UUID identifying the CircleCI project.
 
+| `oidc.circleci.com/pipeline-id`
+| The unique identifier for the pipeline that triggered this job. Its value is a string containing a UUID identifying the CircleCI pipeline.
+
+| `oidc.circleci.com/org-id`
+| The unique identifier for the organization. Its value is a string containing a UUID identifying the CircleCI organization.
+
 | `oidc.circleci.com/vcs-origin`
 | The URL of the repository that triggered the pipeline. Its value is a string similar to `github.com/organization-123/repo-1`. This is not present for pipelines triggered by custom webhooks.
 


### PR DESCRIPTION
This PR documents the new `vcs-sha` claim added to CircleCI OIDC tokens. It contains the git commit SHA that triggered the pipeline.

**Dependencies:**
- based off update-oidc branch which I expect to be merged first
- Depends on circleci/oidc-tasks-service `new-claim` branch being merged first https://github.com/circleci/oidc-tasks-service/pull/287

The vcs-sha claim is included in both V1 and V2 OIDC token formats when VCS information is available.