### PR TITLE
Update chunk sidecar docs to reflect availability on all plans

### DIFF
--- a/docs/guides/modules/toolkit/pages/how-to-use-chunk-cli.adoc
+++ b/docs/guides/modules/toolkit/pages/how-to-use-chunk-cli.adoc
@@ -108,7 +108,7 @@ The following flags are available:
 [badge="Preview"]
 == Validate in a Chunk sidecar
 
-CAUTION: Chunk sidecars are available in preview if you are on a paid plan. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
+NOTE: Chunk sidecars are available in preview on all CircleCI plans. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
 
 Chunk sidecars let you validate your changes in a CircleCI Cloud environment instead of locally. This ensures your code runs against the same environment your CI pipeline uses.
 
@@ -186,7 +186,7 @@ For more details on managing Chunk sidecars, see the <<manage-sidecars>> section
 [badge="Preview"]
 == Manage Chunk sidecars
 
-CAUTION: Chunk sidecars are available in preview if you are on a paid plan. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
+NOTE: Chunk sidecars are available in preview on all CircleCI plans. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
 
 Chunk sidecars are CircleCI Cloud environments where the `chunk` CLI validates your changes remotely. This lets you validate changes against the same environment your CI pipeline uses, without running them locally.
 

--- a/docs/guides/modules/toolkit/pages/how-to-use-chunk-cli.adoc
+++ b/docs/guides/modules/toolkit/pages/how-to-use-chunk-cli.adoc
@@ -108,7 +108,7 @@ The following flags are available:
 [badge="Preview"]
 == Validate in a Chunk sidecar
 
-NOTE: Chunk sidecars are available in preview on all CircleCI plans. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
+CAUTION: Chunk sidecars are available in preview on all CircleCI plans. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
 
 Chunk sidecars let you validate your changes in a CircleCI Cloud environment instead of locally. This ensures your code runs against the same environment your CI pipeline uses.
 
@@ -186,7 +186,7 @@ For more details on managing Chunk sidecars, see the <<manage-sidecars>> section
 [badge="Preview"]
 == Manage Chunk sidecars
 
-NOTE: Chunk sidecars are available in preview on all CircleCI plans. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
+CAUTION: Chunk sidecars are available in preview on all CircleCI plans. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
 
 Chunk sidecars are CircleCI Cloud environments where the `chunk` CLI validates your changes remotely. This lets you validate changes against the same environment your CI pipeline uses, without running them locally.
 


### PR DESCRIPTION
# Description
Updated the plan requirement for Chunk sidecars from paid plans only to all CircleCI plans in the "Validate in a Chunk sidecar" and "Manage Chunk sidecars" sections of `how-to-use-chunk-cli.adoc`.

# Reasons
Chunk sidecars are now available on all CircleCI plans, not just paid ones. The previous wording was incorrect and potentially blocking users on free plans from trying the feature.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).