### PR TITLE
docs(DR-481): document k8s release agent 1.6.0 dynamic managed namespaces

### DIFF
--- a/docs/guides/modules/ROOT/partials/troubleshoot/releases-troubleshoot.adoc
+++ b/docs/guides/modules/ROOT/partials/troubleshoot/releases-troubleshoot.adoc
@@ -16,7 +16,7 @@ spec:
   replicas: 2
 ----
 
-* Check that the Deployment/Rollout is in a namespace managed by the release agent. This can be verified by checking the `MANAGED_NAMESPACES` environment variable on the release agent deployment in the `circleci-release-agent-system` namespace. Here is an example in which only the default namespace is being managed:
+* Check that the Deployment/Rollout is in a namespace managed by the release agent. Verify this by checking the `MANAGED_NAMESPACES` and `MANAGED_NAMESPACES_MODE` environment variables on the release agent deployment in the `circleci-release-agent-system` namespace. `MANAGED_NAMESPACES_MODE` is `static` (default, exact names) or `dynamic` (glob patterns resolved at runtime). The following example shows the default namespace managed in static mode:
 +
 [,yml]
 ----
@@ -32,7 +32,11 @@ spec:
       - env:
         - name: MANAGED_NAMESPACES
           value: default
+        - name: MANAGED_NAMESPACES_MODE
+          value: static
 ----
++
+In dynamic mode, `MANAGED_NAMESPACES` may contain glob patterns such as `team-*`. If the deployment does not appear, verify that its namespace matches at least one configured pattern. Also verify the agent has `get`, `list`, and `watch` permissions on the `namespaces` cluster resource.
 
 [#why-stuck-in-running]
 === Why is my release stuck in the `Running` state?

--- a/docs/guides/modules/ROOT/partials/troubleshoot/releases-troubleshoot.adoc
+++ b/docs/guides/modules/ROOT/partials/troubleshoot/releases-troubleshoot.adoc
@@ -1,7 +1,7 @@
 [#deployment-not-showing-up]
 === Why is my Deployment/Rollout not showing up in the components tab or releases timeline view?
 
-* Check that the Deployment/Rollout is annotated with the required labels. More information is available in the xref:guides:deploy:configure-your-kubernetes-components.adoc[Set up guides]. If the required labels were not present, then adding them should solve the problem.
+* Check that the Deployment/Rollout is annotated with the required labels. More information is available in the xref:guides:deploy:configure-your-kubernetes-components.adoc[Set up Guides]. If the required labels are not present, adding them solves the problem.
 
 * If you are using a Deployment, check that the desired replicas is not set to `0`. Deployments with `0` replicas are not reported as releases, even if they are scaled up subsequently. The configured value can be seen on the release agent deployment in the `circleci-release-agent-system` namespace. Here is an example in which the number of desired replicas is 2:
 +
@@ -60,12 +60,12 @@ If the token has been last used longer than a minute ago, then this is likely to
 .. Compare the value with the partially obscured value for the available Tokens in the CircleCI web app.
 +
 If the token does **not** show up in the list, then it has been revoked or the value configured on the release agent is incorrect.
-In either case, creating a new token and reinstalling the Release Agent with the new value should solve the issue.
+In either case, creating a new token and reinstalling the Release Agent with the new value solves the issue.
 
 [#restore-version-time-out]
 === Why is `restore version` using Helm is timing out?
 
-The time required for a Helm-based _restore version_ to complete successfully is dependent on the specific configuration of the target component. For example, a large number of replicas will lead to a longer duration, which could cause a timeout. It is possible to specify a different timeout by adding the `circleci.com/operation-timeout` annotation to the Rollout or Deployment. The default value for this is 10 minutes. For steps, see the xref:guides:deploy:configure-your-kubernetes-components.adoc#operation-timeout[Configure your Kubernetes components] page.
+The time required for a Helm-based _restore version_ to complete successfully is dependent on the specific configuration of the target component. For example, a large number of replicas will lead to a longer duration, which could cause a timeout. It is possible to specify a different timeout by adding the `circleci.com/operation-timeout` annotation to the Rollout or Deployment. The default value for this is 10 minutes. For steps, see the xref:guides:deploy:configure-your-kubernetes-components.adoc#operation-timeout[Configure Your Kubernetes Components] page.
 
 [#restore-version-button-unavailable]
 === Why is the restore version button not available for a component version?

--- a/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
@@ -180,18 +180,18 @@ You will need a `CCI_INTEGRATION_TOKEN` to install the CircleCI release agent in
 . Select btn:[Create Integration Token] and then btn:[Create Token].
 . The new token will be displayed. Copy the token, then select btn:[Done].
 
-The token is shown only once and cannot be retrieved from CircleCI later. Store it in your organization's secret manager. Examples include HashiCorp Vault, AWS Secrets Manager, or a CircleCI context variable.
+*The integration token is shown only once and cannot be retrieved from CircleCI later*. Store the integration token in your organization's secret manager. Examples of secret managers include HashiCorp Vault, AWS Secrets Manager, or a CircleCI context variable.
 
-Pass the token to Helm at install or upgrade time. Use an environment variable (for example, `++--set tokenSecret.token="${CCI_INTEGRATION_TOKEN}"++`) or a values file that is not committed to source control.
+Pass the integration token to Helm at install or upgrade time. Use an environment variable (for example, `--set tokenSecret.token="${CCI_INTEGRATION_TOKEN}"`) or a values file that is not committed to source control.
 
-After installation, the chart stores the token in a Kubernetes Secret in the `circleci-release-agent-system` namespace. On subsequent `helm upgrade` runs, you do not need to supply the token again unless you use `--reset-values`. The same applies if you apply a values file that omits `tokenSecret.token` without `--reuse-values`.
+After installation, the Helm chart stores the integration token in a Kubernetes Secret in the `circleci-release-agent-system` namespace. On subsequent `helm upgrade` runs, you do not need to supply the integration token again unless you use `--reset-values`. The same applies if you apply a values file that omits `tokenSecret.token` without also setting `--reuse-values`.
 
 [#install-the-release-agent]
 === 3. Install the release agent
 
 Use the following command to install the Helm chart to integrate CircleCI's release agent into your Kubernetes cluster.
 
-If required, you can include a list of Kubernetes namespaces you want to monitor. If you only want to monitor the `default` namespace, you do not need to supply a list with `--set managedNamespaces="{namespace1,namespace2}"`. The `default` namespace is monitored by default. If you struggle to pass the `managedNamespaces` value, try enclosing the array value or the whole parameter itself in a string, with double or single quotes.
+If required, you can include a list of Kubernetes namespaces you want to monitor with `--set managedNamespaces="{namespace1,namespace2}"`. If you only want to monitor the `default` namespace, you do not need to supply a list. The `default` namespace is monitored by default. If you struggle to pass the `managedNamespaces` value, try enclosing the array value or the whole parameter itself in a string, with double or single quotes.
 
 [,shell]
 ----
@@ -260,6 +260,13 @@ NOTE: The `rbac.clusterRoles=true` flag also enables the RBAC permissions the ag
 ==== Upgrade from an earlier version
 
 If you are upgrading from a version earlier than 1.6.0, your existing configuration uses static mode by default. No action is required. The agent continues to monitor the exact namespace names already listed in `managedNamespaces`, and no new RBAC permissions are granted.
+
+To check your installed release agent version, run the following command and refer to the `CHART` and `APP VERSION` columns:
+
+[,shell]
+----
+helm list --namespace circleci-release-agent-system
+----
 
 To switch to dynamic mode after upgrading, re-run `helm upgrade` with `--set managedNamespacesMode=dynamic --set rbac.clusterRoles=true` and update `managedNamespaces` to use glob patterns where needed.
 

--- a/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
@@ -209,8 +209,8 @@ Once you have run this command, you can check your environment is set up by navi
 
 Release agent v1.6.0 and Helm chart v1.6.0 introduce a `managedNamespacesMode` Helm value. This setting (exposed as `MANAGED_NAMESPACES_MODE` on the agent deployment) controls how the agent determines which namespaces to monitor:
 
-* `static` (default) — the agent monitors the exact namespace names listed in `managedNamespaces`. This is the same behavior as prior versions and requires no additional RBAC permissions.
-* `dynamic` — the agent discovers namespaces at runtime by matching the patterns in `managedNamespaces` against all cluster namespaces. Use glob patterns such as `team-*` to monitor any namespace whose name matches the pattern.
+* `static` (default) -- the agent monitors the exact namespace names listed in `managedNamespaces`. This is the same behavior as prior versions and requires no additional RBAC permissions.
+* `dynamic` -- the agent discovers namespaces at runtime by matching the patterns in `managedNamespaces` against all cluster namespaces. Use glob patterns such as `team-*` to monitor any namespace whose name matches the pattern.
 
 [#static-mode]
 ==== Use static mode (default)

--- a/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
@@ -186,7 +186,7 @@ You will need a `CCI_INTEGRATION_TOKEN` to install the CircleCI release agent in
 
 Use the following command to install the Helm chart to integrate CircleCI's release agent into your Kubernetes cluster.
 
-If required, you can include a list of Kubernetes namespaces you want to monitor. If you only want to monitor the `default` namespace, you do not need to supply a list with `--set manageNamespaces="{namespace1,namespace2}"`. The `default` namespace is monitored by default. If you struggle to pass the `manageNamespaces` value, try enclosing the array value or the whole parameter itself in a string, with double or single quotes.
+If required, you can include a list of Kubernetes namespaces you want to monitor. If you only want to monitor the `default` namespace, you do not need to supply a list with `--set managedNamespaces="{namespace1,namespace2}"`. The `default` namespace is monitored by default. If you struggle to pass the `managedNamespaces` value, try enclosing the array value or the whole parameter itself in a string, with double or single quotes.
 
 [,shell]
 ----
@@ -203,6 +203,54 @@ Once you have run this command, you can check your environment is set up by navi
 . Select **Deploys** in the CircleCI web app sidebar.
 . Select the **Environments** tab.
 . Select the name of your environment integration to view the environment details page.
+
+[#managed-namespaces-mode]
+=== Configure managed namespaces mode
+
+Release agent v1.6.0 and Helm chart v1.6.0 introduce a `managedNamespacesMode` Helm value. This setting (exposed as `MANAGED_NAMESPACES_MODE` on the agent deployment) controls how the agent determines which namespaces to monitor:
+
+* `static` (default) — the agent monitors the exact namespace names listed in `managedNamespaces`. This is the same behavior as prior versions and requires no additional RBAC permissions.
+* `dynamic` — the agent discovers namespaces at runtime by matching the patterns in `managedNamespaces` against all cluster namespaces. Use glob patterns such as `team-*` to monitor any namespace whose name matches the pattern.
+
+[#static-mode]
+==== Use static mode (default)
+
+In static mode, `managedNamespaces` contains a list of exact namespace names. This mode requires no additional RBAC permissions beyond those granted in earlier chart versions.
+
+[source,shell]
+----
+helm upgrade --install circleci-release-agent-system release-agent/circleci-release-agent \
+  --set tokenSecret.token=[YOUR_CCI_INTEGRATION_TOKEN] --create-namespace \
+  --namespace circleci-release-agent-system \
+  --set managedNamespaces="{namespace1,namespace2}"
+----
+
+[#dynamic-mode]
+==== Use dynamic mode
+
+In dynamic mode, `managedNamespaces` accepts glob patterns. The agent queries the Kubernetes API at runtime to resolve which namespaces match each pattern.
+
+When installing or upgrading for dynamic mode, set `rbac.clusterRoles=true` (in addition to `rbac.create=true`). This enables the chart to create the required `ClusterRole` with `get`, `list`, and `watch` permissions on the `namespaces` resource.
+
+[source,shell]
+----
+helm upgrade --install circleci-release-agent-system release-agent/circleci-release-agent \
+  --set tokenSecret.token=[YOUR_CCI_INTEGRATION_TOKEN] --create-namespace \
+  --namespace circleci-release-agent-system \
+  --set managedNamespaces="{team-*,platform-*}" \
+  --set managedNamespacesMode=dynamic \
+  --set rbac.create=true \
+  --set rbac.clusterRoles=true
+----
+
+NOTE: The `rbac.clusterRoles=true` flag also enables the RBAC permissions the agent needs to watch workloads across all matching namespaces. Both flags are required for dynamic mode to function correctly.
+
+[#upgrade-path]
+==== Upgrade from an earlier version
+
+If you are upgrading from a version earlier than 1.6.0, your existing configuration uses static mode by default. No action is required — the agent continues to monitor the exact namespace names already listed in `managedNamespaces`, and no new RBAC permissions are granted.
+
+To switch to dynamic mode after upgrading, re-run `helm upgrade` with `--set managedNamespacesMode=dynamic --set rbac.clusterRoles=true` and update `managedNamespaces` to use glob patterns where needed.
 
 [#next-steps]
 == Next steps

--- a/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
@@ -178,8 +178,9 @@ You will need a `CCI_INTEGRATION_TOKEN` to install the CircleCI release agent in
 . Navigate to the **Environments** tab.
 . Select the gear icon icon:settings[Settings icon] corresponding to the environment you just created to enter the Environment Integration Settings page.
 . Select btn:[Create Integration Token] and then btn:[Create Token].
-. The new token will be displayed. Be sure to copy and save this somewhere for use in the next step. Then select btn:[Done].
+. The new token will be displayed. Copy the token, then select btn:[Done].
 
+The token is shown only once and cannot be retrieved from CircleCI later. Store it in your organization's secret manager (for example, HashiCorp Vault, AWS Secrets Manager, or a CircleCI context variable) and pass it to Helm at install or upgrade time using an environment variable (for example, `--set tokenSecret.token="${CCI_INTEGRATION_TOKEN}"`) or a values file that is not committed to source control. After installation, the chart stores the token in a Kubernetes Secret in the `circleci-release-agent-system` namespace. On subsequent `helm upgrade` runs, you do not need to supply the token again unless you use `--reset-values` or apply a values file that omits `tokenSecret.token` without `--reuse-values`.
 
 [#install-the-release-agent]
 === 3. Install the release agent

--- a/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
@@ -182,7 +182,7 @@ You will need a `CCI_INTEGRATION_TOKEN` to install the CircleCI release agent in
 
 *The integration token is shown only once and cannot be retrieved from CircleCI later*. Store the integration token in your organization's secret manager. Examples of secret managers include HashiCorp Vault, AWS Secrets Manager, or a CircleCI context variable.
 
-Pass the integration token to Helm at install or upgrade time. Use an environment variable (for example, `--set tokenSecret.token="${CCI_INTEGRATION_TOKEN}"`) or a values file that is not committed to source control.
+Pass the integration token to Helm at install or upgrade time. Use an environment variable (for example, `--set tokenSecret.token="$CCI_INTEGRATION_TOKEN"`) or a values file that is not committed to source control.
 
 After installation, the Helm chart stores the integration token in a Kubernetes Secret in the `circleci-release-agent-system` namespace. On subsequent `helm upgrade` runs, you do not need to supply the integration token again unless you use `--reset-values`. The same applies if you apply a values file that omits `tokenSecret.token` without also setting `--reuse-values`.
 

--- a/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
@@ -182,7 +182,7 @@ You will need a `CCI_INTEGRATION_TOKEN` to install the CircleCI release agent in
 
 The token is shown only once and cannot be retrieved from CircleCI later. Store it in your organization's secret manager. Examples include HashiCorp Vault, AWS Secrets Manager, or a CircleCI context variable.
 
-Pass the token to Helm at install or upgrade time. Use an environment variable (for example, `--set tokenSecret.token="${CCI_INTEGRATION_TOKEN}"`) or a values file that is not committed to source control.
+Pass the token to Helm at install or upgrade time. Use an environment variable (for example, `++--set tokenSecret.token="${CCI_INTEGRATION_TOKEN}"++`) or a values file that is not committed to source control.
 
 After installation, the chart stores the token in a Kubernetes Secret in the `circleci-release-agent-system` namespace. On subsequent `helm upgrade` runs, you do not need to supply the token again unless you use `--reset-values`. The same applies if you apply a values file that omits `tokenSecret.token` without `--reuse-values`.
 

--- a/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
@@ -207,15 +207,19 @@ Once you have run this command, you can check your environment is set up by navi
 [#managed-namespaces-mode]
 === Configure managed namespaces mode
 
-Release agent v1.6.0 and Helm chart v1.6.0 introduce a `managedNamespacesMode` Helm value. This setting (exposed as `MANAGED_NAMESPACES_MODE` on the agent deployment) controls how the agent determines which namespaces to monitor:
+NOTE: Release agent v1.6.0 and Helm chart v1.6.0 or higher are required to use managed namespaces mode.
 
-* `static` (default) -- the agent monitors the exact namespace names listed in `managedNamespaces`. This is the same behavior as prior versions and requires no additional RBAC permissions.
-* `dynamic` -- the agent discovers namespaces at runtime by matching the patterns in `managedNamespaces` against all cluster namespaces. Use glob patterns such as `team-*` to monitor any namespace whose name matches the pattern.
+Release agent v1.6.0 and Helm chart v1.6.0 introduce a `managedNamespacesMode` Helm value. This setting (exposed as `MANAGED_NAMESPACES_MODE` on the agent deployment) controls how the agent determines which namespaces to monitor. Managed namespaces mode has two options as follows:
+
+* `static` (default): The agent monitors the exact namespace names listed in `managedNamespaces`. This is the same behavior as prior versions and requires no additional RBAC permissions.
+* `dynamic`: The agent discovers namespaces at runtime by matching the patterns in `managedNamespaces` against all cluster namespaces. Use glob patterns such as `team-*` to monitor any namespace whose name matches the pattern.
 
 [#static-mode]
 ==== Use static mode (default)
 
 In static mode, `managedNamespaces` contains a list of exact namespace names. This mode requires no additional RBAC permissions beyond those granted in earlier chart versions.
+
+To upgrade and use `static` mode, run the following command:
 
 [source,shell]
 ----
@@ -230,7 +234,9 @@ helm upgrade --install circleci-release-agent-system release-agent/circleci-rele
 
 In dynamic mode, `managedNamespaces` accepts glob patterns. The agent queries the Kubernetes API at runtime to resolve which namespaces match each pattern.
 
-When installing or upgrading for dynamic mode, set `rbac.clusterRoles=true` (in addition to `rbac.create=true`). This enables the chart to create the required `ClusterRole` with `get`, `list`, and `watch` permissions on the `namespaces` resource.
+When installing or upgrading for dynamic mode, set `rbac.clusterRoles=true`, in addition to `rbac.create=true`. This enables the chart to create the required `ClusterRole` with `get`, `list`, and `watch` permissions on the `namespaces` resource.
+
+To upgrade and use `dynamic` mode, run the following command:
 
 [source,shell]
 ----
@@ -248,7 +254,7 @@ NOTE: The `rbac.clusterRoles=true` flag also enables the RBAC permissions the ag
 [#upgrade-path]
 ==== Upgrade from an earlier version
 
-If you are upgrading from a version earlier than 1.6.0, your existing configuration uses static mode by default. No action is required — the agent continues to monitor the exact namespace names already listed in `managedNamespaces`, and no new RBAC permissions are granted.
+If you are upgrading from a version earlier than 1.6.0, your existing configuration uses static mode by default. No action is required. The agent continues to monitor the exact namespace names already listed in `managedNamespaces`, and no new RBAC permissions are granted.
 
 To switch to dynamic mode after upgrading, re-run `helm upgrade` with `--set managedNamespacesMode=dynamic --set rbac.clusterRoles=true` and update `managedNamespaces` to use glob patterns where needed.
 

--- a/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-the-circleci-release-agent.adoc
@@ -180,7 +180,11 @@ You will need a `CCI_INTEGRATION_TOKEN` to install the CircleCI release agent in
 . Select btn:[Create Integration Token] and then btn:[Create Token].
 . The new token will be displayed. Copy the token, then select btn:[Done].
 
-The token is shown only once and cannot be retrieved from CircleCI later. Store it in your organization's secret manager (for example, HashiCorp Vault, AWS Secrets Manager, or a CircleCI context variable) and pass it to Helm at install or upgrade time using an environment variable (for example, `--set tokenSecret.token="${CCI_INTEGRATION_TOKEN}"`) or a values file that is not committed to source control. After installation, the chart stores the token in a Kubernetes Secret in the `circleci-release-agent-system` namespace. On subsequent `helm upgrade` runs, you do not need to supply the token again unless you use `--reset-values` or apply a values file that omits `tokenSecret.token` without `--reuse-values`.
+The token is shown only once and cannot be retrieved from CircleCI later. Store it in your organization's secret manager. Examples include HashiCorp Vault, AWS Secrets Manager, or a CircleCI context variable.
+
+Pass the token to Helm at install or upgrade time. Use an environment variable (for example, `--set tokenSecret.token="${CCI_INTEGRATION_TOKEN}"`) or a values file that is not committed to source control.
+
+After installation, the chart stores the token in a Kubernetes Secret in the `circleci-release-agent-system` namespace. On subsequent `helm upgrade` runs, you do not need to supply the token again unless you use `--reset-values`. The same applies if you apply a values file that omits `tokenSecret.token` without `--reuse-values`.
 
 [#install-the-release-agent]
 === 3. Install the release agent

--- a/docs/guides/modules/deploy/pages/update-the-kubernetes-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/update-the-kubernetes-release-agent.adoc
@@ -12,11 +12,11 @@ Refer to the link:https://circleci.com/changelog/[CircleCI Changelog] to find ou
 
 To update the Kubernetes release agent you need an operational CircleCI environment integrated with your Kubernetes cluster. Refer to the following pages for steps:
 
-* xref:set-up-the-circleci-release-agent.adoc[Set up the CircleCI release agent]
-* xref:configure-your-kubernetes-components.adoc[Configure your Kubernetes components]
+* xref:set-up-the-circleci-release-agent.adoc[Set up the CircleCI Release Agent]
+* xref:configure-your-kubernetes-components.adoc[Configure Your Kubernetes Components]
 
 ****
-If you were using the release agent prior to version `1.2.0` you were using `app` and `version` in place of `circleci.com/component-name` and `circleci.com/version`. While `app` and `version` are still supported, we recommend migrating to the new labels as soon as possible.
+If you used the release agent prior to version `1.2.0`, you used `app` and `version` in place of `circleci.com/component-name` and `circleci.com/version`. While `app` and `version` are still supported, we recommend migrating to the new labels as soon as possible.
 
 Support for the old labels will be dropped in one of the next releases.
 
@@ -27,7 +27,7 @@ After migrating to the new labels, rolling back to versions that used the old la
 ====
 *Upgrading to v1.6.0:* Release agent v1.6.0 and Helm chart v1.6.0 introduce `managedNamespacesMode` (`static` or `dynamic`). The default is `static`, which preserves the existing behavior — the agent monitors the exact namespace names in `managedNamespaces` with no change to RBAC permissions. No action is required when upgrading if you want to keep the existing static behavior.
 
-To opt in to dynamic mode (glob-pattern namespace discovery), re-run `helm upgrade` with `--set managedNamespacesMode=dynamic --set rbac.clusterRoles=true` after upgrading. See the xref:set-up-the-circleci-release-agent.adoc#managed-namespaces-mode[Managed namespaces mode] section for details.
+To opt in to dynamic mode (glob-pattern namespace discovery), re-run `helm upgrade` with `--set managedNamespacesMode=dynamic --set rbac.clusterRoles=true` after upgrading. See the xref:set-up-the-circleci-release-agent.adoc#managed-namespaces-mode[Managed Namespaces Mode] section for details.
 ====
 
 [#update-steps]

--- a/docs/guides/modules/deploy/pages/update-the-kubernetes-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/update-the-kubernetes-release-agent.adoc
@@ -23,6 +23,13 @@ Support for the old labels will be dropped in one of the next releases.
 After migrating to the new labels, rolling back to versions that used the old labels will be supported only for deployments and Rollouts managed through Helm.
 ****
 
+[NOTE]
+====
+*Upgrading to v1.6.0:* Release agent v1.6.0 and Helm chart v1.6.0 introduce `managedNamespacesMode` (`static` or `dynamic`). The default is `static`, which preserves the existing behavior — the agent monitors the exact namespace names in `managedNamespaces` with no change to RBAC permissions. No action is required when upgrading if you want to keep the existing static behavior.
+
+To opt in to dynamic mode (glob-pattern namespace discovery), re-run `helm upgrade` with `--set managedNamespacesMode=dynamic --set rbac.clusterRoles=true` after upgrading. See the xref:set-up-the-circleci-release-agent.adoc#managed-namespaces-mode[Managed namespaces mode] section for details.
+====
+
 [#update-steps]
 == Update steps
 

--- a/docs/guides/modules/deploy/pages/update-the-kubernetes-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/update-the-kubernetes-release-agent.adoc
@@ -51,3 +51,5 @@ helm upgrade --install circleci-release-agent-system release-agent/circleci-rele
 --namespace circleci-release-agent-system \
 --set managedNamespaces="{namespace1,namespace2}"
 ----
++
+If the agent was installed with the integration token stored in the Helm release, you can omit `--set tokenSecret.token` on upgrade. Use `--reuse-values` when applying a values file that does not include the token. Do not use `--reset-values` unless you also supply the token again. See xref:set-up-the-circleci-release-agent.adoc[Set up the CircleCI Release Agent] for details on storing and managing integration tokens.

--- a/docs/guides/modules/deploy/pages/update-the-kubernetes-release-agent.adoc
+++ b/docs/guides/modules/deploy/pages/update-the-kubernetes-release-agent.adoc
@@ -25,7 +25,10 @@ After migrating to the new labels, rolling back to versions that used the old la
 
 [NOTE]
 ====
-*Upgrading to v1.6.0:* Release agent v1.6.0 and Helm chart v1.6.0 introduce `managedNamespacesMode` (`static` or `dynamic`). The default is `static`, which preserves the existing behavior — the agent monitors the exact namespace names in `managedNamespaces` with no change to RBAC permissions. No action is required when upgrading if you want to keep the existing static behavior.
+*Upgrading to v1.6.0:* Release agent v1.6.0 and Helm chart v1.6.0 introduce `managedNamespacesMode` (`static` or `dynamic`). The default is `static`, which preserves the existing behavior.
+
+The release agent monitors the exact namespace names in `managedNamespaces` with no change to RBAC permissions.
+No action is required when upgrading if you want to keep the existing static behavior.
 
 To opt in to dynamic mode (glob-pattern namespace discovery), re-run `helm upgrade` with `--set managedNamespacesMode=dynamic --set rbac.clusterRoles=true` after upgrading. See the xref:set-up-the-circleci-release-agent.adoc#managed-namespaces-mode[Managed Namespaces Mode] section for details.
 ====


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Documents the `managedNamespacesMode` / `MANAGED_NAMESPACES_MODE` feature shipped in k8s-release-agent v1.6.0 and circleci-release-agent Helm chart v1.6.0 (DR-481 / DR-429).

Changes across three files:

**`set-up-the-circleci-release-agent.adoc`**
- Adds a new "Configure managed namespaces mode" section under the manual install steps
- Explains `managedNamespacesMode` (`static` default vs `dynamic`) and the corresponding `MANAGED_NAMESPACES_MODE` agent env var
- Documents `managedNamespaces` as exact names in static mode and glob patterns (e.g. `team-*`) in dynamic mode
- Documents RBAC requirements: dynamic mode needs `rbac.create=true` + `rbac.clusterRoles=true`; the chart creates a Namespace discovery `ClusterRole` (`get`/`list`/`watch` on `namespaces`) only in that case
- Adds a Helm install example for dynamic mode
- Adds an upgrade-path note: existing static installs are unaffected and require no new RBAC permissions
- Fixes a typo in existing prose: `manageNamespaces` → `managedNamespaces`

**`update-the-kubernetes-release-agent.adoc`**
- Adds a v1.6.0 callout explaining the new `managedNamespacesMode` option, the default static behavior, and how to opt in to dynamic mode

**`releases-troubleshoot.adoc`** (partial)
- Updates the "namespace not managed" troubleshooting bullet to mention both `MANAGED_NAMESPACES` and `MANAGED_NAMESPACES_MODE`
- Adds static/dynamic mode YAML example and RBAC troubleshooting guidance for dynamic mode

# Reasons

k8s-release-agent v1.6.0 ships glob-based namespace discovery (`dynamic` mode). Customers installing from the public chart read circleci-docs for guidance; the docs need to align with the Helm chart README and agent behavior so users know how to enable dynamic mode and what RBAC is required.

# Content checks

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DR-481](https://linear.app/circleci/issue/DR-481/circleci-docs-document-k8s-release-agent-160-dynamic-managed)

<div><a href="https://cursor.com/agents/bc-318ffecd-ea40-4a7b-bc7b-8b370043623c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-318ffecd-ea40-4a7b-bc7b-8b370043623c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

