### PR TITLE
Fix Vale linter error in using-shell-scripts.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/using-shell-scripts.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-shell-scripts.adoc
@@ -118,7 +118,7 @@ set -o pipefail
 [#run-a-shell-script]
 == Run a shell script
 
-In your terminal, navigate to the folder/location of the script you want to run. You can use `ls` to verify you have navigated to the correct path for the script. You should now be able to run the following in your terminal:
+In your terminal, navigate to the folder/location of the script you want to run. You can use `ls` to verify you have navigated to the correct path for the script. You can now run the following in your terminal:
 
 [,bash]
 ----


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 1 Vale linter error in the `using-shell-scripts.adoc` file in the orchestrate module.

## Changes Made

- Changed "should now be able" to "can now" to avoid "should" usage (circleci-docs.Avoid)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 3 warnings and 5 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

