### PR TITLE
NOT-859 change from pipelines to project setup

### DIFF
--- a/docs/guides/modules/integration/pages/enable-checks.adoc
+++ b/docs/guides/modules/integration/pages/enable-checks.adoc
@@ -53,7 +53,7 @@ If you are using GitHub Checks or GitHub status updates with the xref:orchestrat
 +
 .CircleCI VCS Settings Page
 image::guides:ROOT:github-checks.png[CircleCI VCS Settings Page]
-. You are now in the GitHub CircleCI Checks App settings page. Select the repositories that should use checks and select *Save*.
+. You are now in the GitHub CircleCI Checks App settings page. Select the repositories that you want to use checks and select *Save*.
 
 After installation completes, the Checks tab on the GitHub PR view is populated with workflow status information. From the Checks tab you can rerun workflows or navigate to the CircleCI app to view further information.
 

--- a/docs/guides/modules/integration/pages/enable-checks.adoc
+++ b/docs/guides/modules/integration/pages/enable-checks.adoc
@@ -26,7 +26,7 @@ GitHub Checks are different than GitHub status updates:
 
 * *GitHub Checks* are administered from the GitHub UI, and are reported in the GitHub UI per _workflow_.
 ** GitHub Checks from OAuth integrations have the same name as the associated workflow.
-** GitHub Checks from GitHub App integrations are named using a combination of the workflow name and the first eight characters of the pipeline definition ID. The identifier is used to prevent naming collisions. The pipeline definition ID is available in the *Project Settings* > *Project Setup* page in the CircleCI web app.
+** GitHub Checks from GitHub App integrations are named using a combination of the workflow name and the first eight characters of the pipeline definition ID. The identifier is used to prevent naming collisions. The pipeline definition ID is available in the menu:Project Settings[Project Setup] page in the CircleCI web app.
 ** Each workflow in a pipeline generates a GitHub Check. If multiple pipelines trigger for the same commit SHA with workflows that share the same name, only one GitHub Check appears for that workflow name. Use unique workflow names across pipelines to get distinct GitHub Checks.
 * GitHub *status updates* are the default way status updates from your builds are reported in your VCS UI. Status updates are reported per _job_. For more information on status updates, see the xref:status-updates.adoc[Status Updates Overview] guide.
 
@@ -53,7 +53,7 @@ If you are using GitHub Checks or GitHub status updates with the xref:orchestrat
 +
 .CircleCI VCS Settings Page
 image::guides:ROOT:github-checks.png[CircleCI VCS Settings Page]
-. You are now in the GitHub CircleCI Checks App settings page. Select the repositories that you want to use checks and select *Save*.
+. You are now in the GitHub CircleCI Checks App settings page. Select the repositories that you want to use Checks and select *Save*.
 
 After installation completes, the Checks tab on the GitHub PR view is populated with workflow status information. From the Checks tab you can rerun workflows or navigate to the CircleCI app to view further information.
 

--- a/docs/guides/modules/integration/pages/enable-checks.adoc
+++ b/docs/guides/modules/integration/pages/enable-checks.adoc
@@ -26,7 +26,7 @@ GitHub Checks should not be confused with GitHub status updates:
 
 * *GitHub Checks* are administered from the GitHub UI, and are reported in the GitHub UI per _workflow_.
 ** GitHub Checks from OAuth integrations have the same name as the associated workflow.
-** GitHub Checks from GitHub App integrations are named using a combination of the workflow name and the first eight characters of the pipeline definition ID. The identifier is used to prevent naming collisions. The pipeline definition ID is available in the *Project Settings* > *Pipelines* page in the CircleCI web app.
+** GitHub Checks from GitHub App integrations are named using a combination of the workflow name and the first eight characters of the pipeline definition ID. The identifier is used to prevent naming collisions. The pipeline definition ID is available in the *Project Settings* > *Project Setup* page in the CircleCI web app.
 ** Each workflow in a pipeline generates a GitHub Check. If multiple pipelines trigger for the same commit SHA with workflows that share the same name, only one GitHub Check appears for that workflow name. Use unique workflow names across pipelines to get distinct GitHub Checks.
 * GitHub *status updates* are the default way status updates from your builds are reported in your VCS UI. Status updates are reported per _job_. For more information on status updates, see the xref:status-updates.adoc[Status Updates Overview] guide.
 

--- a/docs/guides/modules/integration/pages/enable-checks.adoc
+++ b/docs/guides/modules/integration/pages/enable-checks.adoc
@@ -22,7 +22,7 @@ NOTE: GitHub does not currently provide a granular way for you to rerun workflow
 [#github-check-and-github-status-updates]
 == GitHub Check and GitHub status updates
 
-GitHub Checks should not be confused with GitHub status updates:
+GitHub Checks are different than GitHub status updates:
 
 * *GitHub Checks* are administered from the GitHub UI, and are reported in the GitHub UI per _workflow_.
 ** GitHub Checks from OAuth integrations have the same name as the associated workflow.


### PR DESCRIPTION
# Description
The pipelines page doesn't exist under Project settings. This updates it to Project Setup which is the correct location for pipeline definition

# Reasons
incorrect info

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
