### PR TITLE
remove archived redirect

### DIFF
--- a/scripts/redirects_v2.yml
+++ b/scripts/redirects_v2.yml
@@ -65,9 +65,6 @@
 - old: /caching/
   new: /guides/optimize/caching/
 
-- old: /caching-strategy/
-  new: /guides/optimize/caching-strategy/
-
 - old: /circleci-config-sdk/
   new: /guides/toolkit/circleci-config-sdk/
 


### PR DESCRIPTION
Caching-strategy file has been removed, so remove the redirect that is failing the deployment