### PR TITLE
TEST-158 Set Smarter Testing attributes from release data

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -75,14 +75,7 @@ asciidoc:
     page-toclevels: 6
     idprefix: ""
     idseparator: "-"
-    # Smarter Testing testsuite subcommand attributes.
-    testsuite-version: 1.0.29638-d34fb36
-    testsuite-sha-darwin-arm64: 118c19fb77725c629d18de099b1d37a6c7d1a7695397f8e8732cf30e18d91f1b
-    testsuite-sha-darwin-amd64: c62d62879862785bf812a56c94cd95b3f3a6979d30971e2ed8ae679ddea01182
-    testsuite-sha-linux-amd64: 2e367d0afb8d5f8e1606dbfed2ec9e5bf60989a08501616abdda94bbcc9618ef
-    testsuite-sha-linux-arm: d749c9236bdbe0bf1ecc43040c06eebccec5ce493e884910b90a8e6f7489973c
-    testsuite-sha-linux-arm64: d3fcc1d3b6286ae27f61dce4cec1c81131805b86dd39f1ee2ac722da4fcbe65d
-    testsuite-sha-windows-amd64: e906027399899856088cb3b00c7b9eec0268fd643984bc50123d01637a8dd994
+    # Smarter Testing testsuite subcommand attributes are set by smarter-testing-checksum-update-extension.
   extensions:
   - '@asciidoctor/tabs'
   - ./extensions/theme-icon-extension.js
@@ -140,3 +133,4 @@ antora:
       - '*-dark.svg'
       - 'icons/*.svg'
   - require: ./extensions/llms-txt-generator-extension.js
+  - require: ./extensions/smarter-testing-checksum-update-extension.js

--- a/extensions/smarter-testing-checksum-update-extension.js
+++ b/extensions/smarter-testing-checksum-update-extension.js
@@ -1,0 +1,62 @@
+'use strict'
+
+module.exports.register = function() {
+  const logger = this.getLogger('smarter-testing-checksum-update-extension')
+
+  this.on('beforeProcess', async ({ siteAsciiDocConfig }) => {
+    logger.info("Setting AsciiDoc attributes for Smarter Testing")
+
+    const releaseUrl = "https://circleci-binary-releases.s3.amazonaws.com/circleci-cli-plugins/circleci-testsuite/latest/release.json"
+
+    logger.debug({ releaseDataURL: releaseUrl }, 'Fetching Smarter Testing release data')
+    const response = await fetch(releaseUrl)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${releaseUrl}: ${response.status}`)
+    }
+
+    const releaseData = await response.json()
+    logger.debug({ releaseData: releaseData }, 'Got Smarter Testing Release data')
+
+    const binaries = releaseData.binaries.reduce(
+      (acc, {arch, sys, sha256}) => {
+        if (sha256.length <= 0) {
+          throw new Error(`Found invalid sha256 value for sys:"${sys}", arch:"${arch}" in ${releaseUrl}`)
+        }
+        logger.debug({ sys: sys, arch: arch, sha256: sha256}, 'Found Smarter Testing binary')
+        if (acc[sys] === undefined) {
+          acc[sys] = {}
+        }
+        acc[sys][arch] = sha256
+        return acc
+      },
+      {}
+    )
+
+    logger.debug({ binaries: binaries }, 'Mapped release data')
+
+    const checksumFor = (sys, arch) => {
+      const val = binaries?.[sys]?.[arch]
+      if (val === null || val === undefined) {
+        throw new Error(`No Smarter Testing plugin release data for sys:"${sys}", arch:"${arch}"`)
+      }
+
+      return val
+    }
+
+    const version = releaseData.version
+    if (version === null || version === undefined) {
+      throw new Error(`No version field in Smarter Testing plugin release data`)
+    }
+    siteAsciiDocConfig.attributes['testsuite-version'] = version
+
+    for (const [sys, archs] of Object.entries({"darwin": ["arm64", "amd64"],
+                                               "linux": ["amd64", "arm", "arm64"],
+                                               "windows": ["amd64"]})) {
+      for (const arch of archs) {
+        siteAsciiDocConfig.attributes[`testsuite-sha-${sys}-${arch}`] = checksumFor(sys, arch)
+      }
+    }
+
+    logger.info("Successfully set AsciiDoc attributes for Smarter Testing")
+  })
+}


### PR DESCRIPTION
Add an Antora extension to fetch the latest release.json from S3 and use
that to populate the AsciiDoc attributes for the Smarter Testing CLI
plugin version and checksums.

[Preview](https://output.circle-artifacts.com/output/job/0173d280-a4dc-45f2-bca3-66391a8c04b4/artifacts/0/build/guides/test/getting-started-with-smarter-testing/index.html#install-testsuite-plugin) renders correctly, I've used each download link and confirmed
the shasums match and validate.