### PR TITLE
Update documentation for Xcode 26.1 image

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
@@ -8,12 +8,12 @@
 | Release Notes
 
 | `26.1.0`
-| Xcode 26.1 RC (17B54)
+| Xcode 26.1 (17B55)
 | 15.6
 a| `m4pro.medium` +
    `m4pro.large`
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v15780/manifest.txt[Installed software]
-| link:https://circleci.com/changelog/xcode-26-1-rc-available/[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v15804/manifest.txt[Installed software]
+| link:https://circleci.com/changelog/xcode-26-1-available/[Release Notes]
 
 | `26.0.1`
 | Xcode 26.0.1 (17A400)


### PR DESCRIPTION
# Description
We've replaced Xcode 26.1 RC with 26.1. This change updates links and information to reflect the new image.

# Reasons
A new Xcode 26.1 image was released

# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
