### PR TITLE
Fix Vale linter errors in docker-compose.adoc

### DIFF
--- a/docs/guides/modules/execution-managed/pages/docker-compose.adoc
+++ b/docs/guides/modules/execution-managed/pages/docker-compose.adoc
@@ -10,7 +10,7 @@ If you are new to Docker Compose, you can review the link:https://docs.docker.co
 [#using-docker-compose-with-machine-executor]
 == Using Docker Compose with machine executor
 
-If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `.circleci/config.yml` file. Then use `docker compose` as you would normally (see Linux VM execution environment documentation xref:using-linuxvm.adoc[Using the Linux VM Execution Environment] for more details). If you have a Docker Compose file that shares local directories with a container, this will work as expected.
+If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `.circleci/config.yml` file. Then use `docker compose` as you would normally (see xref:using-linuxvm.adoc[Using the Linux VM Execution Environment] for more details). If you have a Docker Compose file that shares local directories with a container, this will work as expected.
 
 [#using-docker-compose-with-docker-executor]
 == Using Docker Compose with Docker executor

--- a/docs/guides/modules/execution-managed/pages/docker-compose.adoc
+++ b/docs/guides/modules/execution-managed/pages/docker-compose.adoc
@@ -10,7 +10,7 @@ If you are new to Docker Compose, you can review the link:https://docs.docker.co
 [#using-docker-compose-with-machine-executor]
 == Using Docker Compose with machine executor
 
-If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `.circleci/config.yml` file and use `docker compose` as you would normally (see Linux VM execution environment documentation xref:using-linuxvm.adoc[here] for more details). That is, if you have a Docker Compose file that shares local directories with a container, this will work as expected.
+If you want to use Docker Compose to manage a multi-container setup with a Docker Compose file, use the `machine` key in your `.circleci/config.yml` file. Then use `docker compose` as you would normally (see Linux VM execution environment documentation xref:using-linuxvm.adoc[Using the Linux VM Execution Environment] for more details). If you have a Docker Compose file that shares local directories with a container, this will work as expected.
 
 [#using-docker-compose-with-docker-executor]
 == Using Docker Compose with Docker executor
@@ -22,7 +22,7 @@ Using the `docker` execution environment combined with `setup_remote_docker` ena
 The Docker Compose utility is xref:circleci-images#pre-installed-tools[pre-installed in the CircleCI convenience
 images] and machine executor images.
 
-If you are using the Docker executor and *are not* using a convenience image, you can install Docker Compose into your xref:reference:ROOT:glossary.adoc#primary-container[primary container] during the job execution and use the xref:building-docker-images.adoc[Remote Docker Environment], as follows:
+If you are using the Docker executor and *are not* using a convenience image, you can install Docker Compose into your xref:reference:ROOT:glossary.adoc#primary-container[Primary Container] during job execution. Then use the xref:building-docker-images.adoc[Run Docker Commands] guide:
 
 [,yml]
 ----
@@ -48,7 +48,7 @@ If you are using the Docker executor and *are not* using a convenience image, yo
 ----
 
 If you are constructing your own Docker images, consider reading the
-xref:custom-images.adoc[custom Docker images page].
+xref:custom-images.adoc[Using Custom-Built Docker Images].
 
 Once you have Docker Compose installed, you can use it to build images and run containers:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed 5 Vale linter errors in the `docker-compose.adoc` file in the execution-managed module.

## Changes

- **Xref capitalization**: Fixed xref link text to use title case (3 instances):
  - "here" → "Using the Linux VM Execution Environment"
  - "primary container" → "Primary Container"
  - "Remote Docker Environment" → "Run Docker Commands"
  - "custom Docker images page" → "Using Custom-Built Docker Images"
- **Sentence length**: Shortened 2 overly long sentences by breaking into multiple sentences

## Vale Results

Before: 5 errors
After: 0 errors

Related to Linear issue DOC-154
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

