### PR TITLE
DOC-182: put article content before nav sidebar in HTML source order

### DIFF
--- a/ui/src/partials/body.hbs
+++ b/ui/src/partials/body.hbs
@@ -1,8 +1,8 @@
 <div class="flex h-full w-full">
-{{> navigation class= "w-full lg:w-2/6 flex-initial lg:max-w-[420px] lg:min-w-[360px]"}}
   <div class="flex flex-col w-full xl:items-center">
     {{> mobile-component-dropdown}}
     {{> main}}
     {{> footer class="px-12"}}
   </div>
+{{> navigation class= "w-full lg:w-2/6 flex-initial lg:max-w-[420px] lg:min-w-[360px] lg:order-first"}}
 </div>


### PR DESCRIPTION
## What

Reorders the HTML DOM in `ui/src/partials/body.hbs` so article content appears before the navigation sidebar in source order. Adds `lg:order-first` to the nav partial to visually restore it to the left column on desktop via CSS flex order.

## Why

The [Agent-Friendly Documentation Spec](https://agentdocsspec.com/spec/#content-start-position) `content-start-position` check is failing on 38 of 50 sampled pages (worst case: 91%). The root cause is the navigation sidebar being rendered before the article in HTML — it accounts for ~236K characters (~84% of a typical page) before any docs content appears. Agents that fetch the HTML path may never reach the actual documentation.

## Change

**1 file, 1 line moved, 1 class added** — `ui/src/partials/body.hbs`

- Main content wrapper moved before `{{> navigation}}` in the flex container
- `lg:order-first` added to nav so it stays visually left on desktop (sets `order: -9999` at the `lg` breakpoint via Tailwind JIT)
- Mobile layout unaffected — nav is `position: fixed` on mobile and already out of flow

## JS audit

All 15 JS files in `ui/src/js/` were audited for DOM-order dependencies between nav and main. None found. `01-nav.js` is dead code (queries `.nav-container` which doesn't exist in current templates). All other scripts use `data-*` attributes or class selectors scoped to their own component.

## Expected result

`content-start-position` pass rate: 24% (12/50) → 100% (50/50). No change to visual layout for human readers.

## Test

```bash
cd ~/github/circleci-docs-agent-accessibility
ln -s ~/github/circleci-docs/node_modules ./node_modules
ln -s ~/github/circleci-docs/ui/node_modules ./ui/node_modules
npm run preview:ui
```

Open any page, inspect source — `<main>` should appear before `<div data-page-navigation>` in the DOM. Visual layout should be identical.

Made with [Cursor](https://cursor.com)