### PR TITLE
Prevent accordion arrow from shrinking

### DIFF
--- a/ui/src/partials/navigation-tree.hbs
+++ b/ui/src/partials/navigation-tree.hbs
@@ -5,7 +5,7 @@
     {{#if ./content}}
       <div data-navigation-tree-toggle class="flex items-center py-[8px] px-[12px] space-x-2 max-w-fit {{#if (eq ./url @root.page.url)}} rounded-lg bg-fog{{/if}} {{#if (has-active-child ./items)}} border-none{{/if}}">
         {{#if ./items.length }}
-          <button class="block -ml-[1.3rem] p-1 h-full">
+          <button class="block -ml-[1.3rem] p-1 h-full flex-shrink-0">
             <img src="{{{@root.uiRootPath}}}/img/arrow-down.svg" alt="Toggle" class="w-[6px] h-[6px] transform {{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url))) }}-rotate-90{{/if}}">
           </button>
         {{/if}}


### PR DESCRIPTION
Left hand nav accordion arrows were shrinking for long titles:
<img width="443" height="582" alt="Screenshot 2025-12-16 at 11 46 03" src="https://github.com/user-attachments/assets/d7be6cef-3a4d-47d5-bd73-4ba2ff42912a" />

This change prevents shrinking:
<img width="371" height="580" alt="Screenshot 2025-12-16 at 11 46 23" src="https://github.com/user-attachments/assets/e3275d23-ea92-433d-b6c0-e98f4b17115c" />
