### PR TITLE
Fix Vale linter errors in controlling-serial-execution-across-your-organization.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/controlling-serial-execution-across-your-organization.adoc
+++ b/docs/guides/modules/orchestrate/pages/controlling-serial-execution-across-your-organization.adoc
@@ -24,7 +24,7 @@ Once you have identified jobs that need to run sequentially across your organiza
 
 . Choose a meaningful name for your serial group that represents the resource or process being controlled. Use pipeline values in your serial group name to create dynamic grouping patterns if needed.
 
-. Add the `serial-group` key to each job across your organization that should run in sequence, using the same value for all related jobs:
+. Add the `serial-group` key to each job across your organization that runs in sequence, using the same value for all related jobs:
 +
 [,yml]
 ----
@@ -107,6 +107,7 @@ You can manually release a serial group from the CircleCI web app to allow queui
 . Select the workflow name to view the workflow graph.
 . Select the serial group start block (with the key icon). A modal appears with information on the consequences of releasing the group. If you are happy to release the group, select btn:[Release serial group].
 +
+.Screenshot showing the serial group release modal
 image::guides:ROOT:serial-groups/serial-group-release-modal.png[Serial group release modal]
 
 ==== Cancel a workflow with a serial group job
@@ -115,7 +116,7 @@ You can cancel an entire workflow that contains serial group jobs. Cancelling a 
 
 . In the link:https://app.circleci.com/home[CircleCI web app], select your org.
 . Select *Pipelines* in the sidebar and locate your pipeline with a serial group in action.
-. Select the "Cancel Workflow" button to the right of the pipeline (icon:cancel[Cancel icon])
+. Select the "Cancel Workflow" button to the right of the pipeline (icon:cancel[Cancel icon]).
 . Confirm the cancellation when prompted.
 
 == Troubleshooting serial groups
@@ -124,7 +125,7 @@ You can cancel an entire workflow that contains serial group jobs. Cancelling a 
 
 If your job is skipped with a "not run" status, check the following:
 
-* Is another job from a newer pipeline (higher pipeline number) currently running or waiting in the same serial group?
+* Check if another job from a newer pipeline (higher pipeline number) is currently running or waiting in the same serial group.
 * Verify your pipeline number is not lower than a currently active pipeline using the same serial group.
 * Remember that the order protection mechanism automatically skips jobs from older pipelines to maintain queue integrity.
 
@@ -141,7 +142,7 @@ If jobs are running concurrently when you expected them to run in sequence, chec
 
 If your jobs are being canceled after waiting in the queue, check the following:
 
-. Are any of your jobs exceeding the five-hour maximum wait time?
+. Check if any of your jobs are exceeding the five-hour maximum wait time.
 . Investigate if upstream dependencies in your workflow are failing or taking too long.
 . Look for deadlock situations where jobs are waiting for each other to complete.
 
@@ -171,7 +172,7 @@ Serial groups can only be applied at the job level. You cannot configure an enti
 
 === No multiple keys in a single workflow
 
-Using identical serial group values multiple times within the same workflow can result in unexpected behaviour due to the way the jobs join the queue. Each serial group key within a workflow should be unique to prevent conflicts in the execution order.
+Using identical serial group values multiple times within the same workflow can result in unexpected behaviour due to the way the jobs join the queue. Each serial group key within a workflow must be unique to prevent conflicts in the execution order.
 
 === No selective lock release
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 6 Vale linter errors in the `controlling-serial-execution-across-your-organization.adoc` file in the orchestrate module.

## Changes Made

- Changed "should" to "must" on line 175 for more definitive language (circleci-docs.Avoid)
- Added image title for serial group release modal screenshot (circleci-docs.ImageTitles)
- Added period to list item on line 118 (circleci-docs.ListPunctuation)
- Converted question to statement in list item on line 128 for consistency with Vale rules (circleci-docs.ListPunctuation)
- Converted question to statement in list item on line 145 for consistency with Vale rules (circleci-docs.ListPunctuation)
- Changed "should run" to "runs" on line 27 to avoid "should" usage (circleci-docs.Avoid)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 7 warnings and 24 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

