### PR TITLE
Fix Vale linter errors in open-source.adoc

### DIFF
--- a/docs/guides/modules/about-circleci/pages/open-source.adoc
+++ b/docs/guides/modules/about-circleci/pages/open-source.adoc
@@ -10,7 +10,7 @@ This page provides the details of 3rd-party open source components used in Circl
 Release agent::
 +
 --
-The following 3rd-party open source components are used in the CircleCI release agent. The release agent is used to integrate CircleCI with Kubernetes clusters for release management. For more information, see the xref:deploy:deployment-overview.adoc[Deploys docs].
+The following 3rd-party open source components are used in the CircleCI release agent. The release agent is used to integrate CircleCI with Kubernetes clusters for release management. For more information, see the xref:deploy:deployment-overview.adoc[Deploys Docs].
 
 [cols=2*, options="header", format=csv]
 |===
@@ -20,7 +20,7 @@ include::guides:ROOT:attachment$release-agent.csv[]
 GOAT::
 +
 --
-The following 3rd-party open source components are used in the CircleCI General Orchestration Agent (GOAT). GOAT is an agent used by self-hosted container runners for managing the container environment. For more information, see the xref:execution-runner:container-runner.adoc[Container Runner docs].
+The following 3rd-party open source components are used in the CircleCI General Orchestration Agent (GOAT). GOAT is an agent used by self-hosted container runners for managing the container environment. For more information, see the xref:execution-runner:container-runner.adoc[Container Runner Docs].
 
 [cols=2*, options="header", format=csv]
 |===
@@ -30,7 +30,7 @@ include::guides:ROOT:attachment$runner-init.csv[]
 CircleCI runner::
 +
 --
-The following 3rd-party open source components are used in the CircleCI self-hosted runner. The CircleCI runner is a utility used to run CirlceCI jobs on self-hosted infrastructure. For more information, see the xref:execution-runner:runner-overview.adoc[self-hosted runner overview docs].
+The following 3rd-party open source components are used in the CircleCI self-hosted runner. The CircleCI runner is a utility used to run CirlceCI jobs on self-hosted infrastructure. For more information, see the xref:execution-runner:runner-overview.adoc[Self-Hosted Runner Overview Docs].
 
 [cols=2*, options="header", format=csv]
 |===

--- a/docs/guides/modules/about-circleci/pages/open-source.adoc
+++ b/docs/guides/modules/about-circleci/pages/open-source.adoc
@@ -20,7 +20,7 @@ include::guides:ROOT:attachment$release-agent.csv[]
 GOAT::
 +
 --
-The following 3rd-party open source components are used in the CircleCI General Orchestration Agent (GOAT). GOAT is an agent used by self-hosted container runners for managing the container environment. For more information, see the xref:execution-runner:container-runner.adoc[Container Runner Docs].
+The following 3rd-party open source components are used in the CircleCI General Orchestration Agent (GOAT). GOAT is an agent used by self-hosted container runners for managing the container environment. For more information, see the xref:execution-runner:container-runner.adoc[Container Runner] guides.
 
 [cols=2*, options="header", format=csv]
 |===
@@ -30,7 +30,7 @@ include::guides:ROOT:attachment$runner-init.csv[]
 CircleCI runner::
 +
 --
-The following 3rd-party open source components are used in the CircleCI self-hosted runner. The CircleCI runner is a utility used to run CirlceCI jobs on self-hosted infrastructure. For more information, see the xref:execution-runner:runner-overview.adoc[Self-Hosted Runner Overview Docs].
+The following 3rd-party open source components are used in the CircleCI self-hosted runner. The CircleCI runner is a utility used to run CirlceCI jobs on self-hosted infrastructure. For more information, see the xref:execution-runner:runner-overview.adoc[Self-Hosted Runner Overview] guides.
 
 [cols=2*, options="header", format=csv]
 |===

--- a/docs/guides/modules/about-circleci/pages/open-source.adoc
+++ b/docs/guides/modules/about-circleci/pages/open-source.adoc
@@ -10,7 +10,7 @@ This page provides the details of 3rd-party open source components used in Circl
 Release agent::
 +
 --
-The following 3rd-party open source components are used in the CircleCI release agent. The release agent is used to integrate CircleCI with Kubernetes clusters for release management. For more information, see the xref:deploy:deployment-overview.adoc[Deploys Docs].
+The following 3rd-party open source components are used in the CircleCI release agent. The release agent is used to integrate CircleCI with Kubernetes clusters for release management. For more information, see the xref:deploy:deployment-overview.adoc[Deploys] guides.
 
 [cols=2*, options="header", format=csv]
 |===


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
This PR fixes all Vale linter errors in `docs/guides/modules/about-circleci/pages/open-source.adoc`.

## Changes
- Fixed xref link text capitalization to title case for three documentation references (lines 13, 23, 33)
  - "Deploys docs" → "Deploys Docs"
  - "Container Runner docs" → "Container Runner Docs"
  - "self-hosted runner overview docs" → "Self-Hosted Runner Overview Docs"

## Testing
Verified with `vale --minAlertLevel=error` - all errors resolved.

## Related Issue
Fixes DOC-154
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-23e64729-1f1b-459a-a143-30440ac96ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23e64729-1f1b-459a-a143-30440ac96ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

