### PR TITLE
Try out using Kapa search

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -331,6 +331,56 @@ The project includes several custom extensions:
   - See [Markdown Export](#markdown-export) section for configuration
   - Processes 563+ pages, adding significant build time
 
+## Search Integration
+
+### Current Setup: Kapa.ai Search (with Algolia preserved)
+
+The docs site search bar uses **Kapa.ai's unified search/chat modal** instead of the Algolia search UI. Algolia infrastructure is intentionally kept intact because the marketing site depends on it to surface docs search results.
+
+#### What was changed
+
+| File | Change |
+|------|--------|
+| `ui/src/partials/head-scripts.hbs` | Added search-mode attributes to the Kapa widget `<script>` tag |
+| `ui/src/partials/search-bar.hbs` | Changed keyboard shortcut display from `cmd+/` to `cmd+k` |
+| `ui/src/js/07-search.js` | Commented out the `handleKeyboardShortcut` function and its `addEventListener` call (Cmd+/ → Algolia) |
+
+#### Kapa widget attributes added (`head-scripts.hbs`)
+
+```html
+data-search-mode-enabled="true"
+data-search-mode-default="true"
+data-modal-override-open-selector-search="#search-text-input"
+data-modal-open-on-command-k="true"
+data-modal-command-k-search-mode-default="true"
+```
+
+- `data-modal-override-open-selector-search` wires the existing search input (`#search-text-input`) to open the Kapa modal instead of Algolia.
+- `data-search-mode-default` makes the Search tab the default (rather than Ask AI).
+- Cmd+K opens the modal (replaces Cmd+/).
+
+#### Filtering search results to docs only
+
+To restrict Kapa search results to this docs site, add the source ID to the script tag:
+
+```html
+data-search-source-ids-include="29044e81-a3f5-4a86-adf4-981fac02525b"
+```
+
+The source ID comes from the Kapa dashboard URL when viewing a source: `app.kapa.ai/.../sources/view/<source-id>`. If sources are grouped, use `data-source-group-ids-include` instead.
+
+#### How to revert to Algolia search
+
+1. **`head-scripts.hbs`**: Remove the five `data-search-mode-*` and `data-modal-*` attributes from the Kapa `<script>` tag.
+2. **`search-bar.hbs`**: Change `cmd+k` back to `cmd+/` in the keyboard shortcut span.
+3. **`07-search.js`**: Uncomment the `handleKeyboardShortcut` function body and the `document.addEventListener('keydown', handleKeyboardShortcut)` call (search for `Cmd+/ shortcut disabled`).
+
+#### How to disable Kapa entirely
+
+Remove the entire `<script defer src="https://widget.kapa.ai/...">` block from `head-scripts.hbs`.
+
+---
+
 ## Testing
 
 ### Testing Content Changes

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -364,10 +364,10 @@ data-modal-command-k-search-mode-default="true"
 To restrict Kapa search results to this docs site, add the source ID to the script tag:
 
 ```html
-data-search-source-ids-include="29044e81-a3f5-4a86-adf4-981fac02525b"
+data-search-source-ids-include="585f4613-bd84-4fd1-9e73-d3a0265cfd39"
 ```
 
-The source ID comes from the Kapa dashboard URL when viewing a source: `app.kapa.ai/.../sources/view/<source-id>`. If sources are grouped, use `data-source-group-ids-include` instead.
+The source ID (`585f4613-bd84-4fd1-9e73-d3a0265cfd39`) is the "Documentation" source in the Kapa dashboard. It can be found in the Kapa dashboard URL when viewing a source: `app.kapa.ai/.../sources/view/<source-id>`. If sources are grouped, use `data-source-group-ids-include` instead.
 
 #### How to revert to Algolia search
 

--- a/ui/src/js/07-search.js
+++ b/ui/src/js/07-search.js
@@ -706,22 +706,19 @@
 
     // ===== KEYBOARD SHORTCUT HANDLER =====
 
-    function handleKeyboardShortcut (e) {
-      // Check for Cmd+/ (Mac) or Ctrl+/ (Windows/Linux)
-      const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
-      const modifierKey = isMac ? e.metaKey : e.ctrlKey
-
-      if (modifierKey && e.key === '/') {
-        e.preventDefault()
-
-        // Focus the appropriate search input based on current view
-        if (isMobileView && elements.mobileSearchInput) {
-          elements.mobileSearchInput.focus()
-        } else {
-          elements.searchInput.focus()
-        }
-      }
-    }
+    // Cmd+/ shortcut disabled in favour of Cmd+K (handled by Kapa widget)
+    // function handleKeyboardShortcut (e) {
+    //   const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0
+    //   const modifierKey = isMac ? e.metaKey : e.ctrlKey
+    //   if (modifierKey && e.key === '/') {
+    //     e.preventDefault()
+    //     if (isMobileView && elements.mobileSearchInput) {
+    //       elements.mobileSearchInput.focus()
+    //     } else {
+    //       elements.searchInput.focus()
+    //     }
+    //   }
+    // }
 
     function updateKeyboardShortcutVisibility () {
       // Hide keyboard shortcut when input has focus or contains text
@@ -806,8 +803,7 @@
       // Listen for window resize to handle mobile/desktop transitions
       window.addEventListener('resize', updateSearchUIForScreenSize)
 
-      // Listen for keyboard shortcut (Cmd+/ or Ctrl+/)
-      document.addEventListener('keydown', handleKeyboardShortcut)
+      // document.addEventListener('keydown', handleKeyboardShortcut)
     }
 
     // Initialize everything

--- a/ui/src/partials/head-scripts.hbs
+++ b/ui/src/partials/head-scripts.hbs
@@ -60,6 +60,7 @@
     data-modal-override-open-selector-search="#search-text-input"
     data-modal-open-on-command-k="true"
     data-modal-command-k-search-mode-default="true"
+    data-search-source-ids-include="585f4613-bd84-4fd1-9e73-d3a0265cfd39"
 ></script>
 <!-- Hotjar Tracking Code for www.circleci.com -->
 <script>

--- a/ui/src/partials/head-scripts.hbs
+++ b/ui/src/partials/head-scripts.hbs
@@ -55,6 +55,11 @@
 <script defer src="https://widget.kapa.ai/kapa-widget.bundle.js" data-website-id="06cd008c-32ae-46d3-946b-211d1afd443c" data-project-name="CircleCI" data-project-color="#161616" data-project-logo="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTI7jLeuu2k66svJDmHxYKlP7Ysf7FvNbkuvzAhHEPCsvLbhcpVRnoJCm538OSv6o5uzlQ&usqp=CAU"
     data-mcp-enabled="true"
     data-mcp-server-url="https://circleci.mcp.kapa.ai"
+    data-search-mode-enabled="true"
+    data-search-mode-default="true"
+    data-modal-override-open-selector-search="#search-text-input"
+    data-modal-open-on-command-k="true"
+    data-modal-command-k-search-mode-default="true"
 ></script>
 <!-- Hotjar Tracking Code for www.circleci.com -->
 <script>

--- a/ui/src/partials/search-bar.hbs
+++ b/ui/src/partials/search-bar.hbs
@@ -15,7 +15,7 @@
     >
     <span data-keyboard-shortcut class="absolute inset-y-0 right-5 flex items-center text-xs pointer-events-none">
       <span class="px-2 py-1 border border-vapor rounded bg-white text-gray-600">
-        <span data-shortcut-key>cmd</span>+/
+        <span data-shortcut-key>cmd</span>+k
       </span>
     </span>
     <button data-search-clear class="hidden absolute inset-y-0 right-5 items-center gap-2 pl-3 text-link-on-light">


### PR DESCRIPTION
Wires the existing search input to the Kapa unified search/chat modal, disables the Algolia Cmd+/ shortcut in favour of Cmd+K, and documents the full integration (including revert steps) in DEVELOPMENT.md. Algolia indexing is untouched as it serves the marketing site.

