### PR TITLE
DOC-182: put article content before nav sidebar in HTML source order

### DIFF
--- a/ui/src/css/site.css
+++ b/ui/src/css/site.css
@@ -60,3 +60,8 @@ header [data-search-results-container] {
 .landing-page [data-page-navigation-toggle] {
   display: none;
 }
+
+/* Nav is after content in source order for agent readability; CSS restores visual left position */
+@media (width >= 75rem) {
+  [data-page-navigation] { order: -1; }
+}

--- a/ui/src/css/site.css
+++ b/ui/src/css/site.css
@@ -65,9 +65,3 @@ header [data-search-results-container] {
 @media (width >= 75rem) {
   [data-page-navigation] { order: -1; }
 }
-
-/* Prevent off-screen mobile nav from intercepting pointer events on the page beneath it */
-@media (width < 75rem) {
-  [data-page-navigation] { pointer-events: none; }
-  [data-page-navigation].translate-x-0 { pointer-events: auto; }
-}

--- a/ui/src/css/site.css
+++ b/ui/src/css/site.css
@@ -65,3 +65,9 @@ header [data-search-results-container] {
 @media (width >= 75rem) {
   [data-page-navigation] { order: -1; }
 }
+
+/* Prevent off-screen mobile nav from intercepting pointer events on the page beneath it */
+@media (width < 75rem) {
+  [data-page-navigation] { pointer-events: none; }
+  [data-page-navigation].translate-x-0 { pointer-events: auto; }
+}

--- a/ui/src/partials/body.hbs
+++ b/ui/src/partials/body.hbs
@@ -1,8 +1,8 @@
 <div class="flex h-full w-full">
-{{> navigation class= "w-full lg:w-2/6 flex-initial lg:max-w-[420px] lg:min-w-[360px]"}}
   <div class="flex flex-col w-full xl:items-center">
     {{> mobile-component-dropdown}}
     {{> main}}
     {{> footer class="px-12"}}
   </div>
+{{> navigation class= "w-full lg:w-2/6 flex-initial lg:max-w-[420px] lg:min-w-[360px]"}}
 </div>

--- a/ui/src/partials/footer-scripts.hbs
+++ b/ui/src/partials/footer-scripts.hbs
@@ -1,5 +1,5 @@
 <script src="{{{uiRootPath}}}/js/vendor/simple-datatables.js"></script>
-<script id="site-script" src="{{{uiRootPath}}}/js/site.js" data-ui-root-path="{{{uiRootPath}}}"></script>
+<script defer id="site-script" src="{{{uiRootPath}}}/js/site.js" data-ui-root-path="{{{uiRootPath}}}"></script>
 <script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>
 {{#if env.SITE_SEARCH_PROVIDER}}
 {{> search-scripts}}


### PR DESCRIPTION
## Summary

- Moves `{{> navigation}}` after the main content wrapper in `body.hbs` so agents (and HTML-to-markdown converters) encounter article text first
- Adds an explicit `@media (width >= 75rem)` CSS rule in `site.css` to restore the nav's visual left position via `order: -1`

## What's different from the previous attempt (#10445)

The previous attempt used `lg:order-first` (a Tailwind v3 utility) which generated CSS at the default `64rem` breakpoint, mismatching the custom `--breakpoint-lg: 75rem` defined in `site.css`. This version uses a plain CSS rule at exactly `75rem` — verified locally by building the bundle and inspecting the output CSS.

## Test plan

- [ ] Check preview build: nav visually on the left at desktop widths
- [ ] Inspect CI build logs to confirm "Building UI bundle..." ran (not skipped)
- [ ] Confirm `[data-page-navigation] { order: -1 }` at `75rem` is present in the deployed `site.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)