### PR TITLE
[ONPREM-3181] - Add section about runners queuing

### DIFF
--- a/docs/guides/modules/ROOT/partials/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
+++ b/docs/guides/modules/ROOT/partials/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
@@ -193,7 +193,7 @@ NOTE: The `Rerun job with SSH` feature is disabled by default. To enable this fe
 If the link:https://circleci.com/docs/openid-connect-tokens/[OIDC token] environment variables (`$CIRCLE_OIDC_TOKEN`, `$CIRCLE_OIDC_TOKEN_V2`) are missing from jobs, check the default temporary directory. A common cause is that it (for example, `/tmp`) is not writable or is mounted as `noexec`. The system's temporary directory needs to be writable and allow execution for the OIDC plugin to be downloaded and executed from it.
 
 [#runners-queueing]
-=== Runner Tasks Queueing despite idle Runners
+=== Runner tasks queueing despite idle runners
 
 The runner inventory page only displays actively running tasks. Queued tasks are not visible.
 This can make it appear that runners are idle when concurrency is fully consumed by queued jobs.

--- a/docs/guides/modules/ROOT/partials/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
+++ b/docs/guides/modules/ROOT/partials/troubleshoot/self-hosted-runner-troubleshoot-snip.adoc
@@ -191,3 +191,27 @@ NOTE: The `Rerun job with SSH` feature is disabled by default. To enable this fe
 === OIDC tokens missing from jobs
 
 If the link:https://circleci.com/docs/openid-connect-tokens/[OIDC token] environment variables (`$CIRCLE_OIDC_TOKEN`, `$CIRCLE_OIDC_TOKEN_V2`) are missing from jobs, check the default temporary directory. A common cause is that it (for example, `/tmp`) is not writable or is mounted as `noexec`. The system's temporary directory needs to be writable and allow execution for the OIDC plugin to be downloaded and executed from it.
+
+[#runners-queueing]
+=== Runner Tasks Queueing despite idle Runners
+
+The runner inventory page only displays actively running tasks. Queued tasks are not visible.
+This can make it appear that runners are idle when concurrency is fully consumed by queued jobs.
+ 
+Concurrency is calculated across all tasks for a resource class, including those waiting in queue.
+For example, if your concurrency limit is 20 and you submit 20 jobs to resource class `X`, those jobs fill the available concurrency even while they wait to run one at a time.
+Any jobs targeting resource classes `Y` or `Z` will also queue, even if those runners have no active tasks, because the shared concurrency limit is already reached.
+ 
+To check for queued tasks that are consuming concurrency, use the link:https://circleci.com/docs/guides/execution-runner/runner-api/#get-api-v3-tasks[CircleCI Runner API]:
+
+[source,shell]
+----
+curl -X GET https://runner.circleci.com/api/v3/runner/tasks?resource-class=test-namespace/test-resource \
+    -H "Circle-Token: secret-token"
+----
+
+NOTE: Jobs assigned to a resource class that exists but has no runners attached will queue indefinitely.
+Verify that all resource class names in your `.circleci/config.yml` match what is configured in the runner inventory, and that each resource class has at least one runner assigned.
+ 
+ 
+If `unclaimed_task_count` is greater than `0`, cancel those tasks to free up concurrency for other resource classes.


### PR DESCRIPTION
> [!NOTE]
> You may find that there are errors for the `vale/lint` job that are unrelated to your change.
> Vale checks the whole file when a change is made so if there are existing issues on the page they will be flagged.
> You can ignore lint errors outside your changes and the CircleCI docs team will address them for you.
> Vale logs are advisory to help all contributors create content that conforms to our style guide. The `vale/lint` job will not prevent changes from being published.

# Description
This adds a new section about seeing runners queueing. This is somewhat documented in a [support article](https://support.circleci.com/hc/en-us/articles/25596976793755-Machine-runner-jobs-remain-queued), but we want to surface it in our official documentation as well.

# Reasons
The current runner inventory page only shows running tasks, while queued tasks also count against concurrency. This provides documentation as to why the number may be lower than their max, but they still see queuing.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
