### PR TITLE
[ONP-3233] Fix WFC retention setting name in server 4.10 data retention

### DIFF
--- a/docs/server-admin-4.10/modules/operator/pages/data-retention.adoc
+++ b/docs/server-admin-4.10/modules/operator/pages/data-retention.adoc
@@ -30,14 +30,14 @@ lein repl :connect host.docker.internal:16000
 +
 [source,clojure]
 ----
-(circle.http.api.admin-commands/get-setting :wfc-workflow-deletion-retention-period)
+(circle.http.api.admin-commands/get-setting :wfc-workflow-expired-delete-after-days)
 ----
 
-. The retention period can be set as needed (the example below sets it to 90 days):
+. The retention period can be set as needed (the default is 660 days; the example below sets it to 90 days):
 +
 [source,clojure]
 ----
-(circle.http.api.admin-commands/set-setting :wfc-workflow-deletion-retention-period 90)
+(circle.http.api.admin-commands/set-setting :wfc-workflow-expired-delete-after-days 90)
 ----
 
 . The deletion interval can be verified by running:


### PR DESCRIPTION
The WFC workflow-deletion retention setting was renamed in Server 4.10 from wfc-workflow-deletion-retention-period to wfc-workflow-expired-delete-after-days, with no backward-compat alias. The documented REPL command therefore set a key WFC never reads, leaving deletion on the 660-day default. Update the get/set commands to the current key and note the default.
