### PR TITLE
Fix Vale errors in configure-deploy-markers.adoc

### DIFF
--- a/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
+++ b/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
@@ -169,10 +169,10 @@ jobs:
 
 In this example, note the following flags and options:
 
-* The `<deploy-name>` argument is used to identify the deployment. `deploy-name` is an arbitrary positional argument that will be used to identify the deployment and should be unique within the workflow. If not specified, the deployment name will be set to `default`. If you are deploying multiple components or to multiple environments from a single workflow, you need to provide the command with a deployment name.
+* The `<deploy-name>` argument is used to identify the deployment. `deploy-name` is an arbitrary positional argument that will be used to identify the deployment and must be unique within the workflow. If not specified, the deployment name will be set to `default`. If you are deploying multiple components or to multiple environments from a single workflow, you need to provide the command with a deployment name.
 * The `--environment-name` flag sets the target environment. If the specified environment does not exist, it will be created. If you do not specify an environment, CircleCI will create one named `default`.
 * The `--component-name` flag sets the name that will be displayed in the Deploys UI. If you do not already have a component in your project a new one will be created with the name of the project. This will be set as the component that is being deployed.
-* The `--target-version` flag should match the version being deployed. Some examples are provided <<examples-for-target-version,in the next section>>.
+* The `--target-version` flag must match the version being deployed. Some examples are provided <<examples-for-target-version,in the next section>>.
 * The `--namespace` flag is optional and can be provided to use a value other than `default`.
 
 Configuring `circleci run release plan` identifies the deployment you are planning so that you can reference it to update its status later on.
@@ -206,7 +206,7 @@ WARNING: The `circleci run release update` command is only for use with deploy m
 
 After deploying your application, you can update the status of the deployment to `RUNNING` by running the `circleci run release update` command in a new step.
 
-If you specified a `deploy-name` when _planning_ your deploy, remember to provide your deploy name when using the `update` commands too. The deploy name value should match the value you provided when you planned the deploy. If you did not provide a deploy name when you planned the deploy, it will be set to `default` and you do not need to provide it when updating the status.
+If you specified a `deploy-name` when _planning_ your deploy, remember to provide your deploy name when using the `update` commands too. The deploy name value must match the value you provided when you planned the deploy. If you did not provide a deploy name when you planned the deploy, it will be set to `default` and you do not need to provide it when updating the status.
 
 .Update the deploy status to running
 [,yml]
@@ -408,7 +408,7 @@ jobs:
 
 ** The `--environment-name` flag specifies the target environment. If the environment does not exist, it will be created.
 ** The `--component-name` flag sets the name that will be displayed in the CircleCI UI.
-** The `--target-version` flag should match the name of the version being deployed. Some examples are provided <<examples-for-target-version,above>>.
+** The `--target-version` flag matches the name of the version being deployed. Some examples are provided <<examples-for-target-version,above>>.
 ** (Optional) You can provide the following parameter if required:
 *** The `--namespace` flag can be provided to use a value other than `default`.
 


### PR DESCRIPTION
Resolved the following Vale errors:
- Line 172: Changed "should be unique" to "must be unique" (circleci-docs.Avoid)
- Line 175: Changed "should match" to "must match" (circleci-docs.Avoid)
- Line 209: Changed "should match" to "must match" (circleci-docs.Avoid)
- Line 411: Changed "should match" to "matches" (circleci-docs.Avoid)

All changes replace hedging language with definitive language per CircleCI documentation style guide.

