### PR TITLE
Fix Vale linter errors in benefits-of-circleci.adoc

### DIFF
--- a/docs/guides/modules/about-circleci/pages/benefits-of-circleci.adoc
+++ b/docs/guides/modules/about-circleci/pages/benefits-of-circleci.adoc
@@ -7,24 +7,24 @@
 [#benefits-of-circleci]
 == Benefits of CircleCI
 
-Organizations choose CircleCI because jobs run fast and builds can be optimized for speed. CircleCI can be configured to run very complex pipelines efficiently with sophisticated xref:optimize:caching.adoc[caching], xref:optimize:docker-layer-caching.adoc[Docker layer caching], and xref:optimize:optimizations.adoc#resource-class[resource classes] for running on faster machines.
+Organizations choose CircleCI because jobs run fast and builds can be optimized for speed. CircleCI can be configured to run very complex pipelines efficiently with sophisticated xref:optimize:caching.adoc[Caching], xref:optimize:docker-layer-caching.adoc[Docker Layer Caching], and xref:optimize:optimizations.adoc#resource-class[Resource Classes] for running on faster machines.
 
 As a developer using CircleCI you can:
 
-- xref:execution-managed:ssh-access-jobs.adoc[SSH into any job] to debug your build issues.
-- Set up xref:optimize:parallelism-faster-jobs.adoc[parallelism] in your `.circleci/config.yml` file to run test jobs faster.
-- Configure xref:optimize:caching.adoc[caching] with two simple keys to reuse data from previous jobs in your xref:orchestrate:workflows.adoc[workflow].
-- Configure self-hosted xref:execution-runner:runner-overview.adoc[runners] for unique platform support.
-- Access xref:execution-managed:using-arm.adoc[Arm VM resources] and xref:execution-managed:using-docker.adoc#arm[Arm on Docker].
-- Use xref:orbs:use:orb-intro.adoc[orbs], reusable packages of configuration, to integrate with third parties.
-- Use pre-built Docker xref:execution-managed:circleci-images.adoc[images] in a variety of languages.
+- xref:execution-managed:ssh-access-jobs.adoc[SSH Into Any Job] to debug your build issues.
+- Set up xref:optimize:parallelism-faster-jobs.adoc[Parallelism] in your `.circleci/config.yml` file to run test jobs faster.
+- Configure xref:optimize:caching.adoc[Caching] with two simple keys to reuse data from previous jobs in your xref:orchestrate:workflows.adoc[Workflow].
+- Configure self-hosted xref:execution-runner:runner-overview.adoc[Runners] for unique platform support.
+- Access xref:execution-managed:using-arm.adoc[Arm VM Resources] and xref:execution-managed:using-docker.adoc#arm[Arm on Docker].
+- Use xref:orbs:use:orb-intro.adoc[Orbs], reusable packages of configuration, to integrate with third parties.
+- Use pre-built Docker xref:execution-managed:circleci-images.adoc[Images] in a variety of languages.
 - Use the link:https://www.circleci.com/docs/api/v2/[API] to retrieve information about jobs and workflows.
 - Use the xref:toolkit:local-cli.adoc[CLI] to access advanced tools locally.
-- Get flaky test detection with xref:insights:insights-tests.adoc[test insights].
+- Get flaky test detection with xref:insights:insights-tests.adoc[Test Insights].
 
 As an operator or administrator of CircleCI installed on your own servers, CircleCI provides monitoring and insights into your builds and uses link:https://www.nomadproject.io/[Nomad] for scheduling.
 
-See the xref:server-admin:overview:circleci-server-overview.adoc[CircleCI server overview] for server documentation.
+See the xref:server-admin:overview:circleci-server-overview.adoc[CircleCI Server Overview] for server documentation.
 
 [#pricing-options]
 == Pricing options
@@ -33,9 +33,9 @@ Visit CircleCI's link:https://circleci.com/pricing[Pricing page] to view free an
 
 You can link:https://circleci.com/signup[sign up] for free to get access to unlimited projects on CircleCI's fully-hosted cloud platform.
 
-Organizations on the Free Plan are given free credits to use on open source projects. Visit the xref:integration:oss.adoc[Building open source projects] page for more information about free containers for public open source projects.
+Organizations on the Free Plan are given free credits to use on open source projects. Visit the xref:integration:oss.adoc[Building Open Source Projects] page for more information about free containers for public open source projects.
 
 [#next-steps]
 == Next steps
 
-- xref:getting-started:first-steps.adoc[Sign up and try]
+- xref:getting-started:first-steps.adoc[Sign up and Try]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
This PR fixes all Vale linter errors in `docs/guides/modules/about-circleci/pages/benefits-of-circleci.adoc`.

## Changes
- Fixed xref link text capitalization to title case across multiple lines (10, 14-20, 23, 27, 36, 41)
- Updated "CircleCI server" to "CircleCI Server" per Vale.Terms rule (line 27)
- Applied proper title case rules where short prepositions and conjunctions remain lowercase

## Testing
Verified with `vale --minAlertLevel=error` - all errors resolved.

## Related Issue
Fixes DOC-154
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-23e64729-1f1b-459a-a143-30440ac96ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23e64729-1f1b-459a-a143-30440ac96ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

