### PR TITLE
Fix Vale error in nav.adoc

### DIFF
--- a/docs/server-admin-4.9/modules/ROOT/nav.adoc
+++ b/docs/server-admin-4.9/modules/ROOT/nav.adoc
@@ -19,7 +19,7 @@
 *** xref:air-gapped-installation:phase-4-configure-nomad-clients.adoc[Phase 4 - Configure Nomad clients]
 *** xref:air-gapped-installation:phase-5-test-your-installation.adoc[Phase 5 - Test installation]
 *** xref:air-gapped-installation:additional-considerations.adoc[Additional considerations]
-*** xref:air-gapped-installation:example-values.adoc[Example values.YAML]
+*** xref:air-gapped-installation:example-values.adoc[Example values file]
 ** xref:installation:hardening-your-cluster.adoc[Hardening your cluster]
 ** xref:installation:installing-server-behind-a-proxy.adoc[Installing server behind a proxy]
 ** xref:installation:upgrade-server.adoc[Upgrading server]

--- a/docs/server-admin-4.9/modules/ROOT/nav.adoc
+++ b/docs/server-admin-4.9/modules/ROOT/nav.adoc
@@ -19,7 +19,7 @@
 *** xref:air-gapped-installation:phase-4-configure-nomad-clients.adoc[Phase 4 - Configure Nomad clients]
 *** xref:air-gapped-installation:phase-5-test-your-installation.adoc[Phase 5 - Test installation]
 *** xref:air-gapped-installation:additional-considerations.adoc[Additional considerations]
-*** xref:air-gapped-installation:example-values.adoc[Example values.yaml]
+*** xref:air-gapped-installation:example-values.adoc[Example values.YAML]
 ** xref:installation:hardening-your-cluster.adoc[Hardening your cluster]
 ** xref:installation:installing-server-behind-a-proxy.adoc[Installing server behind a proxy]
 ** xref:installation:upgrade-server.adoc[Upgrading server]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview
Fixes Vale linter error in the server-admin-4.9 navigation file.

## Changes
- Capitalized "yaml" to "YAML" on line 22 to match the CircleCI style guide terminology requirements

## Errors Fixed
- **Vale.Terms**: Use 'YAML' instead of 'yaml'

## Validation
Verified with Vale linter - 0 errors remaining.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

