### PR TITLE
Fix Vale linter errors in custom-webhooks.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/custom-webhooks.adoc
+++ b/docs/guides/modules/orchestrate/pages/custom-webhooks.adoc
@@ -11,7 +11,7 @@ NOTE: Custom webhooks are available for projects integrated via the GitHub App. 
 
 Use **custom webhooks** to trigger a pipeline from anywhere that can emit a webhook or run a curl command.
 
-TIP: Custom webhooks are inbound to CircleCI and are used to trigger pipelines from other services. If you are looking for a way to have a CircleCI pipeline trigger a service, use an xref:integration:outbound-webhooks.adoc[outbound webhook].
+TIP: Custom webhooks are inbound to CircleCI and are used to trigger pipelines from other services. If you are looking for a way to have a CircleCI pipeline trigger a service, use an xref:integration:outbound-webhooks.adoc[Outbound Webhook].
 
 == Quickstart
 
@@ -31,7 +31,7 @@ curl -X POST -H "content-type: application/json" '<your-URL>?secret=<your-secret
 
 See our link:https://discuss.circleci.com/t/trigger-pipelines-from-anywhere-inbound-webhooks-now-in-preview/49864[community forum] for more details or how to use this functionality with a link:https://discuss.circleci.com/t/re-build-automatically-when-new-image-is-available-on-dockerhub/50350[3rd party service like DockerHub].
 
-NOTE: Custom webhooks will not work with xref:security:contexts.adoc#security-group-restrictions[security group restrictions].  Additionally, the configuration file that is used for pipelines triggered by a custom webhook will only be visible in the CircleCI web app if the configuration file path is `.circleci/config.yml`.
+NOTE: Custom webhooks will not work with xref:security:contexts.adoc#security-group-restrictions[Security Group Restrictions].  Additionally, the configuration file that is used for pipelines triggered by a custom webhook will only be visible in the CircleCI web app if the configuration file path is `.circleci/config.yml`.
 
 
 == Example: Trigger one pipeline from another
@@ -45,7 +45,7 @@ TIP: You can also use this method to trigger one pipeline from another within th
 * Project A
 * Project B
 
-When a change is made to Project A, we want the full Project A configuration to be run, and then the Project B pipeline should be triggered. To achieve this, follow these steps:
+When a change is made to Project A, we want the full Project A configuration to be run, and then the Project B pipeline to be triggered. To achieve this, follow these steps:
 
 === 1. Set up a custom webhook trigger in Project B
 
@@ -57,7 +57,7 @@ include::ROOT:partial$pipelines-and-triggers/custom-webhook-setup.adoc[]
 
 Navigate to Project A in the CircleCI web app and set up an environment variable. The value of the environment variable will be the secret from the custom webhook you just set up for Project B.
 
-TIP: As an alternative, you can add an environment variable using a xref:security:contexts.adoc[context].
+TIP: As an alternative, you can add an environment variable using a xref:security:contexts.adoc[Context].
 
 . In the link:https://app.circleci.com/[CircleCI web app] select your organization.
 . Select **Projects** in the sidebar.
@@ -94,13 +94,13 @@ workflows:
 
 == Example: Extract custom webhook payload data
 
-The custom webhook body is available by using the `pipeline.trigger_parameters.webhook.body` xref:reference:ROOT:variables.adoc#pipeline-values[pipeline value].
+The custom webhook body is available by using the `pipeline.trigger_parameters.webhook.body` xref:reference:ROOT:variables.adoc#pipeline-values[Pipeline Value].
 
 The following example shows how you can use `jq` to extract values from the webhook payload into environment variables when you want to use them in your configuration.
 
 In this example the webhook body contains a property called `branch`. `jq` is installed and used to extract the `branch` value into an environment variable named `WEBHOOK_BRANCH`, which is then used in a GitHub clone command.
 
-TIP: The xref:reference:ROOT:configuration-reference.adoc#commands[command] configured in this example uses commands from the link:https://circleci.com/developer/orbs/orb/circleci/jq[jq] and link:https://circleci.com/developer/orbs/orb/circleci/github-cli[GitHub CLI] orbs.
+TIP: The xref:reference:ROOT:configuration-reference.adoc#commands[Command] configured in this example uses commands from the link:https://circleci.com/developer/orbs/orb/circleci/jq[jq] and link:https://circleci.com/developer/orbs/orb/circleci/github-cli[GitHub CLI] orbs.
 
 [,yaml]
 ----

--- a/docs/guides/modules/orchestrate/pages/custom-webhooks.adoc
+++ b/docs/guides/modules/orchestrate/pages/custom-webhooks.adoc
@@ -7,7 +7,7 @@ Setting up an inbound webhook (as a **custom webhook** trigger) on CircleCI enab
 
 == Introduction
 
-NOTE: Custom webhooks are available for projects integrated via the GitHub App. Custom webhooks are not available on CircleCI server.
+NOTE: Custom webhooks are available for projects integrated via the GitHub App. Custom webhooks are not available on CircleCI Server.
 
 Use **custom webhooks** to trigger a pipeline from anywhere that can emit a webhook or run a curl command.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 6 Vale linter errors in the `custom-webhooks.adoc` file in the orchestrate module.

## Changes Made

- Changed "outbound webhook" to "Outbound Webhook" in xref link text (circleci-docs.TitleCase)
- Changed "security group restrictions" to "Security Group Restrictions" in xref link text (circleci-docs.TitleCase)
- Changed "should be triggered" to "to be triggered" to avoid "should" usage (circleci-docs.Avoid)
- Changed "context" to "Context" in xref link text (circleci-docs.TitleCase)
- Changed "pipeline value" to "Pipeline Value" in xref link text (circleci-docs.TitleCase)
- Changed "command" to "Command" in xref link text (circleci-docs.TitleCase)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 6 warnings and 9 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

