### PR TITLE
Fix Vale errors in ecs-ecr.adoc

### DIFF
--- a/docs/guides/modules/deploy/pages/ecs-ecr.adoc
+++ b/docs/guides/modules/deploy/pages/ecs-ecr.adoc
@@ -68,7 +68,7 @@ In the CircleCI application, set the following xref:security:set-environment-var
 | Required for deployment. https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#FindingYourAWSId[Find your AWS Account ID].
 
 | AWS_RESOURCE_NAME_PREFIX
-| Prefix for some required AWS resources. Should correspond to the value of `aws_resource_prefix` in `terraform_setup/terraform.tfvars`.
+| Prefix for some required AWS resources. Must correspond to the value of `aws_resource_prefix` in `terraform_setup/terraform.tfvars`.
 
 | AWS_ECR_REGISTRY_ID
 | The 12 digit AWS id associated with the ECR account.


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in `ecs-ecr.adoc`.

## Errors Fixed
- **Line 71**: `circleci-docs.Avoid` - Replaced 'Should correspond' with 'Must correspond'

## Verification
Ran Vale after fixes — 0 errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review
- Changes preserve existing AsciiDoc structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)