### PR TITLE
PIPE-5439: Move <group-name> above table in job-groups config reference

### DIFF
--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -2448,16 +2448,16 @@ workflows:
 
 The `job-groups` key lets you define named sets of jobs at the top level of your config. A job group can be invoked in a workflow just like a regular job, and optionally serialized as an atomic unit by adding `serial-group` to the invocation.
 
+[#group-name]
+=== *<``group-name``>*
+
+Each job group consists of the group's name as a key and a map as a value. The value map has the following attributes:
+
 [.table-scroll]
 --
 [cols="1,1,1,2", options="header"]
 |===
 | Key | Required | Type | Description
-
-| `<group-name>`
-| N
-| Map
-| A named group definition containing a `jobs` key.
 
 | `jobs`
 | Y


### PR DESCRIPTION
> [!NOTE]
> You may find that there are errors for the `vale/lint` job that are unrelated to your change.
> Vale checks the whole file when a change is made so if there are existing issues on the page they will be flagged.
> You can ignore lint errors outside your changes and the CircleCI docs team will address them for you.
> Vale logs are advisory to help all contributors create content that conforms to our style guide. The `vale/lint` job will not prevent changes from being published.

# Description
In the `job-groups` section of the configuration reference, `<group-name>` was listed as a row inside the attributes table. Moved it above the table as a subsection heading (`===`), matching the pattern used by `<job_name>` in the `jobs` section.

# Reasons
Consistency with the existing `<job_name>` pattern — named keys like these are more readable and navigable as subsection headings rather than table rows.

Ticket: [PIPE-5439](https://circleci.atlassian.net/browse/PIPE-5439)

# Content checks

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).

[PIPE-5439]: https://circleci.atlassian.net/browse/PIPE-5439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ