### PR TITLE
DOC-182: advertise markdown alternate in page <head>

### DIFF
--- a/ui/src/partials/head-meta.hbs
+++ b/ui/src/partials/head-meta.hbs
@@ -1,4 +1,4 @@
 {{#if page.attributes.noindex}}
     <meta name="robots" content="noindex">
 {{/if}}
-{{!-- Add additional meta tags here --}}
+    <link rel="alternate" type="text/markdown" href="index.md">


### PR DESCRIPTION
Adds a <link rel="alternate" type="text/markdown" href="index.md"> to every docs page so agents that perform content negotiation or inspect link relations can discover the clean markdown version of each page without having to guess the URL pattern.

The markdown path (index.md) already exists for all pages via the markdown-export-extension and scores 0% on content-start-position — this tag makes it discoverable from the HTML.
