### PR TITLE
Add keyboard shortcut to access search bar

### DIFF
--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -200,9 +200,9 @@ html[data-theme="dark"] .search-icon {
 }
 
 html[data-theme="dark"] [data-keyboard-shortcut] span {
-  background-color: #1f2937;
-  border-color: #374151;
-  color: #9ca3af;
+  background-color: var(--dark-surface-tertiary);
+  border-color: var(--dark-border-secondary);
+  color: var(--dark-text-muted);
 }
 
 /* Hide keyboard shortcut when clear button is visible (not hidden) */

--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -199,6 +199,17 @@ html[data-theme="dark"] .search-icon {
   color: var(--dark-text-muted);
 }
 
+html[data-theme="dark"] [data-keyboard-shortcut] span {
+  background-color: #1f2937;
+  border-color: #374151;
+  color: #9ca3af;
+}
+
+/* Hide keyboard shortcut when clear button is visible (not hidden) */
+div:has([data-search-clear]:not(.hidden)) [data-keyboard-shortcut] {
+  display: none !important;
+}
+
 /* Admonition icon dark mode switching */
 html[data-theme="dark"] .doc .admonitionblock td.icon i.icon-note {
   background: url('../img/note_icon-dark.svg') no-repeat center / contain;

--- a/ui/src/css/site.css
+++ b/ui/src/css/site.css
@@ -49,9 +49,11 @@ header.h-dvh [data-component-explorer-nav] {
 
 /* Center search results container on the page */
 header [data-search-results-container] {
-  max-width: 1440px;
+  max-width: 1200px;
+  width: min(90%, 1200px);
   margin-left: auto;
   margin-right: auto;
+  justify-content: center;
 }
 
 /* Hide hamburger menu on landing page */

--- a/ui/src/js/07-search.js
+++ b/ui/src/js/07-search.js
@@ -30,6 +30,8 @@
       mobileSearchInput: document.querySelector('[data-page-navigation] [data-search-input]'),
       clearButton: document.querySelector('header [data-search-clear]'),
       mobileClearButton: document.querySelector('[data-page-navigation] [data-search-clear]'),
+      keyboardShortcut: document.querySelector('header [data-keyboard-shortcut]'),
+      mobileKeyboardShortcut: document.querySelector('[data-page-navigation] [data-keyboard-shortcut]'),
       searchContainer: document.querySelector('header [data-search-results-container]'),
       mobileSearchContainer: document.querySelector('[data-page-navigation] [data-search-results-container]'),
       navigation: document.querySelector('[data-page-navigation]'),
@@ -510,6 +512,9 @@
         elements.searchInput.value = query
       }
 
+      // Update keyboard shortcut visibility based on input value
+      updateKeyboardShortcutVisibility()
+
       if (query.length < MIN_QUERY_LENGTH) {
         // Hide search results in both desktop and mobile
         elements.searchContainer.classList.add('hidden')
@@ -554,6 +559,9 @@
 
       // Clear URL parameters
       updateUrlWithSearchState('', 0, null)
+
+      // Update keyboard shortcut visibility
+      updateKeyboardShortcutVisibility()
     }
 
     function handlePrevPage (e) {
@@ -647,6 +655,9 @@
           elements.mobileClearButton.classList.add('flex')
         }
 
+        // Hide keyboard shortcut since input has text
+        updateKeyboardShortcutVisibility()
+
         // Perform search without updating URL (since we're loading from URL)
         await search(queryParam, componentParam, true)
 
@@ -683,6 +694,9 @@
           elements.mobileClearButton.classList.add('hidden')
         }
       }
+
+      // Show keyboard shortcut since input is empty
+      updateKeyboardShortcutVisibility()
     }
 
     function handlePopState () {
@@ -690,11 +704,82 @@
       readSearchStateFromUrl()
     }
 
+    // ===== KEYBOARD SHORTCUT HANDLER =====
+
+    function handleKeyboardShortcut (e) {
+      // Check for Cmd+/ (Mac) or Ctrl+/ (Windows/Linux)
+      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
+      const modifierKey = isMac ? e.metaKey : e.ctrlKey
+
+      if (modifierKey && e.key === '/') {
+        e.preventDefault()
+
+        // Focus the appropriate search input based on current view
+        if (isMobileView && elements.mobileSearchInput) {
+          elements.mobileSearchInput.focus()
+        } else {
+          elements.searchInput.focus()
+        }
+      }
+    }
+
+    function updateKeyboardShortcutVisibility () {
+      // Hide keyboard shortcut when input has focus or contains text
+      const shouldHide = document.activeElement === elements.searchInput ||
+                         elements.searchInput.value.length > 0
+
+      if (elements.keyboardShortcut) {
+        if (shouldHide) {
+          elements.keyboardShortcut.classList.add('hidden')
+        } else {
+          elements.keyboardShortcut.classList.remove('hidden')
+        }
+      }
+
+      // Handle mobile keyboard shortcut visibility
+      if (elements.mobileKeyboardShortcut && elements.mobileSearchInput) {
+        const shouldHideMobile = document.activeElement === elements.mobileSearchInput ||
+                                 elements.mobileSearchInput.value.length > 0
+        if (shouldHideMobile) {
+          elements.mobileKeyboardShortcut.classList.add('hidden')
+        } else {
+          elements.mobileKeyboardShortcut.classList.remove('hidden')
+        }
+      }
+    }
+
+    function initializeKeyboardShortcut () {
+      // Detect platform and update shortcut key text
+      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
+      const shortcutKey = isMac ? 'cmd' : 'ctrl'
+
+      // Update desktop shortcut text
+      if (elements.keyboardShortcut) {
+        const shortcutKeyElement = elements.keyboardShortcut.querySelector('[data-shortcut-key]')
+        if (shortcutKeyElement) {
+          shortcutKeyElement.textContent = shortcutKey
+        }
+      }
+
+      // Update mobile shortcut text if it exists
+      if (elements.mobileKeyboardShortcut) {
+        const mobileShortcutKeyElement = elements.mobileKeyboardShortcut.querySelector('[data-shortcut-key]')
+        if (mobileShortcutKeyElement) {
+          mobileShortcutKeyElement.textContent = shortcutKey
+        }
+      }
+
+      // Set initial visibility
+      updateKeyboardShortcutVisibility()
+    }
+
     // ===== INITIALIZATION =====
 
     function initializeEventListeners () {
       // Desktop search event listeners
       elements.searchInput.addEventListener('input', handleSearchInput)
+      elements.searchInput.addEventListener('focus', updateKeyboardShortcutVisibility)
+      elements.searchInput.addEventListener('blur', updateKeyboardShortcutVisibility)
       elements.clearButton.addEventListener('click', handleClearSearch)
       elements.prevButton.addEventListener('click', handlePrevPage)
       elements.nextButton.addEventListener('click', handleNextPage)
@@ -702,6 +787,8 @@
       // Mobile search event listeners (if elements exist)
       if (elements.mobileSearchInput) {
         elements.mobileSearchInput.addEventListener('input', handleSearchInput)
+        elements.mobileSearchInput.addEventListener('focus', updateKeyboardShortcutVisibility)
+        elements.mobileSearchInput.addEventListener('blur', updateKeyboardShortcutVisibility)
       }
       if (elements.mobileClearButton) {
         elements.mobileClearButton.addEventListener('click', handleClearSearch)
@@ -718,10 +805,14 @@
 
       // Listen for window resize to handle mobile/desktop transitions
       window.addEventListener('resize', updateSearchUIForScreenSize)
+
+      // Listen for keyboard shortcut (Cmd+/ or Ctrl+/)
+      document.addEventListener('keydown', handleKeyboardShortcut)
     }
 
     // Initialize everything
     initializeDomReferences()
+    initializeKeyboardShortcut()
     initializeEventListeners()
     readSearchStateFromUrl() // Check for query and page parameters in URL and trigger search if present
     console.log('Search input initialized')

--- a/ui/src/partials/head-scripts.hbs
+++ b/ui/src/partials/head-scripts.hbs
@@ -1,3 +1,27 @@
+<script>
+  // Apply theme immediately to prevent flash
+  (function() {
+    function getThemePreference() {
+      try {
+        const stored = localStorage.getItem('theme')
+        if (stored === 'light' || stored === 'dark' || stored === 'auto') return stored
+      } catch (e) {}
+      return 'auto'
+    }
+    function getResolvedTheme(preference) {
+      if (preference === 'light') return 'light'
+      if (preference === 'dark') return 'dark'
+      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark'
+      }
+      return 'light'
+    }
+    const preference = getThemePreference()
+    const resolvedTheme = getResolvedTheme(preference)
+    document.documentElement.setAttribute('data-theme', resolvedTheme)
+    document.documentElement.style.colorScheme = resolvedTheme
+  })()
+</script>
 {{#with site.keys.cookiebot}}
     <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="{{this}}" data-blockingmode="auto" type="text/javascript"></script>
 {{/with}}

--- a/ui/src/partials/search-bar.hbs
+++ b/ui/src/partials/search-bar.hbs
@@ -11,9 +11,14 @@
       id="search-text-input"
       data-search-input
       placeholder="Search Docs"
-      class="search-input w-full py-2 pl-8 pr-4 border rounded-full border-vapor focus:outline-none focus:ring-2 focus:ring-vapor focus:border-transparent"
+      class="search-input w-full py-2 pl-8 pr-20 border rounded-full border-vapor focus:outline-none focus:ring-2 focus:ring-vapor focus:border-transparent"
     >
-    <button data-search-clear class="absolute inset-y-0 right-5 flex items-center gap-2 pl-3 text-link-on-light">
+    <span data-keyboard-shortcut class="absolute inset-y-0 right-5 flex items-center text-xs pointer-events-none">
+      <span class="px-2 py-1 border border-vapor rounded bg-white text-gray-600">
+        <span data-shortcut-key>cmd</span>+/
+      </span>
+    </span>
+    <button data-search-clear class="hidden absolute inset-y-0 right-5 items-center gap-2 pl-3 text-link-on-light">
       Clear
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" aria-hidden="true">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M12.9864 2.45711C13.3769 2.06658 13.3769 1.43342 12.9864 1.04289C12.5959 0.652369 11.9627 0.652369 11.5722 1.04289L7.0293 5.58579L2.4864 1.04289C2.09588 0.652369 1.46271 0.652369 1.07219 1.04289C0.681666 1.43342 0.681666 2.06658 1.07219 2.45711L5.61508 7L1.07219 11.5429C0.681666 11.9334 0.681666 12.5666 1.07219 12.9571C1.46271 13.3476 2.09588 13.3476 2.4864 12.9571L7.0293 8.41421L11.5722 12.9571C11.9627 13.3476 12.5959 13.3476 12.9864 12.9571C13.3769 12.5666 13.3769 11.9334 12.9864 11.5429L8.44351 7L12.9864 2.45711Z" fill="currentColor"/>

--- a/ui/src/partials/search-results.hbs
+++ b/ui/src/partials/search-results.hbs
@@ -9,7 +9,7 @@
       </li>
     </ul>
   </nav>
-  <div class="flex-1 max-w-[800px]">
+  <div class="flex-1 max-w-[800px] mx-auto">
     <div data-results-current-path class="hidden md:flex gap-2 mb-6 items-center">
       <h2 class="font-medium text-[24px]">[path]</h2>
       <span class="text-[10px] border rounded-full py-1 px-1.5">[numberOfHits]</span>


### PR DESCRIPTION
Implements Cmd+/ (Mac) or Ctrl+/ (Windows/Linux) keyboard shortcut to focus the search bar, with a visual indicator badge that shows the correct key combination for the user's platform. The badge automatically hides when typing or when the Clear button appears.

Also fixes several UX issues:
- Clear button now hidden by default to prevent flash on page load
- Theme applies immediately in head to eliminate flickering
- Search results container properly centered when empty

<img width="1437" height="183" alt="Screenshot 2026-05-08 at 12 49 34" src="https://github.com/user-attachments/assets/4941f42d-85de-4d7e-85ab-94d46c340344" />
<img width="1437" height="182" alt="Screenshot 2026-05-08 at 12 49 27" src="https://github.com/user-attachments/assets/756838a7-bf92-49c1-99ea-85ea78a24865" />

Bonus fix search result block if no results:

Before:
<img width="1445" height="448" alt="Screenshot 2026-05-08 at 13 06 06" src="https://github.com/user-attachments/assets/cc63591f-801f-4168-bf2f-b7dd6eca6122" />

After:
<img width="1454" height="474" alt="Screenshot 2026-05-08 at 13 06 16" src="https://github.com/user-attachments/assets/0e7ab936-4a71-4062-a276-876274fb2b3f" />


