### PR TITLE
Updated pipeline.event.name and pipeline.event.action descriptions

### DIFF
--- a/docs/guides/modules/ROOT/partials/pipelines-and-triggers/pipeline-values.adoc
+++ b/docs/guides/modules/ROOT/partials/pipelines-and-triggers/pipeline-values.adoc
@@ -415,17 +415,21 @@ d| [.nowrap]#GitHub OAuth# +
 
 | `pipeline.event.name`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth# +
+[.nowrap]#Bitbucket Cloud#
 | String
-| The name of the event that triggered the pipeline. Possible values: `custom_webhook`, `api`, `push`, `pull_request`.
+| The name of the event that triggered the pipeline. Possible values: `custom_webhook`, `api`, `push`, `pull_request`, `schedule`.
 | [.circle-green]#**Yes**#
 | [.circle-red]#**No**#
 
 | `pipeline.event.action`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth# +
+[.nowrap]#Bitbucket Cloud#
 | String
-| The action associated with the event. This value is always the same as `pipeline.event.name`, except for link:https://docs.github.com/en/webhooks/webhook-events-and-payloads[GitHub Events] that have an `action` property, for example link:https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request[`pull_request`]. Possible values: `custom_webhook`, `api`, `push`, `opened`, `synchronize`, `reopened`, `closed`, `ready_for_review`, `labeled`. Read more about xref:guides:orchestrate:github-trigger-event-options.adoc#supported-trigger-options[GitHub Trigger Event Options].
+| The action associated with the event. This value is the same as `pipeline.event.name` except for events that have an `action` subtype: link:https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request[GitHub `pull_request`] events and link:https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Pull-request-events[Bitbucket Cloud `pullrequest:*`] events. Possible values: `custom_webhook`, `api`, `push`, `schedule`, `opened`, `synchronize`, `reopened`, `closed`, `ready_for_review`, `labeled`, `created`, `updated`, `fulfilled`, `rejected`. Read more about xref:guides:orchestrate:github-trigger-event-options.adoc#supported-trigger-options[GitHub Trigger Event Options].
 | [.circle-green]#**Yes**#
 | [.circle-red]#**No**#
 


### PR DESCRIPTION
# Description

Updated the descriptions for `pipeline.event.name` and `pipeline.event.action` to mention GitHub OAuth and Bitbucket cloud.

# Reasons

Added support for those PVs in this [PR](https://github.com/circleci/circle/pull/16488) as per Benny's request [here](https://circleci.slack.com/archives/CNPG1R4QZ/p1744274701011719).

Linear ticket: https://linear.app/circleci/issue/SC-38/circlecicircle-add-pipelineeventname-and-pipelineeventaction-to-oauth 

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).


Changes:
<img width="1504" height="856" alt="image" src="https://github.com/user-attachments/assets/03968ffc-cb68-46d7-8a84-1757056c41f2" />

