### PR TITLE
Fix Vale linter errors in resource-class-lifecycle.adoc

### DIFF
--- a/docs/guides/modules/execution-managed/pages/resource-class-lifecycle.adoc
+++ b/docs/guides/modules/execution-managed/pages/resource-class-lifecycle.adoc
@@ -93,7 +93,7 @@ A: Most brownouts last from 10 minutes to 24 hours, depending on the resource cl
 *Q: Does CircleCI notify me before a resource class brownout occurs?*::
 A: Yes, CircleCI sends email notifications to organizations whose projects use deprecated resource classes and posts announcements on the changelog.
 
-*Q: What happens if I don't update my configuration before the EOL date?*::
+*Q: What happens if I do not update my configuration before the EOL date?*::
 A: After the EOL date, deprecated resource classes are permanently removed. Any jobs attempting to use them fail until you update configurations.
 
 *Q: How can I test my workflows with new resource classes before a brownout?*::
@@ -105,4 +105,4 @@ A: Different resource classes have different pricing, so switching resource clas
 *Q: How do I know which resource class to migrate to?*::
 A: Deprecation announcements include recommended migration paths. 
 +
-Generally, you should choose a resource class that matches or exceeds the compute capacity of your deprecated class.
+Generally, you choose a resource class that matches or exceeds the compute capacity of your deprecated class.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed 2 Vale linter errors in the `resource-class-lifecycle.adoc` file in the execution-managed module.

## Changes

- **Avoid contractions**: Changed "don't" to "do not" on line 96
- **Avoid hedging**: Changed "should choose" to "choose" on line 108

## Vale Results

Before: 2 errors
After: 0 errors

Related to Linear issue DOC-154
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

