### PR TITLE
Fix Vale linter errors in remote-docker-images-support-policy.adoc

### DIFF
--- a/docs/guides/modules/execution-managed/pages/remote-docker-images-support-policy.adoc
+++ b/docs/guides/modules/execution-managed/pages/remote-docker-images-support-policy.adoc
@@ -6,7 +6,7 @@
 [#overview]
 == Overview
 
-This document outlines the xref:building-docker-images.adoc[CircleCI remote Docker image] release, update, and deprecation policy. This policy applies to all CircleCI remote Docker images built for the remote Docker feature (`setup_remote_docker`).
+This document outlines the xref:building-docker-images.adoc[CircleCI Remote Docker Image] release, update, and deprecation policy. This policy applies to all CircleCI remote Docker images built for the remote Docker feature (`setup_remote_docker`).
 
 [#release-policy]
 == Release policy
@@ -16,7 +16,7 @@ This setup enables the execution of Docker commands within jobs using the Docker
 
 We aim to support the latest three versions of the Docker Engine that are classified as within Security Support status.
 
-Remote Docker images will be updated when a patch version is released upstream. Tags will be redirected to the updated images automatically as described in the xref:#tagging[tagging] section of this document. We will announce these releases on our link:https://discuss.circleci.com/[Discuss Forum].
+Remote Docker images will be updated when a patch version is released upstream. Tags will be redirected to the updated images automatically as described in the xref:#tagging[Tagging] section of this document. We will announce these releases on our link:https://discuss.circleci.com/[Discuss Forum].
 
 [#tagging]
 == Tagging


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed 2 Vale linter errors in the `remote-docker-images-support-policy.adoc` file in the execution-managed module.

## Changes

- **Xref capitalization**: Fixed xref link text to use title case (2 instances):
  - "CircleCI remote Docker image" → "CircleCI Remote Docker Image"
  - "tagging" → "Tagging"

## Vale Results

Before: 2 errors
After: 0 errors

Related to Linear issue DOC-154
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

