### PR TITLE
Rearrange orchestration section navigation

### DIFF
--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -35,35 +35,37 @@
 ** xref:migrate:migrating-from-travis.adoc[Migrate from Travis CI]
 
 * Orchestrate
-** Pipelines
+** Set up pipelines and workflows
 *** xref:orchestrate:pipelines.adoc[Pipeline overview and setup]
 *** xref:orchestrate:jobs-steps.adoc[Jobs and steps overview]
 *** xref:orchestrate:workflows.adoc[Workflow orchestration]
-*** xref:orchestrate:automatic-reruns.adoc[Automatic reruns]
-*** xref:orchestrate:workspaces.adoc[Use workspaces to share data between jobs]
-*** xref:orchestrate:dynamic-config.adoc[Use dynamic configuration]
-*** xref:orchestrate:skip-build.adoc[Skip CI, auto-cancel, and block new pipelines]
-*** xref:orchestrate:controlling-serial-execution-across-your-organization.adoc[Controlling serial execution across your organization]
 *** xref:orchestrate:pipeline-variables.adoc[Pipeline values and parameters]
-** Triggers
+** Trigger and schedule pipelines
 *** xref:orchestrate:triggers-overview.adoc[Trigger options]
 *** xref:orchestrate:set-up-triggers.adoc[Set up triggers]
 *** xref:orchestrate:github-trigger-event-options.adoc[GitHub trigger event options]
 *** xref:orchestrate:gitlab-trigger-options.adoc[GitLab trigger options]
 *** xref:orchestrate:custom-webhooks.adoc[Custom webhooks]
 *** xref:orchestrate:schedule-triggers.adoc[Schedule triggers]
-** How-to guides
-*** xref:orchestrate:orchestration-cookbook.adoc[Orchestration cookbook]
 *** xref:orchestrate:set-up-cross-repo-triggers-for-library-consumers.adoc[Set up cross-repo triggers for library consumers]
-*** xref:orchestrate:how-to-override-config.adoc[How to override config]
-*** xref:orchestrate:set-up-multiple-configuration-files-for-a-project.adoc[Set up multiple configuration files for a project]
-*** xref:orchestrate:notify-a-slack-channel-of-a-paused-workflow.adoc[Notify a Slack channel of a paused workflow]
-*** xref:orchestrate:using-branch-filters.adoc[Using branch filters]
-*** xref:orchestrate:selecting-a-workflow-to-run-using-pipeline-parameters.adoc[Select a workflow to run using pipeline parameters]
 *** xref:orchestrate:migrate-scheduled-workflows-to-schedule-triggers.adoc[Migrate scheduled workflows to schedule triggers]
 *** xref:orchestrate:schedule-triggers-with-multiple-workflows.adoc[Schedule triggers with multiple workflows]
 *** xref:orchestrate:set-a-nightly-schedule-trigger.adoc[Set a nightly schedule trigger]
+** Control workflow execution
+*** xref:orchestrate:automatic-reruns.adoc[Automatic reruns]
+*** xref:orchestrate:skip-build.adoc[Skip CI, auto-cancel, and block new pipelines]
+*** xref:orchestrate:controlling-serial-execution-across-your-organization.adoc[Controlling serial execution across your organization]
+*** xref:orchestrate:using-branch-filters.adoc[Using branch filters]
+*** xref:orchestrate:selecting-a-workflow-to-run-using-pipeline-parameters.adoc[Select a workflow to run using pipeline parameters]
+*** xref:orchestrate:notify-a-slack-channel-of-a-paused-workflow.adoc[Notify a Slack channel of a paused workflow]
+** Share data
+*** xref:orchestrate:workspaces.adoc[Use workspaces to share data between jobs]
+** Advanced configuration
+*** xref:orchestrate:orchestration-cookbook.adoc[Orchestration cookbook]
+*** xref:orchestrate:dynamic-config.adoc[Dynamic configuration overview]
 *** xref:orchestrate:using-dynamic-configuration.adoc[Using dynamic configuration]
+*** xref:orchestrate:how-to-override-config.adoc[Override configuration]
+*** xref:orchestrate:set-up-multiple-configuration-files-for-a-project.adoc[Set up multiple configuration files for a project]
 *** xref:orchestrate:databases.adoc[Configure databases]
 *** xref:orchestrate:migrate-from-deploy-to-run.adoc[Migrate from deploy to run]
 *** xref:orchestrate:using-shell-scripts.adoc[Using shell scripts]


### PR DESCRIPTION
The orchestration section navigation had become too simple and many pages were hidden in a How-to guides section that doesn't help anyone.

This change reorganises the section using a more task-based approach.

Part of ongoing work to remove sections like Tutorials and How-to Guides which don't describe what they contain