### PR TITLE
Prevent page TOC overlapping wide breadcrumbs

### DIFF
--- a/ui/src/css/main.css
+++ b/ui/src/css/main.css
@@ -52,6 +52,39 @@ body.-toc aside.toc.sidebar {
     flex: 0 0 var(--toc-width);
     order: 1;
   }
+
+  /* The breadcrumb toolbar sits above the article/TOC flex row and spans the
+     full width of main. Constrain its width to the article column so the trail
+     truncates before it can reach the (negatively offset) sticky TOC.
+     The 5rem subtracted is the toolbar's own left margin (lg:ml-12 = 3rem) plus a
+     ~2rem gap before the TOC; keep it in sync with that margin.
+     A percentage width is used rather than margin-right because margins count
+     toward intrinsic (max-content) width: a wide right margin would inflate main
+     to its max-width and overflow the viewport. The percentage is ignored during
+     intrinsic sizing, while the existing max-w-[800px] still caps the trail. */
+  .article-toolbar {
+    width: calc(100% - var(--toc-width) - 5rem);
+  }
+
+  /* Pages without a sidebar TOC (body.-toc) give the article full width, so the
+     toolbar should not reserve a TOC column. */
+  body.-toc .article-toolbar {
+    width: auto;
+  }
+
+  /* Keep the trail on a single line and truncate it with an ellipsis at the
+     reserved boundary. Wrapping would grow the toolbar and push the whole
+     article/TOC row — and therefore the TOC — down a line. min-width: 0 lets the
+     nav flex item shrink below its content width so the overflow can be clipped. */
+  .article-toolbar nav[aria-label="breadcrumbs"] {
+    min-width: 0;
+  }
+
+  .article-toolbar nav[aria-label="breadcrumbs"] ul {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 @media screen and (min-width: 1280px) { /* Use xl breakpoint to match existing xl:items-center */
@@ -68,5 +101,10 @@ body.-toc aside.toc.sidebar {
 
   main {
     max-width: calc(var(--doc-max-width--desktop) + var(--toc-width--widescreen)); /* Article + wider TOC */
+  }
+
+  /* Match the wider sidebar TOC column at widescreen widths. */
+  .article-toolbar {
+    width: calc(100% - var(--toc-width--widescreen) - 5rem);
   }
 }

--- a/ui/src/partials/article-toolbar.hbs
+++ b/ui/src/partials/article-toolbar.hbs
@@ -1,3 +1,3 @@
-<div role="navigation" aria-label="Article Toolbar" class="flex flex-col max-w-[800px] md:items-center mx-[32px] md:ml-[3.5rem] lg:ml-12 mt-6 md:mt-12 md:flex-row text-sm font-normal" >
+<div role="navigation" aria-label="Article Toolbar" class="article-toolbar flex flex-col max-w-[800px] md:items-center mx-[32px] md:ml-[3.5rem] lg:ml-12 mt-6 md:mt-12 md:flex-row text-sm font-normal" >
   {{> breadcrumbs}}
 </div>


### PR DESCRIPTION
At desktop widths (>=1200px) a wide breadcrumb trail could overlap the right-hand sticky page TOC. Constrain the breadcrumb toolbar to the article-column width (using the existing --toc-width tokens) and keep the trail on a single line, truncating with an ellipsis, so it can never reach the TOC. A percentage width is used rather than margin-right because margins count toward intrinsic width and would inflate main past the viewport. Pages without a sidebar TOC (body.-toc) keep the full-width breadcrumb.

**Before:**

<img width="1256" height="685" alt="Screenshot 2026-06-08 at 11 56 02" src="https://github.com/user-attachments/assets/ca8eca0f-6a44-48e7-9dae-16a3b6b9168b" />

**After:**

<img width="1262" height="705" alt="Screenshot 2026-06-08 at 11 56 56" src="https://github.com/user-attachments/assets/84aa6f2b-e5f8-492b-9aa1-c9b0b382af18" />

## Testing

Check some pages with really long breadcrumbs, check on the production site by shrinking the browser horizontally until you see the overlap. Then check the preview site for the same pages to see the breadcrumbs are truncated

* https://circleci.com/docs/guides/execution-runner/runner-api/
* https://circleci.com/docs/guides/test/fix-flaky-tests/ 

