### PR TITLE
perf: add metric-matched Inter fallback font to eliminate font-swap CLS

### DIFF
--- a/ui/src/css/typeface-inter.css
+++ b/ui/src/css/typeface-inter.css
@@ -1,4 +1,13 @@
 @font-face {
+  font-family: "Inter Fallback";
+  src: local("Arial"), local("Helvetica Neue");
+  ascent-override: 96.88%;
+  descent-override: 24.12%;
+  line-gap-override: 0%;
+  size-adjust: 105.27%;
+}
+
+@font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 400;

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -207,7 +207,7 @@
   --body-font-size--desktop: 1.125em; /* 18px */
   --body-font-size--print: 0.9375em; /* 15px */
   --body-line-height: 1.6;
-  --body-font-family: "Inter", sans-serif;
+  --body-font-family: "Inter", "Inter Fallback", sans-serif;
   --body-font-weight-bold: 700;
   --monospace-font-family: "IBM Plex Mono", monospace;
   --monospace-font-weight-bold: 600;


### PR DESCRIPTION
## Summary

- Adds an `"Inter Fallback"` `@font-face` rule to `typeface-inter.css` using `local("Arial")` as the source, with ascent, descent, line-gap, and size-adjust values calculated directly from Inter's font metrics
- Updates `--body-font-family` in `vars.css` to include `"Inter Fallback"` in the stack between Inter and `sans-serif`

## Why

`font-display: swap` (added in #10487) causes the browser to render text with a fallback system font while Inter loads, then swap it in. If the fallback font has different metrics to Inter, this swap causes a layout reflow — shifting text and contributing to CLS. On pages with an anchor in the URL, this reflow was causing a visible scroll bounce on page refresh.

The fix is to define a fallback font whose metrics exactly match Inter, so the swap is visually invisible.

## Metric calculation

Values derived from Inter's actual font file (`inter-latin-400-normal.woff`, UPM: 2048):

| Metric | Inter value | Override |
|--------|-------------|----------|
| Ascender | 1984 | `ascent-override: 96.88%` |
| Descender | 494 | `descent-override: 24.12%` |
| Line gap | 0 | `line-gap-override: 0%` |
| x-height | 1118 vs Arial 1062 | `size-adjust: 105.27%` |

## Test plan

- [ ] Refresh a docs page with a section anchor in the URL (e.g. `/docs/some-page/#some-section`) — page should snap directly to the heading with no scroll bounce
- [ ] Check that in-page anchor link clicks still work and scroll correctly
- [ ] Verify no visible font flash or layout shift on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)