### PR TITLE
DOC-188: fix responsive layout jumps between mobile, tablet and desktop

### DIFF
--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -12,7 +12,11 @@ html {
   color-scheme: light dark; /* Support both light and dark modes */
 }
 
-@media screen and (min-width: 1024px) {
+/* Type scale matches desktop from the tablet breakpoint up; only mobile drops
+   down (the design has one mobile type scale and a shared tablet/desktop scale).
+   Kept at 768px (md) to align with the heading sizes in doc.css. The structural
+   reflow to sidebars stays at 1200px (lg) — see main.css. */
+@media screen and (min-width: 768px) {
   html {
     font-size: var(--body-font-size--desktop);
   }

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -15,7 +15,7 @@
 @media screen and (max-width: 1199.5px) {
   .doc {
     max-width: var(--doc-max-width--desktop);
-    padding: 0 32px 4rem;
+    padding: 0 var(--doc-padding-x) 4rem;
   }
 }
 

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -99,6 +99,14 @@
     font-size: 24px;
   }
 
+  /* Gives the breadcrumbs→title gap on mobile, matching the tablet/desktop rule.
+     Uses the same --rem-base calc as the ≥768 rule for consistency; note the root
+     is 17px below 768px, so this resolves to ~37.8px rather than a true 40px until
+     the 17px-root quirk is revisited. */
+  .doc h1.page {
+    margin-top: calc(40 / var(--rem-base) * 1rem);
+  }
+
   .doc h2 {
     font-size: 20px;
     margin-bottom: 24px;

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -89,8 +89,10 @@
   font-size: 16px;
 }
 
-/* Mobile heading sizes */
-@media screen and (max-width: 1023.5px) {
+/* Mobile heading sizes (below the tablet breakpoint). 767.5px pairs with the
+   768px html font-size bump in base.css so the whole type scale switches at one
+   boundary. */
+@media screen and (max-width: 767.5px) {
   .doc h1 {
     font-size: 24px;
   }

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -7,28 +7,30 @@
   padding: 0 1rem 4rem;
 }
 
-@media screen and (max-width: 1023.5px) {
+/* Below the 1200px sidebar-TOC reflow (mobile + tablet) there is no TOC beside
+   the article, so the article is a centered column — capped at the same width it
+   uses on desktop and centred via the base `margin: 0 auto` — with wider side
+   padding. The breadcrumb toolbar is centred to the same column in
+   article-toolbar.hbs so their left edges line up. */
+@media screen and (max-width: 1199.5px) {
   .doc {
+    max-width: var(--doc-max-width--desktop);
     padding: 0 32px 4rem;
   }
 }
 
-@media screen and (min-width: 1024px) {
-  .doc {
-    flex: auto;
-    font-size: var(--doc-font-size--desktop);
-    margin: var(--doc-margin--desktop);
-    max-width: var(--doc-max-width--desktop);
-    min-width: 0;
-  }
-}
-
-/* Apply aggressive flexbox fix only above 1200px where the original problem occurs */
+/* The article column only narrows for the TOC at 1200px, where the sidebar TOC
+   actually appears (see main.css). Below that — the entire tablet range — the
+   article stays full-width, so there is no capped column with an empty gutter
+   where the TOC will later sit. Previously this block fired at 1024px, 176px
+   before the TOC arrived, which left that dead gutter on the right. */
 @media screen and (min-width: 1200px) {
   .doc {
     flex: 1 1 0%;
     width: 0; /* Force flexbox to ignore content width */
-    max-width: var(--doc-max-width--desktop); /* Restore max-width for centering */
+    margin: var(--doc-margin--desktop);
+    max-width: var(--doc-max-width--desktop);
+    min-width: 0;
     transition: max-width 0.3s ease;
   }
 }

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -11,9 +11,19 @@
    the article, so the article is a centered column — capped at the same width it
    uses on desktop and centred via the base `margin: 0 auto` — with wider side
    padding. The breadcrumb toolbar is centred to the same column in
-   article-toolbar.hbs so their left edges line up. */
+   article-toolbar.hbs so their left edges line up.
+
+   width:100% + min-width:0 are required because .doc is a flex item and the base
+   `margin: 0 auto` gives it auto cross-axis margins. Auto margins make a flex
+   item size to its content (capped at max-width), so wide content (long code
+   lines, wide tables) would push it out to the 888px max-width even on a phone,
+   overflowing the page horizontally. width:100% sizes it to the container instead
+   (still capped/centred by max-width), and min-width:0 lets wide children be
+   clipped/scrolled inside the article rather than widening it. */
 @media screen and (max-width: 1199.5px) {
   .doc {
+    width: 100%;
+    min-width: 0;
     max-width: var(--doc-max-width--desktop);
     padding: 0 var(--doc-padding-x) 4rem;
   }

--- a/ui/src/css/main.css
+++ b/ui/src/css/main.css
@@ -12,7 +12,11 @@ body.-toc aside.toc.sidebar {
     margin-bottom: 2.5rem;
   }
 
-  main > div {
+  /* Overflow guard for the content wrapper only. Excludes the breadcrumb
+     toolbar: this unlayered max-width would otherwise override the toolbar's
+     max-w-[888px] utility (unlayered beats @layer) and break its centring,
+     making the breadcrumbs jump to the left below 1024px. */
+  main > div:not(.article-toolbar) {
     overflow-x: auto;
     max-width: 100vw;
   }

--- a/ui/src/css/main.css
+++ b/ui/src/css/main.css
@@ -65,7 +65,8 @@ body.-toc aside.toc.sidebar {
      A percentage width is used rather than margin-right because margins count
      toward intrinsic (max-content) width: a wide right margin would inflate main
      to its max-width and overflow the viewport. The percentage is ignored during
-     intrinsic sizing, while the existing max-w-[800px] still caps the trail. */
+     intrinsic sizing, while the toolbar's max-width (the shared article column
+     width) still caps the trail. */
   .article-toolbar {
     width: calc(100% - var(--toc-width) - 5rem);
   }

--- a/ui/src/css/toc.css
+++ b/ui/src/css/toc.css
@@ -31,7 +31,10 @@
   margin-bottom: 1.2rem;
 }
 
-@media screen and (max-width: 1023.5px) {
+/* The embedded TOC is shown the whole way up to the 1200px sidebar reflow, so
+   its heading spacing must cover that range too — previously this stopped at
+   1024px, leaving the heading cramped against the links in the 1024–1199 band. */
+@media screen and (max-width: 1199.5px) {
   .toc.embedded .toc-menu h3 {
     margin-bottom: 1.25rem;
   }
@@ -94,7 +97,10 @@
   transition: border-left-color 0.3s ease, border-left-width 0.3s ease;
 }
 
-@media screen and (max-width: 48rem) {
+/* The embedded TOC (shown below the 1200px sidebar reflow) uses link-blue for its
+   items on both mobile and tablet — previously this stopped at 768px, leaving the
+   tablet links grey. The sidebar TOC at 1200px+ keeps its own grey styling. */
+@media screen and (max-width: 1199.5px) {
   .toc .toc-menu a {
     color: var(--link-font-color);
   }

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -212,7 +212,6 @@
   --monospace-font-family: "IBM Plex Mono", monospace;
   --monospace-font-weight-bold: 600;
   --doc-font-size: 16px;
-  --doc-font-size--desktop: 16px;
   --doc-line-height: 1.7;
   --heading-font-weight: 500;
   --alt-heading-font-weight: 500;

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -244,6 +244,10 @@
   --doc-max-width--desktop: calc(888 / var(--rem-base) * 1rem);
   --doc-margin: 0 auto;
   --doc-margin--desktop: 0 2rem;
+  /* Side padding of the centred article column below the 1200px reflow. Shared by
+     .doc (doc.css) and the breadcrumb toolbar (article-toolbar.hbs) so their
+     content edges stay aligned — keep them pointed at this one value. */
+  --doc-padding-x: 32px;
 
   /* ============================================
      STACKING (Z-INDEX)

--- a/ui/src/partials/article-toolbar.hbs
+++ b/ui/src/partials/article-toolbar.hbs
@@ -1,3 +1,3 @@
-<div role="navigation" aria-label="Article Toolbar" class="article-toolbar flex flex-col max-w-[888px] md:items-center ml-auto mr-auto px-[32px] lg:ml-12 lg:mr-0 lg:px-0 mt-6 md:mt-12 md:flex-row text-sm font-normal" >
+<div role="navigation" aria-label="Article Toolbar" class="article-toolbar flex flex-col max-w-[var(--doc-max-width--desktop)] md:items-center ml-auto mr-auto px-[var(--doc-padding-x)] lg:ml-12 lg:mr-0 lg:px-0 mt-6 md:mt-12 md:flex-row text-sm font-normal" >
   {{> breadcrumbs}}
 </div>

--- a/ui/src/partials/article-toolbar.hbs
+++ b/ui/src/partials/article-toolbar.hbs
@@ -1,3 +1,3 @@
-<div role="navigation" aria-label="Article Toolbar" class="article-toolbar flex flex-col max-w-[800px] md:items-center mx-[32px] md:ml-[3.5rem] lg:ml-12 mt-6 md:mt-12 md:flex-row text-sm font-normal" >
+<div role="navigation" aria-label="Article Toolbar" class="article-toolbar flex flex-col max-w-[888px] md:items-center ml-auto mr-auto px-[32px] lg:ml-12 lg:mr-0 lg:px-0 mt-6 md:mt-12 md:flex-row text-sm font-normal" >
   {{> breadcrumbs}}
 </div>


### PR DESCRIPTION
## Summary

Fixes a cluster of responsive layout bugs caused by breakpoint drift: site styles were keyed to several different boundaries (768px, 1024px, 1200px) that no longer lined up, producing an awkward "two tablet views" effect, an article column that reflowed before its TOC appeared, misaligned elements, and inconsistent tablet styling.

### Background

The site has effectively **two structural breakpoints**:
- **768px** — mobile ↔ tablet (the *type scale* boundary; the design shares one type scale across tablet + desktop and only drops it for mobile)
- **1200px** — tablet ↔ desktop (the *structural* reflow: left nav becomes a persistent sidebar and the page TOC moves from embedded to a right sidebar). This is Tailwind's `lg`, overridden to `75rem` in `@theme`.

A previous breakpoint cleanup (#179) raised `lg` from 1040px → 1200px but left several rules stranded at **1024px**, opening a 176px "dead band" where styles were half-tablet, half-desktop. This PR re-homes those rules onto the two real boundaries and aligns the article column with the Figma design (centred, 888px max content width below the reflow).

## Changes (one fix per commit)

1. **Type scale → 768px** — the root font bump and mobile heading sizes switched at 1024px; moved to 768px so the type scale flips once, at the mobile/tablet boundary.
2. **Cap & centre the article column at 1200px** — the article gained its 888px cap at 1024px, before the sidebar TOC (1200px) it makes room for, leaving a dead right-hand gutter. Now it stays a centred, full-width-capped column below 1200px and only narrows when the TOC actually arrives. Breadcrumb toolbar centred to the same column. Excludes the toolbar from the unlayered `main > div` overflow guard (which was overriding the toolbar's `max-w` utility — unlayered CSS beats `@layer` — and breaking centring below 1024px). Also drops the dead `--doc-font-size--desktop` (it equalled `--doc-font-size`).
3. **Embedded TOC consistency** — the TOC heading spacing (stopped at 1024px) and link colour (stopped at 768px) now both extend across the whole tablet range to 1200px.
4. **Mobile breadcrumbs→title gap** — `h1.page` only had its top margin at ≥768px; added it for mobile too.
5. **Tidy-up** — dedupe the centred-column geometry (width + side padding) into shared variables so the article and toolbar can't drift out of alignment; fix a stale comment.

## Test plan

Resize the browser slowly and confirm clean, single transitions:
- **~768px** — type scale steps up (headings larger); no layout reflow; nav stays a hamburger.
- **~1024px** — **no jump** (the bug): article stays a centred column, breadcrumbs stay aligned, TOC heading spacing and link colour unchanged.
- **~1200px** — the *one* structural reflow: article caps + sidebar TOC appears together.
- **Mobile (<768px)** — breadcrumbs→title gap restored; TOC links blue.
- **Desktop / widescreen (1280px, 1600px)** — sanity-check breadcrumb truncation and TOC width are unaffected.

## Follow-ups (not in this PR)

- Replace the broad `main > div` selector with a dedicated wrapper class so the toolbar/wrapper stop sharing a selector (would remove the `:not(.article-toolbar)` patch).
- Establish a single source of truth for breakpoint values (currently duplicated between Tailwind `@theme` and hand-written px media queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)