### PR TITLE
Typos - Plans Pricing Section

### DIFF
--- a/docs/guides/modules/ROOT/partials/faq/billing-faq-snip.adoc
+++ b/docs/guides/modules/ROOT/partials/faq/billing-faq-snip.adoc
@@ -27,7 +27,7 @@ You can choose to pay for premium features per active user, compute, and optiona
 [#run-out-of-credits]
 === What happens when I run out of credits?
 
-On the *Performance Plan*, when you reach 0 credits, you will be refilled approximately 25% of your credit subscription, with a minimum refill of 25,000 credits. For example, if your monthly package size is 100,000 credits, you will automatically be refilled 25,000 credits when you reach 0 remaining credits. Credits are priced at $.0006 each, not including applicable taxes.
+On the *Performance Plan*, when you reach 0 credits, you will be refilled approximately 25% of your credit subscription, with a minimum refill of 25,000 credits. For example, if your monthly package size is 100,000 credits, you will automatically be refilled 25,000 credits when you reach 0 remaining credits. Credits are priced at $0.0006 each, not including applicable taxes.
 
 If you notice that your account is receiving repeated refills, review your credit usage by logging in to the CircleCI web app, then select menu:Plan[Plan Usage]. In most cases, increasing your credit package should minimize repeat refills. You can manage your plan by clicking `Plan Overview`.
 
@@ -83,7 +83,7 @@ On the *Performance Plan*, at the beginning of your billing cycle, you will be c
 [#what-is-prepaid-billing]
 === What is prepaid billing?
 
-Prepaid billing is a payment option for customers on the Performance Plan. Prepaid Billing allows you to purchase credits in bulk, pay upfront, and be able to get discounted prices for credits based on volume purchased.
+Prepaid billing is a payment option for customers on the Performance Plan. Prepaid billing allows you to purchase credits in bulk, pay upfront, and be able to get discounted prices for credits based on volume purchased.
 
 [#how-can-i-get-on-prepaid-billing]
 === How can I get on prepaid billing?
@@ -95,7 +95,7 @@ All Performance Plan customers can choose to get on prepaid billing through the 
 . Select to **Set up and switch** to get started switching to prepaid billing.
 
 [#i-still-have-credits-from-my-monthly-subscription]
-=== I still have credits from my Monthly subscription, what happens if I get on prepaid billing now?
+=== I still have credits from my monthly subscription, what happens if I get on prepaid billing now?
 
 You will still have access to any balance credits that were previously purchased, and the 12 month expiry date will remain.
 
@@ -119,7 +119,7 @@ Upon selecting prepaid billing, your credit card will be charged immediately. Su
 
 You can follow these steps:
 
-. Select **Plan* in the web app.
+. Select **Plan** in the web app.
 . Select the **Manage** tab.
 . Select the pencil icon in the **Credits** section to edit your auto refill rate.
 
@@ -145,19 +145,19 @@ You pay to the next nearest credit. First we round up to the nearest second, and
 [#calculate-monthly-storage-and-network-costs]
 === How do I calculate my monthly storage and network costs?
 
-Calculate your monthly storage and network costs by finding your storage and network usage on the link:https://app.circleci.com/[CircleCI web app] by navigating to menu:Plan[Plan] Usage.
+Calculate your monthly storage and network costs by finding your storage and network usage on the link:https://app.circleci.com/[CircleCI web app] by navigating to menu:Plan[Plan Usage].
 
 [#storage]
 ==== Storage
 
-To calculate monthly storage costs from your daily usage, select the *Storage* tab to see if your organization has accrued any overages beyond the GB-monthly allotment. Your overage (GB-Months/TB-Months) can be multiplied by 420 credits to estimate the total monthly costs. Example: 2 GB-Months overage x 420 credits = 840 credits ($.50).
+To calculate monthly storage costs from your daily usage, select the *Storage* tab to see if your organization has accrued any overages beyond the GB-monthly allotment. Your overage (GB-Months/TB-Months) can be multiplied by 420 credits to estimate the total monthly costs. Example: 2 GB-Months overage x 420 credits = 840 credits ($0.50).
 
 [#network]
 ==== Network
 
 Billing for network usage is only applicable to traffic from CircleCI to self-hosted runners. Read more on the xref:guides:optimize:persist-data.adoc#overview-of-network-and-storage-transfer[Persisting Data] page.
 
-Your network overage GB/TB can be multiplied by 420 credits to estimate the total monthly costs. Example: 2 GB-Months overage x 420 credits = 840 credits ($.50).
+Your network overage GB/TB can be multiplied by 420 credits to estimate the total monthly costs. Example: 2 GB-Months overage x 420 credits = 840 credits ($0.50).
 
 [#calculate-monthly-IP-ranges-costs]
 === How do I calculate my monthly IP ranges cost?
@@ -215,7 +215,7 @@ The first credit card charge on the day you upgrade to a paid plan or change pai
 [#credit-plans-for-open-source-projects]
 === Are there credit plans for open source projects?
 
-Open source organizations on our *Free Plan* receive 400,000 free credits per month that can be spent on Linux open source projects.  Open-source credit availability and limits will not be visible in the UI.
+Open source organizations on our *Free Plan* receive 400,000 free credits per month that can be spent on Linux open source projects. Open source credit availability and limits will not be visible in the UI.
 
 If you build on macOS, we also offer organizations on our Free Plan 25,000 free credits per month to use on macOS open source builds. To find out more, visit the CircleCI link:https://support.circleci.com/hc/en-us[support portal], which includes an Ask AI option to get you the information you need. Free credits for macOS open source builds can be used on a maximum of 2 concurrent jobs per organization.
 

--- a/docs/guides/modules/ROOT/partials/shared-sections/features-of-circleci.adoc
+++ b/docs/guides/modules/ROOT/partials/shared-sections/features-of-circleci.adoc
@@ -26,7 +26,7 @@ For more information about Docker Layer Caching, refer to the xref:guides:optimi
 ifndef::server[]
 === Deploys
 
-Visualise and control your deployments with CircleCI deploys. Deployments to Kubernetes are supported.
+Visualize and control your deployments with CircleCI deploys. Deployments to Kubernetes are supported.
 
 Start with the xref:guides:deploy:deployment-overview.adoc[Deploys overview] for more information.
 endif::server[]

--- a/docs/guides/modules/plans-pricing/pages/credits.adoc
+++ b/docs/guides/modules/plans-pricing/pages/credits.adoc
@@ -14,7 +14,7 @@ The right plan for you and your team will depend on several factors:
 
 - How many users are on your team
 - How much support you need (community and free support, standard support, or premium support)
-- If you want access to different machine-types and resource classes
+- If you want access to different machine types and resource classes
 - If you want a limited or unlimited number of self-hosted runners
 
 You can view the xref:plan-overview.adoc[Plan Overview] page for more information, or if you would like more details on what features are available per plan, view the individual plan pages:
@@ -41,16 +41,16 @@ Organizations on our Free Plan can use up to 400,000 credits per month, for free
 If you build on macOS, we also offer organizations on our Free Plan 30,000 credits every month to use on macOS open source builds. To find out more, visit the CircleCI link:https://support.circleci.com/hc/en-us[support portal], which includes an Ask AI option to get you the information you need.
 
 [#troubleshooting-job-is-queued]
-== Troubleshooting: Do I get  charged if my job is "queued" or "preparing"?
+== Troubleshooting: Do I get charged if my job is "queued" or "preparing"?
 
 No. If you are notified that a job is "queued", it indicates that your job is waiting due to a **plan** or **concurrency** limit. If your job indicates that it is "preparing", it means that CircleCI is setting up or _dispatching_ your job so that it may run.
 
-If your jobs use the Docker executor and you find that they are "preparing" for quite some time. You may be able to reduce the delay by using more recent Docker images. See xref:execution-managed:building-docker-images.adoc[Building Docker Images] for more information.
+If your jobs use the Docker executor and you find that they are "preparing" for quite some time, you may be able to reduce the delay by using more recent Docker images. See xref:execution-managed:building-docker-images.adoc[Building Docker Images] for more information.
 
 [#questions-and-comments]
-## Questions and comments
+== Questions and comments
 
-Consider reading the section below on <<#billing-faqs,billing>>. For any further questions, do not hesitate to open a link:https://support.circleci.com/hc/en-us/requests/new[open a support ticket].
+Consider reading the section below on <<#billing-faqs,billing>>. For any further questions, do not hesitate to link:https://support.circleci.com/hc/en-us/requests/new[open a support ticket].
 
 [#billing-faqs]
 == FAQs

--- a/docs/guides/modules/plans-pricing/pages/manage-budgets.adoc
+++ b/docs/guides/modules/plans-pricing/pages/manage-budgets.adoc
@@ -67,7 +67,7 @@ The following steps show you how to set up budget controls for your organization
 . Navigate to *Plan* in the CircleCI web app sidebar and select the *Credit Usage* tab.
 . Scroll down to the *Credit Budget* section.
 . Locate the budget you want to edit (organization or project).
-. Select the corresponding budget edit icon icon:edit-solid[Edit icon]
+. Select the corresponding budget edit icon icon:edit-solid[Edit icon].
 . Update the credit budget limit in the text field.
 . Select btn:[Save].
 

--- a/docs/guides/modules/plans-pricing/pages/manage-budgets.adoc
+++ b/docs/guides/modules/plans-pricing/pages/manage-budgets.adoc
@@ -11,11 +11,11 @@ Budget controls help you manage and monitor your CircleCI credit usage by settin
 
 Budget controls allow you to:
 
-* **Set weekly budget limits** for your entire organization or individual projects.
-* **Track credit consumption** in real-time as a percentage of your budget.
-* **Receive automated notifications** when you approach or reach budget thresholds.
+* *Set weekly budget limits* for your entire organization or individual projects.
+* *Track credit consumption* in real-time as a percentage of your budget.
+* *Receive automated notifications* when you approach or reach budget thresholds.
 
-Budgets run on weekly cycles from Monday 00:00 UTC through Sunday 23:59:59 UTC and reset automatically each week.
+Budgets run on weekly cycles from Monday 00:00:00 UTC through Sunday 23:59:59 UTC and reset automatically each week.
 
 == What counts towards budgets?
 
@@ -23,16 +23,16 @@ NOTE: User seat charges are excluded from budget limits, as these are fixed orga
 
 Your budget limits track credits consumed across:
 
-* **Compute usage** for all execution environments (Docker, machine, macOS, Windows, GPU, Arm).
-* **Docker Layer Caching (DLC)** usage.
-* **Storage costs** for artifact and workspace storage.
-* **IP ranges** usage, to restrict traffic to specific IP ranges.
-* **Network usage**, data transfer costs.
-* **AI agents** usage.
+* *Compute usage* for all execution environments (Docker, machine, macOS, Windows, GPU, Arm).
+* *Docker Layer Caching (DLC)* usage.
+* *Storage costs* for artifact and workspace storage.
+* *IP ranges* usage, to restrict traffic to specific IP ranges.
+* *Network usage*, data transfer costs.
+* *AI agents* usage.
 
 == Prerequisites
 
-To use Budget Controls, you need:
+To use budget controls, you need:
 
 * A CircleCI Scale Plan.
 * Organization administrator permissions to create, edit, or delete budgets.
@@ -44,7 +44,7 @@ The following steps show you how to set up budget controls for your organization
 
 === Create an organization budget
 
-. In the link:https://app.circleci.com[CircleCI web app] select your organization.
+. In the link:https://app.circleci.com[CircleCI web app], select your organization.
 . Navigate to *Plan* in the CircleCI web app sidebar and select the *Credit Usage* tab.
 . Scroll down to the *Credit Budget* section.
 . Select btn:[Add organization budget] to open the add organization budget modal.
@@ -53,7 +53,7 @@ The following steps show you how to set up budget controls for your organization
 
 === Create a project budget
 
-. In the link:https://app.circleci.com[CircleCI web app] select your organization.
+. In the link:https://app.circleci.com[CircleCI web app], select your organization.
 . Navigate to *Plan* in the CircleCI web app sidebar and select the *Credit Usage* tab.
 . Scroll down to the *Credit Budget* section.
 . Select btn:[Add project budget] to open the add project budget modal.
@@ -63,7 +63,7 @@ The following steps show you how to set up budget controls for your organization
 
 === Edit a budget
 
-. In the link:https://app.circleci.com[CircleCI web app] select your organization.
+. In the link:https://app.circleci.com[CircleCI web app], select your organization.
 . Navigate to *Plan* in the CircleCI web app sidebar and select the *Credit Usage* tab.
 . Scroll down to the *Credit Budget* section.
 . Locate the budget you want to edit (organization or project).
@@ -73,10 +73,10 @@ The following steps show you how to set up budget controls for your organization
 
 === Delete a budget
 
-. In the link:https://app.circleci.com[CircleCI web app] select your organization.
+. In the link:https://app.circleci.com[CircleCI web app], select your organization.
 . Navigate to *Plan* in the CircleCI web app sidebar and select the *Credit Usage* tab.
 . Scroll down to the *Credit Budget* section.
-. Locate the budget you want to edit (organization or project).
+. Locate the budget you want to delete (organization or project).
 . Select the corresponding budget trash bin icon icon:delete[Trash bin icon].
 . Confirm the deletion by selecting btn:[Delete budget].
 

--- a/docs/guides/modules/plans-pricing/pages/plan-overview.adoc
+++ b/docs/guides/modules/plans-pricing/pages/plan-overview.adoc
@@ -13,15 +13,15 @@ The right plan for you and your team will depend on several factors:
 
 - How many users are on your team
 - How much link:https://support.circleci.com/hc/en-us/articles/4415357235995-Support-Plans-Priority-Response-Timings[support] you need (community and free support, standard support, or premium support)
-- If you want access to different machine-types and resource classes
+- If you want access to different machine types and resource classes
 - If you want a limited or unlimited number of self-hosted runners
 
-Let us look at how a team might use credits. In this example, your team is divided into several groups working on different projects. Some projects are larger while others are smaller and need less resources from a CI/CD configuration. With credits, it is possible to specify exactly where and when you need to maximize machine resources.
+Let's look at how a team might use credits. In this example, your team is divided into several groups working on different projects. Some projects are larger while others are smaller and need fewer resources from a CI/CD configuration. With credits, it is possible to specify exactly where and when you need to maximize machine resources.
 
 For example, your team might:
 
 * Use a `large` `resource_class` (4 CPUs and 8 GB of memory) and make use of more credits/minute to speed up a build for a bigger project.
-* Use a `small` `resource_class` (1 CPU, 2 GB memory) with less credits/minute for a smaller project that may not ship code as frequently, or where build time is inconsequential.
+* Use a `small` `resource_class` (1 CPU, 2 GB memory) with fewer credits/minute for a smaller project that may not ship code as frequently, or where build time is inconsequential.
 
 The documents in this section cover what each plan offers developers for their CI/CD needs. Consider also taking a moment to look at the CircleCI link:https://circleci.com/pricing/[Pricing] page to learn about how credits are distributed across different machine types.
 
@@ -38,7 +38,7 @@ Visit the pages below to learn about the features of CircleCI's plans.
 == Configuring your credit plan
 To set up a Free or Performance Plan, go to **Plan > Plan Overview** in the CircleCI link:https://app.circleci.com/[web application]. From there, select the plan that best fits your needs. To set up a Scale or Server Plan, link:https://circleci.com/talk-to-us/[contact us].
 
-For details on cancelling a Performance Plan, refer to the xref:reference:ROOT:faq.adoc#cancel-performance-plan[Cancel Performance Plan FAQ].
+For details on canceling a Performance Plan, refer to the xref:reference:ROOT:faq.adoc#cancel-performance-plan[Cancel Performance Plan FAQ].
 
 [#managing-credit-usage]
 == Managing credit usage

--- a/docs/guides/modules/plans-pricing/pages/plan-performance.adoc
+++ b/docs/guides/modules/plans-pricing/pages/plan-performance.adoc
@@ -20,7 +20,7 @@ For detailed information about user types, how to ensure your team is registered
 === Access to IP ranges
 Configure IP-based access to restricted environments with IP ranges. Jobs that have this feature enabled have their traffic routed through one of the defined IP address ranges during job execution.
 
-For more information about this features, refer to the xref:security:ip-ranges.adoc[IP Ranges] page.
+For more information about this feature, refer to the xref:security:ip-ranges.adoc[IP Ranges] page.
 
 [#additional-resource-classes]
 === Additional resource classes
@@ -42,13 +42,13 @@ A significant increase in the number of self-hosted runners, allowing you to run
 
 [#custom-storage-retention]
 === Custom storage retention
-The link:https://app.circleci.com/[CircleCI web app] allows for the customization of the storage retention periods of artifact, workspace, and cache objects. This allows you to determine how to store each of these objects types in a way that best suits your project. Lowering storage retention periods can also reduce your monthly bill.
+The link:https://app.circleci.com/[CircleCI web app] allows for the customization of the storage retention periods of artifact, workspace, and cache objects. This allows you to determine how to store each of these object types in a way that best suits your project. Lowering storage retention periods can also reduce your monthly bill.
 
 [#additional-support-options]
 === Additional support options
 Additional support through SLAs (limited hours and days), and support package add-ons. The Performance Plan also has access to the link:https://discuss.circleci.com/[community forums], link:https://support.circleci.com/hc/en-us[support portal], and our link:https://support.circleci.com/hc/en-us/requests/new[global ticket-based system].
 
-NOTE: For details on cancelling a Performance Plan, refer to the xref:reference:ROOT:faq.adoc#cancel-performance-plan[Cancel Performance Plan FAQ].
+NOTE: For details on canceling a Performance Plan, refer to the xref:reference:ROOT:faq.adoc#cancel-performance-plan[Cancel Performance Plan FAQ].
 
 [#circleci-features]
 == CircleCI features

--- a/docs/guides/modules/plans-pricing/pages/plan-scale.adoc
+++ b/docs/guides/modules/plans-pricing/pages/plan-scale.adoc
@@ -15,7 +15,7 @@ The Scale Plan offers several improvements over the Free and Performance Plans:
 === Access to IP ranges
 Configure IP-based access to restricted environments with IP ranges. Jobs that have the IP ranges feature enabled have traffic routed through one of the defined IP address ranges during job execution. The IP ranges feature is the same on the Performance and Scale Plans.
 
-For more information about this features, refer to the xref:security:ip-ranges.adoc[IP ranges] page.
+For more information about this feature, refer to the xref:security:ip-ranges.adoc[IP ranges] page.
 
 [#access-to-all-resource-classes]
 === Access to all resource classes
@@ -37,7 +37,7 @@ Unlimited self-hosted runners, allowing you to run more jobs on your own infrast
 
 [#custom-storage-retention]
 === Custom storage retention
-The link:https://app.circleci.com/[CircleCI web app] allows for the customization of the storage retention periods of artifact, workspace, and cache objects. This allows you to determine how to store each of these objects types in a way that best suits your project. Lowering storage retention periods can also reduce your monthly bill.
+The link:https://app.circleci.com/[CircleCI web app] allows for the customization of the storage retention periods of artifact, workspace, and cache objects. This allows you to determine how to store each of these object types in a way that best suits your project. Lowering storage retention periods can also reduce your monthly bill.
 
 [#additional-support-options]
 === Additional support options

--- a/docs/guides/modules/plans-pricing/pages/plan-server.adoc
+++ b/docs/guides/modules/plans-pricing/pages/plan-server.adoc
@@ -28,7 +28,7 @@ Customize the number of active users based on your needs.
 
 [#custom-storage-retention]
 === Custom storage retention
-The link:https://app.circleci.com/[CircleCI web app] allows for the customization of the storage retention periods of artifact, workspace, and cache objects. This allows you to determine how to store each of these objects types in a way that best suits your project. Lowering storage retention periods can also reduce your monthly bill.
+The link:https://app.circleci.com/[CircleCI web app] allows for the customization of the storage retention periods of artifact, workspace, and cache objects. This allows you to determine how to store each of these object types in a way that best suits your project. Lowering storage retention periods can also reduce your monthly bill.
 
 [#additional-support-options]
 === Additional support options

--- a/docs/guides/modules/plans-pricing/pages/user-types-and-registration.adoc
+++ b/docs/guides/modules/plans-pricing/pages/user-types-and-registration.adoc
@@ -9,13 +9,13 @@ This page explains the different user types in CircleCI and how to ensure all te
 
 Understanding user types is important for managing your CircleCI organization effectively and controlling costs. CircleCI tracks three types of users:
 
-**Registered users**:: Users with a CircleCI account.
-**Unregistered users**:: Users who trigger builds but do not have a CircleCI account.
-**Active users**:: Users who trigger builds and consume credits (for billing purposes).
+*Registered user*:: Users with a CircleCI account.
+*Unregistered users*:: Users who trigger builds but do not have a CircleCI account.
+*Active users*:: Users who trigger builds and consume credits (for billing purposes).
 
 == Registered users
 
-A **registered user** is anyone who has created a CircleCI account by signing up at link:https://circleci.com/signup/[circleci.com/signup]. Registered users have the following capabilities:
+A *registered user* is anyone who has created a CircleCI account by signing up at link:https://circleci.com/signup/[circleci.com/signup]. Registered users have the following capabilities:
 
 * Access to the CircleCI web app.
 * The ability to view pipelines, jobs, and build history.
@@ -25,7 +25,7 @@ A **registered user** is anyone who has created a CircleCI account by signing up
 
 == Unregistered users
 
-An **unregistered user** is someone who has triggered builds or pipelines in your CircleCI organization but has not signed up for a CircleCI account. Common scenarios include:
+An *unregistered user* is someone who has triggered builds or pipelines in your CircleCI organization but has not signed up for a CircleCI account. Common scenarios include:
 
 * Developers who commit code to a repository connected to CircleCI but have never logged in to CircleCI.
 * Contributors who create pull requests that trigger CI builds.
@@ -41,11 +41,11 @@ Organizations on Performance or Scale Plans can control unregistered user spendi
 
 == Active users
 
-An **active user** is any user (registered or unregistered) who triggers the use of compute resources on non-OSS projects during a billing period. This includes activities such as:
+An *active user* is any user (registered or unregistered) who triggers the use of compute resources on non-OSS projects during a billing period. This includes activities such as:
 
 * Commits from users that trigger builds, including PR merge commits.
-* Re-running jobs in the CircleCI web application, including xref:guides:execution-managed:ssh-access-jobs.adoc[SSH Debugging].
-* Approving xref:guides:orchestrate:workflows.adoc#holding-a-workflow-for-a-manual-approval[On-Hold Jobs]. The approver is considered the actor of all downstream jobs.
+* Re-running jobs in the CircleCI web application, including xref:guides:execution-managed:ssh-access-jobs.adoc[SSH debugging].
+* Approving xref:guides:orchestrate:workflows.adoc#holding-a-workflow-for-a-manual-approval[on-hold jobs]. The approver is considered the actor of all downstream jobs.
 * Using scheduled workflows.
 * Machine users.
 
@@ -60,11 +60,11 @@ To find a list of your active users, log in to the CircleCI web app and navigate
 
 Having your team members register for CircleCI accounts provides several benefits:
 
-* **Better visibility**: Registered users can view build results, logs, and insights directly in the CircleCI web app.
-* **Improved collaboration**: Team members can re-run failed builds, SSH into jobs for debugging, and approve manual workflows.
-* **Cost management**: You can track and manage who is consuming credits in your organization.
-* **Access control**: Registered users can be assigned roles and permissions within your organization.
-* **Audit trails**: Actions taken by registered users are correctly attributed in audit logs.
+* *Better visibility*: Registered users can view build results, logs, and insights directly in the CircleCI web app.
+* *Improved collaboration*: Team members can re-run failed builds, SSH into jobs for debugging, and approve manual workflows.
+* *Cost management*: You can track and manage who is consuming credits in your organization.
+* *Access control*: Registered users can be assigned roles and permissions within your organization.
+* *Audit trails*: Actions taken by registered users are correctly attributed in audit logs.
 
 [#how-to-register]
 == How to become a registered user
@@ -76,19 +76,19 @@ If you or your team members are currently unregistered users (triggering builds 
 
 As an organization admin, you can help ensure all team members who trigger builds have CircleCI accounts:
 
-. **Identify unregistered users**:
+. *Identify unregistered users*:
 +
 Navigate to menu:Plan[Plan Usage > Users] in the CircleCI web app to view all active users. Unregistered users will be listed with limited information.
 
-. **Send invites**:
+. *Send invites*:
 +
 Navigate to menu:Organization Settings[People] and use the btn:[Invite] button to send email invitations to team members. See the xref:guides:getting-started:invite-your-team.adoc#invite-teammates[Join Teammates] section for detailed steps.
 
-. **Enable unregistered user spend prevention** (Performance and Scale Plans only):
+. *Enable unregistered user spend prevention* (Performance and Scale Plans only):
 +
-If you want to require registration before allowing builds, enable the "Prevent unregistered user spend" feature. See xref:prevent-unregistered-users-from-spending-credits.adoc[Prevent Unregistered Users From Spending Credits] for instructions.
+If you want to require registration before allowing builds, enable the *Prevent unregistered user spend* feature. See xref:prevent-unregistered-users-from-spending-credits.adoc[Prevent Unregistered Users From Spending Credits] for instructions.
 
-. **Communicate with your team**:
+. *Communicate with your team*:
 +
 Let your team know about the benefits of registering and provide them with instructions or invite links.
 


### PR DESCRIPTION
# SPG review: plans-pricing section

## Summary

Spelling, punctuation, and grammar fixes across the plans-pricing documentation section. All changes are non-content — no technical information has been altered.

## Files changed

### `plan-overview.adoc`
- `fewer resources` (was `less resources`) — countable noun
- `fewer credits/minute` (was `less credits/minute`) — countable noun (×2)
- `machine types` (was `machine-types`) — unnecessary hyphen
- `canceling` (was `cancelling`) — US English spelling
- `Let's look at` (was `Let us look at`) — standard contraction

### `credits.adoc`
- `machine types` (was `machine-types`) — unnecessary hyphen
- Removed duplicate "open a" in "do not hesitate to open a [open a support ticket]"
- Fixed `##` heading to `==` (Markdown syntax in AsciiDoc file)
- Fixed sentence fragment in troubleshooting section (dangling subordinate clause)
- Removed double space in troubleshooting section heading
- `canceling` (was `cancelling`) — US English spelling

### `billing-faq-snip.adoc` (partial)
- `$0.0006` (was `$.0006`) — leading zero added
- `$0.50` (was `$.50`) — leading zero added (×2)
- `menu:Plan[Plan Usage]` (was `menu:Plan[Plan] Usage`) — malformed macro fixed
- `prepaid billing` (was `Prepaid Billing`) — unnecessary capitalisation
- `monthly subscription` (was `Monthly subscription`) — unnecessary capitalisation
- `Open source` (was `Open-source`) — unnecessary hyphen
- Removed double space before "Open source credit availability..."

### `user-types-and-registration.adoc`
- `SSH debugging` (was `SSH Debugging`) — not a proper noun
- `on-hold jobs` (was `On-Hold Jobs`) — not a proper noun
- All `**...**` bold markers changed to `*...*` (×12) — correct AsciiDoc syntax for whole-word bold

### `manage-budgets.adoc`
- All `**...**` bold markers changed to `*...*` — correct AsciiDoc syntax
- `budget controls` (was `Budget Controls`) — not a proper noun
- Added missing comma after introductory phrase in procedure steps (×4)
- `00:00:00` (was `00:00`) — consistent time format with `23:59:59`
- `Locate the budget you want to delete` (was `edit`) in Delete a budget procedure

### `plan-free.adoc`
- `*five*` (was `**five**`) — correct AsciiDoc syntax

### `plan-performance.adoc`
- `*five*` (was `**five**`) — correct AsciiDoc syntax
- `this feature` (was `this features`) — grammatical error
- `canceling` (was `cancelling`) — US English spelling
- `each of these object types` (was `objects types`) — grammatical error

### `plan-scale.adoc`
- `this feature` (was `this features`) — grammatical error
- `each of these object types` (was `objects types`) — grammatical error

### `plan-server.adoc`
- `each of these object types` (was `objects types`) — grammatical error

### `features-of-circleci.adoc` (shared partial)
- `Visualize` (was `Visualise`) — US English spelling