### PR TITLE
Fix Vale linter error in linux-vm-support-policy.adoc

### DIFF
--- a/docs/guides/modules/execution-managed/pages/linux-vm-support-policy.adoc
+++ b/docs/guides/modules/execution-managed/pages/linux-vm-support-policy.adoc
@@ -6,7 +6,7 @@
 [#overview]
 == Overview
 
-This document outlines the CircleCI Linux VM (machine) image release, update and deprecation policy. This policy applies to all CircleCI Linux VM (machine) images built for the machine executor. Note that there is a separate xref:linux-cuda-images-support-policy.adoc[CUDA image support policy].
+This document outlines the CircleCI Linux VM (machine) image release, update and deprecation policy. This policy applies to all CircleCI Linux VM (machine) images built for the machine executor. Note that there is a separate xref:linux-cuda-images-support-policy.adoc[CUDA Image Support Policy].
 
 [#release-policy]
 == Release policy


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed 1 Vale linter error in the `linux-vm-support-policy.adoc` file in the execution-managed module.

## Changes

- **Xref capitalization**: Fixed xref link text to use title case: "CUDA image support policy" → "CUDA Image Support Policy"

## Vale Results

Before: 1 error
After: 0 errors

Related to Linear issue DOC-154
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

