### PR TITLE
Bump handlebars to 4.7.9 for CVE-2026-33937

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4809,9 +4809,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "overrides": {
     "form-data": "^4.0.4",
     "minimatch": "^10.2.3",
-    "qs": "^6.14.1"
+    "qs": "^6.14.1",
+    "handlebars": "^4.7.9"
   }
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -37,7 +37,7 @@
         "gulp-postcss": "~10.0.0",
         "gulp-stylelint": "~13.0",
         "gulp-uglify": "~3.0",
-        "handlebars": "~4.7",
+        "handlebars": "~4.7.9",
         "highlight.js": "11.11.1",
         "js-yaml": "~4.1.0",
         "merge-stream": "~2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,7 +37,7 @@
     "gulp-postcss": "~10.0.0",
     "gulp-stylelint": "~13.0",
     "gulp-uglify": "~3.0",
-    "handlebars": "~4.7",
+    "handlebars": "~4.7.9",
     "highlight.js": "11.11.1",
     "js-yaml": "~4.1.0",
     "merge-stream": "~2.0",


### PR DESCRIPTION
## Summary
- Bumps `handlebars` from `~4.7` to `~4.7.9` in `ui/package.json`
- Adds `handlebars: ^4.7.9` override in root `package.json` to ensure transitive dependencies also resolve to >=4.7.9
- Addresses CVE-2026-33937

## Test plan
- [ ] Verify `npm install` succeeds
- [ ] Verify docs site builds with `npm run build:docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)