### PR TITLE
Fix Vale linter errors in migrating-from-gitlab.adoc

### DIFF
--- a/docs/guides/modules/migrate/pages/migrating-from-gitlab.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-gitlab.adoc
@@ -10,9 +10,9 @@ TIP: The link:https://circleci.com/developer/tools/configTranslator[CircleCI con
 **Tips provided by ImagineX Consulting**
 
 [#sign-up-with-gitlab]
-== Sign up with GitLab
+== Sign up
 
-Follow the steps on the xref:getting-started:first-steps.adoc#github-gitlab-bitbucket-data-center[Sign Up and Try] page to connect your GitLab account with CircleCI, then follow the steps in the following sections to migrate your CI/CD setup to CircleCI.
+Follow the steps on the xref:getting-started:first-steps.adoc#github-gitlab-bitbucket-data-center[Sign up and Try] page to connect your GitLab account with CircleCI. Then follow the steps in the following sections to migrate your CI/CD setup to CircleCI.
 
 [#build-configuration]
 == Build configuration

--- a/styles/config/vocabularies/Docs/accept.txt
+++ b/styles/config/vocabularies/Docs/accept.txt
@@ -162,6 +162,7 @@ geckodriver
 Gemfile
 GitHub
 \bGitHub Checks\b
+GitLab
 \bGitLab self-managed\b
 GKE
 \bGoogle Cloud\b


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes Vale linter errors in `migrating-from-gitlab.adoc`.

## Changes

- Added "GitLab" to vocabulary exceptions (`styles/config/vocabularies/Docs/accept.txt`) to allow proper camelCase branding
- Fixed heading "Sign up with GitLab" → "Sign up" to comply with sentence case requirements
- Fixed xref link text capitalization: "Sign Up and Try" → "Sign up and Try"
- Split long sentence into two shorter sentences for better readability (line 15)

## Verification

Ran Vale linter to confirm all errors are resolved:
- Before: 4 errors
- After: 0 errors

Part of DOC-154: fixing Vale linter errors across all documentation pages.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-197cf8d7-0bad-41d9-b01f-7edd21dd717d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197cf8d7-0bad-41d9-b01f-7edd21dd717d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

