### PR TITLE
Add dark mode versions of red green text colours

### DIFF
--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -302,6 +302,8 @@ html[data-theme="dark"] {
   --link-font-color: var(--dark-link-color);
   --link-hover-font-color: #8cc9ff;
   --color-link-on-light: var(--dark-link-color);
+  --link-success-color: var(--dark-accent-green); /* #94E5AB for circle-green */
+  --link-error-color: #ED9187; /* Light red for circle-red */
 
   /* Breadcrumbs */
   --breadcrumb-font-color: var(--dark-text-secondary);


### PR DESCRIPTION
Update dark mode colours for red/green text to match design and to improve readability:

Before:
<img width="759" height="629" alt="Screenshot 2026-04-21 at 23 20 19" src="https://github.com/user-attachments/assets/96ad04e6-3304-49d7-ac23-dd1cd9b88811" />

After:
<img width="746" height="604" alt="Screenshot 2026-04-21 at 23 21 11" src="https://github.com/user-attachments/assets/f51c5050-6b24-4db9-8330-142047c6bced" />