### PR TITLE
Document container runner private-registry images (SUPENG-380)

### DIFF
--- a/docs/guides/modules/execution-runner/pages/container-runner-installation.adoc
+++ b/docs/guides/modules/execution-runner/pages/container-runner-installation.adoc
@@ -83,6 +83,66 @@ agent:
 helm install container-agent container-agent/container-agent -n circleci -f values.yaml
 ----
 
+[#private-container-registry]
+== Using a private container registry (optional)
+
+If your cluster cannot pull images from Docker Hub (for example, in an air-gapped environment or when outbound registry access is restricted), mirror the CircleCI container runner images to your own registry or configure a pull-through cache, then point the Helm chart at those locations.
+
+Container runner uses **three separate images**. Each is configured with a **top-level** key in `values.yaml` (not nested under `agent`):
+
+[cols="1,1,1",options="header"]
+|===
+| Helm key | Default image | Where it runs
+| `agent.image` | `circleci/runner-agent` | container-agent deployment
+| `orchestrator.image` | `circleci/runner-init` | init container on each task pod
+| `logging.image` | `circleci/logging-collector` | sidecar on task pods that use service containers
+|===
+
+Setting `agent.image` alone does not repoint the orchestrator or logging sidecar. Task pods may still try to pull from Docker Hub and fail with `ImagePullBackOff` if those keys are omitted.
+
+Add the following to your `values.yaml`, substituting your registry host, repository path, and tags (tags should match your container-agent chart version for compatibility):
+
+[source,yaml]
+----
+agent:
+  image:
+    registry: registry.example.com
+    repository: circleci/runner-agent
+    tag: kubernetes-3
+  resourceClasses:
+    <your-namespace>/<your-resource-class-name>:
+      token: <your-resource_class_token>
+
+orchestrator:
+  image:
+    registry: registry.example.com
+    repository: circleci/runner-init
+    tag: agent-server-4.7
+
+logging:
+  image:
+    registry: registry.example.com
+    repository: circleci/logging-collector
+    tag: 3.1.9-9141-f95ed2b
+----
+
+If you use CircleCI Server, include `agent.runnerAPI` as shown in <<#container-runner-installation,step 2>> above. Adjust the `runner-init` tag to match your Server version.
+
+After updating `values.yaml`, upgrade the release:
+
+[source,shell]
+----
+helm upgrade container-agent container-agent/container-agent -n circleci -f values.yaml
+----
+
+Verify the container-agent pod exposes your registry paths (not Docker Hub defaults):
+
+[source,shell]
+----
+kubectl describe pod -n circleci -l app=container-agent | grep -E 'KUBE_LOGGING_IMAGE|KUBE_RUNNER_INIT_IMAGE'
+----
+
+For job images (not CircleCI runner components), use `imagePullSecrets` on the resource class pod spec. See xref:container-runner.adoc#resource-class-configuration-custom-pod[Resource class configuration] and the link:https://support.circleci.com/hc/en-us/articles/20665530773403[Support Center article on imagePullSecrets for container runner].
 
 [#enable-rerun-job-with-ssh]
 [badge="Open preview"]

--- a/docs/guides/modules/execution-runner/pages/container-runner-installation.adoc
+++ b/docs/guides/modules/execution-runner/pages/container-runner-installation.adoc
@@ -84,11 +84,11 @@ helm install container-agent container-agent/container-agent -n circleci -f valu
 ----
 
 [#private-container-registry]
-== Using a private container registry (optional)
+=== Using a private container registry (optional)
 
 If your cluster cannot pull images from Docker Hub, mirror the CircleCI container runner images to your own registry or configure a pull-through cache. This applies in air-gapped environments or when outbound registry access is restricted. Then point the Helm chart at those locations.
 
-Container runner uses **three separate images**. Each is configured with a **top-level** key in `values.yaml` (not nested under `agent`):
+Container runner uses three separate images. Configure each image with a top-level key in `values.yaml` (not nested under `agent`):
 
 [cols="1,1,1",options="header"]
 |===
@@ -98,7 +98,7 @@ Container runner uses **three separate images**. Each is configured with a **top
 | `logging.image` | `circleci/logging-collector` | sidecar on task pods that use service containers
 |===
 
-Setting `agent.image` alone does not override the orchestrator or logging sidecar image settings. Task pods may still try to pull from Docker Hub and fail with `ImagePullBackOff` if those keys are omitted.
+Setting `agent.image` alone does not override the orchestrator or logging sidecar image settings. Task pods may still try to pull from Docker Hub and fail with `ImagePullBackOff` if you omit those keys.
 
 Add the following to your `values.yaml`, substituting your registry host, repository path, and tags (tags must match your container-agent chart version for compatibility):
 
@@ -126,7 +126,7 @@ logging:
     tag: 3.1.9-9141-f95ed2b
 ----
 
-If you use CircleCI Server, include `agent.runnerAPI` as shown in <<#container-runner-installation,step 2>> above. Adjust the `runner-init` tag to match your Server version.
+If you use CircleCI Server, include `agent.runnerAPI` as shown in the CircleCI Server step above. Adjust the `runner-init` tag to match your Server version.
 
 After updating `values.yaml`, upgrade the release:
 

--- a/docs/guides/modules/execution-runner/pages/container-runner-installation.adoc
+++ b/docs/guides/modules/execution-runner/pages/container-runner-installation.adoc
@@ -86,7 +86,7 @@ helm install container-agent container-agent/container-agent -n circleci -f valu
 [#private-container-registry]
 == Using a private container registry (optional)
 
-If your cluster cannot pull images from Docker Hub (for example, in an air-gapped environment or when outbound registry access is restricted), mirror the CircleCI container runner images to your own registry or configure a pull-through cache, then point the Helm chart at those locations.
+If your cluster cannot pull images from Docker Hub, mirror the CircleCI container runner images to your own registry or configure a pull-through cache. This applies in air-gapped environments or when outbound registry access is restricted. Then point the Helm chart at those locations.
 
 Container runner uses **three separate images**. Each is configured with a **top-level** key in `values.yaml` (not nested under `agent`):
 
@@ -98,9 +98,9 @@ Container runner uses **three separate images**. Each is configured with a **top
 | `logging.image` | `circleci/logging-collector` | sidecar on task pods that use service containers
 |===
 
-Setting `agent.image` alone does not repoint the orchestrator or logging sidecar. Task pods may still try to pull from Docker Hub and fail with `ImagePullBackOff` if those keys are omitted.
+Setting `agent.image` alone does not override the orchestrator or logging sidecar image settings. Task pods may still try to pull from Docker Hub and fail with `ImagePullBackOff` if those keys are omitted.
 
-Add the following to your `values.yaml`, substituting your registry host, repository path, and tags (tags should match your container-agent chart version for compatibility):
+Add the following to your `values.yaml`, substituting your registry host, repository path, and tags (tags must match your container-agent chart version for compatibility):
 
 [source,yaml]
 ----
@@ -142,7 +142,7 @@ Verify the container-agent pod exposes your registry paths (not Docker Hub defau
 kubectl describe pod -n circleci -l app=container-agent | grep -E 'KUBE_LOGGING_IMAGE|KUBE_RUNNER_INIT_IMAGE'
 ----
 
-For job images (not CircleCI runner components), use `imagePullSecrets` on the resource class pod spec. See xref:container-runner.adoc#resource-class-configuration-custom-pod[Resource class configuration] and the link:https://support.circleci.com/hc/en-us/articles/20665530773403[Support Center article on imagePullSecrets for container runner].
+For job images (not CircleCI runner components), use `imagePullSecrets` on the resource class pod spec. See xref:container-runner.adoc#resource-class-configuration-custom-pod[Resource Class Configuration] and the link:https://support.circleci.com/hc/en-us/articles/20665530773403[Support Center article on imagePullSecrets for container runner].
 
 [#enable-rerun-job-with-ssh]
 [badge="Open preview"]

--- a/docs/guides/modules/execution-runner/pages/container-runner.adoc
+++ b/docs/guides/modules/execution-runner/pages/container-runner.adoc
@@ -446,12 +446,23 @@ Container runner will drain and restart cleanly when sent a termination signal. 
 
 If the container runner crashes, there is no expectation that in-process or queued tasks are handled gracefully.
 
+[#private-container-registry]
+== Private container registry
+
+In environments that block outbound access to Docker Hub, mirror the CircleCI runner images to your own registry (or use a pull-through cache) and set `agent.image`, `orchestrator.image`, and `logging.image` in the Helm chart `values.yaml`. All three keys are top-level; only configuring `agent.image` leaves task pods pulling `circleci/runner-init` and `circleci/logging-collector` from the public registry by default.
+
+See xref:container-runner-installation.adoc#private-container-registry[Using a private container registry] for a full example and verification steps.
+
+The orchestrator init container image is configured under `orchestrator.image`. The logging sidecar image is configured under `logging.image`. Both accept the same fields as `agent.image` (`registry`, `repository`, `tag`, and optional `digest`). Refer to the link:https://github.com/CircleCI-Public/container-runner-helm-chart/blob/main/values.yaml[Helm chart values.yaml] for defaults.
+
 [#logging-containers]
 == Logging containers
 
 Container runner schedules a logging container if there are secondary (service) containers in the task pod. This container will get the secondary container logs and stream them to the steps UI in the CircleCI web app. Task agent, which runs in the primary container, is responsible for streaming all other step output to the CircleCI web app. The only exception is the `Task lifecycle` step, which is streamed by container runner itself.
 
 Logging containers require a service account token with the minimal privileges to get container logs.
+
+The logging sidecar image defaults to `circleci/logging-collector` from Docker Hub. To use a private registry, set the top-level `logging.image` values in your Helm chart. See <<private-container-registry,Private container registry>>.
 
 Container runner currently sets default resource limits and requests on the logging container, they are:
 

--- a/docs/guides/modules/execution-runner/pages/container-runner.adoc
+++ b/docs/guides/modules/execution-runner/pages/container-runner.adoc
@@ -449,9 +449,9 @@ If the container runner crashes, there is no expectation that in-process or queu
 [#private-container-registry]
 == Private container registry
 
-In environments that block outbound access to Docker Hub, mirror the CircleCI runner images to your own registry (or use a pull-through cache) and set `agent.image`, `orchestrator.image`, and `logging.image` in the Helm chart `values.yaml`. All three keys are top-level; only configuring `agent.image` leaves task pods pulling `circleci/runner-init` and `circleci/logging-collector` from the public registry by default.
+In environments that block outbound access to Docker Hub, mirror the CircleCI runner images to your own registry (or use a pull-through cache). Set `agent.image`, `orchestrator.image`, and `logging.image` in the Helm chart `values.yaml`. All three keys are top-level. Only configuring `agent.image` leaves task pods pulling `circleci/runner-init` and `circleci/logging-collector` from the public registry by default.
 
-See xref:container-runner-installation.adoc#private-container-registry[Using a private container registry] for a full example and verification steps.
+See xref:container-runner-installation.adoc#private-container-registry[Using a Private Container Registry] for a full example and verification steps.
 
 The orchestrator init container image is configured under `orchestrator.image`. The logging sidecar image is configured under `logging.image`. Both accept the same fields as `agent.image` (`registry`, `repository`, `tag`, and optional `digest`). Refer to the link:https://github.com/CircleCI-Public/container-runner-helm-chart/blob/main/values.yaml[Helm chart values.yaml] for defaults.
 

--- a/docs/guides/modules/execution-runner/pages/container-runner.adoc
+++ b/docs/guides/modules/execution-runner/pages/container-runner.adoc
@@ -449,11 +449,11 @@ If the container runner crashes, there is no expectation that in-process or queu
 [#private-container-registry]
 == Private container registry
 
-In environments that block outbound access to Docker Hub, mirror the CircleCI runner images to your own registry (or use a pull-through cache). Set `agent.image`, `orchestrator.image`, and `logging.image` in the Helm chart `values.yaml`. All three keys are top-level. Only configuring `agent.image` leaves task pods pulling `circleci/runner-init` and `circleci/logging-collector` from the public registry by default.
+In environments that block outbound access to Docker Hub, mirror the CircleCI runner images to your own registry (or use a pull-through cache). Set `agent.image`, `orchestrator.image`, and `logging.image` in the Helm chart `values.yaml`. All three keys are top-level. If you configure only `agent.image`, task pods still pull `circleci/runner-init` and `circleci/logging-collector` from the public registry by default.
 
 See xref:container-runner-installation.adoc#private-container-registry[Using a Private Container Registry] for a full example and verification steps.
 
-The orchestrator init container image is configured under `orchestrator.image`. The logging sidecar image is configured under `logging.image`. Both accept the same fields as `agent.image` (`registry`, `repository`, `tag`, and optional `digest`). Refer to the link:https://github.com/CircleCI-Public/container-runner-helm-chart/blob/main/values.yaml[Helm chart values.yaml] for defaults.
+Set the orchestrator init container image under `orchestrator.image`. Set the logging sidecar image under `logging.image`. Both accept the same fields as `agent.image` (`registry`, `repository`, `tag`, and optional `digest`). Refer to the link:https://github.com/CircleCI-Public/container-runner-helm-chart/blob/main/values.yaml[Helm Chart values.yaml] for defaults.
 
 [#logging-containers]
 == Logging containers
@@ -462,7 +462,7 @@ Container runner schedules a logging container if there are secondary (service) 
 
 Logging containers require a service account token with the minimal privileges to get container logs.
 
-The logging sidecar image defaults to `circleci/logging-collector` from Docker Hub. To use a private registry, set the top-level `logging.image` values in your Helm chart. See <<private-container-registry,Private container registry>>.
+The logging sidecar image defaults to `circleci/logging-collector` from Docker Hub. To use a private registry, set the top-level `logging.image` values in your Helm chart. See <<private-container-registry,Private Container Registry>>.
 
 Container runner currently sets default resource limits and requests on the logging container, they are:
 


### PR DESCRIPTION
## Summary

- Add **Using a private container registry (optional)** to the container runner installation guide, covering all three Helm image keys: `agent.image`, `orchestrator.image`, and `logging.image`
- Add **Private container registry** reference section and expand **Logging containers** to point at `logging.image` configuration

Customer context: Zendesk #172931 (Server + container runner). Jobs failed with `ImagePullBackOff` on `circleci/logging-collector` because only `agent.image` was set. Linear: https://linear.app/circleci/issue/SUPENG-380

## Test plan

- [ ] AsciiDoc builds cleanly (CI)
- [ ] Installation page renders the new section at `/guides/execution-runner/container-runner-installation/#private-container-registry`
- [ ] Reference page cross-links resolve