### PR TITLE
feat: add Xcode 26.6 to supported versions

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
@@ -9,6 +9,14 @@
 | VM Software Manifest
 | Release Notes
 
+| `26.6`
+| Xcode 26.6 (17F109)
+| 26.3
+a| `m4pro.medium` +
+   `m4pro.large`
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18595/manifest.txt[Installed software]
+| link:https://circleci.com/changelog/xcode-26-6-available/[Release Notes]
+
 | `26.5`
 | Xcode 26.5 (17F42)
 | 26.3.1


### PR DESCRIPTION
## Summary

- Adds Xcode 26.6 (17F109) on macOS 26.3 to the supported Xcode versions table
- Manifest: [v18595](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18595/manifest.txt)
- Release notes: https://circleci.com/changelog/xcode-26-6-available/
