### PR TITLE
Fix Vale linter error in pipeline-variables.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/pipeline-variables.adoc
+++ b/docs/guides/modules/orchestrate/pages/pipeline-variables.adoc
@@ -207,7 +207,7 @@ More information on setup workflows can be found in the xref:dynamic-config.adoc
 [#conditional-workflows]
 == Pipeline parameters and conditional workflows
 
-Use the xref:reference:ROOT:configuration-reference.adoc#using-when-in-workflows[`when` clause] (or the inverse clause `unless`) under a workflow declaration, along with a xref:reference:ROOT:configuration-reference.adoc#logic-statements[logic statement], to decide whether or not to run that workflow. Logic statements in a `when` or `unless` clause should evaluate to a truthy or falsy value.
+Use the xref:reference:ROOT:configuration-reference.adoc#using-when-in-workflows[`when` clause] (or the inverse clause `unless`) under a workflow declaration, along with a xref:reference:ROOT:configuration-reference.adoc#logic-statements[logic statement], to decide whether or not to run that workflow. Logic statements in a `when` or `unless` clause must evaluate to a truthy or falsy value.
 
 The most common use of this construct is to use a pipeline parameter as the value, allowing a trigger to pass that parameter to determine which workflows to run. Below is an example configuration using the pipeline parameter `run_integration_tests` to set whether the workflow `integration_tests` will run.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 1 Vale linter error in the `pipeline-variables.adoc` file in the orchestrate module.

## Changes Made

- Changed "should evaluate" to "must evaluate" to avoid "should" usage (circleci-docs.Avoid)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 13 warnings and 41 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

