### PR TITLE
Replace byte-chunking with section-based Algolia indexing

### DIFF
--- a/extensions/export-content-extension.js
+++ b/extensions/export-content-extension.js
@@ -5,7 +5,9 @@ const path = require('path');
 const { algoliasearch } = require('algoliasearch');
 
 /**
- * An Antora extension that exports page content to JSON and indexes it in Algolia v5 with chunking support.
+ * An Antora extension that exports page content to JSON and indexes it in Algolia.
+ * One record per section (h2/h3/h4 heading), with the section heading stored as a
+ * dedicated field and the section anchor included in the record URL.
  */
 module.exports.register = function () {
   this.once('navigationBuilt', async ({ playbook, contentCatalog }) => {
@@ -18,8 +20,8 @@ module.exports.register = function () {
     console.log(`Wrote JSON to ${outPath}`);
 
     if (shouldSkipIndexing()) {
-        console.log('Skipping Algolia indexing (requested by configuration)');
-        return;
+      console.log('Skipping Algolia indexing (requested by configuration)');
+      return;
     }
 
     if (!hasIndexed(tempDir) && hasAlgoliaCredentials()) {
@@ -37,12 +39,11 @@ module.exports.register = function () {
 };
 
 /**
- * Collect pages from contentCatalog and extract text, including component, version, and relative URL
+ * Collect all sections across all pages, one entry per h2/h3/h4 section.
  */
 function collectPages(contentCatalog, siteUrl) {
   const all = [];
 
-  // Define which server-admin versions to exclude from indexing
   const excludedServerAdminVersions = [
     'server-4.2',
     'server-4.3',
@@ -56,10 +57,9 @@ function collectPages(contentCatalog, siteUrl) {
 
   contentCatalog.getComponents().forEach(({ name: comp, versions }) => {
     versions.forEach(({ version }) => {
-      // Skip indexing for excluded server-admin versions
       if (comp === 'server-admin' && excludedServerAdminVersions.includes(version)) {
         console.log(`Skipping Algolia indexing for server-admin version: ${version}`);
-        return; // Skip this entire component version
+        return;
       }
 
       const compVer = contentCatalog.getComponentVersion(comp, version);
@@ -68,36 +68,72 @@ function collectPages(contentCatalog, siteUrl) {
         .findBy({ component: comp, version, family: 'page' })
         .filter(page => page.pub)
         .forEach(page => {
-          const relUrl = page.pub.url; // e.g. '/path/to/page.html'
-          const html = `<article>${page.contents}</article>`
-            .replace(/<\/(h[1-6]|p|div|li|blockquote|pre)>/gi, '</$1>\n\n')
-          const text = parseHTML(html)
-            .textContent.trim()
-            .replace(/<[^>]*>/g, '')
-            .replace(/[ \t]+/g, ' ')
-            .replace(/\n{3,}/g, '\n\n')
+          const relUrl = page.pub.url;
           const pathSegments = [compVer.title];
           const nav = navMap[relUrl]?.path.map(item => item.content);
           if (nav) pathSegments.push(...nav);
-          all.push({
-            component: comp,
-            componentTitle: compVer.title,
-            version,
-            relUrl,
-            url: siteUrl + relUrl,
-            title: page.title,
-            text,
-            path: pathSegments,
+
+          const sections = extractSections(page.contents.toString(), page.title || '', relUrl);
+          sections.forEach(section => {
+            all.push({
+              component: comp,
+              componentTitle: compVer.title,
+              version,
+              relUrl: section.relUrl,
+              url: siteUrl + section.relUrl,
+              title: page.title || '',
+              heading: section.heading,
+              content: section.content,
+              path: pathSegments,
+            });
           });
         });
     });
   });
-  console.log(`Collected ${all.length} pages`);
+  console.log(`Collected ${all.length} sections across all pages`);
   return all;
 }
 
 /**
- * Recursively map navigation entries by URL
+ * Split a page's HTML into sections at h2/h3/h4 boundaries.
+ * Returns one record per section with heading text, body content, and anchor URL.
+ * AsciiDoc with idprefix="" and idseparator="-" generates IDs like "pipeline-states".
+ */
+function extractSections(html, pageTitle, pageRelUrl) {
+  const parts = html.split(/(?=<h[2-4][\s>])/i);
+  const sections = [];
+
+  parts.forEach((part, index) => {
+    if (!part.trim()) return;
+
+    const parsed = parseHTML(`<div>${part}</div>`);
+    const headingEl = parsed.querySelector('h2, h3, h4');
+
+    const heading = headingEl
+      ? headingEl.textContent.trim()
+      : (index === 0 ? pageTitle : '');
+
+    const anchor = headingEl?.getAttribute('id') || '';
+    const relUrl = anchor ? `${pageRelUrl}#${anchor}` : pageRelUrl;
+    const content = parsed.textContent.trim().replace(/\s+/g, ' ');
+
+    if (!content) return;
+    sections.push({ heading, content, relUrl });
+  });
+
+  // Fallback for pages with no h2/h3/h4 structure
+  if (sections.length === 0) {
+    const content = parseHTML(`<article>${html}</article>`)
+      .textContent.trim()
+      .replace(/\s+/g, ' ');
+    sections.push({ heading: pageTitle, content, relUrl: pageRelUrl });
+  }
+
+  return sections;
+}
+
+/**
+ * Recursively map navigation entries by URL.
  */
 function getNavEntriesByUrl(items = [], accum = {}, trail = []) {
   items.forEach(item => {
@@ -111,9 +147,8 @@ function getNavEntriesByUrl(items = [], accum = {}, trail = []) {
 
 function shouldSkipIndexing() {
   if (process.env.CI === 'true') {
-      return process.env.CIRCLE_BRANCH !== 'main';
+    return process.env.CIRCLE_BRANCH !== 'main';
   }
-
   const val = (process.env.SKIP_INDEX_SEARCH || '').toLowerCase();
   return ['1', 'true'].includes(val);
 }
@@ -130,65 +165,8 @@ function hasAlgoliaCredentials() {
 }
 
 /**
- * Chunk pages into smaller records to meet Algolia's 10KB limit.
- */
-function chunkText(text, maxBytes = 8500) {  // Reduced from 10000 to have margin for metadata
-  const chunks = [];
-  let current = '';
-
-  text.split(/\n\n/).forEach(paragraph => {
-    const para = paragraph + '\n\n';
-    const combined = current + para;
-    const size = Buffer.byteLength(combined, 'utf8');
-
-    if (size > maxBytes) {
-      if (current) chunks.push(current.trim());
-
-      if (Buffer.byteLength(para, 'utf8') > maxBytes) {
-        // Paragraph too big: split by sentences
-        let sentenceBuf = '';
-        paragraph.split(/(?<=\.)\s/).forEach(sentence => {
-          const combinedSentence = sentenceBuf + sentence + ' ';
-          const sentSize = Buffer.byteLength(combinedSentence, 'utf8');
-
-          if (sentSize > maxBytes) {
-            if (sentenceBuf) chunks.push(sentenceBuf.trim());
-
-            if (Buffer.byteLength(sentence, 'utf8') > maxBytes) {
-              // Sentence too big: split by characters
-              let charBuf = '';
-              for (const char of sentence) {
-                charBuf += char;
-                if (Buffer.byteLength(charBuf, 'utf8') >= maxBytes) {
-                  chunks.push(charBuf.trim());
-                  charBuf = '';
-                }
-              }
-              if (charBuf) chunks.push(charBuf.trim());
-            } else {
-              sentenceBuf = sentence + ' ';
-            }
-          } else {
-            sentenceBuf = combinedSentence;
-          }
-        });
-
-        if (sentenceBuf) chunks.push(sentenceBuf.trim());
-        current = '';
-      } else {
-        current = para;
-      }
-    } else {
-      current = combined;
-    }
-  });
-
-  if (current) chunks.push(current.trim());
-  return chunks;
-}
-
-/**
- * Index to Algolia v5 using chunked records with component:version:pagePath-based objectIDs
+ * Index section records to Algolia. One record per section, no chunking.
+ * Oversized sections (large code blocks) are truncated rather than split.
  */
 async function indexToAlgolia(pages) {
   const appId = process.env.ALGOLIA_APP_ID;
@@ -200,61 +178,46 @@ async function indexToAlgolia(pages) {
   const records = [];
 
   pages.forEach((p) => {
-    const pathId = p.relUrl.replace(/^\/+/, '').replace(/[\/]/g, '_');
-    const baseId = `${p.component}:${p.version}:${pathId}`;
-    const chunks = chunkText(p.text);
+    const objectID = p.relUrl.replace(/^\/+/, '').replace(/[^a-zA-Z0-9-]/g, '_');
 
-    chunks.forEach((chunk, i) => {
-      // Create the record with all fields except content
-      const record = {
-        url: p.url,
-        relUrl: p.relUrl,
-        title: p.title,
-        path: p.path,
-        component: `${p.componentTitle}:${p.version}`,
-        version: p.version,
-        objectID: `${baseId}:${i}`,
-      };
+    const record = {
+      url: p.url,
+      relUrl: p.relUrl,
+      title: p.title,
+      heading: p.heading,
+      path: p.path,
+      component: `${p.componentTitle}:${p.version}`,
+      version: p.version,
+      objectID,
+    };
 
-      // Calculate metadata size
-      const metadataSize = Buffer.byteLength(JSON.stringify(record), 'utf8');
-      // Maximum allowed content size
-      const maxContentSize = 9500 - metadataSize;
+    const metadataSize = Buffer.byteLength(JSON.stringify(record), 'utf8');
+    const maxContentSize = 9500 - metadataSize;
 
-      // Trim content if necessary to ensure total record size is under limit
-      let content = chunk.replace(/\s+/g, ' ').trim()
-      if (Buffer.byteLength(content, 'utf8') > maxContentSize) {
-        content = content.slice(0, Math.floor(maxContentSize * 0.9));
-      }
+    let content = p.content;
+    if (Buffer.byteLength(content, 'utf8') > maxContentSize) {
+      content = content.slice(0, Math.floor(maxContentSize * 0.9));
+    }
 
-      record.content = content;
-      records.push(record);
-    });
+    record.content = content;
+    records.push(record);
   });
 
-  console.log(`Prepared ${records.length} chunked records for indexing`);
+  console.log(`Prepared ${records.length} section records for indexing`);
 
-
-  // Configure index settings with path faceting
   try {
     const settingsResponse = await client.setSettings({
       indexName,
       indexSettings: {
-        // Enable faceting on path for hierarchical navigation
-        attributesForFaceting: ['path', 'searchable(path)', 'component', 'searchable(component)', 'version', 'searchable(version)'],
-        // Optional: Adjust search settings for better relevance
-        searchableAttributes: ['title', 'content', 'path'],
-        // Set a reasonable pagination limit
+        attributesForFaceting: ['component', 'searchable(component)', 'version', 'searchable(version)'],
+        searchableAttributes: ['title', 'heading', 'content', 'path'],
         paginationLimitedTo: 1000,
       },
     });
 
     console.log(`Applied index settings, task ID: ${settingsResponse.taskID}`);
-
-    // Wait for task completion
     await waitForTask(client, indexName, settingsResponse.taskID);
     console.log('Index settings update completed successfully');
-
   } catch (err) {
     console.error('Error configuring index settings:', err);
   }
@@ -268,25 +231,14 @@ async function indexToAlgolia(pages) {
   return response;
 }
 
-/**
- * Wait for an Algolia task to complete
- * @param {Object} client - Algolia client
- * @param {String} indexName - Index name
- * @param {Number} taskID - Task ID to check
- * @param {Number} timeout - Maximum time to wait in ms (default: 60000)
- * @param {Number} pollInterval - How often to check status in ms (default: 1000)
- */
 async function waitForTask(client, indexName, taskID, timeout = 60000, pollInterval = 1000) {
   const startTime = Date.now();
 
   while (Date.now() - startTime < timeout) {
     const taskResponse = await client.getTask({ indexName, taskID });
-
     if (taskResponse.status === 'published') {
       return taskResponse;
     }
-
-    // Wait before checking again
     await new Promise(resolve => setTimeout(resolve, pollInterval));
   }
 

--- a/extensions/export-content-extension.js
+++ b/extensions/export-content-extension.js
@@ -108,6 +108,7 @@ function extractSections(html, pageTitle, pageRelUrl) {
 
     const parsed = parseHTML(`<div>${part}</div>`);
     const headingEl = parsed.querySelector('h2, h3, h4');
+    headingEl?.querySelector('.subsection-badge')?.remove();
 
     const heading = headingEl
       ? headingEl.textContent.trim()

--- a/extensions/export-content-extension.js
+++ b/extensions/export-content-extension.js
@@ -116,7 +116,11 @@ function extractSections(html, pageTitle, pageRelUrl) {
 
     const anchor = headingEl?.getAttribute('id') || '';
     const relUrl = anchor ? `${pageRelUrl}#${anchor}` : pageRelUrl;
-    const content = parsed.textContent.trim().replace(/\s+/g, ' ');
+    // Remove the heading node first — textContent inserts no separator where a
+    // tag is stripped, so heading text would otherwise fuse to the first body word.
+    headingEl?.remove();
+    const body = parsed.textContent.trim();
+    const content = `${heading} ${body}`.trim().replace(/\s+/g, ' ');
 
     if (!content) return;
     sections.push({ heading, content, relUrl });

--- a/ui/src/js/07-search.js
+++ b/ui/src/js/07-search.js
@@ -116,7 +116,7 @@
       const results = await searchIndex.search(searchQuery, {
         hitsPerPage: 10,
         page: paginationData?.page || 0,
-        attributesToRetrieve: ['title', 'url', 'relUrl', 'path', 'content', 'component', 'version'],
+        attributesToRetrieve: ['title', 'heading', 'url', 'relUrl', 'path', 'content', 'component', 'version'],
         highlightPreTag: '<strong class="font-bold">',
         highlightPostTag: '</strong>',
         facets: ['component'],
@@ -291,7 +291,11 @@
         const titleElement = resultElement.querySelector('h3')
         const contentElement = resultElement.querySelector('p')
 
-        titleElement.innerHTML = hit._highlightResult?.title?.value ?? hit.title ?? ''
+        const pageTitle = hit._highlightResult?.title?.value ?? hit.title ?? ''
+        const sectionHeading = hit._highlightResult?.heading?.value ?? hit.heading ?? ''
+        titleElement.innerHTML = (sectionHeading && sectionHeading !== pageTitle)
+          ? `${pageTitle} <span class="font-normal opacity-50">/ ${sectionHeading}</span>`
+          : pageTitle
 
         // Cap content to approximately 2 lines (~200 characters)
         const contentText = hit._highlightResult?.content?.value ?? hit.content ?? ''


### PR DESCRIPTION
## Summary

- **Root cause of poor search**: The previous indexing split pages at arbitrary byte boundaries (~8,500 bytes), producing ~520 large records with no awareness of document structure. Chunk boundaries fell mid-phrase (e.g. splitting "Pipeline states" across two records), and huge records diluted Algolia relevance scores so the right section ranked below unrelated pages.
- **New approach**: One Algolia record per `h2`/`h3`/`h4` section. The section heading is stored in a dedicated `heading` field with higher search priority than body content. The section anchor (`#pipeline-states`) is included in the record URL so clicking a result links directly to the right section on the page.
- **Expected record count**: ~5,000–15,000 (from ~520), average size ~1KB (from ~5.5KB) — matching what the old Algolia crawler produced.
- **Search results display**: Shows `Page title / Section heading` so users can see both which page and which section matched.

## Changes

**`extensions/export-content-extension.js`**
- Replace `collectPages` + `chunkText` with section-based extraction using `extractSections`
- `extractSections` splits page HTML at `h2`/`h3`/`h4` boundaries, extracts heading text and `id` attribute (anchor) per section
- `indexToAlgolia` simplified: one record per section, no chunking loop
- `searchableAttributes` updated to `[title, heading, content, path]` — section heading matches rank above body text

**`ui/src/js/07-search.js`**
- Add `heading` to `attributesToRetrieve`
- Result title displays as `Page title / Section heading` when a section heading exists

## Test plan

- [ ] Run a local build with `SKIP_INDEX_SEARCH=true` and inspect `.temp/site-content.json` — records should have `heading` field and `relUrl` values with `#` anchors
- [ ] After merge and CI index rebuild: search "pipeline states" — should return the Pipeline states section of the pipelines overview page as a top result
- [ ] Verify search result displays as `Pipelines overview and setup / Pipeline states`
- [ ] Verify clicking the result lands on the `#pipeline-states` anchor
- [ ] Check Algolia dashboard record count is substantially higher than 520

🤖 Generated with [Claude Code](https://claude.com/claude-code)