### PR TITLE
Fix code block scroll within blocks

### DIFF
--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -605,6 +605,7 @@
 .doc .admonitionblock td.content {
   width: 100%;
   word-wrap: anywhere;
+  min-width: 0;
 }
 
 .doc .imageblock,
@@ -956,6 +957,11 @@
   padding: 1rem;
   box-sizing: border-box;
   padding: 1rem 1rem 0.75rem;
+}
+
+.doc .sidebarblock > .content {
+  min-width: 0;
+  width: 100%;
 }
 
 .doc .sidebarblock > .content > .title {


### PR DESCRIPTION
Code blocks with long lines are breaking formatting of sidebar and admonition blocks

When using flexbox, flex items have an implicit `min-width: auto` which prevents them from shrinking below their content's intrinsic width. This causes the `<pre>` elements to expand beyond the container.

**Fix**: add `min-width: 0` to the flex items containing the content. This will allow them to shrink properly and let the horizontal scrolling on the code blocks work as intended.

Before: 
<img width="775" height="235" alt="Screenshot 2025-12-16 at 23 08 36" src="https://github.com/user-attachments/assets/955cc5a5-bdd0-46f5-9f17-60fc160b5790" />

After:
<img width="763" height="268" alt="Screenshot 2025-12-16 at 23 08 48" src="https://github.com/user-attachments/assets/9e1baf05-97c3-45b5-9588-c8bff5df8849" />

