### PR TITLE
Update Linux VM Docs to reference gen2

### DIFF
--- a/docs/guides/modules/execution-managed/pages/using-linuxvm.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-linuxvm.adoc
@@ -5,17 +5,17 @@
 
 You can run your jobs in the Linux VM (virtual machine) execution environment by using the machine executor and specifying a Linux image. Using the machine executor runs your jobs in a dedicated, ephemeral VM.
 
-Using the machine executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful in situations where you need full access to the network stack, for example, to listen on a network interface, or to modify the system with `sysctl` commands.
+Using the machine executor gives your application full access to OS resources and provides you with full control over the job environment. This control can be useful when you need full access to the network stack. For example, you can listen on a network interface or modify the system with `sysctl` commands.
 
 To use the machine executor, use the xref:reference:ROOT:configuration-reference.adoc#machine[`machine` key] in your job configuration and specify an image:
 
 ****
-The use of `machine: true` is deprecated when using **CircleCI cloud**. You must specify an image to use.
+The use of `machine: true` is deprecated when using **CircleCI Cloud**. You must specify an image to use.
 
 `machine: true` **is** supported when using:
 
 * Self-hosted runners
-* When using the machine executor on CircleCI server
+* When using the machine executor on CircleCI Server.
 ****
 
 [tabs]
@@ -29,8 +29,8 @@ version: 2.1
 jobs:
   my-job:
     machine:
-      image: ubuntu-2004:current
-    resource_class: large
+      image: ubuntu-2404:current
+    resource_class: large.gen2
 ----
 --
 Server::
@@ -47,7 +47,7 @@ jobs:
 --
 ====
 
-You can view the list of available images xref:reference:ROOT:configuration-reference.adoc#available-linux-machine-images-cloud[in the Configuration Reference], or on the link:https://circleci.com/developer/images?imageType=machine[Developer Hub]. If you are working on an installation of CircleCI server, you will notice in the example above the syntax is slightly different, and the available Linux images are managed by your system administrator.
+You can view the list of available images xref:reference:ROOT:configuration-reference.adoc#available-linux-machine-images-cloud[In the Configuration Reference], or on the link:https://circleci.com/developer/images?imageType=machine[Developer Hub]. If you are working on an installation of CircleCI Server, the syntax is slightly different. The available Linux images are managed by your system administrator.
 
 [#available-linuxvm-resource-classes]
 == Available LinuxVM resource classes
@@ -64,7 +64,7 @@ include::ROOT:partial$execution-resources/resource-class-view.adoc[]
 
 The most up to date list of pre-installed software can be found on the link:https://discuss.circleci.com/tag/machine-images[Discuss] page.
 
-If you are already using an image and would like to verify the all the packages that come pre-installed, you can run the `apt list --installed` command as a step, like in the example below:
+If you are already using an image, you can verify all the packages that come pre-installed. Run the `apt list --installed` command as a step, like in the example below:
 
 [,yaml]
 ----
@@ -73,7 +73,7 @@ version: 2.1
 jobs:
   whats-installed:
     machine: # executor type
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2404:current
     steps:
       - run: apt list --installed
 ...
@@ -84,23 +84,23 @@ Additional packages can be installed with `sudo apt-get install <package>`. If t
 [#use-machine-with-docker]
 == Use machine with Docker
 
-Using the machine executor also means that you get full access to the Docker process. This allows you to run privileged Docker containers and build new Docker images.
+Using the machine executor also means that you get full access to the Docker process. This allows you to run privileged Docker containers and build Docker images.
 
-The following example uses an image and enables xref:optimize:docker-layer-caching.adoc[Docker layer caching] (DLC) which is useful when you are building Docker images during your jobs.
+The following example uses an image and enables xref:optimize:docker-layer-caching.adoc[Docker Layer Caching] (DLC) which is useful when you are building Docker images during your jobs.
 
 [,yaml]
 ----
 machine:
-  image: ubuntu-2004:202104-01
+  image: ubuntu-2404:current
   docker_layer_caching: true    # default - false
 ----
 
 [#using-machine-and-ip-ranges]
 == Using machine and IP ranges
 
-The IP range `192.168.53.0/24` is reserved by CircleCI for internal use on the machine executor. This range should not be used in your jobs.
+The IP range `192.168.53.0/24` is reserved by CircleCI for internal use on the machine executor. Do not use this range in your jobs.
 
 [#next-steps]
 == Next steps
 
-To find out about migrating a project from using the Docker executor to using `machine`, see the xref:docker-to-machine.adoc[Executor Migration from Docker to Machine] document.
+To find out about migrating a project from using the Docker executor to using `machine`, see the xref:docker-to-machine.adoc[Executor Migration] from Docker to Machine document.


### PR DESCRIPTION
# Description
Updating Linux VM docs to reference gen2 and fix Vale lint issues along the way.

# Reasons
To encourage adoption of gen2 and update any references to images to the latest versions.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.