### PR TITLE
[DOCCS-1980] Fixed docker runner web app installation section

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -19,3 +19,7 @@ attribute-missing = drop
 
 [*.adoc]
 BasedOnStyles = circleci-docs, Vale, Readability, Openly, AsciiDoc
+
+[**/nav.adoc]
+circleci-docs.XrefTitleCase = NO
+circleci-docs.ListPunctuation = NO

--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -119,7 +119,7 @@
 *** xref:execution-runner:install-machine-runner-3-on-linux.adoc[Install machine runner 3 on Linux]
 *** xref:execution-runner:install-machine-runner-3-on-macos.adoc[Install machine runner 3 on macOS]
 *** xref:execution-runner:install-machine-runner-3-on-windows.adoc[Install machine runner 3 on Windows]
-*** xref:execution-runner:install-machine-runner-3-on-docker.adoc[Install on Docker]
+*** xref:execution-runner:install-machine-runner-3-on-docker.adoc[Install machine runner 3 on Docker]
 *** xref:execution-runner:machine-runner-3-manual-installation.adoc[Manual install on Linux and macOS]
 *** xref:execution-runner:machine-runner-3-manual-installation-on-windows.adoc[Manual install on Windows]
 *** xref:execution-runner:migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc[Migrate from launch agent to machine runner 3 on Linux]

--- a/docs/guides/modules/execution-runner/pages/install-machine-runner-3-on-docker.adoc
+++ b/docs/guides/modules/execution-runner/pages/install-machine-runner-3-on-docker.adoc
@@ -8,7 +8,7 @@
 This page describes how to install CircleCI's machine runner 3 with the Docker executor. If you are looking to set up self-hosted runners in a private Kubernetes cluster, visit the <<container-runner-installation#,Container runner>> page.
 
 ****
-xref:container-runner.adoc[Container runner] is the **recommended method** for self-hosted runner Docker installation. The instructions on this page are for a simple Docker setup using machine runner 3.
+xref:container-runner.adoc[Container Runner] is the **recommended method** for self-hosted runner Docker installation. The instructions on this page are for a simple Docker setup using machine runner 3.
 
 Container runner is the recommended approach for running containerized jobs on self-hosted runners. Container runner offers the ability to seamlessly define, publish, and use custom Docker images during job execution. Container runner also has the ability to manage dependencies or libraries through custom Docker images instead of enumerating dependencies as part of `steps` in the `.circleci/config.yml` file.
 ****

--- a/styles/circleci-docs/XrefTitleCase.yml
+++ b/styles/circleci-docs/XrefTitleCase.yml
@@ -13,7 +13,7 @@ script: |
   // Words that should not be capitalized in title case (unless first/last word)
   // Articles, coordinating conjunctions, and short prepositions only
   lowercase_words := ["a", "an", "the", "and", "but", "or", "for", "nor", "so", "yet",
-                      "at", "by", "in", "of", "on", "to", "up", "as", "via", "per"]
+                      "at", "by", "in", "of", "on", "to", "up", "as", "via", "per", "macos"]
 
   for i, line in lines {
     // Find all xref patterns: xref:path[Link Text]


### PR DESCRIPTION
# Description
https://circleci.com/docs/guides/execution-runner/install-machine-runner-3-on-docker/#self-hosted-runner-terms-agreement

This section incorrectly displays CLI installation steps when on the Web app installation page. This PR fixes this issue.

## Old

<img width="766" height="689" alt="image" src="https://github.com/user-attachments/assets/e026366e-ab9a-4b49-89a7-0122eebdefc5" />

## New
<img width="750" height="677" alt="image" src="https://github.com/user-attachments/assets/310bf980-7806-4aa2-a114-e649372013a1" />


## Side Note
Lint is failing due to conflicting lint rules:
1. Link names must start with uppercase
2. 'MacOS' must be 'macOS'

Unrelated to my change but not sure how to resolve