### PR TITLE
Fix Vale linter errors in migrating-from-github.adoc

### DIFF
--- a/docs/guides/modules/migrate/pages/migrating-from-github.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-github.adoc
@@ -13,7 +13,7 @@ TIP: The link:https://circleci.com/developer/tools/configTranslator[CircleCI con
 [#jobs-and-workflows]
 === Jobs and workflows
 
-Both GitHub Actions and CircleCI share similar concepts around "jobs" and "workflows". A workflow is an end-to-end flow of connected jobs, which in turn consist of commands to achieve an atomic task (for example, "run unit tests" or "build a Docker image").
+Both GitHub Actions and CircleCI share similar concepts around "jobs" and "workflows". A workflow is an end-to-end flow of connected jobs. Jobs consist of commands to achieve an atomic task (for example, "run unit tests" or "build a Docker image").
 
 CircleCI differs primarily in configuration syntax, setting up workflow and job dependencies in a separate section as opposed to inline in the job.
 
@@ -71,13 +71,13 @@ workflows:
 === Actions vs. orbs
 "Actions" in GitHub are reusable commands or tasks to run inside a job. However, they are written for execution inside a Docker container or coded as individual steps using JavaScript. This adds additional work and limits the scope in which they can be applied.
 
-CircleCI offers similar functionality in our xref:orbs:use:orb-intro.adoc[orbs]. The primary difference is that CircleCI orbs are just packaged, reusable YAML, so you can create orbs with reusable jobs, executors, or commands, and use them however you see fit in any of your jobs or workflows.
+CircleCI offers similar functionality in our xref:orbs:use:orb-intro.adoc[Orbs]. The primary difference is that CircleCI orbs are packaged, reusable YAML. You can create orbs with reusable jobs, executors, or commands, and use them in any of your jobs or workflows.
 
 GitHub offers browsing of Actions in their Marketplace; CircleCI has an https://circleci.com/developer/orbs[Orb Registry] as well as an https://circleci.com/integrations/[Integrations Page] containing numerous Certified, Partner, and community orbs / integrations.
 
 [#runners-vs-executors]
 === Runners vs. executors
-In GitHub, you can specify your builds to run in Linux, macOS, and Windows environments via a `runs-on` key in the YAML, and if you want to run anything in a container, you specify an additional `container` key.
+In GitHub, you can specify your builds to run in Linux, macOS, and Windows environments via a `runs-on` key in the YAML. If you want to run anything in a container, specify an additional `container` key.
 
 In CircleCI, you have the same choice of environments (called Executors), with additional options and features for Docker.
 
@@ -239,11 +239,11 @@ jobs:
 
 2+a| Using conditional steps in the workflow. CircleCI offers the following:
 
-* xref:reference:ROOT:configuration-reference.adoc#the-when-attribute[Basic conditions on steps, using the `when` attribute] (for example, `on_success` [default], +
+* xref:reference:ROOT:configuration-reference.adoc#the-when-attribute[The When Attribute] (for example, `on_success` [default], +
 `always`, `on_failure`).
 * https://circleci.com/docs/configuration-reference/#the-when-step[Conditional steps] based on parameters.
 * https://circleci.com/docs/reusing-config/#using-the-parameters-declaration[Conditional jobs].
-* Conditional, parameterized xref:orchestrate:workflows.adoc#use-conditional-logic-in-workflows[workflows].
+* Conditional, parameterized xref:orchestrate:workflows.adoc#use-conditional-logic-in-workflows[Workflows].
 
 a|
 [source,yaml]
@@ -283,9 +283,9 @@ jobs:
 
 For more configuration examples on CircleCI, visit our xref:toolkit:examples-and-guides-overview.adoc[Examples and Guides Overview] and xref:toolkit:example-configs.adoc[Example Projects] pages.
 
-Since the configuration between GitHub Actions and CircleCI is similar, it should be fairly trivial to migrate your jobs and workflows. However, for best chances of success, we recommend migrating over items in the following order:
+Since the configuration between GitHub Actions and CircleCI is similar, migrating your jobs and workflows is straightforward. For best chances of success, we recommend migrating over items in the following order:
 
 . xref:about-circleci:concepts.adoc[Jobs, Steps, and Workflows]
 . xref:orchestrate:workflows.adoc[More Advanced Workflow and Job Dependency Configuration]
 . xref:orbs:use:orb-intro.adoc[Actions to Orbs]. Our registry can be found https://circleci.com/developer/orbs?filterBy=all[here].
-. xref:optimize:optimizations.adoc[Optimizations like caching, workspaces, and parallelism]
+. xref:optimize:optimizations.adoc[Optimizations Like Caching, Workspaces, and Parallelism]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes Vale linter errors in `migrating-from-github.adoc`.

## Changes

- Split long sentences into shorter ones for improved readability (lines 16, 74, 80)
- Fixed xref link text capitalization:
  - "orbs" → "Orbs"
  - "workflows" → "Workflows"
  - "Basic conditions on steps, using the `when` attribute" → "The When Attribute"
  - "Optimizations like caching, workspaces, and parallelism" → "Optimizations Like Caching, Workspaces, and Parallelism"
- Replaced hedging language: "should be fairly trivial" → "is straightforward"
- Improved overall sentence structure and clarity

## Verification

Ran Vale linter to confirm all errors are resolved:
- Before: 8 errors
- After: 0 errors

Part of DOC-154: fixing Vale linter errors across all documentation pages.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-197cf8d7-0bad-41d9-b01f-7edd21dd717d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197cf8d7-0bad-41d9-b01f-7edd21dd717d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

