### PR TITLE
Fix Vale linter errors in migrating-from-teamcity.adoc

### DIFF
--- a/docs/guides/modules/migrate/pages/migrating-from-teamcity.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-teamcity.adoc
@@ -368,7 +368,7 @@ CircleCI's equivalent of Meta-Runners and Build Templates is orbs, which are tem
 
 For larger and more complex builds, we recommend moving over in phases until you get comfortable with the CircleCI platform. We recommend this order:
 
-. Execution of shell scripts and Docker compose files
+. Execution of shell scripts and Docker compose files.
 . https://circleci.com/docs/workflows/[Workflows]
 . https://circleci.com/docs/artifacts/[Artifacts]
 . https://circleci.com/docs/caching/[Caching]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes Vale linter errors in `migrating-from-teamcity.adoc`.

## Changes

- Added punctuation to list item (line 371)

## Verification

Ran Vale linter to confirm all errors are resolved:
- Before: 1 error
- After: 0 errors

Part of DOC-154: fixing Vale linter errors across all documentation pages.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-197cf8d7-0bad-41d9-b01f-7edd21dd717d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197cf8d7-0bad-41d9-b01f-7edd21dd717d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

