### PR TITLE
TEST-162 note when setting up test impact analysis is finished

### DIFF
--- a/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
+++ b/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
@@ -352,7 +352,11 @@ jobs:
           path: test-reports
 ----
 
-Commit both `.circleci/test-suites.yml` and `.circleci/config.yml` to your feature branch and push to your VCS.
+Commit both `.circleci/test-suites.yml` and `.circleci/config.yml` to your feature branch and push to your VCS. Follow your usual process to merge to your default branch.
+
+*Test impact analysis is now set up for your test suite*. Feature branches will run the tests impacted by code changes, and your default branch will first run all tests and then analyze the tests impacted by code changes.
+
+There are xref:#set-up-examples[other options] available if these defaults don't suit your project.
 
 [#set-up-examples]
 == Common setup examples
@@ -362,6 +366,8 @@ Commit both `.circleci/test-suites.yml` and `.circleci/config.yml` to your featu
 No changes required, this is the default setting.
 
 === Analyze impacted tests as a non-blocking job in the same workflow
+
+This approach runs analysis concurrently with the rest of your workflow jobs. It can be helpful in reducing overall workflow time if analyzing tests takes longer than running tests.
 
 .CircleCI configuration with separate analysis job
 [source,yaml]
@@ -398,18 +404,18 @@ workflows:
       - test
       # Only analyze tests on main.
       - analysis:
-          filters:
-            branches:
-              only: main
+          filters pipeline.git.branch == "main"
       - deploy:
           requires:
             - test
-          filters:
-            branches:
-              only: main
+          filters: pipeline.git.branch == "main"
 ----
 
 === Analyze impacted tests in a separate workflow in the same pipeline
+
+This approach runs analysis concurrently with your main workflow. This is useful if you need to avoid any possible additional latency on your main workflow.
+
+Only use this approach if analyzing impacted tests in a non-blocking job isn't sufficient.
 
 .CircleCI configuration with separate workflows
 [source,yaml]
@@ -449,21 +455,19 @@ workflows:
       - deploy:
           requires:
             - test
-          filters:
-            branches:
-              only: main
+          filters: pipeline.git.branch == "main"
 
   analysis-workflow:
     jobs:
       # Only analyze tests on main.
       - analysis:
-          filters:
-            branches:
-              only: main
+          filters: pipeline.git.branch == "main"
 ----
 
 [#run-analysis-on-non-default-branch]
-=== Analyze impacted tests on a non-default and run tests on all other branches
+=== Analyze impacted tests on a non-default branch and run tests on all other branches
+
+This approach is useful if you use a non-default branch as the base of development, for example in the "git flow" development model.
 
 .CircleCI configuration for running analysis on a branch named `develop` and selection on all other branches
 [source,yaml]
@@ -479,25 +483,6 @@ jobs:
       # Analyze impacted tests on "develop" branch, otherwise disable.
       # (Default) Run all tests on default branches, run impacted tests on feature branches.
       - run: circleci run testsuite "ci tests" --analyze-tests=<< pipeline.git.branch == "develop" and "impacted" or "none" >>
-      - store_test_results:
-          path: test-reports
-----
-
-=== Run higher parallelism on the analysis branch
-
-.CircleCI configuration for running parallelism of 10 on the main branch and 2 on all other branches
-[source,yaml]
-----
-# .circleci/config.yml
-version: 2.1
-jobs:
-  test:
-    executor: node-with-service
-    # Set parallelism to 10 on main, and 2 on all other branches.
-    parallelism: << pipeline.git.branch == "main" and 10 or 2 >>
-    steps:
-      - setup
-      - run: circleci run testsuite "ci tests"
       - store_test_results:
           path: test-reports
 ----


### PR DESCRIPTION
We didn't have an explicit "you are done now" part of the docs and
noticed that some people would continue following the next section,
which is informational only.

Changes:
* Add a paragraph to say that test impact analysis is set up.
* Add a brief explanation to the `Common setup examples` to explain why
  you might choose that setup.
* Remove the section on parameterising parallelism for analysis, this
  doesn't fit in with the other examples, and is documented elsewhere in
  config.