### PR TITLE
Fix Vale error in managing-orbs.adoc

### DIFF
--- a/docs/server-admin-4.9/modules/operator/pages/managing-orbs.adoc
+++ b/docs/server-admin-4.9/modules/operator/pages/managing-orbs.adoc
@@ -5,7 +5,7 @@
 
 This section describes how to manage orbs for an installation of server 4.9. Server installations include their own local orb registry. All orbs referenced in configs refer to the orbs in the server orb registry. You are responsible for maintaining orbs. This includes copying orbs from the public registry, updating orbs that may have been previously copied, and registering your company's private orbs, if they exist.
 
-For information on orbs and related use cases, see the xref:orbs:use:orb-intro.adoc#[orbs docs].
+For information on orbs and related use cases, see the xref:orbs:use:orb-intro.adoc#[Orbs Docs].
 
 If you are looking for information on creating an orb, see the xref:orbs:author:orb-author.adoc#[Introduction to Authoring Orbs].
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview
Fixes Vale linter error in the managing orbs page.

## Changes
- Changed xref link text from "orbs docs" to "Orbs Docs" on line 8 to use proper title case

## Errors Fixed
- **circleci-docs.XrefTitleCase**: Use title case for xref link text

## Validation
Verified with Vale linter - 0 errors remaining.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

