### PR TITLE
Fix Vale linter errors in databases.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/databases.adoc
+++ b/docs/guides/modules/orchestrate/pages/databases.adoc
@@ -149,13 +149,13 @@ jobs:
 
 It is possible to apply the same principle for the following databases:
 
-* MySQL: `dockerize -wait tcp://localhost:3306 -timeout 1m`
+* MySQL: `dockerize -wait tcp://localhost:3306 -timeout 1m`.
 
-* Redis: `dockerize -wait tcp://localhost:6379 -timeout 1m`
+* Redis: `dockerize -wait tcp://localhost:6379 -timeout 1m`.
 +
 Redis also has a CLI available: `sudo apt-get install redis-tools ; while ! redis-cli ping 2>/dev/null ; do sleep 1 ; done`
 
-* Other services, such as web servers: `+dockerize -wait http://localhost:80 -timeout 1m+`
+* Other services, such as web servers: `+dockerize -wait http://localhost:80 -timeout 1m+`.
 
 === Custom MySQL configuration
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 3 Vale linter errors in the `databases.adoc` file in the orchestrate module.

## Changes Made

- Added periods to 3 list items that were missing them (circleci-docs.ListPunctuation)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 6 warnings and 8 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

