### PR TITLE
server: expand on release/support policy to make it clearer

### DIFF
--- a/docs/server-admin-4.8/modules/ROOT/nav.adoc
+++ b/docs/server-admin-4.8/modules/ROOT/nav.adoc
@@ -41,7 +41,7 @@
 ** xref:operator:managing-build-artifacts.adoc[Managing build artifacts]
 ** xref:operator:usage-data-collection.adoc[Usage data collection]
 ** xref:operator:circleci-server-security-features.adoc[CircleCI Server security features]
-** xref:operator:application-lifecycle.adoc[Application lifecycle]
+** xref:operator:application-lifecycle.adoc[Release cycle]
 ** xref:operator:troubleshooting-and-support.adoc[Troubleshooting and support]
 ** xref:operator:backup-and-restore.adoc[Backup and restore]
 ** xref:operator:upgrade-mongo.adoc[Upgrade MongoDB]

--- a/docs/server-admin-4.8/modules/operator/pages/application-lifecycle.adoc
+++ b/docs/server-admin-4.8/modules/operator/pages/application-lifecycle.adoc
@@ -4,15 +4,15 @@
 :page-description: Learn about CircleCI Server 4.8 semantic versioning and release schedules.
 :experimental:
 
-CircleCI supports the two most recent versions of CircleCI Server at any time, whether the new release is a minor or major version bump. For example, if 4.9 is the current release and 5.0 ships next, then 5.0 and 4.9 become the supported pair.
+CircleCI supports the two most recent versions of CircleCI Server at any time, whether the release is a minor or major version bump. For example, if 4.9 is the current release and 5.0 ships next, then 5.0 and 4.9 become the supported pair.
 
-New versions are released approximately every six months, though the exact timing may vary.
+CircleCI targets a six-month release cadence, though the exact timing varies.
 
-CircleCI supports each version for up to 12 months. A new release takes precedence: when a new version ships, the older of the two currently supported versions reaches end of life.
+CircleCI supports each version for up to 12 months. A release takes precedence: when a version ships, the older of the two currently supported versions reaches end of life.
 
-For example: if 4.8 and 4.9 are the supported pair and 4.10 ships ten months after 4.8, then 4.8 immediately reaches end of life. The new supported pair becomes 4.9 and 4.10.
+For example: if 4.8 and 4.9 are the supported pair and 4.10 ships ten months after 4.8, then 4.8 reaches end of life. The supported pair becomes 4.9 and 4.10.
 
-We use semantic versioning to identify releases and communicate the impact on your installation. Patch releases are published monthly as needed for bugs and security fixes.
+We use semantic versioning to identify releases and communicate the impact on your installation. We publish patch releases each month as needed for bugs and security fixes.
 
 [#semantic-versioning]
 == Semantic versioning
@@ -26,13 +26,13 @@ Additional labels for pre-release and build metadata are available as extensions
 
 [#release-schedule]
 == Release schedule
-We release monthly patch fixes for bugs and security concerns. We will have twice yearly new minor or major (feature) releases. All releases will be posted to the change log. To stay up to date with the most recent releases, subscribe to the link:https://circleci.com/server/changelog/[change log].
+We release patch fixes for bugs and security concerns each month. We release minor and major (feature) versions twice a year. Subscribe to the link:https://circleci.com/server/changelog/[change log] to stay up to date.
 
 [#end-of-support]
 == End of support
 With each minor or major release, in accordance with our link:https://circleci.com/legal/terms-of-service/[terms of service], we end support for previous versions of CircleCI Server. The following table provides dates for previously released versions.
 
-CAUTION: Future dates listed here may change at any time.
+CAUTION: These dates are subject to change.
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]

--- a/docs/server-admin-4.8/modules/operator/pages/application-lifecycle.adoc
+++ b/docs/server-admin-4.8/modules/operator/pages/application-lifecycle.adoc
@@ -6,11 +6,9 @@
 
 CircleCI supports the two most recent versions of CircleCI Server at any time, whether the release is a minor or major version bump. For example, if 4.9 is the current release and 5.0 ships next, then 5.0 and 4.9 become the supported pair.
 
-CircleCI targets a six-month release cadence, though the exact timing varies.
+CircleCI targets a six-month release cadence, though the exact timing varies. When a version ships, the older of the two currently supported versions reaches end of life.
 
-CircleCI supports each version for up to 12 months. A release takes precedence: when a version ships, the older of the two currently supported versions reaches end of life.
-
-For example: if 4.8 and 4.9 are the supported pair and 4.10 ships ten months after 4.8, then 4.8 reaches end of life. The supported pair becomes 4.9 and 4.10.
+For example: if 4.8 and 4.9 are the supported pair and 4.10 ships, then 4.8 reaches end of life. The supported pair becomes 4.9 and 4.10.
 
 We use semantic versioning to identify releases and communicate the impact on your installation. We publish patch releases each month as needed for bugs and security fixes.
 

--- a/docs/server-admin-4.8/modules/operator/pages/application-lifecycle.adoc
+++ b/docs/server-admin-4.8/modules/operator/pages/application-lifecycle.adoc
@@ -1,34 +1,41 @@
-= Application lifecycle
+= Release cycle and versioning policy
 :page-noindex: true
-:page-platform: Server v4.8, Server Admin
-:page-description: Learn about CircleCI server v4.8 semantic versioning and release schedules.
+:page-platform: Server 4.8, Server Admin
+:page-description: Learn about CircleCI Server 4.8 semantic versioning and release schedules.
 :experimental:
 
-CircleCI is committed to supporting two minor versions of the software. This means a minor version will be released twice yearly and receive patches for up to 12 months. We use semantic versioning to help identify releases and their impact on your installation. Patch releases will continue to be monthly as needed.
+CircleCI supports the two most recent versions of CircleCI Server at any time, whether the new release is a minor or major version bump. For example, if 4.9 is the current release and 5.0 ships next, then 5.0 and 4.9 become the supported pair.
+
+New versions are released approximately every six months, though the exact timing may vary.
+
+Each version is supported for up to 12 months, but a new release takes precedence: when a new version ships, the older of the two currently supported versions reaches end of life, regardless of how long it has been available.
+
+For example: if 4.8 and 4.9 are the two supported versions and 4.10 is released ten months after 4.8, then 4.8 reaches end of life when 4.10 is released. The new supported pair becomes 4.9 and 4.10.
+
+We use semantic versioning to identify releases and communicate the impact on your installation. Patch releases are published monthly as needed for bugs and security fixes.
 
 [#semantic-versioning]
 == Semantic versioning
 Given a version number, MAJOR.MINOR.PATCH increment, use the:
 
-. MAJOR version when you make incompatible API changes,
-. MINOR version when you add functionality in a backwards-compatible manner, and
+. MAJOR version when you make incompatible API changes.
+. MINOR version when you add functionality in a backwards-compatible manner.
 . PATCH version when you make backwards compatible bug fixes.
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 
 [#release-schedule]
 == Release schedule
-We release monthly patch fixes for bugs and security concerns. We will have twice yearly new minor (feature) releases. All releases will be posted to the change log. To stay up to date with the most recent releases, subscribe to the link:https://circleci.com/server/changelog/[change log].
+We release monthly patch fixes for bugs and security concerns. We will have twice yearly new minor or major (feature) releases. All releases will be posted to the change log. To stay up to date with the most recent releases, subscribe to the link:https://circleci.com/server/changelog/[change log].
 
 [#end-of-support]
 == End of support
-With each minor release, in accordance with our link:https://circleci.com/legal/terms-of-service/[terms of service], we end support for previous versions of server. The following table provides dates for previously released versions.
+With each minor or major release, in accordance with our link:https://circleci.com/legal/terms-of-service/[terms of service], we end support for previous versions of CircleCI Server. The following table provides dates for previously released versions.
 
 CAUTION: Future dates listed here may change at any time.
 
-[.table-scroll]
---
-[cols=3*, options="header"]
+[.table.table-striped]
+[cols=3*, options="header", stripes=even]
 |===
 | Version | Released | End of Support
 
@@ -68,4 +75,3 @@ CAUTION: Future dates listed here may change at any time.
 |7/28/2022
 |7/31/2023
 |===
---

--- a/docs/server-admin-4.8/modules/operator/pages/application-lifecycle.adoc
+++ b/docs/server-admin-4.8/modules/operator/pages/application-lifecycle.adoc
@@ -8,9 +8,9 @@ CircleCI supports the two most recent versions of CircleCI Server at any time, w
 
 New versions are released approximately every six months, though the exact timing may vary.
 
-Each version is supported for up to 12 months, but a new release takes precedence: when a new version ships, the older of the two currently supported versions reaches end of life, regardless of how long it has been available.
+CircleCI supports each version for up to 12 months. A new release takes precedence: when a new version ships, the older of the two currently supported versions reaches end of life.
 
-For example: if 4.8 and 4.9 are the two supported versions and 4.10 is released ten months after 4.8, then 4.8 reaches end of life when 4.10 is released. The new supported pair becomes 4.9 and 4.10.
+For example: if 4.8 and 4.9 are the supported pair and 4.10 ships ten months after 4.8, then 4.8 immediately reaches end of life. The new supported pair becomes 4.9 and 4.10.
 
 We use semantic versioning to identify releases and communicate the impact on your installation. Patch releases are published monthly as needed for bugs and security fixes.
 

--- a/docs/server-admin-4.9/modules/ROOT/nav.adoc
+++ b/docs/server-admin-4.9/modules/ROOT/nav.adoc
@@ -41,7 +41,7 @@
 ** xref:operator:managing-build-artifacts.adoc[Managing build artifacts]
 ** xref:operator:usage-data-collection.adoc[Usage data collection]
 ** xref:operator:circleci-server-security-features.adoc[CircleCI Server security features]
-** xref:operator:application-lifecycle.adoc[Application lifecycle]
+** xref:operator:application-lifecycle.adoc[Release cycle]
 ** xref:operator:troubleshooting-and-support.adoc[Troubleshooting and support]
 ** xref:operator:backup-and-restore.adoc[Backup and restore]
 ** xref:operator:upgrade-mongo.adoc[Upgrade MongoDB]

--- a/docs/server-admin-4.9/modules/operator/pages/application-lifecycle.adoc
+++ b/docs/server-admin-4.9/modules/operator/pages/application-lifecycle.adoc
@@ -5,11 +5,9 @@
 
 CircleCI supports the two most recent versions of CircleCI Server at any time, whether the release is a minor or major version bump. For example, if 4.9 is the current release and 5.0 ships next, then 5.0 and 4.9 become the supported pair.
 
-CircleCI targets a six-month release cadence, though the exact timing varies.
+CircleCI targets a six-month release cadence, though the exact timing varies. When a version ships, the older of the two currently supported versions reaches end of life.
 
-CircleCI supports each version for up to 12 months. A release takes precedence: when a version ships, the older of the two currently supported versions reaches end of life.
-
-For example: if 4.8 and 4.9 are the supported pair and 4.10 ships ten months after 4.8, then 4.8 reaches end of life. The supported pair becomes 4.9 and 4.10.
+For example: if 4.8 and 4.9 are the supported pair and 4.10 ships, then 4.8 reaches end of life. The supported pair becomes 4.9 and 4.10.
 
 We use semantic versioning to identify releases and communicate the impact on your installation. We publish patch releases each month as needed for bugs and security fixes.
 

--- a/docs/server-admin-4.9/modules/operator/pages/application-lifecycle.adoc
+++ b/docs/server-admin-4.9/modules/operator/pages/application-lifecycle.adoc
@@ -1,9 +1,17 @@
-= Application lifecycle
+= Release cycle and versioning policy
 :page-platform: Server 4.9, Server Admin
 :page-description: Learn about CircleCI Server 4.9 semantic versioning and release schedules.
 :experimental:
 
-CircleCI is committed to supporting two minor versions of the software. This means a minor version will be released twice yearly and receive patches for up to 12 months. We use semantic versioning to help identify releases and their impact on your installation. Patch releases will continue to be monthly as needed.
+CircleCI supports the two most recent versions of CircleCI Server at any time, whether the new release is a minor or major version bump. For example, if 4.9 is the current release and 5.0 ships next, then 5.0 and 4.9 become the supported pair.
+
+New versions are released approximately every six months, though the exact timing may vary.
+
+Each version is supported for up to 12 months, but a new release takes precedence: when a new version ships, the older of the two currently supported versions reaches end of life, regardless of how long it has been available.
+
+For example: if 4.8 and 4.9 are the two supported versions and 4.10 is released ten months after 4.8, then 4.8 reaches end of life when 4.10 is released. The new supported pair becomes 4.9 and 4.10.
+
+We use semantic versioning to identify releases and communicate the impact on your installation. Patch releases are published monthly as needed for bugs and security fixes.
 
 [#semantic-versioning]
 == Semantic versioning
@@ -17,11 +25,11 @@ Additional labels for pre-release and build metadata are available as extensions
 
 [#release-schedule]
 == Release schedule
-We release monthly patch fixes for bugs and security concerns. We will have twice yearly new minor (feature) releases. All releases will be posted to the change log. To stay up to date with the most recent releases, subscribe to the link:https://circleci.com/server/changelog/[change log].
+We release monthly patch fixes for bugs and security concerns. We will have twice yearly new minor or major (feature) releases. All releases will be posted to the change log. To stay up to date with the most recent releases, subscribe to the link:https://circleci.com/server/changelog/[change log].
 
 [#end-of-support]
 == End of support
-With each minor release, in accordance with our link:https://circleci.com/legal/terms-of-service/[terms of service], we end support for previous versions of server. The following table provides dates for previously released versions.
+With each minor or major release, in accordance with our link:https://circleci.com/legal/terms-of-service/[terms of service], we end support for previous versions of CircleCI Server. The following table provides dates for previously released versions.
 
 CAUTION: Future dates listed here may change at any time.
 

--- a/docs/server-admin-4.9/modules/operator/pages/application-lifecycle.adoc
+++ b/docs/server-admin-4.9/modules/operator/pages/application-lifecycle.adoc
@@ -3,15 +3,15 @@
 :page-description: Learn about CircleCI Server 4.9 semantic versioning and release schedules.
 :experimental:
 
-CircleCI supports the two most recent versions of CircleCI Server at any time, whether the new release is a minor or major version bump. For example, if 4.9 is the current release and 5.0 ships next, then 5.0 and 4.9 become the supported pair.
+CircleCI supports the two most recent versions of CircleCI Server at any time, whether the release is a minor or major version bump. For example, if 4.9 is the current release and 5.0 ships next, then 5.0 and 4.9 become the supported pair.
 
-New versions are released approximately every six months, though the exact timing may vary.
+CircleCI targets a six-month release cadence, though the exact timing varies.
 
-CircleCI supports each version for up to 12 months. A new release takes precedence: when a new version ships, the older of the two currently supported versions reaches end of life.
+CircleCI supports each version for up to 12 months. A release takes precedence: when a version ships, the older of the two currently supported versions reaches end of life.
 
-For example: if 4.8 and 4.9 are the supported pair and 4.10 ships ten months after 4.8, then 4.8 immediately reaches end of life. The new supported pair becomes 4.9 and 4.10.
+For example: if 4.8 and 4.9 are the supported pair and 4.10 ships ten months after 4.8, then 4.8 reaches end of life. The supported pair becomes 4.9 and 4.10.
 
-We use semantic versioning to identify releases and communicate the impact on your installation. Patch releases are published monthly as needed for bugs and security fixes.
+We use semantic versioning to identify releases and communicate the impact on your installation. We publish patch releases each month as needed for bugs and security fixes.
 
 [#semantic-versioning]
 == Semantic versioning
@@ -25,13 +25,13 @@ Additional labels for pre-release and build metadata are available as extensions
 
 [#release-schedule]
 == Release schedule
-We release monthly patch fixes for bugs and security concerns. We will have twice yearly new minor or major (feature) releases. All releases will be posted to the change log. To stay up to date with the most recent releases, subscribe to the link:https://circleci.com/server/changelog/[change log].
+We release patch fixes for bugs and security concerns each month. We release minor and major (feature) versions twice a year. Subscribe to the link:https://circleci.com/server/changelog/[change log] to stay up to date.
 
 [#end-of-support]
 == End of support
 With each minor or major release, in accordance with our link:https://circleci.com/legal/terms-of-service/[terms of service], we end support for previous versions of CircleCI Server. The following table provides dates for previously released versions.
 
-CAUTION: Future dates listed here may change at any time.
+CAUTION: These dates are subject to change.
 
 [.table.table-striped]
 [cols=3*, options="header", stripes=even]

--- a/docs/server-admin-4.9/modules/operator/pages/application-lifecycle.adoc
+++ b/docs/server-admin-4.9/modules/operator/pages/application-lifecycle.adoc
@@ -7,9 +7,9 @@ CircleCI supports the two most recent versions of CircleCI Server at any time, w
 
 New versions are released approximately every six months, though the exact timing may vary.
 
-Each version is supported for up to 12 months, but a new release takes precedence: when a new version ships, the older of the two currently supported versions reaches end of life, regardless of how long it has been available.
+CircleCI supports each version for up to 12 months. A new release takes precedence: when a new version ships, the older of the two currently supported versions reaches end of life.
 
-For example: if 4.8 and 4.9 are the two supported versions and 4.10 is released ten months after 4.8, then 4.8 reaches end of life when 4.10 is released. The new supported pair becomes 4.9 and 4.10.
+For example: if 4.8 and 4.9 are the supported pair and 4.10 ships ten months after 4.8, then 4.8 immediately reaches end of life. The new supported pair becomes 4.9 and 4.10.
 
 We use semantic versioning to identify releases and communicate the impact on your installation. Patch releases are published monthly as needed for bugs and security fixes.
 


### PR DESCRIPTION
# Description

Clarifies cadence and support policies for CircleCI Server releases.

> [!IMPORTANT]
> We previously announced that versions would not be supported after 12 months, but this simplifies things to only consider the most recent two releases.

# Reasons
We changed our policy some time ago here: https://circleci.com/changelog/server-releases-moving-to-twice-yearly/.

That changelog entry explains some details better, but it is now buried under other announcements. This makes it easier for folks to find and link to the current policies.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
