### PR TITLE
Fix Vale linter errors in skip-build.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/skip-build.adoc
+++ b/docs/guides/modules/orchestrate/pages/skip-build.adoc
@@ -14,7 +14,7 @@ All methods are described below.
 [#skip-jobs]
 == Skip CI for a specific push
 
-If you have a trigger configured to run a pipeline on push events to your repository, you can override this behavior by adding one of the following tags within the first 250 characters of the body or title of the **latest commit** you pushed:
+If you have a trigger configured to run a pipeline on push events, you can override this behavior. Add one of the following tags within the first 250 characters of the body or title of the **latest commit** you pushed:
 
 * `[ci skip]`
 * `[skip ci]`
@@ -35,7 +35,7 @@ A few points to note regarding the scope of the `ci skip` feature:
 * If you push multiple commits at once, and the latest commit includes a `[ci skip]` or `[skip ci]` tag, it will skip the pipeline execution for all commits in that push.
 * This feature is not supported for fork PRs. Scheduled workflows will run even if you push a commit with `[ci skip]` message. Changing the config file is the way to upgrade the current schedule.
 * For GitHub OAuth and Bitbucket Cloud pipelines, this functionality applies also when the pipeline is triggered via API, manually via the web app, or via schedule.
-* GitHub App pipelines triggered via Custom webhook, schedule or API are never skipped
+* GitHub App pipelines triggered via Custom webhook, schedule or API are never skipped.
 
 === Example commit title
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 2 Vale linter errors in the `skip-build.adoc` file in the orchestrate module.

## Changes Made

- Split long sentence (30+ words) into shorter sentences (circleci-docs.SentenceLength)
- Added period to list item (circleci-docs.ListPunctuation)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 27 warnings and 16 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

