### PR TITLE
Fix Vale errors in delete-organizations-and-projects.adoc

### DIFF
--- a/docs/guides/modules/security/pages/delete-organizations-and-projects.adoc
+++ b/docs/guides/modules/security/pages/delete-organizations-and-projects.adoc
@@ -5,7 +5,7 @@
 
 This page details everything you need to know about deleting organizations and projects connected to CircleCI.
 
-If you only want to stop builds for a project and keep the complete build history, see the xref:security:stop-building-a-project-on-circleci.adoc[Stop building a project on CircleCI] page.
+If you only want to stop builds for a project and keep the complete build history, see the xref:security:stop-building-a-project-on-circleci.adoc[Stop Building a Project on CircleCI] page.
 
 [.table-scroll]
 --
@@ -69,7 +69,7 @@ CircleCI web app::
 API::
 +
 --
-. Set up your API authentication. Steps are available in the xref:toolkit:api-developers-guide.adoc#add-an-api-token[API developers guide].
+. Set up your API authentication. Steps are available in the xref:toolkit:api-developers-guide.adoc#add-an-api-token[API Developers Guide].
 . You can use the link:https://circleci.com/docs/api/v2/#tag/Organization/operation/deleteOrganization[Delete an organization] endpoint with either your organization ID or your organization slug. You can retrieve both from the CircleCI web app under menu:Organization Settings[Overview].
 +
 [,shell]
@@ -104,7 +104,7 @@ include::guides:ROOT:partial$app-navigation/steps-to-project-settings.adoc[]
 API::
 +
 --
-. Set up your API authentication. Steps are available in the xref:toolkit:api-developers-guide.adoc#add-an-api-token[API developers guide].
+. Set up your API authentication. Steps are available in the xref:toolkit:api-developers-guide.adoc#add-an-api-token[API Developers Guide].
 . You need the project slug to use the link:https://circleci.com/docs/api/v2/#tag/Project/operation/deleteProjectBySlug[Delete a project] endpoint. You can retrieve the project slug from the CircleCI web app under menu:Project Settings[Overview].
 +
 [,shell]


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in `delete-organizations-and-projects.adoc`.

## Errors Fixed
- **Line 8**: XrefTitleCase - Updated xref link text to title case: "Stop Building a Project on CircleCI"
- **Line 72**: XrefTitleCase - Updated xref link text to title case: "API Developers Guide"
- **Line 107**: XrefTitleCase - Updated xref link text to title case: "API Developers Guide"

## Verification
Ran Vale after fixes — no errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Made with [Cursor](https://cursor.com)