### PR TITLE
[ONPREM-1452] Use relative xrefs for db volumes link in server 4.8/4.9

### DIFF
--- a/docs/server-admin-4.8/modules/installation/pages/installation-reference.adoc
+++ b/docs/server-admin-4.8/modules/installation/pages/installation-reference.adoc
@@ -757,7 +757,7 @@ externalized MongoDB instance.
 
 |mongodb.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 |mongodb.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"datadir"+` |
@@ -1127,7 +1127,7 @@ values are not used by the PostgreSQL chart.
 
 |postgresql.primary.persistence.existingClaim |string |`+""+` |To
 increase PVC size, follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 |postgresql.primary.persistence.size |string |`+"8Gi"+` |
 
@@ -1209,7 +1209,7 @@ this value is '`15672`' else port of external rabbitmq instance
 
 |rabbitmq.persistence.existingClaim |string |`+""+` |To increase PVC
 size, follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 |rabbitmq.persistence.size |string |`+"8Gi"+` |
 
@@ -1245,7 +1245,7 @@ https://circleci.com/docs/server/operator/expanding-internal-database-volumes
 
 |redis.master.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 |redis.master.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |
@@ -1260,7 +1260,7 @@ https://circleci.com/docs/server/operator/expanding-internal-database-volumes
 
 |redis.slave.persistence.size |string |`+"8Gi"+` |To increase PVC size,
 follow this guide:
-https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 |redis.slave.podAnnotations.”backup.velero.io/backup-volumes” |string
 |`+"redis-data"+` |

--- a/docs/server-admin-4.9/modules/ROOT/partials/installation/values.adoc
+++ b/docs/server-admin-4.9/modules/ROOT/partials/installation/values.adoc
@@ -930,7 +930,7 @@ Throughput can range from 125 to 1,000 MiB/s for gp3 volumes.
 | mongodb.persistence.size
 | string
 | `"8Gi"`
-| To increase PVC size, follow this guide: https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+| To increase PVC size, follow this guide: xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 | mongodb.podAnnotations."backup.velero.io/backup-volumes"
 | string
@@ -1586,7 +1586,7 @@ The secret must be named 'nomad-mtls', be in the same namespace, and have the ke
 | postgresql.primary.persistence.existingClaim
 | string
 | `""`
-| To increase PVC size, follow this guide: https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+| To increase PVC size, follow this guide: xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 | postgresql.primary.persistence.size
 | string
@@ -1741,7 +1741,7 @@ The secret must be named 'nomad-mtls', be in the same namespace, and have the ke
 | rabbitmq.persistence.existingClaim
 | string
 | `""`
-| To increase PVC size, follow this guide: https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+| To increase PVC size, follow this guide: xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 | rabbitmq.persistence.size
 | string
@@ -1826,7 +1826,7 @@ The secret must be named 'nomad-mtls', be in the same namespace, and have the ke
 | redis.master.persistence.size
 | string
 | `"8Gi"`
-| To increase PVC size, follow this guide: https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+| To increase PVC size, follow this guide: xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 | redis.master.podAnnotations."backup.velero.io/backup-volumes"
 | string
@@ -1856,7 +1856,7 @@ The secret must be named 'nomad-mtls', be in the same namespace, and have the ke
 | redis.slave.persistence.size
 | string
 | `"8Gi"`
-| To increase PVC size, follow this guide: https://circleci.com/docs/server/operator/expanding-internal-database-volumes
+| To increase PVC size, follow this guide: xref:operator:expanding-internal-database-volumes.adoc[Expanding internal database volumes]
 
 | redis.slave.podAnnotations."backup.velero.io/backup-volumes"
 | string


### PR DESCRIPTION
> [!NOTE]
> You may find that there are errors for the `vale/lint` job that are unrelated to your change.
> Vale checks the whole file when a change is made so if there are existing issues on the page they will be flagged.
> You can ignore lint errors outside your changes and the CircleCI docs team will address them for you.
> Vale logs are advisory to help all contributors create content that conforms to our style guide. The `vale/lint` job will not prevent changes from being published.

# Description
What did you change?

# Reasons
Why did you make these changes? What problem does this solve?

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
