### PR TITLE
Document prefer_same_region option for setup_remote_docker

### DIFF
--- a/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
+++ b/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
@@ -243,6 +243,17 @@ jobs:
       - run: docker push company/app:$CIRCLE_BRANCH
 ----
 
+[#prefer-same-region-pulls]
+== Prefer same-region image pulls
+
+When `prefer_same_region` is set to `true`, CircleCI will attempt to pull the image from the same region as the VM on a best-effort basis. If the same-region pull fails, it falls back to pulling from the image's original region.
+
+[,yaml]
+----
+      - setup_remote_docker:
+          prefer_same_region: true
+----
+
 [#see-also]
 == See also
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -1958,6 +1958,11 @@ Allows Docker commands to be run locally. See xref:guides:execution-managed:buil
 | boolean
 | Set this to `true` to enable xref:guides:optimize:docker-layer-caching.adoc#[Docker Layer Caching] in the Remote Docker Environment (default: `false`)
 
+| `prefer_same_region`
+| N
+| boolean
+| Set this to `true` to attempt pulling images from the same region as the VM on a best-effort basis, falling back to the image's original region if the pull fails (default: `false`)
+
 | `version`
 | N
 | String


### PR DESCRIPTION
Adds documentation for the new `prefer_same_region` option on `setup_remote_docker`, which attempts to pull images from the same region as the VM on a best-effort basis.