### PR TITLE
Update Xcode 26.5 to RC 1

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
@@ -10,12 +10,12 @@
 | Release Notes
 
 | `26.5`
-| Xcode 26.5 beta 3 (17F5032f)
-| 26.3
+| Xcode 26.5 RC 1 (17F42)
+| 26.3.1
 a| `m4pro.medium` +
    `m4pro.large`
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v17822/manifest.txt[Installed software]
-| link:https://circleci.com/changelog/xcode-26-5-beta-3-available/[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18108/manifest.txt[Installed software]
+| link:https://circleci.com/changelog/xcode-26-5-rc-1-available/[Release Notes]
 
 | `26.4.1`
 | Xcode 26.4.1 (17E202)


### PR DESCRIPTION
# Description
Updated the documentation for Xcode 26.5 to our RC 1 release info.

# Reasons
We are releasing a new Xcode 26.5 image for Xcode 26.5 RC 1 and need to provide updated information.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
