### PR TITLE
DOC-145 Force UI rebuild when dependencies are updated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,35 +63,44 @@ jobs:
           keys:
             - ui-bundle-v1-{{ checksum "ui/package-lock.json" }}-{{ checksum "ui/gulpfile.js" }}
             - ui-bundle-v1-{{ checksum "ui/package-lock.json" }}
-            - ui-bundle-v1-
       - run:
           name: Check if UI rebuild needed
           command: |
             set -e
             echo "[INFO] Checking if UI rebuild is necessary..."
 
-            # Check if UI bundle exists from cache
-            if [ -f "ui-bundle.zip" ]; then
-              echo "[INFO] UI bundle found in cache"
-
-              # Determine base branch for comparison
-              if [ "${CIRCLE_BRANCH}" = "main" ]; then
-                BASE_REF="HEAD~1"
-                echo "[INFO] On main branch, comparing against HEAD~1"
-              else
-                BASE_REF="origin/main"
-                echo "[INFO] On feature branch, comparing against origin/main"
-              fi
-
-              # Check if ui/ directory has changes
-              if git diff --quiet $BASE_REF HEAD -- ui/; then
-                echo "[INFO] No UI changes detected, skipping UI rebuild"
-                echo "export SKIP_UI_BUILD=true" >> $BASH_ENV
-              else
-                echo "[INFO] UI changes detected, will rebuild UI bundle"
-              fi
+            # Determine base branch for comparison
+            if [ "${CIRCLE_BRANCH}" = "main" ]; then
+              BASE_REF="HEAD~1"
+              echo "[INFO] On main branch, comparing against HEAD~1"
             else
+              BASE_REF="origin/main"
+              echo "[INFO] On feature branch, comparing against origin/main"
+            fi
+
+            # Check for dependency file changes (forces full UI rebuild)
+            DEPENDENCY_FILES="package.json package-lock.json ui/package.json ui/package-lock.json"
+            DEPENDENCY_CHANGED=false
+
+            for file in $DEPENDENCY_FILES; do
+              if ! git diff --quiet $BASE_REF HEAD -- "$file" 2>/dev/null; then
+                echo "[INFO] Dependency file changed: $file"
+                DEPENDENCY_CHANGED=true
+              fi
+            done
+
+            if [ "$DEPENDENCY_CHANGED" = true ]; then
+              echo "[INFO] Dependency changes detected, forcing UI rebuild"
+              echo "export SKIP_UI_BUILD=false" >> $BASH_ENV
+            elif [ ! -f "ui-bundle.zip" ]; then
               echo "[INFO] No cached UI bundle found, will build UI"
+              echo "export SKIP_UI_BUILD=false" >> $BASH_ENV
+            elif git diff --quiet $BASE_REF HEAD -- ui/; then
+              echo "[INFO] No UI changes detected, skipping UI rebuild"
+              echo "export SKIP_UI_BUILD=true" >> $BASH_ENV
+            else
+              echo "[INFO] UI changes detected, will rebuild UI bundle"
+              echo "export SKIP_UI_BUILD=false" >> $BASH_ENV
             fi
       - run:
           name: Build UI bundle (conditional)


### PR DESCRIPTION
Update CircleCI pipeline to explicitly check for changes in dependency files (package.json, package-lock.json, ui/package.json, ui/package-lock.json) and force a full UI rebuild when any are modified. This ensures dependency updates are properly tested before merging.

Also removed overly permissive cache fallback key that could restore stale UI bundles when dependencies changed.

> [!NOTE]
> You may find that there are errors for the `vale/lint` job that are unrelated to your change.
> Vale checks the whole file when a change is made so if there are existing issues on the page they will be flagged.
> You can ignore lint errors outside your changes and the CircleCI docs team will address them for you.
> Vale logs are advisory to help all contributors create content that conforms to our style guide. The `vale/lint` job will not prevent changes from being published.

# Description
What did you change?

# Reasons
Why did you make these changes? What problem does this solve?

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
