### PR TITLE
Update reference from 'Manage deploys' to 'Manage releases'

### DIFF
--- a/docs/guides/modules/deploy/pages/configure-your-kubernetes-components.adoc
+++ b/docs/guides/modules/deploy/pages/configure-your-kubernetes-components.adoc
@@ -285,4 +285,4 @@ spec:
 [#next-steps]
 == Next steps
 
-In this tutorial you have configured your Kubernetes components for visibility and control from the CircleCI deploys dashboard. Next, learn how to manage your deploys in the xref:manage-deploys.adoc[Manage releases] how-to guide.
+In this tutorial you have configured your Kubernetes components for visibility and control from the CircleCI deploys dashboard. Next, learn how to manage your deploys in the xref:manage-releases.adoc[Manage Releases] guide.


### PR DESCRIPTION
> [!NOTE]
> You may find that there are errors for the `vale/lint` job that are unrelated to your change.
> Vale checks the whole file when a change is made so if there are existing issues on the page they will be flagged.
> You can ignore lint errors outside your changes and the CircleCI docs team will address them for you.
> Vale logs are advisory to help all contributors create content that conforms to our style guide. The `vale/lint` job will not prevent changes from being published.

# Description
Changed "managed deploys" to "manage release"

# Reasons
Follows new naming convention

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
