### PR TITLE
Remove read time but allow opt in for some how-to pages

### DIFF
--- a/docs/guides/modules/getting-started/pages/getting-started.adoc
+++ b/docs/guides/modules/getting-started/pages/getting-started.adoc
@@ -1,6 +1,8 @@
 = Quickstart guide
 :page-platform: Cloud
 :page-description: A quickstart guide for adding a project to CircleCI and exploring some features
+:page-show-readtime: true
+:experimental:
 
 This quickstart provides a guided tour through setting up a project, collaborating, and tools to iterate on and debug your build configuration. The following sections cover the following:
 

--- a/docs/guides/modules/test/pages/smarter-testing.adoc
+++ b/docs/guides/modules/test/pages/smarter-testing.adoc
@@ -4,7 +4,6 @@
 :page-description: This page describes CircleCI's Smarter Testing. Only run tests that are impacted by code changes and evenly distribute tests across parallel execution nodes.
 :experimental:
 :page-noindex: true
-:page-hide-readtime: true
 :page-aliases: adaptive-testing.adoc
 
 CAUTION: *Smarter Testing* is available in preview. This means the product is in early stages and you may encounter bugs, unexpected behavior, or incomplete features. When the feature is made generally available, there will be a cost associated with access and usage.

--- a/extensions/page-metadata-extension.js
+++ b/extensions/page-metadata-extension.js
@@ -30,8 +30,8 @@ module.exports.register = function () {
         pages.forEach((page) => {
           let { abspath, origin, path } = page.src
           const { branch, startPath, webUrl } = origin
-          const index = abspath?.indexOf('docs/')
-          const pagePath = abspath ? (index > -1 ? abspath.substring(index) : abspath ) :  startPath + '/' + path
+          // Use startPath + path for the git path (relative to repo root)
+          const pagePath = startPath + '/' + path
 
           const key = `${component}:${version}:${page.path}`
 

--- a/ui/src/partials/article-info-bar.hbs
+++ b/ui/src/partials/article-info-bar.hbs
@@ -1,6 +1,6 @@
 <div class="mt-5 mb-10 lg:mt-0 w-full md:w-fit max-w-full md:px-4 flex flex-col md:flex-row border border-vapor rounded-xl items-stretch justify-between {{#if class}}{{class}}{{/if}}">
   {{#with (get-page-meta page)}}
-    
+
     <div class="flex items-center pl-3 md:pl-0 pr-3 py-2">
       <!-- Article Last Updated -->
       {{#if lastUpdate}}
@@ -8,19 +8,19 @@
           <img src="{{{@root.uiRootPath}}}/img/calendar.svg" alt="Language Icon" class="inline-block h-5 w-5 mr-2">
           {{format-time-ago lastUpdate}}
         </a>
-        <span class="text-xl px-2">&middot;</span>
       {{/if}}
       <!-- Read Time -->
-      {{#unless @root.page.attributes.hide-readtime}}
+      {{#if @root.page.attributes.show-readtime}}
         {{#if readingTime}}
+          <span class="text-xl px-2">&middot;</span>
           <span class="flex min-w-fit items-center">
             {{readingTime}}
           </span>
         {{/if}}
-      {{/unless}}
+      {{/if}}
     </div>
   {{/with}}
-  
+
   <!-- Platform Tags -->
   {{#if page.attributes.platform}}
     <div class="flex items-center min-w-fit space-x-1 px-3 py-2 md:py-0 border-t md:border-t-0 md:border-l border-inherit">


### PR DESCRIPTION
Right now all pages show read time.

The read time calculation is unhelpful, especially when there are many code blocks and when there is content in tabs (reader would likely pick one tab rather than read through all) because all words are counted equally in the calculation.

**This change removes the read time from all pages but allows it to be added back for specific pages - I've added it back to the quickstart guide.**

Other change is just to fix a path that was broken for loacl builds which was preventing the Last Updated section from being shown in a local build.