### PR TITLE
Fix Vale error in data-retention.adoc

### DIFF
--- a/docs/server-admin-4.9/modules/operator/pages/data-retention.adoc
+++ b/docs/server-admin-4.9/modules/operator/pages/data-retention.adoc
@@ -88,4 +88,4 @@ NOTE: **Object Storage Paths** +
 If a retention policy of `n` days is configured for both MongoDB and PostgreSQL data, you can set `n+1` for **all objects** in your S3/GCS buckets to expire at `n+1` days. This ensures alignment between database retention and object storage retention.
 
 CAUTION: **Audit Logs** +
-Be sure to configure exceptions for critical paths, such as `audit-logs/*`, in accordance with your organization's compliance or audit requirements. Objects under these paths should not be expired by default.
+Be sure to configure exceptions for critical paths, such as `audit-logs/*`, in accordance with your organization's compliance or audit requirements. Objects under these paths must not be expired by default.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview
Fixes Vale linter error in the data retention page.

## Changes
- Changed "should" to "must" on line 91 to use more definitive language

## Errors Fixed
- **circleci-docs.Avoid**: Try to avoid using 'should'

## Validation
Verified with Vale linter - 0 errors remaining.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

