### PR TITLE
Fix Vale errors in ip-ranges.adoc

### DIFF
--- a/docs/guides/modules/security/pages/ip-ranges.adoc
+++ b/docs/guides/modules/security/pages/ip-ranges.adoc
@@ -57,7 +57,7 @@ workflows:
 [#example-configuration-pipeline-parameters]
 === Example configuration file using IP ranges with pipeline parameters
 
-Use conditional logic to control when IP ranges is enabled with pipeline parameters. You can set the pipeline parameter `ip_ranges` to `true` to enable IP ranges for the `build` job. For more information on triggering pipelines with pipeline parameters, see the xref:orchestrate:triggers-overview.adoc[Trigger a pipeline] page.
+Use conditional logic to control when IP ranges is enabled with pipeline parameters. You can set the pipeline parameter `ip_ranges` to `true` to enable IP ranges for the `build` job. For more information on triggering pipelines with pipeline parameters, see the xref:orchestrate:triggers-overview.adoc[Trigger a Pipeline] page.
 
 [,yaml]
 ----
@@ -137,16 +137,18 @@ Enabling IP ranges consumes 450 credits from your account for each GB of data us
 
 IP ranges usage is visible in the *Plan Usage* section of the CircleCI app:
 
+.IP ranges feature in Plan Usage
 image::guides:ROOT:ip-ranges.png[Screenshot showing the location of the IP ranges feature]
 
 On the *Resources* tab within the *Job Details* UI page, you can view approximations of network transfer for any Docker job, even those without the IP ranges feature enabled. This approximation can be used to predict the cost of enabling the IP ranges feature on a job without having to turn the feature on. You can also view whether or not the job has IP ranges enabled by viewing the IP Ranges badge.
 
+.Approximate network transfer on the Resources tab
 image::guides:ROOT:resources-network-transfer.png[Screenshot showing the approximate network transfer]
 
 [#known-limitations]
 == Known limitations
 
-* IP ranges is currently available for the xref:reference:ROOT:configuration-reference.adoc#docker[Docker executor], not including `remote_docker`. Jobs that attempt to use the IP ranges feature with a xref:reference:ROOT:configuration-reference.adoc#machine[Machine executor], or with `setup_remote_docker`, will fail with an error. See this link:https://discuss.circleci.com/t/fyi-jobs-that-use-the-ip-ranges-feature-and-remote-docker-will-begin-to-fast-fail-this-week/44639[Discuss post] for details.
+* IP ranges is currently available for the xref:reference:ROOT:configuration-reference.adoc#docker[Docker Executor], not including `remote_docker`. Jobs that attempt to use the IP ranges feature with a xref:reference:ROOT:configuration-reference.adoc#machine[Machine Executor], or with `setup_remote_docker`, will fail with an error. See this link:https://discuss.circleci.com/t/fyi-jobs-that-use-the-ip-ranges-feature-and-remote-docker-will-begin-to-fast-fail-this-week/44639[Discuss post] for details.
 
 == IP ranges for core CircleCI services
 
@@ -155,7 +157,7 @@ This section covers the IP ranges used by CircleCI core services. Core service I
 [#list-of-ip-address-ranges-for-core-services]
 === List of IP address ranges for core CircleCI services
 
-The following list shows the IP address ranges for core CircleCI cloud services (used to trigger jobs, exchange information about users between CircleCI and GitHub/GitLab/Bitbucket):
+The following list shows the IP address ranges for core CircleCI Cloud services (used to trigger jobs, exchange information about users between CircleCI and GitHub/GitLab/Bitbucket):
 
 * 18.214.70.5
 * 52.20.166.242


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in `ip-ranges.adoc`.

## Errors Fixed
- **Line 60**: XrefTitleCase - Updated xref link text: "Trigger a Pipeline"
- **Line 140**: ImageTitles - Added title before IP ranges screenshot
- **Line 144**: ImageTitles - Added title before network transfer screenshot
- **Line 149**: XrefTitleCase - Updated xref link text: "Docker Executor", "Machine Executor"
- **Line 160**: Vale.Terms - Changed "CircleCI cloud" to "CircleCI Cloud"

## Verification
Ran Vale after fixes — no errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Made with [Cursor](https://cursor.com)