### PR TITLE
[ONP-3233] Note WFC retention key change in server 4.10 upgrade

### DIFF
--- a/docs/server-admin-4.10/modules/installation/pages/upgrade-server.adoc
+++ b/docs/server-admin-4.10/modules/installation/pages/upgrade-server.adoc
@@ -55,4 +55,6 @@ helm upgrade circleci-server oci://cciserver.azurecr.io/circleci-server -n $name
 
 . Deploy and run link:https://github.com/circleci/realitycheck[`reality check`] in your test environment to ensure your installation is fully operational.
 
+. If you have configured a custom workflow data retention period, re-apply it after upgrading. In server 4.10 the setting key changed from `:wfc-workflow-deletion-retention-period` to `:wfc-workflow-expired-delete-after-days`, and the existing value is *not* migrated automatically. If you leave the new key unset, workflow retention reverts to the default of 660 days. See the xref:operator:data-retention.adoc#setting-postgres-retention[Data Retention in Server] guide for the steps to set the new key.
+
 . Migrate any existing machine runner instances from the launch agent to the machine runner 3.0 agent, see the xref:guides:execution-runner:migrate-from-launch-agent-to-machine-runner-3-on-linux.adoc#[Migration Guide]. The launch agent is not supported.


### PR DESCRIPTION
The workflow retention setting key changed from `:wfc-workflow-deletion-retention-period` to `:wfc-workflow-expired-delete-after-days` in 4.10 (see #10413) but the value is not migrated. Add an upgrade step to re-apply a custom value.