### PR TITLE
CIAM-106: Update API docs to mention bearer authentication support

### DIFF
--- a/api-v1/index.html
+++ b/api-v1/index.html
@@ -2038,15 +2038,18 @@ Access to billing functions is only available from the CircleCI application.
 <aside class="notice">
 All API calls are made in the same way, by making standard HTTP calls, using JSON, a content-type, and your API token.
 </aside>
-<h2 id='get-authenticated'>Get Authenticated</h2><div class="highlight"><pre class="highlight sh tab-shell"><code>curl <span class="nt">-H</span> <span class="s2">"Circle-Token: &lt;circle-token&gt;"</span> <span class="s2">"https://circleci.com/api/..."</span>
+<h2 id='get-authenticated'>Get Authenticated</h2><div class="highlight"><pre class="highlight sh tab-shell"><code>curl <span class="nt">-H</span> <span class="s2">"Authorization: Bearer &lt;circle-token&gt;"</span> <span class="s2">"https://circleci.com/api/..."</span>
+</code></pre></div><div class="highlight"><pre class="highlight sh tab-shell"><code>curl <span class="nt">-H</span> <span class="s2">"Circle-Token: &lt;circle-token&gt;"</span> <span class="s2">"https://circleci.com/api/..."</span>
 </code></pre></div><div class="highlight"><pre class="highlight sh tab-shell"><code>curl <span class="nt">-u</span> &lt;circle-token&gt;: <span class="s2">"https://circleci.com/api/..."</span>
 </code></pre></div><div class="highlight"><pre class="highlight sh tab-shell"><code>curl <span class="s2">"https://circleci.com/api/v1.1/me?circle-token=&lt;circle-token&gt;"</span>
 </code></pre></div>
 <p>You can add the API token using your <a href="https://circleci.com/account/api">account dashboard</a>. We recommend using <strong>personal API tokens</strong> at this time because project API tokens are <strong>not</strong> supported for API v2. Project API tokens are supported for most API v1 endpoints. Notes are included below to indicate when a personal API token is required.</p>
 
-<p>To be authenticated by the API server, use this as the value of the Circle-Token header:</p>
+<p>To be authenticated by the API server, pass your API token in the <code>Authorization</code> header using Bearer Authentication (recommended):</p>
 
-<p>Or you can use the API token as the username for HTTP Basic Authentication, by passing the <code>-u</code> flag to the <code>curl</code> command:</p>
+<p>Or use the <code>Circle-Token</code> header:</p>
+
+<p>Or use the API token as the username for HTTP Basic Authentication, by passing the <code>-u</code> flag to the <code>curl</code> command:</p>
 
 <aside class="notice">
 the colon ":" tells curl that there's no password.

--- a/api-v1/index.html
+++ b/api-v1/index.html
@@ -2045,17 +2045,18 @@ All API calls are made in the same way, by making standard HTTP calls, using JSO
 </code></pre></div>
 <p>You can add the API token using your <a href="https://circleci.com/account/api">account dashboard</a>. We recommend using <strong>personal API tokens</strong> at this time because project API tokens are <strong>not</strong> supported for API v2. Project API tokens are supported for most API v1 endpoints. Notes are included below to indicate when a personal API token is required.</p>
 
-<p>To be authenticated by the API server, pass your API token in the <code>Authorization</code> header using Bearer Authentication (recommended):</p>
-
-<p>Or use the <code>Circle-Token</code> header:</p>
-
-<p>Or use the API token as the username for HTTP Basic Authentication, by passing the <code>-u</code> flag to the <code>curl</code> command:</p>
+<p>To be authenticated by the API server, pass your API token in the <code>Authorization</code> header using one of the following methods: </p>
+<ul>
+  <li><strong>Bearer Authentication</strong> (recommended).</li>
+  <li><strong>Circle-Token header</strong>.</li>
+  <li><strong>HTTP Basic Authentication</strong>, by passing the <code>-u</code> flag to the <code>curl</code> command.</li>
+</ul>
 
 <aside class="notice">
-the colon ":" tells curl that there's no password.
+The colon ":" as shown in the examples tells curl that there's no password.
+The API token can be added to the <code>circle-token</code> query param:
 </aside>
 
-<p>DEPRECATED (this option will be removed in the future): The API token can be added to the <code>circle-token</code> query param:</p>
 <h2 id='summary-of-api-endpoints'>Summary of API Endpoints</h2>
 <p>All CircleCI API endpoints begin with <code>https://circleci.com/api/v1.1/</code></p>
 <h3 id='get-requests'>GET Requests</h3>

--- a/api-v1/index.html
+++ b/api-v1/index.html
@@ -2045,16 +2045,16 @@ All API calls are made in the same way, by making standard HTTP calls, using JSO
 </code></pre></div>
 <p>You can add the API token using your <a href="https://circleci.com/account/api">account dashboard</a>. We recommend using <strong>personal API tokens</strong> at this time because project API tokens are <strong>not</strong> supported for API v2. Project API tokens are supported for most API v1 endpoints. Notes are included below to indicate when a personal API token is required.</p>
 
-<p>To be authenticated by the API server, pass your API token in the <code>Authorization</code> header using one of the following methods: </p>
+<p>To be authenticated by the API server, use one of the following methods: </p>
 <ul>
-  <li><strong>Bearer Authentication</strong> (recommended).</li>
-  <li><strong>Circle-Token header</strong>.</li>
-  <li><strong>HTTP Basic Authentication</strong>, by passing the <code>-u</code> flag to the <code>curl</code> command.</li>
+  <li><strong>Bearer Authentication</strong> (recommended). Pass the token in the <code>Authorization</code> header.</li>
+  <li><strong>Circle-Token header</strong>. Pass the token in the <code>Circle-Token</code> header.</li>
+  <li><strong>Basic Authentication</strong>. Use the API token as the username by passing the <code>-u</code> flag to the <code>curl</code> command.</li>
+  <li><strong>Query parameter</strong> (deprecated, will be removed in the future). Add the token as the <code>circle-token</code> query param.</li>
 </ul>
 
 <aside class="notice">
-The colon ":" as shown in the examples tells curl that there's no password.
-The API token can be added to the <code>circle-token</code> query param:
+For Basic Authentication, the colon ":" as shown in the example tells curl that there's no password.
 </aside>
 
 <h2 id='summary-of-api-endpoints'>Summary of API Endpoints</h2>

--- a/docs/guides/modules/toolkit/pages/api-developers-guide.adoc
+++ b/docs/guides/modules/toolkit/pages/api-developers-guide.adoc
@@ -32,7 +32,11 @@ NOTE: Currently, xref:managing-api-tokens.adoc#creating-a-personal-api-token[Per
 
 The CircleCI API utilizes token-based authentication to manage access to the API server and validate that a user has permission to make API requests. Before you can make an API request, you must first add an API token and then verify that you are authenticated by the API server to make requests. The process to add an API token and have the API server authenticate you is described in the next section.
 
-You can use the token in the request header with the name `Circle-Token`, as shown in the examples below. You may also use the API token as the username (Base64-encoded) with HTTP Basic Authentication.
+The following authentication methods are supported:
+
+* **Bearer Authentication** (recommended): industry-standard (RFC 6750) - pass the token as a Bearer token in the `Authorization` header.
+* **Circle-Token header**: CircleCI-specific header, widely used in existing integrations - pass the token in the `Circle-Token` header.
+* **Basic Authentication**: legacy option, not recommended for new integrations - use the token as the username (Base64-encoded).
 
 [#using-the-api-securely-wtih-curl]
 === Using the API securely with cURL
@@ -51,6 +55,11 @@ To add an API token, perform the steps listed below.
 [,shell]
 ----
 export CIRCLE_TOKEN={your_api_token}
+
+# using bearer authentication (recommended):
+curl https://circleci.com/api/v2/me --header "Authorization: Bearer $CIRCLE_TOKEN"
+
+# or, using Circle-Token header:
 curl https://circleci.com/api/v2/me --header "Circle-Token: $CIRCLE_TOKEN"
 ----
 

--- a/docs/guides/modules/toolkit/pages/api-developers-guide.adoc
+++ b/docs/guides/modules/toolkit/pages/api-developers-guide.adoc
@@ -34,9 +34,9 @@ The CircleCI API utilizes token-based authentication to manage access to the API
 
 The following authentication methods are supported:
 
-* **Bearer Authentication** (recommended): industry-standard (RFC 6750) - pass the token as a Bearer token in the `Authorization` header.
-* **Circle-Token header**: CircleCI-specific header, widely used in existing integrations - pass the token in the `Circle-Token` header.
-* **Basic Authentication**: legacy option, not recommended for new integrations - use the token as the username (Base64-encoded).
+* **Bearer Authentication** (recommended): Industry-standard (RFC 6750). Pass the token as a Bearer token in the `Authorization` header.
+* **Circle-Token header**: CircleCI-specific header, widely used in existing integrations. Pass the token in the `Circle-Token` header.
+* **Basic Authentication**: Legacy option, not recommended for new integrations. Use the token as the username (Base64-encoded).
 
 [#using-the-api-securely-wtih-curl]
 === Using the API securely with cURL


### PR DESCRIPTION
**Ticket:** https://linear.app/circleci/issue/CIAM-106

# Description
- Updated API dev guide to mention Bearer token support
- Updated v1 API docs to mention Bearer token support

# Reasons
This is a follow up to https://github.com/circleci/circle/pull/16449 and https://github.com/circleci/circle/pull/16459.

https://github.com/circleci/circle/pull/16449 is merged and tested. Our public endpoints now support Bearer token authentication. Updating this doc will ensure the reader will be aware of this new feature.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
