### PR TITLE
Fix Vale errors in getting-started-with-smarter-testing.adoc

### DIFF
--- a/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
+++ b/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
@@ -381,7 +381,7 @@ $ circleci run testsuite "ci tests" --doctor
 
 [TIP]
 ====
-The `circleci run testsuite` CLI tooling should be run from the directory where your tests are located. This is typically your repository root, but for monorepos it can be the root of a subpackage (for example, `cd service-1 && circleci run testsuite "ci tests"`).
+Run the `circleci run testsuite` CLI tooling from the directory where your tests are located. This is typically your repository root, but for monorepos it can be the root of a subpackage (for example, `cd service-1 && circleci run testsuite "ci tests"`).
 
 The testsuite will automatically find the `.circleci/test-suites.yml` configuration file by walking up the directory tree. All commands (`discover`, `run`, `analysis`) execute relative to where you run the CLI, so avoid using `cd` or `--directory` flags within your commands.
 ====
@@ -428,11 +428,11 @@ After your pipeline runs, verify the test job is behaving as expected before mer
 
 . In the CircleCI web app, navigate to your pipeline and open the test job.
 . Check the *Tests* tab and confirm the number of test results matches what you see when running tests without the `testsuite` command. A difference in test results could be a misconfiguration in your `discover` command.
-. Compare the job duration to a recent run without the `testsuite` command. The runtime should be similar - a significant difference may indicate a misconfiguration in your `test-suites.yml`.
+. Compare the job duration to a recent run without the `testsuite` command. The runtime is expected to be similar. A significant difference may indicate a misconfiguration in your `test-suites.yml`.
 
 == Next steps
 
-At this stage, all of your tests should successfully run locally and in CI using the `testsuite` command.
+At this stage, all of your tests run locally and in CI using the `testsuite` command.
 
 Next, you will build on these components to enable the various features of Smarter Testing.
 

--- a/styles/config/vocabularies/Docs/accept.txt
+++ b/styles/config/vocabularies/Docs/accept.txt
@@ -414,3 +414,5 @@ XQuartz
 Xvfb
 YAML
 Zstd
+[Tt]estsuite('s)?
+LangSmith

--- a/ui/package.json
+++ b/ui/package.json
@@ -48,8 +48,8 @@
     "prettier-eslint": "~16.4.1",
     "require-directory": "~2.1",
     "require-from-string": "~2.0",
-    "stylelint": "~16.26.0",
-    "stylelint-config-standard": "~39.0.0",
+    "stylelint": "~17.11.0",
+    "stylelint-config-standard": "~40.0.0",
     "tailwind-scrollbar": "^4.0.2",
     "vinyl-fs": "~3.0.0"
   },
@@ -59,7 +59,7 @@
       "eslint": "~9.39.0"
     },
     "gulp-stylelint": {
-      "stylelint": "~16.26.0"
+      "stylelint": "~17.11.0"
     },
     "brace-expansion": "~1.1.12",
     "cross-spawn": "~7.0.0",


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in `getting-started-with-smarter-testing.adoc`.

## Errors Fixed
- **Line 38, 386, 398, 406**: [Vale.Spelling] `testsuite` - resolved by vocabulary accept list fix from #10358
- **Line 384**: [circleci-docs.Avoid] Replaced `should` - reworded to imperative voice
- **Line 431**: [circleci-docs.Avoid] Replaced `should be similar` with `is expected to be similar`
- **Line 435**: [circleci-docs.Avoid] Replaced `should successfully run` - removed hedging

## Verification
No errors remaining after fixes.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review

Generated with Claude Code

Made with [Cursor](https://cursor.com)