### PR TITLE
Add deploy markers configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,14 +87,32 @@ jobs:
       - attach_workspace:
           at: .
       - aws-setup
+      - run:
+          name: Plan deployment
+          command: |
+            circleci run release plan "${CIRCLE_JOB}" \
+              --environment-name="production" \
+              --component-name="${CIRCLE_PROJECT_REPONAME}" \
+              --target-version="1.0.${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:7}"
       - go/with-cache:
           steps:
             - run: task mod-download
             - run: task deploy
             - run: task deploy-redirects
             - run: task validate-redirects
+      - run:
+          name: Update deployment status to running
+          command: circleci run release update "${CIRCLE_JOB}" --status=RUNNING
       - notify_error:
           message: "Production deployment job failed for branch ${CIRCLE_BRANCH}"
+      - run:
+          name: Update deployment status to success
+          command: circleci run release update "${CIRCLE_JOB}" --status=SUCCESS
+          when: on_success
+      - run:
+          name: Update deployment status to failed
+          command: circleci run release update "${CIRCLE_JOB}" --status=FAILED
+          when: on_fail
 
 workflows:
   main:


### PR DESCRIPTION
This PR adds Deploy Markers to your CircleCI configuration. Deploy Markers enable CircleCI to automatically track when deployments happen in your pipelines, giving you:
- Deployment visibility in the CircleCI UI
- Deployment frequency and success metrics
- Better insights into your release pipeline
- Integration with deployment tracking features
Learn more about Deploy Markers in our [documentation](https://circleci.com/docs/guides/deploy/configure-deploy-markers/).