### PR TITLE
Remove "Preview" label from Slack integration nav entry

### DIFF
--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -294,7 +294,7 @@
 *** xref:integration:webhooks-airtable.adoc[Webhooks With Airtable]
 ** Notifications and status
 *** xref:integration:notifications.adoc[Notifications overview]
-*** xref:integration:slack-integration.adoc[Slack integration - Preview]
+*** xref:integration:slack-integration.adoc[Slack integration]
 *** xref:getting-started:slack-orb-tutorial.adoc[Use the Slack orb to set up notifications]
 *** xref:integration:status-badges.adoc[Status Badges]
 


### PR DESCRIPTION
## Summary
- Drop the stale `- Preview` suffix from the Slack integration sidebar entry in `nav.adoc`. The page badge is now `Beta` (set in #10334), so the nav text no longer matches.

## Test plan
- [ ] Verify the sidebar under **Notifications and status** renders as "Slack integration" (no "- Preview").
- [ ] Confirm the link still resolves to the Slack integration page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)