### PR TITLE
Fix Vale error in upgrade-server.adoc

### DIFF
--- a/docs/server-admin-4.9/modules/installation/pages/upgrade-server.adoc
+++ b/docs/server-admin-4.9/modules/installation/pages/upgrade-server.adoc
@@ -21,7 +21,7 @@ To see some common upgrade path options, see link:https://support.circleci.com/h
 
 We have moved away from Vault to Tink for encryption. The process for migration is link:https://github.com/CircleCI-Public/server-scripts/tree/main/vault-to-tink[documented here]. The migration includes a convenience script to move existing secrets.
 
-If you are using Vault, you should complete the migration to Tink on your current installation. Complete this migration before backing up your server in preparation for upgrading to 4.9.
+If you are using Vault, you must complete the migration to Tink on your current installation. Complete this migration before backing up your server in preparation for upgrading to 4.9.
 
 Customers that do not perform this step may have issues restoring Vault from backup in server 4.9.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview
Fixes Vale linter error in the upgrade server page.

## Changes
- Changed "should" to "must" on line 24 to use more definitive language

## Errors Fixed
- **circleci-docs.Avoid**: Try to avoid using 'should'

## Validation
Verified with Vale linter - 0 errors remaining.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

