### PR TITLE
Fix Vale errors in deploy-ios-applications.adoc

### DIFF
--- a/docs/guides/modules/deploy/pages/deploy-ios-applications.adoc
+++ b/docs/guides/modules/deploy/pages/deploy-ios-applications.adoc
@@ -39,9 +39,9 @@ increment_build_number(
 [#circleci-config-for-fastlane-integration]
 == CircleCI configuration for Fastlane integration
 
-All the examples on this page use Fastlane to configure deployment. For each example the following example `.circleci/config.yml` configuration can be used to integrate your Fastlane setup with CircleCI. The example config should be edited to fit the needs of your project:
+All the examples on this page use Fastlane to configure deployment. For each example the following example `.circleci/config.yml` configuration can be used to integrate your Fastlane setup with CircleCI. Edit the example config to fit the needs of your project:
 
-NOTE: The environment variable `FL_OUTPUT_DIR` is the artifact directory where Fastlane logs, and a signed `.ipa` file should be stored. Use this to set the path in the `store_artifacts` step to automatically save logs and build artifacts from Fastlane.
+NOTE: The environment variable `FL_OUTPUT_DIR` is the artifact directory where Fastlane logs and a signed `.ipa` file are stored. Use this to set the path in the `store_artifacts` step to automatically save logs and build artifacts from Fastlane.
 
 [,yaml]
 ----


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in \`deploy-ios-applications.adoc\`.

## Errors Fixed
- **Line 42**: \`circleci-docs.Avoid\` - Replaced 'should be edited' with active imperative 'Edit'
- **Line 44**: \`circleci-docs.Avoid\` - Replaced 'should be stored' with 'are stored'

## Verification
Ran Vale after fixes — 0 errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review
- Changes preserve existing AsciiDoc structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)