### PR TITLE
TEST-125 Add Smarter Testing plugin installation instructions

### DIFF
--- a/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
+++ b/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
@@ -73,6 +73,10 @@ Some starter configs are shown below. Choose the one for your test runner and co
 Vitest::
 +
 --
+Follow the instructions to add the link:https://github.com/circleci/vitest-circleci-coverage[vitest-circleci-coverage] plugin as a dev dependency.
+
+Add the `analysis` command to your `.circleci/test-suites.yml`.
+
 [source,yaml]
 ----
 ---
@@ -87,6 +91,10 @@ options:
 Jest::
 +
 --
+Follow the instructions to add the link:https://github.com/circleci/jest-circleci-coverage[jest-circleci-coverage] plugin as a dev dependency.
+
+Add the `analysis` command to your `.circleci/test-suites.yml`.
+
 [source,yaml]
 ----
 ---
@@ -101,6 +109,10 @@ options:
 Mocha::
 +
 --
+Follow the instructions to add the link:https://github.com/circleci/mocha-circleci-coverage[mocha-circleci-coverage] plugin as a dev dependency.
+
+Add the `analysis` command to your `.circleci/test-suites.yml`.
+
 [source,yaml]
 ----
 ---
@@ -115,6 +127,10 @@ options:
 pytest::
 +
 --
+Follow the instructions to add the link:https://github.com/circleci/pytest-circleci-coverage[pytest-circleci-coverage] plugin as a dev dependency.
+
+Add the `analysis` command to your `.circleci/test-suites.yml`.
+
 [source,yaml]
 ----
 ---
@@ -142,6 +158,10 @@ options:
 RSpec::
 +
 --
+Follow the instructions to add the link:https://github.com/circleci/rspec-circleci-coverage[rspec-circleci-coverage] plugin as a dev dependency.
+
+Add the `analysis` command to your `.circleci/test-suites.yml`.
+
 [source,yaml]
 ----
 ---


### PR DESCRIPTION

# Description

Some analysis examples use plugins, this change adds the instructions to install and configure them.

# Reasons

Improve Smarter Testing docs.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
