### PR TITLE
Fix Vale linter errors in migrate-from-deploy-to-run.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/migrate-from-deploy-to-run.adoc
+++ b/docs/guides/modules/orchestrate/pages/migrate-from-deploy-to-run.adoc
@@ -6,7 +6,7 @@
 [#introduction]
 == Introduction
 
-A configuration file that uses the deprecated `deploy` step _must_ be converted, and _all_ instances of the `deploy` step must be removed, regardless of whether or not xref:optimize:parallelism-faster-jobs.adoc[parallelism] is used in the job.
+A configuration file that uses the deprecated `deploy` step _must_ be converted, and _all_ instances of the `deploy` step must be removed, regardless of whether or not xref:optimize:parallelism-faster-jobs.adoc[Parallelism] is used in the job.
 
 - *Does your job have parallelism of 1?* Swap out the `deploy` key for the xref:reference:ROOT:configuration-reference.adoc#run[`run`] key. Nothing more is needed to migrate.
 
@@ -96,7 +96,7 @@ workflows:
 [#using-workspaces]
 === Using workspaces
 
-If files are needed from `doing-things-job` in the `deploy-job`, use xref:workspaces.adoc[workspaces]. This enables sharing of files between two jobs so that the `deploy-job` can access them. See example below.
+If files are needed from `doing-things-job` in the `deploy-job`, use xref:workspaces.adoc[Workspaces]. This enables sharing of files between two jobs so that the `deploy-job` can access them. See example below.
 
 ```yml
 version: 2.1
@@ -145,6 +145,6 @@ workflows:
             - doing-things-job
 ```
 
-The example above is effectively using a "fan-in" workflow which is described in detail on the xref:workflows.adoc#fan-outfan-in-workflow[workflows] page.
+The example above is effectively using a "fan-in" workflow which is described in detail on the xref:workflows.adoc#fan-outfan-in-workflow[Workflows] page.
 
 WARNING: Support for the deprecated `deploy` step will eventually be removed. Ample time will be given for customers to migrate their configuration.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 3 Vale linter errors in the `migrate-from-deploy-to-run.adoc` file in the orchestrate module.

## Changes Made

- Changed xref link text to title case for 3 xrefs (circleci-docs.TitleCase):
  - "parallelism" → "Parallelism"
  - "workspaces" → "Workspaces"
  - "workflows" → "Workflows"

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 6 warnings and 10 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

