### PR TITLE
Fix Vale linter error in using-matrix-jobs.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/using-matrix-jobs.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-matrix-jobs.adoc
@@ -8,7 +8,7 @@ Matrix jobs provide a way to run a job multiple times with arguments. Arguments 
 [#use-matrix-jobs-to-run-multiple-os-tests]
 == Use matrix jobs to run multiple OS tests
 
-In the following example, the `test` job is run across a Linux Docker container, Linux VM, and macOS environments, using two different versions of Node.js. On each run of the `test` job, different parameters are passed to set both the OS and the Node.js version:
+In the following example, the `test` job runs across a Linux Docker container, Linux VM, and macOS environments. It uses two different versions of Node.js. On each run of the `test` job, different parameters are passed to set the OS and Node.js version:
 
 include::ROOT:partial$notes/docker-auth.adoc[]
 

--- a/docs/guides/modules/orchestrate/pages/using-matrix-jobs.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-matrix-jobs.adoc
@@ -3,7 +3,7 @@
 :page-description: "A how to guide for using matrix jobs to simplify your CircleCI configuration."
 :experimental:
 
-Matrix jobs provide a way to run a job multiple times with arguments. Arguments are supplied using parameters. There are many uses for this feature, including testing on multiple operating systems and against different language or library versions.
+Matrix jobs provide a way to run a job multiple times with arguments. Arguments are supplied using parameters. Use matrix jobs to run a job multiple times with arguments for example, to configure testing on multiple operating systems and against different language or library versions.
 
 [#use-matrix-jobs-to-run-multiple-os-tests]
 == Use matrix jobs to run multiple OS tests


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 1 Vale linter error in the `using-matrix-jobs.adoc` file in the orchestrate module.

## Changes Made

- Split long sentence (30+ words) into shorter sentences (circleci-docs.SentenceLength)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 3 warnings and 6 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

