### PR TITLE
Fix Vale linter error in using-gpu.adoc

### DIFF
--- a/docs/guides/modules/execution-managed/pages/using-gpu.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-gpu.adoc
@@ -22,7 +22,7 @@ jobs:
       - run: nvidia-smi
 ----
 
-To use the Windows GPU execution environment, you can either choose to use the Windows orb and specify the built-in GPU executor, or use the machine executor and specify a Windows GPU-enabled image. Refer to the link:https://circleci.com/developer/orbs/orb/circleci/windows[Orb Registry page] for full details, and the link:https://circleci.com/developer/images?imageType=machine[Developer Hub] for full details of available machine executor images.
+To use the Windows GPU execution environment, you can either choose to use the Windows orb and specify the built-in GPU executor. Alternatively, use the machine executor and specify a Windows GPU-enabled image. Refer to the link:https://circleci.com/developer/orbs/orb/circleci/windows[Orb Registry page] for full details, and the link:https://circleci.com/developer/images?imageType=machine[Developer Hub] for full details of available machine executor images.
 
 [tabs]
 ====


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed 1 Vale linter error in the `using-gpu.adoc` file in the execution-managed module.

## Changes

- **Sentence length**: Shortened overly long sentence by breaking into two sentences

## Vale Results

Before: 1 error
After: 0 errors

Related to Linear issue DOC-154
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

