### PR TITLE
Fix Vale linter errors in set-up-cross-repo-triggers-for-library-consumers.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/set-up-cross-repo-triggers-for-library-consumers.adoc
+++ b/docs/guides/modules/orchestrate/pages/set-up-cross-repo-triggers-for-library-consumers.adoc
@@ -247,7 +247,7 @@ Follow steps in the xref:guides:getting-started:create-project.adoc[Create a Pro
 
 == 3. Set up the consumer pipeline
 
-The consumer pipeline defines what should run when the library changes. Follow these steps, selecting the project you set up for your consumer repository.
+The consumer pipeline defines what runs when the library changes. Follow these steps, selecting the project you set up for your consumer repository.
 
 include::guides:ROOT:partial$app-navigation/steps-to-project-settings.adoc[]
 
@@ -347,7 +347,7 @@ $ git push origin v1.2.3
 ----
 
 . Open the link:https://app.circleci.com/[CircleCI web app, window="_blank"] in your browser and select your organization.
-. You should see a new pipeline running with the name you configured in step 2.
+. You will see a new pipeline running with the name you configured in step 2.
 . Select the running pipeline to view the workflow and jobs.
 . Verify that the library information is passed to your jobs by checking the job output.
 +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 2 Vale linter errors in the `set-up-cross-repo-triggers-for-library-consumers.adoc` file in the orchestrate module.

## Changes Made

- Changed "should run" to "runs" to avoid "should" usage (circleci-docs.Avoid)
- Changed "should see" to "will see" to avoid "should" usage (circleci-docs.Avoid)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 20 warnings and 24 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

