### PR TITLE
Site performance fixes

### DIFF
--- a/ui/src/css/typeface-ibm-plex-mono.css
+++ b/ui/src/css/typeface-ibm-plex-mono.css
@@ -2,6 +2,7 @@
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src:
     url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-300-normal.woff2) format("woff2"),
     url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-300-normal.woff) format("woff");
@@ -13,6 +14,7 @@
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-cyrillic-300-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -22,6 +24,7 @@
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src:
     url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-400-normal.woff2) format("woff2"),
     url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-400-normal.woff) format("woff");
@@ -33,6 +36,7 @@
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-cyrillic-400-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -42,6 +46,7 @@
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src:
     url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2) format("woff2"),
     url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff) format("woff");
@@ -53,6 +58,7 @@
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src: url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-cyrillic-500-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -62,6 +68,7 @@
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src:
     url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-600-normal.woff2) format("woff2"),
     url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-600-normal.woff) format("woff");
@@ -73,6 +80,7 @@
   font-family: "IBM Plex Mono";
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src: url(~@fontsource/ibm-plex-mono/files/ibm-plex-mono-cyrillic-600-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }

--- a/ui/src/css/typeface-inter.css
+++ b/ui/src/css/typeface-inter.css
@@ -2,6 +2,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-400-normal.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-400-normal.woff) format("woff");
@@ -12,6 +13,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-400-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -20,6 +22,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 400;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-400-italic.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-400-italic.woff) format("woff");
@@ -30,6 +33,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 400;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-400-italic.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -38,6 +42,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-500-normal.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-500-normal.woff) format("woff");
@@ -48,6 +53,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 600;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-500-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -56,6 +62,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 600;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-500-italic.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-500-italic.woff) format("woff");
@@ -66,6 +73,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 600;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-500-italic.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -75,6 +83,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 200;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-200-normal.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-200-normal.woff) format("woff");
@@ -84,6 +93,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 200;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-200-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -91,6 +101,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 200;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-200-italic.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-200-italic.woff) format("woff");
@@ -100,6 +111,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 200;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-200-italic.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -109,6 +121,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-300-normal.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-300-normal.woff) format("woff");
@@ -118,6 +131,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-300-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -125,6 +139,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 300;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-300-italic.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-300-italic.woff) format("woff");
@@ -134,6 +149,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 300;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-300-italic.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -143,6 +159,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-500-normal.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-500-normal.woff) format("woff");
@@ -152,6 +169,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-500-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -159,6 +177,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 500;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-500-italic.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-500-italic.woff) format("woff");
@@ -168,6 +187,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 500;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-500-italic.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -177,6 +197,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-700-normal.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-700-normal.woff) format("woff");
@@ -186,6 +207,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-700-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -193,6 +215,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 700;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-700-italic.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-700-italic.woff) format("woff");
@@ -202,6 +225,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 700;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-700-italic.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -211,6 +235,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 800;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-800-normal.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-800-normal.woff) format("woff");
@@ -220,6 +245,7 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 800;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-800-normal.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -227,6 +253,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 800;
+  font-display: swap;
   src:
     url(~@fontsource/inter/files/inter-latin-800-italic.woff2) format("woff2"),
     url(~@fontsource/inter/files/inter-latin-800-italic.woff) format("woff");
@@ -236,6 +263,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 800;
+  font-display: swap;
   src: url(~@fontsource/inter/files/inter-cyrillic-800-italic.woff2) format("woff2");
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }

--- a/ui/src/css/typeface-roboto.css
+++ b/ui/src/css/typeface-roboto.css
@@ -2,6 +2,7 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src:
     url(~@fontsource/roboto/files/roboto-latin-700-normal.woff2) format("woff2"),
     url(~@fontsource/roboto/files/roboto-latin-700-normal.woff) format("woff");

--- a/ui/src/js/06-navigation.js
+++ b/ui/src/js/06-navigation.js
@@ -22,8 +22,10 @@
       const content = current?.nextElementSibling
       if (content) {
         content.classList.toggle('hidden')
-        const img = toggleButton.querySelector('img')
-        if (img) img.classList.toggle('-rotate-90')
+        const svg = toggleButton.querySelector('svg')
+        if (svg) svg.classList.toggle('-rotate-90')
+        const button = toggleButton.querySelector('button')
+        if (button) button.setAttribute('aria-expanded', !content.classList.contains('hidden'))
       }
     })
   })

--- a/ui/src/partials/footer-content.hbs
+++ b/ui/src/partials/footer-content.hbs
@@ -1,7 +1,7 @@
 <footer class="mt-6 pb-24 w-full {{#if class}}{{class}}{{/if}}">
 
-  <img src="{{uiRootPath}}/img/logo.svg" alt="CircleCI Logo" class="h-[44px] logo-light">
-  <img src="{{uiRootPath}}/img/logo-dark.svg" alt="CircleCI Logo" class="h-[44px] logo-dark hidden">
+  <img src="{{uiRootPath}}/img/logo.svg" alt="CircleCI Logo" class="h-[44px] logo-light" width="167" height="44">
+  <img src="{{uiRootPath}}/img/logo-dark.svg" alt="CircleCI Logo" class="h-[44px] logo-dark hidden" width="175" height="44">
 
   <div class="font-normal mt-6">
     <ul class="flex space-x-6 space-y-4 flex-col md:flex-row">

--- a/ui/src/partials/head-styles.hbs
+++ b/ui/src/partials/head-styles.hbs
@@ -1,2 +1,4 @@
+    <link rel="preload" href="{{{uiRootPath}}}/font/inter-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="{{{uiRootPath}}}/font/inter-latin-700-normal.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
     {{> shiki-styles }}

--- a/ui/src/partials/header-content.hbs
+++ b/ui/src/partials/header-content.hbs
@@ -3,8 +3,8 @@
     <!-- Logo + Title -->
     <div class="flex items-center space-x-2">
       <a href="{{{relativize '/'}}}">
-        <img src="{{{uiRootPath}}}/img/logo.svg" alt="CircleCI Logo" class="h-[44px] logo-light">
-        <img src="{{{uiRootPath}}}/img/logo-dark.svg" alt="CircleCI Logo" class="h-[44px] logo-dark hidden">
+        <img src="{{{uiRootPath}}}/img/logo.svg" alt="CircleCI Logo" class="h-[44px] logo-light" width="167" height="44">
+        <img src="{{{uiRootPath}}}/img/logo-dark.svg" alt="CircleCI Logo" class="h-[44px] logo-dark hidden" width="175" height="44">
       </a>
     </div>
 

--- a/ui/src/partials/navigation-tree.hbs
+++ b/ui/src/partials/navigation-tree.hbs
@@ -5,7 +5,7 @@
     {{#if ./content}}
       <div data-navigation-tree-toggle class="flex items-center py-[8px] px-[12px] space-x-2 max-w-fit {{#if (eq ./url @root.page.url)}} rounded-lg bg-fog{{/if}} {{#if (has-active-child ./items)}} border-none{{/if}}"{{#if (has-active-child ./items)}} data-active-parent{{/if}}>
         {{#if ./items.length }}
-          <button class="block -ml-[1.3rem] p-1 h-full flex-shrink-0">
+          <button class="block -ml-[1.3rem] p-1 h-full flex-shrink-0" aria-label="Toggle {{./content}}" aria-expanded="{{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url)))}}false{{else}}true{{/if}}">
             <svg width="6" height="4" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-[6px] h-[6px] transform {{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url))) }}-rotate-90{{/if}}" aria-hidden="true">
               <path fill-rule="evenodd" clip-rule="evenodd" d="M3.35355 3.85355C3.15829 4.04882 2.84171 4.04882 2.64645 3.85355L0.146447 1.35355C-0.0488155 1.15829 -0.0488155 0.841708 0.146447 0.646446C0.341709 0.451184 0.658292 0.451184 0.853554 0.646446L3 2.79289L5.14645 0.646447C5.34171 0.451184 5.65829 0.451184 5.85355 0.646447C6.04882 0.841709 6.04882 1.15829 5.85355 1.35355L3.35355 3.85355Z" fill="currentColor"/>
             </svg>


### PR DESCRIPTION
DOC-195

Fix 1: `font-display: swap`

Without this, when a browser encounters a custom font it hasn't loaded yet, it holds back rendering that text entirely until the font arrives (called FOIT — Flash of Invisible Text). This blocks painting and contributes to both FCP and LCP delays.

With font-display: swap, the browser immediately renders the text using a fallback system font, then swaps in the custom font when it finishes loading. The page is readable instantly; the only trade-off is a brief visual swap when the font arrives. Lighthouse estimated this saves ~1,250ms of FCP time for this page.

Also, preload most important font to avoid a lag in seeing the correct font

---
Fix 2: width and height attributes on the logo <img> tags

When a browser parses an <img> tag with no width/height, it doesn't know how much space to reserve for it. It renders the page with a 0×0 placeholder, then once the image loads it shifts everything around it to make room — that shift is what shows up as CLS (Cumulative Layout Shift).

With explicit width="167" height="44", the browser knows the aspect ratio upfront and pre-reserves the right amount of space before the image loads. The CSS (h-[44px]) still controls the actual rendered size — the HTML attributes are just the hint that eliminates the layout shift.

---
Fix 3: add aria labels to nav toggle buttons
