### PR TITLE
Fix Vale linter errors in set-a-nightly-schedule-trigger.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/set-a-nightly-schedule-trigger.adoc
+++ b/docs/guides/modules/orchestrate/pages/set-a-nightly-schedule-trigger.adoc
@@ -71,5 +71,5 @@ You can view the build scheduling of this link:https://github.com/zmarkan/Androi
 [#next-steps]
 == Next steps
 
-- xref:migrate-scheduled-workflows-to-schedule-triggers.adoc[Migrate scheduled workflows to schedule triggers]
-- xref:schedule-pipelines-with-multiple-workflows.adoc[Schedule pipelines with multiple workflows]
+- xref:migrate-scheduled-workflows-to-schedule-triggers.adoc[Migrate Scheduled Workflows to Schedule Triggers]
+- xref:schedule-pipelines-with-multiple-workflows.adoc[Schedule Pipelines With Multiple Workflows]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 2 Vale linter errors in the `set-a-nightly-schedule-trigger.adoc` file in the orchestrate module.

## Changes Made

- Changed xref link text to title case for 2 xrefs (circleci-docs.TitleCase)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 5 warnings and 2 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

