### PR TITLE
Fix Vale linter error in gitlab-trigger-options.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/gitlab-trigger-options.adoc
+++ b/docs/guides/modules/orchestrate/pages/gitlab-trigger-options.adoc
@@ -3,7 +3,7 @@
 :page-description: A guide to the options available for triggering GitLab pipelines
 :experimental:
 
-GitLab **Trigger filters** allow you to determine when a trigger should start a build based on the parameters provided by GitLab's webhook.
+GitLab **Trigger filters** allow you to determine when a trigger starts a build based on the parameters provided by GitLab's webhook.
 
 == Introduction
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 1 Vale linter error in the `gitlab-trigger-options.adoc` file in the orchestrate module.

## Changes Made

- Changed "should start" to "starts" to avoid "should" usage (circleci-docs.Avoid)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 1 warning and 5 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

