### PR TITLE
Add full-test-run-paths and test-selection-rules to TIA docs

### DIFF
--- a/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
+++ b/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
@@ -189,6 +189,53 @@ options:
 --
 ====
 
+=== Configure the test suite
+
+Code coverage cannot detect every relationship between source files and test atoms. The following options can be used to change how many test atoms are selected and run.
+
+For the full list of available options, see the xref:testsuite-configuration-reference.adoc#options[Options] section in the test suite configuration reference.
+
+==== Full test run paths
+
+Some project files affect the running system without being directly covered by tests. Examples include dependency manifests, database migration files, or CI configuration. Use `full-test-run-paths` to list files that cause all test atoms to be selected and run.
+
+.Example test suite with full test run paths configured
+[source,yaml]
+----
+# .circleci/test-suites.yml
+---
+name: ci tests
+# ...
+options:
+  test-impact-analysis: true
+  full-test-run-paths:
+    - package.json
+    - go.mod
+    - .circleci/*.yml
+    - database-migrations/**/*.sql
+----
+
+==== Test selection rules
+
+Use `test-selection-rules` to extend test selection to cover non-source files, or to always run specific test atoms. For example, run integration tests when database migrations change, or always run acceptance tests regardless of which files changed.
+
+.Example test suite with test selection rules
+[source,yaml]
+----
+# .circleci/test-suites.yml
+---
+name: ci tests
+# ...
+options:
+  test-impact-analysis: true
+  test-selection-rules:
+    - test-atom: db/integration_test.ts
+      include: database-migrations/**/*.sql
+    - test-atom: acceptance/test.ts
+      include: true
+----
+
+
 == 2. Run locally
 
 


### PR DESCRIPTION
# Description

Some options are important to configure upfront during onboarding, `full-test-run-paths` and `test-selection-rules`. Currently, these are hidden away on the config reference. This change adds a section during onboarding to ensure that they aren't missed.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
