### PR TITLE
Remove EOL'ed Xcode versions

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
@@ -49,14 +49,6 @@ a| `m4pro.medium` +
 | link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v15895/manifest.txt[Installed software]
 | link:https://circleci.com/changelog/xcode-26-1-1-available/[Release Notes]
 
-| `26.0.1`
-| Xcode 26.0.1 (17A400)
-| 15.6
-a| `m4pro.medium` +
-   `m4pro.large`
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v15738/manifest.txt[Installed software]
-| link:https://circleci.com/changelog/xcode-26-0-1-released/[Release Notes]
-
 | `16.4.0`
 | Xcode 16.4 (16F6)
 | 15.3.2
@@ -64,14 +56,6 @@ a| `m4pro.medium` +
    `m4pro.large`
 | link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v15338/manifest.txt[Installed software]
 | link:https://circleci.com/changelog/xcode-16-4-ga-available/[Release Notes]
-
-| `16.3.0`
-| Xcode 16.3 (16E140)
-| 15.3.2
-a| `m4pro.medium` +
-   `m4pro.large`
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v15328/manifest.txt[Installed software]
-| link:https://circleci.com/changelog/xcode-16-3-available/[Release Notes]
 
 | `15.4.0`
 | Xcode 15.4 (15F31d)


### PR DESCRIPTION
# Description
Removes Xcode versions 16.3.0 and 26.0.1, which have been EOL'ed and removed per the changelog announcement: https://circleci.com/changelog/deprecation-of-xcode-16-3-0-and-26-0-1/