### PR TITLE
PIPE-5433 Document serial groups for multiple jobs (job groups)

### DIFF
--- a/docs/guides/modules/ROOT/examples/orchestration-examples/job-group-multiple-invocations.yml
+++ b/docs/guides/modules/ROOT/examples/orchestration-examples/job-group-multiple-invocations.yml
@@ -1,0 +1,25 @@
+# Invoke the same job group twice using distinct name: values.
+# Each invocation can have its own serial-group and requires.
+
+job-groups:
+  deploy:
+    jobs:
+      - deploy-service
+      - run-smoke-tests:
+          requires:
+            - deploy-service
+
+workflows:
+  main-workflow:
+    jobs:
+      - build
+      - deploy:
+          name: deploy-staging
+          serial-group: << pipeline.project.slug >>/staging-deploy
+          requires:
+            - build
+      - deploy:
+          name: deploy-production
+          serial-group: << pipeline.project.slug >>/production-deploy
+          requires:
+            - deploy-staging

--- a/docs/guides/modules/ROOT/examples/orchestration-examples/job-group-with-serial-group.yml
+++ b/docs/guides/modules/ROOT/examples/orchestration-examples/job-group-with-serial-group.yml
@@ -1,0 +1,22 @@
+# Use job-groups with serial-group to serialize an entire set of jobs as an
+# atomic unit. Only one pipeline can execute the group at a time across your org.
+
+job-groups:
+  deploy-and-release:
+    jobs:
+      - deploy
+      - release:
+          requires:
+            - deploy
+
+workflows:
+  main-workflow:
+    jobs:
+      - build
+      - deploy-and-release:
+          serial-group: << pipeline.project.slug >>/deploy-group
+          requires:
+            - build
+      - notify:
+          requires:
+            - deploy-and-release

--- a/docs/guides/modules/ROOT/examples/orchestration-examples/job-group.yml
+++ b/docs/guides/modules/ROOT/examples/orchestration-examples/job-group.yml
@@ -1,0 +1,21 @@
+# Use job-groups to define a reusable set of jobs.
+# The group is expanded inline in the workflow without serialization.
+
+job-groups:
+  deploy-and-release:
+    jobs:
+      - deploy
+      - release:
+          requires:
+            - deploy
+
+workflows:
+  main-workflow:
+    jobs:
+      - build
+      - deploy-and-release:
+          requires:
+            - build
+      - notify:
+          requires:
+            - deploy-and-release

--- a/docs/guides/modules/orchestrate/pages/controlling-serial-execution-across-your-organization.adoc
+++ b/docs/guides/modules/orchestrate/pages/controlling-serial-execution-across-your-organization.adoc
@@ -119,6 +119,63 @@ You can cancel an entire workflow that contains serial group jobs. Cancelling a 
 . Select the "Cancel Workflow" button to the right of the pipeline (icon:cancel[Cancel icon]).
 . Confirm the cancellation when prompted.
 
+== Job groups
+
+Job groups let you define a named set of jobs and their internal dependencies under the top-level `job-groups` key. You can invoke a job group in a workflow just like a regular job, and optionally apply a `serial-group` to the invocation to serialize the entire group as an atomic unit.
+
+=== Define a job group
+
+Add a `job-groups` key at the top level of your config. Each group has a name and a `jobs` list that follows the same format as workflow job entries, including internal `requires` dependencies:
+
+[source,yaml]
+----
+job-groups:
+  migrate-and-verify:
+    jobs:
+      - migrate
+      - verify:
+          requires:
+            - migrate
+----
+
+=== Use a job group in a workflow
+
+Reference the group by name in a workflow's `jobs` list, just like a regular job. Jobs downstream of the group can depend on it using `requires`:
+
+[,yaml]
+----
+include::ROOT:example$orchestration-examples/job-group.yml[]
+----
+
+When invoked without `serial-group`, the compiler expands the group inline and wraps it with no-op boundary jobs.
+
+=== Use serial-group with a job group
+
+Add the `serial-group` key to a group invocation to serialize the entire group as an atomic unit. No other serial group with the same `serial-group` key across your organization can start until all jobs in the group complete:
+
+[,yaml]
+----
+include::ROOT:example$orchestration-examples/job-group-with-serial-group.yml[]
+----
+
+=== Invoke a job group multiple times
+
+You can invoke the same job group more than once in a workflow by adding a `name:` attribute to each invocation. Each `name:` value must be unique within the workflow and is used as a prefix for the expanded job names:
+
+[,yaml]
+----
+include::ROOT:example$orchestration-examples/job-group-multiple-invocations.yml[]
+----
+
+=== How job group expansion works
+
+When CircleCI processes a job group invocation, it inlines all jobs from the group definition and adds synthetic boundary jobs at each end:
+
+* *Entry job*: Inserted before the root jobs (jobs in the group with no internal `requires` dependencies). With `serial-group`, this is a serial group start job. Without it, this is a no-op group-start job.
+* *Exit job*: Inserted after the leaf jobs (jobs in the group that no other group job depends on). With `serial-group`, this is a serial group end job. Without it, this is a no-op group-end job.
+
+The group invocation's `requires` and branch/tag filters are applied to the entry job. Jobs in the workflow that depend on the group invocation using `requires` are rewired to depend on the exit job.
+
 == Troubleshooting serial groups
 
 === Job skipped unexpectedly?
@@ -154,6 +211,24 @@ If you are experiencing deployment order problems, check the following:
 . Check the pipeline numbers of recent deployments to understand execution order.
 . Consider using more specific serial group naming conventions that include branch or environment information.
 
+=== Job group compile errors
+
+If your pipeline fails to compile after adding a job group, check for the following configuration errors:
+
+* A name appears in both `jobs` and `job-groups`.
+* A job inside a `job-groups` definition references another job group. Nesting is not supported.
+* A job group invocation includes `matrix`, `override-with`, `context`, `pre-steps`, or `post-steps` attributes.
+* A job group definition includes a `parameters` key.
+* A job group is invoked more than once in a workflow without distinct `name:` values.
+* A workflow job uses `requires` to depend on an individual job inside a group, rather than on the group invocation.
+* A job inside a group uses `requires` to depend on a job that belongs to a different group.
+
+=== Failure-handling job not triggering for a job group?
+
+If a downstream job configured to run on failure does not trigger after a job group fails, it may be waiting on the group's exit job rather than the individual job that failed. Downstream jobs that depend on a job group invocation observe the exit job's status, not the status of individual jobs inside the group.
+
+To react to a failure inside the group, add a failure-handling job inside the group definition itself.
+
 === Still experiencing resource conflicts?
 
 If you are still experiencing resource conflicts despite using serial groups, check the following:
@@ -168,7 +243,7 @@ Serial groups provide powerful orchestration capabilities, but they do have limi
 
 === No workflow-level configuration
 
-Serial groups can only be applied at the job level. You cannot configure an entire workflow to run as a serial group. Each job that needs serialization must have the `serial-group` key individually specified. This means you cannot wrap a collection of jobs with a single serial group declaration.
+Serial groups can be applied at the job or job group invocation level. You cannot configure an entire workflow to run as a serial group. To serialize a collection of jobs as an atomic unit using a single `serial-group` declaration, see <<job-groups,Job groups>>.
 
 === No multiple keys in a single workflow
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -2443,6 +2443,40 @@ workflows:
 
 '''
 
+[#job-groups]
+== *`job-groups`*
+
+The `job-groups` key lets you define named sets of jobs at the top level of your config. A job group can be invoked in a workflow just like a regular job, and optionally serialized as an atomic unit by adding `serial-group` to the invocation.
+
+[.table-scroll]
+--
+[cols="1,1,1,2", options="header"]
+|===
+| Key | Required | Type | Description
+
+| `<group-name>`
+| N
+| Map
+| A named group definition containing a `jobs` key.
+
+| `jobs`
+| Y
+| List
+| A list of job invocations for the group, following the same format as workflow job entries. Jobs within the group can use `requires` to declare internal dependencies on other jobs in the same group.
+|===
+--
+
+*Example:*
+
+[,yaml]
+----
+include::guides:ROOT:example$orchestration-examples/job-group.yml[]
+----
+
+For more information, see the xref:guides:orchestrate:controlling-serial-execution-across-your-organization.adoc#job-groups[Job groups] section of the Controlling Serial Execution Across Your Organization page.
+
+'''
+
 [#workflows]
 == *`workflows`*
 
@@ -2824,7 +2858,7 @@ If the `my-orb/my-test` job is not defined inside the orb, the `test` job will c
 
 The `serial-group` key is used to add a property to a job to allow a group of jobs to run in series, rather than concurrently, across an organization. Serial groups control the orchestration of jobs across an organization, not just within projects and pipelines.
 
-The `serial-group` key is configurable per job. It is not possible to configure the key for a group of jobs at this time.
+The `serial-group` key is configurable per job, or at the job group invocation level. To apply `serial-group` to an entire job group, see <<job-groups,`job-groups`>>.
 
 The value of the `serial-group` key is a string that is used to group jobs together to run one after another. The key must meet the following requirements:
 


### PR DESCRIPTION
> [!NOTE]
> You may find that there are errors for the `vale/lint` job that are unrelated to your change.
> Vale checks the whole file when a change is made so if there are existing issues on the page they will be flagged.
> You can ignore lint errors outside your changes and the CircleCI docs team will address them for you.
> Vale logs are advisory to help all contributors create content that conforms to our style guide. The `vale/lint` job will not prevent changes from being published.

# Description

Adds documentation for the new `job-groups` feature (PIPE-5433), which lets customers define a named subgraph of jobs and run the entire group in series using `serial-group`.

Changes:
- New **Job groups** section in the serial execution guide covering: defining a group, invoking with/without `serial-group`, and how entry/exit job expansion works
- Two new troubleshooting entries: job group compile errors, and failure-handling jobs not triggering for a job group
- Updated "No workflow-level configuration" limitation to reflect that `serial-group` can now be applied at the job or job group invocation level
- New `job-groups` top-level key entry in the configuration reference
- Updated `serial-group` config reference entry to cross-reference `job-groups`
- Two new example YAML files for job groups (with and without `serial-group`)

# Reasons

The [PIPE-5433](https://circleci.atlassian.net/browse/PIPE-5433) implementation plan calls for public docs to document serial groups for multiple jobs, including error cases and edge cases. This covers all acceptance criteria from the design doc.

# Content checks

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).

[PIPE-5433]: https://circleci.atlassian.net/browse/PIPE-5433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ