### PR TITLE
Fix Vale linter errors in schedule-triggers-with-multiple-workflows.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/schedule-triggers-with-multiple-workflows.adoc
+++ b/docs/guides/modules/orchestrate/pages/schedule-triggers-with-multiple-workflows.adoc
@@ -32,7 +32,7 @@ nightly-run-workflow:
 ...
 ```
 
-You may also add filtering for workflows that should *not* run when a schedule is triggered:
+You may also add filtering for workflows that do *not* run when a schedule is triggered:
 
 [,yaml]
 ----
@@ -54,12 +54,12 @@ nightly-run-workflow:
 ...
 ----
 
-For a full list of pipeline values, visit the xref:reference:ROOT:variables.adoc#pipeline-values[Pipeline values and parameters] page.
+For a full list of pipeline values, visit the xref:reference:ROOT:variables.adoc#pipeline-values[Pipeline Values and Parameters] page.
 
 [#schedule-using-pipeline-parameters]
 ## Schedule using pipeline parameters
 
-In the example below, a parameter is created called `run-schedule`, which is set as `type: boolean` and `default: false`. This allows the workflows section to use `when` to specify conditionals about when the pipeline should run. If you use the `when` conditional, you will also need to set a `when: not:`, like in the example below.
+In the example below, a parameter is created called `run-schedule`, which is set as `type: boolean` and `default: false`. This allows the workflows section to use `when` to specify conditionals about when the pipeline runs. If you use the `when` conditional, you will also need to set a `when: not:`, like in the example below.
 
 ```yaml
 version: 2.1
@@ -86,7 +86,7 @@ workflows:
 ...
 ```
 
-For the full configuration sample, visit the link:https://github.com/zmarkan/Android-Espresso-ScrollableScroll/blob/main/.circleci/config.yml[sample project] on GitHub. For a full list of pipeline parameters, see the xref:pipeline-variables.adoc#pipeline-parameters-in-configuration[Pipeline values and parameters] page.
+For the full configuration sample, visit the link:https://github.com/zmarkan/Android-Espresso-ScrollableScroll/blob/main/.circleci/config.yml[sample project] on GitHub. For a full list of pipeline parameters, see the xref:pipeline-variables.adoc#pipeline-parameters-in-configuration[Pipeline Values and Parameters] page.
 
 [#set-up-multiple-workflows-with-multiple-schedules]
 == Set up multiple workflows with multiple schedules
@@ -120,5 +120,5 @@ workflows:
 [#next-steps]
 == Next steps
 
-- xref:set-a-nightly-schedule-trigger.adoc[Set a nightly schedule trigger]
-- xref:migrate-scheduled-workflows-to-schedule-triggers.adoc[Migrate scheduled workflows to schedule triggers]
+- xref:set-a-nightly-schedule-trigger.adoc[Set a Nightly Schedule Trigger]
+- xref:migrate-scheduled-workflows-to-schedule-triggers.adoc[Migrate Scheduled Workflows to Schedule Triggers]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 6 Vale linter errors in the `schedule-triggers-with-multiple-workflows.adoc` file in the orchestrate module.

## Changes Made

- Changed "should not run" to "do not run" to avoid "should" usage (circleci-docs.Avoid)
- Changed "should run" to "runs" to avoid "should" usage (circleci-docs.Avoid)
- Changed xref link text to title case for 4 xrefs (circleci-docs.TitleCase)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 7 warnings and 9 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

