### PR TITLE
Fix Vale errors in deploy-to-firebase.adoc

### DIFF
--- a/docs/guides/modules/deploy/pages/deploy-to-firebase.adoc
+++ b/docs/guides/modules/deploy/pages/deploy-to-firebase.adoc
@@ -93,7 +93,7 @@ workflows:
 [#google-cloud-functions]
 == Google Cloud Functions
 
-If you are using Cloud Functions with Firebase, you should do the following:
+If you are using Cloud Functions with Firebase, do the following:
 
 * Instruct CircleCI to navigate to the folder where the Cloud Functions are held (in this case 'functions') and run `npm install`.
 * Add the following to your `.circleci/config.yml` file:


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in \`deploy-to-firebase.adoc\`.

## Errors Fixed
- **Line 96**: \`circleci-docs.Avoid\` - Replaced 'you should do' with direct imperative 'do'

## Verification
Ran Vale after fixes — 0 errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review
- Changes preserve existing AsciiDoc structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)