### PR TITLE
Revert "DOC: put article content before nav sidebar in HTML source order (#10445)"

### DIFF
--- a/ui/src/partials/body.hbs
+++ b/ui/src/partials/body.hbs
@@ -1,8 +1,8 @@
 <div class="flex h-full w-full">
+{{> navigation class= "w-full lg:w-2/6 flex-initial lg:max-w-[420px] lg:min-w-[360px]"}}
   <div class="flex flex-col w-full xl:items-center">
     {{> mobile-component-dropdown}}
     {{> main}}
     {{> footer class="px-12"}}
   </div>
-{{> navigation class= "w-full lg:w-2/6 flex-initial lg:max-w-[420px] lg:min-w-[360px] lg:order-first"}}
 </div>


### PR DESCRIPTION
## Summary

Reverts #10445, which broke the site.

- Restores `ui/src/partials/body.hbs` to its previous state
- Removes the `lg:order-first` class added to the nav partial

## Test plan

- [ ] Confirm site builds and renders correctly after merge