### PR TITLE
Fix Algolia search returning no results for known content

### DIFF
--- a/extensions/export-content-extension.js
+++ b/extensions/export-content-extension.js
@@ -69,11 +69,13 @@ function collectPages(contentCatalog, siteUrl) {
         .filter(page => page.pub)
         .forEach(page => {
           const relUrl = page.pub.url; // e.g. '/path/to/page.html'
-          const html = `<article>${page.contents}</article>`;
+          const html = `<article>${page.contents}</article>`
+            .replace(/<\/(h[1-6]|p|div|li|blockquote|pre)>/gi, '</$1>\n\n')
           const text = parseHTML(html)
             .textContent.trim()
-            .replace(/<[^>]*>/g, '')  // Strip all HTML tags
-            .replace(/\s+/g, ' ');    // Normalize whitespace
+            .replace(/<[^>]*>/g, '')
+            .replace(/[ \t]+/g, ' ')
+            .replace(/\n{3,}/g, '\n\n')
           const pathSegments = [compVer.title];
           const nav = navMap[relUrl]?.path.map(item => item.content);
           if (nav) pathSegments.push(...nav);
@@ -220,7 +222,7 @@ async function indexToAlgolia(pages) {
       const maxContentSize = 9500 - metadataSize;
 
       // Trim content if necessary to ensure total record size is under limit
-      let content = chunk;
+      let content = chunk.replace(/\s+/g, ' ').trim()
       if (Buffer.byteLength(content, 'utf8') > maxContentSize) {
         content = content.slice(0, Math.floor(maxContentSize * 0.9));
       }

--- a/ui/src/js/07-search.js
+++ b/ui/src/js/07-search.js
@@ -291,10 +291,10 @@
         const titleElement = resultElement.querySelector('h3')
         const contentElement = resultElement.querySelector('p')
 
-        titleElement.innerHTML = hit._highlightResult.title.value
+        titleElement.innerHTML = hit._highlightResult?.title?.value ?? hit.title ?? ''
 
         // Cap content to approximately 2 lines (~200 characters)
-        const contentText = hit._highlightResult.content.value
+        const contentText = hit._highlightResult?.content?.value ?? hit.content ?? ''
         contentElement.innerHTML = contentText.length > 300
           ? contentText.substring(0, 200).replace(/\s+\S*$/, '') + '...'
           : contentText


### PR DESCRIPTION
## Summary

- **Silent TypeError fix**: Guards against missing `_highlightResult` fields in the search result renderer (`07-search.js`). When any Algolia hit lacked a `title` or `content` attribute, accessing `.value` on `undefined` threw a TypeError that cleared the results container without showing "No results found" — users saw a blank results area instead of the results that did exist.
- **Content chunking fix**: Preserves paragraph structure during indexing (`export-content-extension.js`). The previous code collapsed all whitespace (including `\n\n`) to single spaces *before* chunking, meaning `chunkText`'s paragraph-based splitting never worked. Pages with large code blocks or diagrams fell back to character-level splitting, which broke multi-word phrases across chunk boundaries. For example, searching "pipeline states" returned nothing because the heading was split mid-phrase by a Mermaid diagram block immediately below it. Fix: insert explicit `\n\n` after block-level HTML elements before text extraction, then normalise whitespace per chunk after splitting.

## Test plan

- [ ] Search for "pipeline states" on the live site after this merges and the index rebuilds — should return the pipelines overview page
- [ ] Search for a multi-word subheading on any page with a large code block below it — confirm results appear
- [ ] Confirm search still works normally for single-word queries and page titles
- [ ] Check browser console — no TypeErrors when search results load

🤖 Generated with [Claude Code](https://claude.com/claude-code)