### PR TITLE
disable vale for values reference table 

### DIFF
--- a/docs/server-admin-4.9/modules/ROOT/partials/installation/values.adoc
+++ b/docs/server-admin-4.9/modules/ROOT/partials/installation/values.adoc
@@ -1,3 +1,4 @@
+pass:[<!-- vale off -->]
 |===
 | Key | Type | Default | Description
 
@@ -2275,3 +2276,4 @@ The secret must be named 'vault' and have the key; token. +
 | `"8Gi"`
 | Memory limit configuration for the workflows-conductor-grpc deployment.
 |===
+pass:[<!-- vale on -->]


### PR DESCRIPTION
data for table is generated outside docs so disable linter