### PR TITLE
Fix Vale errors in release-notes.adoc

### DIFF
--- a/docs/server-admin-4.9/modules/overview/pages/release-notes.adoc
+++ b/docs/server-admin-4.9/modules/overview/pages/release-notes.adoc
@@ -6,12 +6,12 @@
 [#overview]
 == Overview
 
-The 4.9 release introduces xref:guides:orchestrate:controlling-serial-execution-across-your-organization.adoc#[Serial Groups] for job serialization, xref:guides:orchestrate:automatic-reruns.adoc#[Automatic Reruns] for workflows and steps, and improved caching with Zstd compression.
+The 4.9 release introduces xref:guides:orchestrate:controlling-serial-execution-across-your-organization.adoc#[Serial Groups] for job serialization, xref:guides:orchestrate:automatic-reruns.adoc#[Automatic Reruns] for workflows and steps, and improved caching with `zstd` compression.
 
 [#upgrade]
 == Upgrade
 
-NOTE: Server 4.9 requires mongoDB 4.4 or higher. If your MongoDB instance is not externalized then please follow our xref:operator:upgrade-mongo.adoc#upgrade-mongodb-to-4[Upgrade MongoDB to 4.4 guide] before upgrading to Server 4.9.0.
+NOTE: Server 4.9 requires mongoDB 4.4 or higher. If your MongoDB instance is not externalized then follow our xref:operator:upgrade-mongo.adoc#upgrade-mongodb-to-4[Upgrade MongoDB to 4.4 Guide] before upgrading to Server 4.9.0.
 
 For upgrade steps see the xref:installation:upgrade-server.adoc#[Upgrade Server 4.9 Guide].
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview
Fixes Vale linter errors in the release notes page.

## Changes
- Wrapped "zstd" in backticks on line 9 to mark it as code/technical term
- Removed "please" on line 14 to avoid unnecessary hedging language
- Changed "guide" to "Guide" in xref link text on line 14 to use proper title case

## Errors Fixed
- **Vale.Spelling**: Did you really mean 'Zstd'?
- **Vale.Avoid**: Avoid using 'please'
- **circleci-docs.Avoid**: Try to avoid using 'please'
- **circleci-docs.XrefTitleCase**: Use title case for xref link text

## Validation
Verified with Vale linter - 0 errors remaining.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-154](https://linear.app/circleci/issue/DOC-154/fix-linter-error-across-all-pages)

<div><a href="https://cursor.com/agents/bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05d36222-e2ac-46c1-83c9-b0678accf468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

