### PR TITLE
Fix Vale linter errors in schedule-triggers.adoc

### DIFF
--- a/docs/guides/modules/orchestrate/pages/schedule-triggers.adoc
+++ b/docs/guides/modules/orchestrate/pages/schedule-triggers.adoc
@@ -8,11 +8,11 @@ NOTE: This feature is not supported for GitLab or Bitbucket Data Center pipeline
 
 Schedule triggers allow you to trigger pipelines periodically based on a schedule. Schedule triggers retain all the features of pipelines:
 
-- Control the actor (yourself, or the scheduling system) associated with the pipeline, which can enable the use of xref:security:contexts.adoc#project-restrictions[Restricted contexts].
-- Use xref:dynamic-config.adoc[Dynamic configuration] via setup workflows.
+- Control the actor (yourself, or the scheduling system) associated with the pipeline, which can enable the use of xref:security:contexts.adoc#project-restrictions[Restricted Contexts].
+- Use xref:dynamic-config.adoc[Dynamic Configuration] via setup workflows.
 - Modify the schedule without having to edit `.circleci/config.yml`.
-- Take advantage of xref:skip-build.adoc#auto-cancel[auto-cancelling] (only applicable to GitHub OAuth and Bitbucket Cloud pipelines. GitHub App schedule triggers are never auto-cancelled by design)
-- Specify xref:pipeline-variables.adoc#pipeline-parameters-in-configuration[Pipeline parameters] associated with a schedule.
+- Take advantage of xref:skip-build.adoc#auto-cancel[Auto-Cancelling] (only applicable to GitHub OAuth and Bitbucket Cloud pipelines. GitHub App schedule triggers are never auto-cancelled by design)
+- Specify xref:pipeline-variables.adoc#pipeline-parameters-in-configuration[Pipeline Parameters] associated with a schedule.
 - Manage common schedules, for example, across workflows.
 
 Configure schedule triggers from menu:Project Settings[Project Setup] or menu:Project Setting[Triggers] in the web app, or via the API for GitHub OAuth or Bitbucket Cloud pipelines.
@@ -28,9 +28,9 @@ Pipeline parameters are typed pipeline variables in the form of a string, intege
 
 Schedule triggers are set to run by an "actor", either the CircleCI scheduling system, or a specific user (for example, yourself). The scheduling actor is important to consider if making use of restricted contexts in workflows. If the user (actor) running the workflow does not have access to the context, the workflow will fail with the `Unauthorized` status. Using the Scheduling system to be the actor will not count towards your organization's active user quota.
 
-You can find a basic how-to guide on the xref:set-a-nightly-schedule-trigger.adoc[Set a nightly schedule trigger] page, and more advanced examples on the xref:schedule-triggers-with-multiple-workflows.adoc[Schedule pipelines with multiple workflows] pages.
+You can find a basic how-to guide on the xref:set-a-nightly-schedule-trigger.adoc[Set a Nightly Schedule Trigger] page, and more advanced examples on the xref:schedule-triggers-with-multiple-workflows.adoc[Schedule Pipelines With Multiple Workflows] pages.
 
-NOTE: Schedule triggers were previously named "scheduled pipelines".
+NOTE: Schedule triggers are the new name for what was previously known as "scheduled pipelines".
 
 [#get-started-with-schedule-triggers]
 == Get started with schedule triggers
@@ -39,7 +39,7 @@ To get started with schedule triggers, you have the option of using the API, or 
 
 include::ROOT:partial$pipelines-and-triggers/set-up-schedule-trigger.adoc[]
 
-If you would like to manage common schedules for multiple workflows, you will need to manually set this in your `.circleci/config.yml` file. See the xref:guides:orchestrate:schedule-pipelines-with-multiple-workflows.adoc[Schedule pipelines with multiple workflows] page for examples.
+If you would like to manage common schedules for multiple workflows, you will need to manually set this in your `.circleci/config.yml` file. See the xref:guides:orchestrate:schedule-pipelines-with-multiple-workflows.adoc[Schedule Pipelines With Multiple Workflows] page for examples.
 
 [#use-the-api]
 === Use the API
@@ -48,7 +48,7 @@ NOTE: Setting up schedule trigger via the API is not yet available for GitHub Ap
 
 If your project has no scheduled workflows, and you would like to try out schedule triggers:
 
-. Have your CircleCI token ready, or create a new token by following the steps on the xref:toolkit:managing-api-tokens.adoc[Managing API tokens] page.
+. Have your CircleCI token ready, or create a new token by following the steps on the xref:toolkit:managing-api-tokens.adoc[Managing API Tokens] page.
 . Create a new schedule link:https://circleci.com/docs/api/v2/index.html#operation/createSchedule[using the API]. For example:
 +
 [source,shell]
@@ -74,11 +74,11 @@ curl --location --request POST "https://circleci.com/api/v2/project/<project-slu
 
 include::ROOT:partial$tips/find-project-slug.adoc[]
 
-For additional information, refer to the **Schedule** section under the link:https://circleci.com/docs/api/v2/[API v2 docs]. Also see the xref:toolkit:api-developers-guide.adoc#getting-started-with-the-api[Getting started with the API] section of the API Developer's Guide for more guidance on making requests.
+For additional information, refer to the **Schedule** section under the link:https://circleci.com/docs/api/v2/[API v2 docs]. Also see the xref:toolkit:api-developers-guide.adoc#getting-started-with-the-api[Getting Started With the API] section of the API Developer's Guide for more guidance on making requests.
 
 == Migrate scheduled workflows to schedule triggers
 
-If you have existing scheduled workflows you need to migrate to schedule triggers, use the xref:migrate-scheduled-workflows-to-schedule-triggers.adoc[Schedule triggers migration] guide.
+If you have existing scheduled workflows you need to migrate to schedule triggers, use the xref:migrate-scheduled-workflows-to-schedule-triggers.adoc[Schedule Triggers Migration] guide.
 
 [#scheduled-pipelines-faqs]
 == FAQs
@@ -88,6 +88,6 @@ include::ROOT:partial$faq/schedule-trigger-faq-snip.adoc[]
 [#next-steps]
 == Next steps
 
-- xref:migrate-scheduled-workflows-to-schedule-triggers.adoc[Migrate scheduled workflows to schedule triggers]
-- xref:schedule-triggers-with-multiple-workflows.adoc[Schedule pipelines with multiple workflows]
-- xref:set-a-nightly-schedule-trigger.adoc[Set a nightly schedule trigger]
+- xref:migrate-scheduled-workflows-to-schedule-triggers.adoc[Migrate Scheduled Workflows to Schedule Triggers]
+- xref:schedule-triggers-with-multiple-workflows.adoc[Schedule Pipelines With Multiple Workflows]
+- xref:set-a-nightly-schedule-trigger.adoc[Set a Nightly Schedule Trigger]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes 13 Vale linter errors in the `schedule-triggers.adoc` file in the orchestrate module.

## Changes Made

- Changed xref link text to title case for 12 xrefs (circleci-docs.TitleCase)
- Changed "were previously named" to "are the new name for what was previously known as" to avoid "were" usage (circleci-docs.Avoid)

## Verification

Ran Vale linter and confirmed 0 errors remaining:
```
✖ 0 errors, 13 warnings and 8 suggestions in 1 file.
```

## Related Issue

Part of DOC-154: Fix linter errors across all pages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fb3404-c862-402b-ab3a-a8f5344229f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

