### PR TITLE
Refresh resource class overview content

### DIFF
--- a/docs/guides/modules/execution-managed/pages/resource-class-lifecycle.adoc
+++ b/docs/guides/modules/execution-managed/pages/resource-class-lifecycle.adoc
@@ -31,7 +31,7 @@ When a brownout occurs, you have two options:
 
 === Option 1: Update your configuration (recommended)
 
-Update your link:/guides/execution-managed/resource-class-overview/[CircleCI config file] to use supported resource classes:
+Update your `.circleci/config.yml` to use supported resource classes:
 
 *For Docker executor:*
 
@@ -78,7 +78,7 @@ You must update your configurations before the EOL date.
 
 == Tips to minimize brownout impact
 
-*Review resource class usage*:: Audit your resource class specifications to ensure you use actively supported options. Consider whether your workloads might benefit from link:/guides/execution-managed/resource-class-overview/[newer, more efficient resource classes].
+*Review resource class usage*:: Audit your resource class specifications to ensure you use actively supported options. Consider whether your workloads might benefit from newer, more efficient resource classes by reviewing the xref:resource-class-overview.adoc[Resource Class Overview] page.
 
 *Update orbs*:: If you use CircleCI orbs, ensure you update them to current versions. Outdated orbs may specify deprecated resource classes internally.
 

--- a/docs/guides/modules/execution-managed/pages/resource-class-lifecycle.adoc
+++ b/docs/guides/modules/execution-managed/pages/resource-class-lifecycle.adoc
@@ -31,7 +31,7 @@ When a brownout occurs, you have two options:
 
 === Option 1: Update your configuration (recommended)
 
-Update your `.circleci/config.yml` to use supported resource classes:
+Update your CircleCI configuration file to use supported resource classes:
 
 *For Docker executor:*
 

--- a/docs/guides/modules/execution-managed/pages/resource-class-overview.adoc
+++ b/docs/guides/modules/execution-managed/pages/resource-class-overview.adoc
@@ -1,7 +1,9 @@
 = Resource class overview
 :page-platform: Cloud, Server v4+
-:page-description: An overview of resource classes in CircleCI
+:page-description: Learn how to use resource classes in CircleCI to specify compute resources for jobs, configure self-hosted runners, and choose execution environments.
 :experimental:
+
+Use the `resource_class` key in your `.circleci/config.yml` to control the compute resources available to each job. Specifying the right resource class speeds up builds and reduces credit usage. Over-provisioned jobs cost more than necessary, and under-provisioned jobs run slowly or fail.
 
 Use resource classes to:
 
@@ -9,20 +11,16 @@ Use resource classes to:
 * Configure xref:execution-runner:runner-concepts.adoc#namespaces-and-resource-classes[Self-Hosted Runners] for use in your `.circleci/config.yml` file.
 * Specify an execution environment.
 
-[#introduction]
-== Introduction
-
-The `resource_class` configuration option has multiple uses: specifying compute resource size, optimizing executors, configuring self-hosted runners, and specifying an execution environment.
-
 The most common usage is to specify CPU and RAM requirements for a job by configuring the `resource_class` key for an executor.
 
+.Specify a resource class for a Docker job
 [source,yaml]
 ----
 jobs:
   my-job:
-    docker: # use the Docker executor
+    docker:
       - image: cimg/base:2022.09 # specify a Docker image
-    resource_class: xlarge # specify a resource class
+    resource_class: xlarge # sets CPU and RAM for this job
     steps:
       - run: echo "Hello World"
 ----
@@ -33,25 +31,27 @@ NOTE: **For a full list of available resource class options,** see the xref:refe
 
 When using CircleCI's self-hosted runners, use the `resource_class` key in your project configuration to specify which runner to use for a job. Self-hosted runner resource classes are assigned and configured during the xref:execution-runner:runner-overview.adoc#getting-started[Runner Installation Process].
 
+.Self-hosted runner resource class
 [source,yaml]
 ----
 jobs:
   my-job:
     machine: true
-    resource_class: <my-namespace>/<my-runner>
+    resource_class: <my-namespace>/<my-runner> # namespace/runner-name assigned during runner installation
     steps:
       - run: echo "Hello runner"
 ----
 
 Another use of the `resource_class` key is to specify an execution environment. For example, xref:using-arm.adoc[Arm] is a resource class option when using the `machine` executor.
 
+.Arm execution environment via resource class
 [source,yaml]
 ----
 jobs:
   my-job:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: arm.medium
+    resource_class: arm.medium # arm.medium or arm.large selects the Arm execution environment
     steps:
       - run: uname -a
       - run: echo "Hello, Arm!"
@@ -79,7 +79,7 @@ NOTE: **To get started setting up a self-hosted runner**, see the xref:execution
 If a `resource_class` is not explicitly declared for a job, CircleCI will use a default resource class size. Defaults are subject to change. It is best practice to specify a resource class, rather than relying on a default.
 
 [#resource-class-usage-tools]
-== Resource class usage tools
+== View and monitor resource class usage
 
 Information about the resource classes used in your jobs can be found in the web app, or by using the API. See the sections below for details.
 


### PR DESCRIPTION
Improve clarity and value of the resource-class-overview page: expand the page-description to meet the 70-char minimum, add a value-led opening paragraph, remove the redundant Introduction heading, add titles and explanatory comments to all three code examples, and rename the usage tools section heading to start with a verb.

Also fix two broken absolute link: paths in resource-class-lifecycle.adoc,
replacing them with correct xref: syntax and accurate link text.

