### PR TITLE
Fix Vale linter errors in migrating-from-buildkite.adoc

### DIFF
--- a/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
@@ -38,14 +38,14 @@ git remote add enterprise git@[hostname]:[owner]/[repo-name].git
 git push enterprise --mirror
 ```
 
-Once you have imported your code into GitHub, Bitbucket or GitLab, you can start creating a project in CircleCI using the xref:getting-started:getting-started.adoc[Getting Started guide].
+Once you have imported your code into GitHub, Bitbucket or GitLab, you can start creating a project in CircleCI using the xref:getting-started:getting-started.adoc[Getting Started Guide].
 
 [#build-configuration]
 == Build configuration
 
 Next, you will need to migrate your build configuration. On Buildkite, the build configuration is either defined in the web interface or in a file called `.pipeline.yml` in the root directory of your source code repository. If you use shell scripts to perform your build, you can reuse those scripts in CircleCI.
 
-First, create a CircleCI build configuration file. In the root directory of your source code repository, create a folder named `.circleci` and create a file in that folder named config.yml. Next, follow the CircleCI documentation here to learn how to configure the .config.yml file.
+First, create a CircleCI build configuration file. In the root directory of your source code repository, create a folder named `.circleci`. Create a file in that folder named config.yml. Follow the CircleCI documentation to learn how to configure the .config.yml file.
 
 The Buildkite and CircleCI configurations will be different. It may be helpful to have both Buildkite and CircleCI reference documentation open side-by-side to help with the conversion of the build steps:
 
@@ -204,7 +204,7 @@ jobs:
 
 For larger and more complex build files, we recommend moving over the build steps in phases until you get comfortable with the CircleCI platform. We recommend this order:
 
-. Execution of shell scripts and Docker compose files
+. Execution of shell scripts and Docker compose files.
 . link:https://circleci.com/docs/workflows/[Workflows]
 . link:https://circleci.com/docs/artifacts/[Artifacts]
 . link:https://circleci.com/docs/caching/[Caching]

--- a/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
@@ -38,7 +38,7 @@ git remote add enterprise git@[hostname]:[owner]/[repo-name].git
 git push enterprise --mirror
 ```
 
-Once you have imported your code into GitHub, Bitbucket or GitLab, you can start creating a project in CircleCI using the xref:getting-started:getting-started.adoc[Getting Started Guide].
+Once you have imported your code into GitHub, Bitbucket or GitLab, you can start creating a project in CircleCI using the xref:getting-started:getting-started.adoc[Getting Started] guide.
 
 [#build-configuration]
 == Build configuration


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes Vale linter errors in `migrating-from-buildkite.adoc`.

## Changes

- Fixed xref link text capitalization: "Getting Started guide" → "Getting Started Guide"
- Split long sentence into shorter sentences (line 48) to improve readability
- Added punctuation to list item (line 207)

## Verification

Ran Vale linter to confirm all errors are resolved:
- Before: 3 errors
- After: 0 errors

Part of DOC-154: fixing Vale linter errors across all documentation pages.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-197cf8d7-0bad-41d9-b01f-7edd21dd717d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197cf8d7-0bad-41d9-b01f-7edd21dd717d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

