### PR TITLE
Update openid-connect-tokens.adoc to fix incorrect parameters

### DIFF
--- a/docs/guides/modules/permissions-authentication/pages/openid-connect-tokens.adoc
+++ b/docs/guides/modules/permissions-authentication/pages/openid-connect-tokens.adoc
@@ -178,12 +178,12 @@ jobs:
       - checkout
       # run the aws-cli/setup command from the orb
       - aws-cli/setup:
-          role-arn: "arn:aws:iam::123456789012:role/OIDC-ROLE"
-          aws-region: ${AWS_REGION}
+          role_arn: "arn:aws:iam::123456789012:role/OIDC-ROLE"
+          region: ${AWS_REGION}
           # optional parameters
-          profile-name: "OIDC-PROFILE"
-          role-session-name: "example-session"
-          session-duration: "1800"
+          profile_name: "OIDC-PROFILE"
+          role_session_name: "example-session"
+          session_duration: "1800"
 ----
 +
 You can optionally provide a `profile-name`, `role-session-name`, and `session-duration`. If you provide a `profile-name`, the temporary keys and token will be configured to that specific profile. You must use that same `profile-name` with the rest of your AWS commands. If a `profile-name` is not provided, the keys and token will be configured to the default profile.


### PR DESCRIPTION
Fix outdated/wrong parameters in one of the aws-cli/setup commands

# Description
What did you change?

Updated openid-connect-tokens.adoc section in `Adding AWS to the CircleCI configuration file`, as the code-block references incorrect/wrong parameters that circleci doesn't take. Link to documentation is here:
https://circleci.com/developer/orbs/orb/circleci/aws-cli

# Reasons
Why did you make these changes?

Changing to follow the orb documentation and to match the syntax that is further page.


# Content Checklist
Please follow our style when contributing to CircleCI docs. Our style guide is here: [https://circleci.com/docs/style/style-guide-overview](https://circleci.com/docs/style/style-guide-overview).

Please take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Keep the title between 20 and 70 characters.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
- [ ] Include relevant backlinks to other CircleCI docs/pages.
