### PR TITLE
Fix Vale linter errors in docker-to-machine.adoc

### DIFF
--- a/docs/guides/modules/execution-managed/pages/docker-to-machine.adoc
+++ b/docs/guides/modules/execution-managed/pages/docker-to-machine.adoc
@@ -34,4 +34,4 @@ All executors have their pros and cons, which have been laid out here to help de
 [#further-reading]
 == Further reading
 
-We have more details on each specific executor xref:executor-intro.adoc[Execution Environments Overview]. This includes links to specific memory and vCPU allocation details. It also shows how to implement each one in your own configuration.
+We have more details on each specific executor in the xref:executor-intro.adoc[Execution Environments Overview]. This page includes links to specific memory and vCPU allocation details. It also shows how to implement each one in your own configuration.

--- a/docs/guides/modules/execution-managed/pages/docker-to-machine.adoc
+++ b/docs/guides/modules/execution-managed/pages/docker-to-machine.adoc
@@ -8,7 +8,7 @@ This page contains some general guidelines and considerations to make when movin
 [#overview]
 == Overview
 
-In some situations, the Docker executor is not the right fit for your builds, for example if using a Docker resource class is providing a lack of memory or if there is a requirement for more dedicated CPU power. Moving to a dedicated virtual machine can help alleviate these issues. However, changing out an executor is not as simple as replacing a few lines of configuration. You will also need to consider the tools and libraries required to be installed for your application and tests.
+In some situations, the Docker executor is not the right fit for your builds. For example, if using a Docker resource class provides a lack of memory or there is a requirement for more dedicated CPU power. Moving to a dedicated virtual machine can help alleviate these issues. However, changing out an executor is not as simple as replacing a few lines of configuration. You will also need to consider the tools and libraries required to be installed for your application and tests.
 
 [#pre-installed-software]
 == Pre-installed software
@@ -20,18 +20,18 @@ Additional packages can be installed with `sudo apt-get install <package>`. If t
 [#running-docker-containers-on-machine]
 == Running Docker containers on machine
 
-Machine executors come installed with Docker, which can be used to run your application within a container rather than installing additional dependencies. We recommend using a custom Docker image rather than a CircleCI convenience image, which are built under the assumption they will be used with the Docker executor and may be tricky to work around. Since each machine executor environment is a dedicated virtual machine, commands to run background containers can be used as normal.
+Machine executors come installed with Docker, which can be used to run your application within a container rather than installing additional dependencies. We recommend using a custom Docker image rather than a CircleCI convenience image. CircleCI convenience images are built under the assumption they will be used with the Docker executor and may be tricky to work around. Since each machine executor environment is a dedicated virtual machine, commands to run background containers can be used as normal.
 
 If you have Docker Layer Caching (DLC) enabled for your account, machine executors can utilize this to cache your image layers for subsequent runs.
 
 [#why-use-docker-executors-at-all]
 == Why use Docker executors at all?
 
-Machine executors offer double the memory and a more isolated environment for running builds, but there is additional overhead regarding spin up time, and, depending on the approach taken for running the application, more time taken to install the required dependencies or pull your Docker image. The Docker executor will also cache as many layers as possible from your image during spin-up, as opposed to the machine executor, where DLC will need to be enabled.
+Machine executors offer double the memory and a more isolated environment for running builds. However, there is additional overhead regarding spin up time. Depending on the approach taken for running the application, there may be more time taken to install the required dependencies or pull your Docker image. The Docker executor will also cache as many layers as possible from your image during spin-up, as opposed to the machine executor, where DLC will need to be enabled.
 
 All executors have their pros and cons, which have been laid out here to help decide which is right for your pipelines.
 
 [#further-reading]
 == Further reading
 
-We have more details on each specific executor xref:executor-intro.adoc[here], which includes links to specific memory and vCPU allocation details, as well as how to implement each one in your own configuration.
+We have more details on each specific executor xref:executor-intro.adoc[Execution Environments Overview]. This includes links to specific memory and vCPU allocation details. It also shows how to implement each one in your own configuration.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed 5 Vale linter errors in the `docker-to-machine.adoc` file in the execution-managed module.

## Changes

- **Sentence length**: Shortened 4 overly long sentences by breaking into multiple sentences:
  - Line 11: Split overview paragraph
  - Line 23: Split sentence about Docker images
  - Line 30: Split sentence about machine executor overhead
  - Line 37: Split sentence about executor details
- **Xref capitalization**: Fixed xref link text: "here" → "Execution Environments Overview"

## Vale Results

Before: 5 errors
After: 0 errors

Related to Linear issue DOC-154
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

