### PR TITLE
Fix Vale linter errors in high-uid-error.adoc

### DIFF
--- a/docs/guides/modules/execution-managed/pages/high-uid-error.adoc
+++ b/docs/guides/modules/execution-managed/pages/high-uid-error.adoc
@@ -17,7 +17,7 @@ This document explains the problem and how to fix it.
 
 The user namespace (`userns`) is a feature of the Linux kernel that adds another security layer to Linux containers. The `userns` allows a host machine to run containers outside its UID/GID namespace. This means all containers can have a root account (UID 0) in their own namespace and run processes without receiving root privileges from the host machine.
 
-When a `userns` is created, the Linux kernel provides a mapping between the container and the host machine. For example, if you start a container and run a process with UID 0 inside of it, the Linux kernel maps the container's UID 0 to a non-privileged UID on the host machine. This allows the container to run a process as if it were the root user, while *actually* being run by the non-root user on the host machine.
+When a `userns` is created, the Linux kernel provides a mapping between the container and the host machine. For example, if you start a container and run a process with UID 0 inside of it, the Linux kernel maps the container's UID 0 to a non-privileged UID on the host machine. This allows the container to run a process as if it is the root user. The process is *actually* run by the non-root user on the host machine.
 
 [#problem]
 == Problem
@@ -54,7 +54,7 @@ If you are the image maintainer, identify the file with the high UID/GID and cor
 
 . After locating the offending file, change its ownership and re-create the image.
 
-It is possible for an invalid file to be generated and removed while a container is building. In this case, you may have to modify the `RUN` step in the Dockerfile itself. Adding `&& chown -R root:root /root` to the problem step should fix the problem without creating a bad interim.
+It is possible for an invalid file to be generated and removed while a container is building. In this case, you may have to modify the `RUN` step in the Dockerfile itself. Adding `&& chown -R root:root /root` to the problem step fixes the problem without creating a bad interim.
 
 [#see-also]
 == See Also

--- a/docs/guides/modules/execution-managed/pages/high-uid-error.adoc
+++ b/docs/guides/modules/execution-managed/pages/high-uid-error.adoc
@@ -17,7 +17,7 @@ This document explains the problem and how to fix it.
 
 The user namespace (`userns`) is a feature of the Linux kernel that adds another security layer to Linux containers. The `userns` allows a host machine to run containers outside its UID/GID namespace. This means all containers can have a root account (UID 0) in their own namespace and run processes without receiving root privileges from the host machine.
 
-When a `userns` is created, the Linux kernel provides a mapping between the container and the host machine. For example, if you start a container and run a process with UID 0 inside of it, the Linux kernel maps the container's UID 0 to a non-privileged UID on the host machine. This allows the container to run a process as if it is the root user. The process is *actually* run by the non-root user on the host machine.
+When a `userns` is created, the Linux kernel provides a mapping between the container and the host machine. For example, if a container runs a process as UID 0, the Linux kernel maps it to a non-privileged UID on the host. This allows the container to run a process as if it is the root user. The process is *actually* run by the non-root user on the host machine.
 
 [#problem]
 == Problem


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed 3 Vale linter errors in the `high-uid-error.adoc` file in the execution-managed module.

## Changes

- **Sentence length**: Shortened overly long sentence on line 20 by breaking into two sentences
- **Avoid past tense**: Changed "were" to "is" on line 20  
- **Avoid hedging**: Changed "should fix" to "fixes" on line 57

## Vale Results

Before: 3 errors
After: 0 errors

Related to Linear issue DOC-154
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb46a047-177d-4ebc-a9ca-3a212a353e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

