### PR TITLE
Fix Vale errors in publish-packages-to-packagecloud.adoc

### DIFF
--- a/docs/guides/modules/deploy/pages/publish-packages-to-packagecloud.adoc
+++ b/docs/guides/modules/deploy/pages/publish-packages-to-packagecloud.adoc
@@ -174,7 +174,7 @@ The packagecloud npm registry URL is in the following format:
 https://packagecloud.io/:username/:repo_name/npm/
 ----
 
-The full `.circleci/config.yml` should look something like this:
+The full `.circleci/config.yml` looks something like this:
 
 [,yaml]
 ----


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in \`publish-packages-to-packagecloud.adoc\`.

## Errors Fixed
- **Line 177**: \`circleci-docs.Avoid\` - Replaced 'should look' with present tense 'looks'

## Verification
Ran Vale after fixes — 0 errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review
- Changes preserve existing AsciiDoc structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)