### PR TITLE
[DOCSS-2001] test results can be directly in path directory

### DIFF
--- a/docs/guides/modules/test/pages/collect-test-data.adoc
+++ b/docs/guides/modules/test/pages/collect-test-data.adoc
@@ -6,7 +6,7 @@
 [#introduction]
 == Introduction
 
-When you run tests in CircleCI there are two ways to store your test results. You can either use xref:optimize:artifacts.adoc[artifacts] or the xref:reference:ROOT:configuration-reference.adoc#storetestresults[`store_test_results` step]. Each of these methods has advantages, so the decision needs to be made for each project.
+When you run tests in CircleCI there are two ways to store your test results. You can either use xref:optimize:artifacts.adoc[Artifacts] or the xref:reference:ROOT:configuration-reference.adoc#storetestresults[`store_test_results` step]. Each of these methods has advantages, so the decision needs to be made for each project.
 
 When you save test data using the `store_test_results` step, CircleCI collects data from XML files and uses it to provide insights into your job. This page describes how to configure CircleCI to output test data as XML for some common test runners and store reports with the `store_test_results` step.
 
@@ -18,20 +18,21 @@ Using the *`store_test_results` step* gives you access to:
 
 You can also store test results as *artifacts*, which means you can look at the raw XML. Using artifacts can be useful when debugging issues with setting up your project's test results handling, for example, finding incorrectly uploaded files.
 
-To see test results as build artifacts, upload them using the xref:reference:ROOT:configuration-reference.adoc#storeartifacts[`store_artifacts` step]. Storing artifacts has associated costs due to the use of storage. See the xref:optimize:persist-data.adoc#custom-storage-usage[Persisting data] page for information on how to customize storage retention periods for objects like artifacts.
+To see test results as build artifacts, upload them using the xref:reference:ROOT:configuration-reference.adoc#storeartifacts[`store_artifacts` Step]. Storing artifacts has associated costs due to the use of storage. See the xref:optimize:persist-data.adoc#custom-storage-usage[Persisting Data] page for information on how to customize storage retention periods for objects like artifacts.
 
 TIP: You can choose to upload your test results using both `store_test_results` and `store_artifacts`.
 
-Using the xref:reference:ROOT:configuration-reference.adoc#storetestresults[`store_test_results` step] allows you to do the following:
+Using the xref:reference:ROOT:configuration-reference.adoc#storetestresults[`store_test_results` Step] allows you to do the following:
 
 * Upload and store test results.
 * Get a view of your passing/failing tests in the CircleCI web app.
 
 Access test results from the *Tests tab* when viewing a job, as shown below.
 
+.Test summary view
 image::guides:ROOT:test-summary.png[store-test-results-view]
 
-Below is an example of using the xref:reference:ROOT:configuration-reference.adoc#storetestresults[`store_test_results` key] in your `.circleci/config.yml`.
+Below is an example of using the xref:reference:ROOT:configuration-reference.adoc#storetestresults[`store_test_results` Key] in your `.circleci/config.yml`.
 
 [,yml]
 ----
@@ -44,14 +45,14 @@ steps:
     path: test-results
 ----
 
-The `path` key is an absolute or relative path to your `working_directory` containing JUnit XML test metadata files (either directly in the directory or in subdirectories), or the path of a single file containing all test results.
+The `path` key is an absolute or relative path to your `working_directory`. It can contain JUnit XML test metadata files directly in the directory, in subdirectories, or point to a single file containing all test results.
 
 CAUTION: Make sure that your `path` value is not a hidden folder. For example, `.my_hidden_directory` would be an invalid format.
 
 [#viewing-storage-usage]
 == Viewing storage usage
 
-For information on viewing your storage usage, and calculating your monthly storage overage costs, see the xref:optimize:persist-data.adoc#managing-network-and-storage-usage[Persisting data] guide.
+For information on viewing your storage usage, and calculating your monthly storage overage costs, see the xref:optimize:persist-data.adoc#managing-network-and-storage-usage[Persisting Data] guide.
 
 [#test-insights]
 == Test Insights
@@ -84,7 +85,7 @@ gem 'minitest-ci'
 
 * Django should be configured using the link:https://github.com/django-nose/django-nose[`django-nose`] test runner.
 
-For detailed information on how to test your iOS applications, refer to the xref:testing-ios.adoc[Testing iOS applications] page.
+For detailed information on how to test your iOS applications, refer to the xref:testing-ios.adoc[Testing iOS Applications] page.
 
 [#test-runner-examples-by-language]
 == Test runner examples by language

--- a/styles/circleci-docs/XrefTitleCase.yml
+++ b/styles/circleci-docs/XrefTitleCase.yml
@@ -31,6 +31,12 @@ script: |
           continue
         }
 
+        // Skip if link text starts with a backtick (code references)
+        trimmed_link := text.trim_space(link_text)
+        if text.re_match("^`", trimmed_link) {
+          continue
+        }
+
         // Split into words
         words := text.split(link_text, " ")
         has_error := false
@@ -59,6 +65,12 @@ script: |
           if is_exception {
             continue
           }
+
+          // Skip iOS (capitalized) - only allow capitalized version
+          if clean_word == "iOS" {
+            continue
+          }
+
           // Get first character
           first_char := text.substr(clean_word, 0, 1)
           is_capitalized := text.re_match("[A-Z]", first_char)


### PR DESCRIPTION
# Description 
Fixed incorrect documentation about `store_test_results` path requirements.

# Reasons
Customer was confused because we specify that the test results must be in a subdirectory but this is not true.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a small linter rule tweak; low risk aside from potentially missing title-case violations for backticked xref link text.
> 
> **Overview**
> Clarifies the `store_test_results` documentation to state that the configured `path` may contain JUnit XML files directly, in subdirectories, or be a single results file, addressing confusion about subdirectory-only requirements.
> 
> Updates the xref title-case Vale rule (`XrefTitleCase.yml`) to **skip enforcement** when xref link text begins with a backtick (code-style link text) and to avoid flagging intentionally capitalized terms like `iOS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47d1df5eab1f6c52800cd15db947b9ff62733943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->