### PR TITLE
Fix Vale linter errors in workflows.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/workflows.adoc
+++ b/docs/guides/modules/orchestrate/pages/workflows.adoc
@@ -13,7 +13,7 @@ A *workflow* is a set of rules for defining a collection of jobs and their run o
 With workflows, you can:
 
 * Run and troubleshoot jobs independently with real-time status feedback.
-* Schedule workflows for jobs that should only run periodically.
+* Schedule workflows for jobs that only run periodically.
 * Fan-out to run multiple jobs concurrently for efficient version testing.
 * Fan-in to deploy to multiple platforms.
 * Catch failures in real-time and rerun only failed jobs.
@@ -60,7 +60,7 @@ See the link:https://github.com/CircleCI-Public/circleci-demo-workflows/blob/par
 
 When using workflows, note the following best practices:
 
-* Move the quickest jobs up to the start of your workflow. For example, lint or syntax checking should happen before longer-running, more computationally expensive jobs.
+* Move the quickest jobs up to the start of your workflow. For example, lint or syntax checking happens before longer-running, more computationally expensive jobs.
 * Using a "setup" job at the _start_ of a workflow can be helpful to do some preflight checks and populate a workspace for all the following jobs.
 
 TIP: Refer to the xref:optimize:optimizations.adoc[Optimization Reference] for tips to improve your configuration.
@@ -1026,7 +1026,7 @@ NOTE: You cannot rerun jobs and workflows that are >= 90 days.
 [#workflows-waiting-for-status-in-github]
 === Workflows waiting for status in GitHub
 
-If you have workflows configured on a protected branch and the status check never completes, check the `ci/circleci` status key. `ci/circleci` is related to a deprecated check and should be and deselected.
+If you have workflows configured on a protected branch and the status check never completes, check the `ci/circleci` status key. `ci/circleci` is related to a deprecated check and must be deselected.
 
 .Uncheck GitHub Status Keys
 image::guides:ROOT:github_branches_status.png[Uncheck GitHub Status Keys]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 3 Vale linter errors in the `workflows.adoc` file in the orchestrate module.

## Changes Made

- Changed "should only run" to "only run" to avoid "should" usage (circleci-docs.Avoid)
- Changed "should happen" to "happens" to avoid "should" usage (circleci-docs.Avoid)
- Changed "should be and deselected" to "must be deselected" to avoid "should" usage and fix typo (circleci-docs.Avoid)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 20 warnings and 60 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

