### PR TITLE
Rewrite glossary and resolve cross-doc terminology conflicts (DOC-196)

### DIFF
--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -55,7 +55,7 @@
 *** xref:orchestrate:automatic-reruns.adoc[Automatic reruns]
 *** xref:orchestrate:skip-build.adoc[Skip CI, auto-cancel, and block new pipelines]
 *** xref:orchestrate:controlling-serial-execution-across-your-organization.adoc[Controlling serial execution across your organization]
-*** xref:orchestrate:using-branch-filters.adoc[Using branch filters]
+*** xref:orchestrate:using-branch-filters.adoc[Branch and tag filtering]
 *** xref:orchestrate:selecting-a-workflow-to-run-using-pipeline-parameters.adoc[Select a workflow to run using pipeline parameters]
 *** xref:orchestrate:notify-a-slack-channel-of-a-paused-workflow.adoc[Notify a Slack channel of a paused workflow]
 ** Share data

--- a/docs/guides/modules/about-circleci/pages/concepts.adoc
+++ b/docs/guides/modules/about-circleci/pages/concepts.adoc
@@ -11,7 +11,7 @@ This guide introduces some basic concepts to help you understand how CircleCI ma
 [#concurrency]
 == Concurrency
 
-In CircleCI, _concurrency_ refers to utilizing multiple containers to run multiple jobs at the same time. To keep the system stable for all CircleCI customers, we use different soft concurrency limits on each of the xref:reference:ROOT:configuration-reference.adoc#resourceclass[Resource Classes] for different executors. If you experience queueing on your jobs, you may be hitting these limits. Customers on annual plans can request an increase to those limits at no extra charge.
+In CircleCI, _concurrency_ refers to utilizing multiple containers to run multiple jobs at the same time. This is different from CircleCI _parallelism_, which splits the tests of a single job across multiple containers. To keep the system stable for all CircleCI customers, we use different soft concurrency limits on each of the xref:reference:ROOT:configuration-reference.adoc#resourceclass[Resource Classes] for different executors. If you experience queueing on your jobs, you may be hitting these limits. Customers on annual plans can request an increase to those limits at no extra charge.
 
 See the xref:optimize:concurrency.adoc[Concurrency] page for more information.
 
@@ -536,6 +536,8 @@ Examples for all execution environments are available on the following pages:
 Pricing and plans information for the various resource classes can be found on the link:https://circleci.com/product/features/resource-classes/[Resource classes] product page.
 
 The `resource_class` key is also used to configure a xref:execution-runner:runner-concepts.adoc#namespaces-and-resource-classes[Self-Hosted Runner Instance].
+
+For full details on both uses of resource classes, see the xref:execution-managed:resource-class-overview.adoc[Resource Class Overview] page.
 
 [#steps]
 == Steps

--- a/docs/guides/modules/about-circleci/pages/concepts.adoc
+++ b/docs/guides/modules/about-circleci/pages/concepts.adoc
@@ -11,7 +11,7 @@ This guide introduces some basic concepts to help you understand how CircleCI ma
 [#concurrency]
 == Concurrency
 
-In CircleCI, _concurrency_ refers to utilizing multiple containers to run multiple jobs at the same time. This is different from CircleCI _parallelism_, which splits the tests of a single job across multiple containers. To keep the system stable for all CircleCI customers, we use different soft concurrency limits on each of the xref:reference:ROOT:configuration-reference.adoc#resourceclass[Resource Classes] for different executors. If you experience queueing on your jobs, you may be hitting these limits. Customers on annual plans can request an increase to those limits at no extra charge.
+In CircleCI, _concurrency_ refers to utilizing multiple containers to run multiple jobs at the same time. Concurrency is different from CircleCI _parallelism_, which splits the tests of a single job across multiple containers. To keep the system stable for all CircleCI customers, we use different soft concurrency limits on each of the xref:reference:ROOT:configuration-reference.adoc#resourceclass[Resource Classes] for different executors. If you experience queueing on your jobs, you may be hitting these limits. Customers on annual plans can request an increase to those limits at no extra charge.
 
 See the xref:optimize:concurrency.adoc[Concurrency] page for more information.
 

--- a/docs/guides/modules/deploy/pages/deployment-overview.adoc
+++ b/docs/guides/modules/deploy/pages/deployment-overview.adoc
@@ -153,21 +153,21 @@ To get started with the release agent see the following guides:
 
 The sections below explain some key software delivery concepts. Understanding these concepts will help you take full advantage of CircleCI deploy markers and the release agent.
 
-=== Command
+=== Release agent command
 
-TIP: Commands are available when using the release agent. For more information, see the xref:release-agent-overview.adoc[Release Agent Overview] guide.
+TIP: Release agent commands are available when using the release agent. For more information, see the xref:release-agent-overview.adoc[Release Agent Overview] guide.
 
-A _command_ is a user-initiated action CircleCI performs on the user's behalf to manipulate a specific component.
+A _release agent command_ is a user-initiated action CircleCI performs on the user's behalf to manipulate a specific component. Release agent commands are distinct from the reusable `commands` you define in your configuration file.
 
-Actions are run asynchronously via our release agent and the results are reported back to the CircleCI web app. You can see the results in the deployments dashboard, just like the step output works for CI jobs.
+Release agent commands are run asynchronously via our release agent and the results are reported back to the CircleCI web app. You can see the results in the deployments dashboard, just like the step output works for CI jobs.
 
-Some commands are available for all components:
+Some release agent commands are available for all components:
 
 * Restore version
 * Scale component
 * Restart component
 
-A subset of commands are available for _progressive_ deployments (when using Argo Rollouts):
+A subset of release agent commands are available for _progressive_ deployments (when using Argo Rollouts):
 
 * Retry deployment
 * Promote deployment
@@ -281,14 +281,14 @@ To view all deployments for an environment, follow these steps:
 . Select your environment by name.
 . You are now on the environment details page. Select the **Deployments** tab to view a list of all deployments for your chosen environment.
 
-=== View all commands run for an environment
+=== View all release agent commands run for an environment
 
-To view all commands run for an environment, follow these steps:
+To view all release agent commands run for an environment, follow these steps:
 
 . Select *Deploys* in the CircleCI web app sidebar.
 . You are now in the timeline view. Select the **Environments** tab.
 . Select your environment by name.
-. You are now on the environment details page. Select the **Commands** tab to view a list of all commands that have been run for your chosen environment.
+. You are now on the environment details page. Select the **Commands** tab to view a list of all release agent commands that have been run for your chosen environment.
 
 === View all deployments for a component
 
@@ -299,14 +299,14 @@ To view all deployments for a component, follow these steps:
 . Select your component by name. You can use the filter at the top of the page to help.
 . You are now on the component details page. Select the **Deployments** tab to view a list of all deployments for your chosen component.
 
-=== View all commands run for a component
+=== View all release agent commands run for a component
 
-To view all commands run for a component, follow these steps:
+To view all release agent commands run for a component, follow these steps:
 
 . Select *Deploys* in the CircleCI web app sidebar.
 . You are now in the timeline view. Select the **Components** tab.
 . Select your component by name. You can use the filter at the top of the page to help.
-. You are now on the component details page. Select the **Commands** tab to view a list of all commands run for your chosen component.
+. You are now on the component details page. Select the **Commands** tab to view a list of all release agent commands run for your chosen component.
 
 [#release-status]
 == Deploy status
@@ -333,7 +333,7 @@ A deployment can be in one of the following states:
 |The deployment has been cancelled, either using the `cancel deployment` option, or by being superseded by another deployment.
 
 |EXPIRED
-|Deployment commands failed to be picked up by the release agent within the required time window.
+|Release agent commands failed to be picked up by the release agent within the required time window.
 
 |LOGGED
 |Deployment has been logged using a deploy marker and is available in the CircleCI deploys UI.

--- a/docs/guides/modules/deploy/pages/release-agent-overview.adoc
+++ b/docs/guides/modules/deploy/pages/release-agent-overview.adoc
@@ -12,7 +12,7 @@ image::guides:ROOT:releases/releases-architecture.png[Diagram showing the archit
 
 Configure an environment integration to install the CircleCI release agent into your Kubernetes cluster. Configure the release agent to only monitor the namespaces you require.
 
-Developers can monitor deployments in the CircleCI web app, and run commands to manage those deployments from the UI. Commands are monitored by CircleCI and relayed to the release agent, which then runs the commands for you.
+Developers can monitor deployments in the CircleCI web app, and run release agent commands to manage those deployments from the UI. Release agent commands are monitored by CircleCI and relayed to the release agent, which then runs them for you.
 
 Using the release agent, you have access to the following deploy management tools from CircleCI:
 

--- a/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
+++ b/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
@@ -258,5 +258,4 @@ When `prefer_same_region` is set to `true`, CircleCI will attempt to pull the im
 == See also
 
 * xref:optimize:docker-layer-caching.adoc[Docker Layer Caching]
-* xref:reference:ROOT:glossary.adoc#job-space[Job Space]
 * xref:reference:ROOT:glossary.adoc#primary-container[Primary Container]

--- a/docs/guides/modules/execution-managed/pages/custom-images.adoc
+++ b/docs/guides/modules/execution-managed/pages/custom-images.adoc
@@ -21,7 +21,7 @@ See <<adding-an-entrypoint,Adding an Entrypoint>> for more details.
 [#creating-a-custom-image-manually]
 == Create a custom image manually
 
-The following sections provide a walkthrough of how to create a custom image manually. In most cases you will want to have a custom image for your xref:reference:ROOT:glossary.adoc#primary-container[Primary Container] so that is the focus of this guide. You can also apply this knowledge to create images for secondary containers.
+The following sections provide a walkthrough of how to create a custom image manually. In most cases you will want to have a custom image for your xref:reference:ROOT:glossary.adoc#primary-container[Primary Container] so that is the focus of this guide. You can also apply this knowledge to create images for service containers.
 
 [#prerequisites]
 === Prerequisites

--- a/docs/guides/modules/execution-managed/pages/using-docker.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-docker.adoc
@@ -252,7 +252,7 @@ jobs:
     docker:
     # Primary container image where all steps run.
      - image: cimg/base:current
-    # Secondary container image on common network.
+    # Service container image on common network.
      - image: cimg/mariadb:10.6
 
     steps:

--- a/docs/guides/modules/execution-runner/pages/container-runner.adoc
+++ b/docs/guides/modules/execution-runner/pages/container-runner.adoc
@@ -390,7 +390,7 @@ Additional instructions can be found in our link:https://support.circleci.com/hc
 [#parameters]
 == Helm chart parameters
 
-The container runner Helm chart is hosted link:https://github.com/CircleCI-Public/container-runner-helm-chart[here]. You can find a full link:https://github.com/circleci-public/container-runner-helm-chart#values[chart values reference] section in the README.
+The link:https://github.com/CircleCI-Public/container-runner-helm-chart[container runner Helm chart is hosted here]. You can find a full link:https://github.com/circleci-public/container-runner-helm-chart#values[chart values reference] section in the README.
 
 
 [#container-permissions]

--- a/docs/guides/modules/execution-runner/pages/container-runner.adoc
+++ b/docs/guides/modules/execution-runner/pages/container-runner.adoc
@@ -458,7 +458,7 @@ Set the orchestrator init container image under `orchestrator.image`. Set the lo
 [#logging-containers]
 == Logging containers
 
-Container runner schedules a logging container if there are secondary (service) containers in the task pod. This container will get the secondary container logs and stream them to the steps UI in the CircleCI web app. Task agent, which runs in the primary container, is responsible for streaming all other step output to the CircleCI web app. The only exception is the `Task lifecycle` step, which is streamed by container runner itself.
+Container runner schedules a logging container if there are service containers in the task pod. This container will get the service container logs and stream them to the steps UI in the CircleCI web app. Task agent, which runs in the primary container, is responsible for streaming all other step output to the CircleCI web app. The only exception is the `Task lifecycle` step, which is streamed by container runner itself.
 
 Logging containers require a service account token with the minimal privileges to get container logs.
 

--- a/docs/guides/modules/orchestrate/pages/databases.adoc
+++ b/docs/guides/modules/orchestrate/pages/databases.adoc
@@ -10,7 +10,7 @@ This page describes how to use the official CircleCI pre-built Docker container 
 
 CircleCI provides pre-built images (Docker and VM) for languages and services, like databases, with commonly-used tools preinstalled. For a full list, see the link:https://circleci.com/developer/images[CircleCI Developer Hub].
 
-When configuring a job, the first executor you select is the primary container. The primary container is where all execution occurs. You can add additional containers to the job; these are service, or secondary containers.
+When configuring a job, the first executor you select is the primary container. The primary container is where all execution occurs. You can add additional containers to the job; these are service containers (also called secondary containers).
 
 The example in the next section shows a CircleCI configuration file with the following:
 

--- a/docs/guides/modules/orchestrate/pages/jobs-steps.adoc
+++ b/docs/guides/modules/orchestrate/pages/jobs-steps.adoc
@@ -19,7 +19,7 @@ The following diagram illustrates how data flows between jobs:
 .Jobs overview
 image::guides:ROOT:jobs-overview.png[Jobs overview]
 
-Jobs can be run in Docker containers, using the Docker executor, or in virtual machines using the `machine` executor, with Linux, macOS, or Windows images. Secondary containers or VMs can be configured to attach services, such as databases, to run alongside your jobs.
+Jobs can be run in Docker containers, using the Docker executor, or in virtual machines using the `machine` executor, with Linux, macOS, or Windows images. Service containers or VMs can be configured to attach services, such as databases, to run alongside your jobs.
 
 When using the Docker executor, images listed under the `docker` key specify the containers you want to start for your job. Any public Docker images can be used with the Docker executor, but CircleCI provides convenience images for a variety of use-cases. Full lists of available convenience and VM images are available in the link:https://circleci.com/developer/images[CircleCI Developer Hub].
 

--- a/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
@@ -1,18 +1,98 @@
-= Using branch filters
+= Branch and tag filtering
 :page-platform: Cloud, Server v4+
-:page-description: A how to guide for using branch fileters at the job level to simplify your CircleCI configuration.
+:page-description: Control whether jobs, workflows, and steps run, based on the git branch or tag, using workflow filters or expression-based conditions.
 :experimental:
 
-[#branch-filtering-for-job-steps]
-== Branch-filtering to control when job steps will run
+You can control whether a job, workflow, or step runs, based on the git branch or tag that triggered the pipeline. CircleCI provides several mechanisms, covered in the sections below. Choose one based on what you want to control:
 
-Branch filtering has previously only been available for workflows, but with compile-time logic statements, you can also implement branch filtering for job steps.
+* Filter a *job* by branch or tag with workflow filters.
+* Filter a *job* with an expression, for finer control than branch and tag filters allow.
+* Run a whole *workflow* only when a condition is met, using an expression.
+* Run a single *step* only when a condition is met, using a `when` step.
 
-The following example shows using the <<pipeline-variables#pipeline-values,pipeline value>> `pipeline.git.branch` to control `when` a step runs. In this case, the step `run: echo "I am on main"` only runs when the commit is on the main branch:
+Expression-based conditions are the most flexible option. They can reference pipeline values and pipeline parameters and use comparison and logic operators, so they cover most cases where you previously needed branch filters.
 
-include::ROOT:partial$notes/docker-auth.adoc[]
+[#filter-a-job-by-branch-or-tag]
+== Filter a job by branch or tag
 
-```yaml
+To control which branches or tags run a job, add a `filters` key to the job in your workflow. The `filters` key takes `branches` and `tags` keys. Each accepts `only` and `ignore` values, which can be exact strings or regular expressions.
+
+[source,yaml]
+----
+version: 2.1
+
+workflows:
+  build-test-deploy:
+    jobs:
+      - test:
+          filters:
+            branches:
+              only:
+                - main
+                - /^feature-.*/ # any branch beginning feature-
+      - deploy:
+          filters:
+            branches:
+              ignore: main
+----
+
+NOTE: CircleCI does not run workflows for tags unless you specify a `tags` filter. If a job uses a tag filter, every job it depends on must specify the same tag filter.
+
+For regular-expression examples and tag-filtering detail, see the xref:workflows.adoc#using-filters-in-your-workflows[Using Filters in Your Workflows] section.
+
+[#filter-a-job-with-an-expression]
+== Filter a job with an expression
+
+For finer control than `branches` and `tags` allow, set the `filters` key on a job to an expression instead of a `branches` or `tags` map. The job runs only when the expression evaluates to true. Expressions can reference pipeline values and pipeline parameters and use comparison and logic operators. A single expression can replace conditions that would otherwise need several filters.
+
+The following example runs `integration-test` on `main` or any branch starting with `integration-`, and runs `deploy` only on `main`:
+
+[source,yaml]
+----
+version: 2.1
+
+workflows:
+  build-deploy:
+    jobs:
+      - integration-test:
+          filters: pipeline.git.branch == "main" or pipeline.git.branch starts-with "integration-"
+      - deploy:
+          requires:
+            - integration-test
+          filters: pipeline.git.branch == "main"
+----
+
+Use either the expression form or the `branches` and `tags` form for a given job, not both. For the full operator list and more examples, see the xref:reference:ROOT:configuration-reference.adoc#expression-based-job-filters[Expression-Based Job Filters] reference.
+
+[#filter-a-workflow-with-an-expression]
+== Filter a workflow with an expression
+
+To run an entire workflow only when a condition is met, add a `when` clause (or the inverse `unless` clause) with a logic statement to the workflow declaration. This approach is more flexible than `filters` because the condition can use pipeline values, pipeline parameters, and operators.
+
+The following example runs the `integration_tests` workflow only when the pipeline is on the `main` branch:
+
+[source,yaml]
+----
+version: 2.1
+
+workflows:
+  integration_tests:
+    when: pipeline.git.branch == "main"
+    jobs:
+      - mytestjob
+----
+
+For the operators you can use in a condition, see the xref:reference:ROOT:configuration-reference.adoc#logic-statements[Logic Statements] reference.
+
+[#filter-a-step-with-when]
+== Filter a step with when
+
+To control whether a single step runs, wrap it in a `when` step with a condition. Use this approach when most of a job is shared across branches but one step runs only on a particular branch.
+
+The following example uses the `pipeline.git.branch` pipeline value to run the `echo` step only when the commit is on the `main` branch:
+
+[source,yaml]
+----
 version: 2.1
 
 jobs:
@@ -31,4 +111,4 @@ workflows:
   my-workflow:
     jobs:
       - my-job
-```
+----

--- a/docs/guides/modules/permissions-authentication/pages/users-organizations-and-integrations-guide.adoc
+++ b/docs/guides/modules/permissions-authentication/pages/users-organizations-and-integrations-guide.adoc
@@ -48,7 +48,7 @@ The following table describes user authorization for the different VCS providers
 
 == Organizations
 
-An organization in CircleCI is a workspace that serves as a container for your team's projects, settings, permissions, and billing. Organizations are typically linked to your version control system (VCS) account(s) (GitHub, GitLab, or Bitbucket).
+An organization in CircleCI is a top-level account that serves as a container for your team's projects, settings, permissions, and billing. Organizations are typically linked to your version control system (VCS) account(s) (GitHub, GitLab, or Bitbucket).
 
 Each organization has its own settings, including security, integrations, and resource management, allowing you to coordinate and control your CI/CD processes across multiple projects and users.
 

--- a/docs/guides/modules/toolkit/pages/postgres-config.adoc
+++ b/docs/guides/modules/toolkit/pages/postgres-config.adoc
@@ -3,7 +3,7 @@
 :page-description: See example database config.yml files using PostgreSQL/Rails and MySQL/Ruby for rails app with structure.sql, go app with postgresql, and MySQL project.
 :experimental:
 
-This document provides example database xref:orchestrate:databases.adoc[config.yml] files using PostgreSQL/Rails and MySQL/Ruby.
+This document provides example database configuration files using PostgreSQL/Rails and MySQL/Ruby.
 
 include::ROOT:partial$notes/docker-auth.adoc[]
 
@@ -11,8 +11,7 @@ include::ROOT:partial$notes/docker-auth.adoc[]
 == Example CircleCI configuration for a rails app with structure.sql
 
 If you are migrating a Rails app configured with a `structure.sql` file make
-sure that `psql` is installed in your PATH and has the proper permissions, as
-follows, because the `cimg/ruby:3.0-node` image does not have `psql` installed
+sure that `psql` is installed in your PATH and has the proper permissions. The `cimg/ruby:3.0-node` image does not have `psql` installed
 by default and uses `pg` gem for database access.
 
 [,yaml]
@@ -82,7 +81,7 @@ NOTE: An alternative is to build your own image by extending the current image, 
 
 You must declare your database configuration explicitly because multiple pre-built or custom images may be in use. For example, Rails will try to use a database URL in the following order:
 
-. DATABASE_URL environment variable, if set
+. DATABASE_URL environment variable, if set.
 . The test section configuration for the appropriate environment in your `config.yml` file (usually `test` for your test suite).
 
 The following example demonstrates this order by combining the `environment` setting with the image and by also including the `environment` configuration in the shell command to enable the database connection:
@@ -253,10 +252,10 @@ workflows:
 
 While it is possible to make MySQL your primary and only container, this example
 does not. As a more practical use case, the example uses a PHP Docker image as
-its primary container, and will wait until MySQL is up and running before performing any `run` commands
+its primary container. It will wait until MySQL is up and running before performing any `run` commands
 involving the database (DB).
 
-Once the DB is up, install the `mysql` client into the primary container so that you can run a command to connect and import the dummy data, presumably found at `sql-data/dummy.sql` at the root of your project. In this case, that dummy data contains an example set of SQL commands:
+Once the DB is up, install the `mysql` client into the primary container. You can then run a command to connect and import the dummy data, presumably found at `sql-data/dummy.sql` at the root of your project. In this case, that dummy data contains an example set of SQL commands:
 
 [,sql]
 ----

--- a/docs/guides/modules/toolkit/pages/postgres-config.adoc
+++ b/docs/guides/modules/toolkit/pages/postgres-config.adoc
@@ -208,7 +208,7 @@ jobs:
 [#example-mysql-project]
 == Example MySQL project
 
-The following example sets up MySQL as a secondary container alongside a PHP container.
+The following example sets up MySQL as a service container alongside a PHP container.
 
 [,yaml]
 ----

--- a/docs/guides/modules/toolkit/pages/sample-config.adoc
+++ b/docs/guides/modules/toolkit/pages/sample-config.adoc
@@ -252,7 +252,7 @@ jobs:
     docker:
       # The primary container is an instance of the first image listed. The job's commands run in this container.
       - image: cimg/node:current
-      # The secondary container is an instance of the second listed image which is run in a common network where ports exposed on the primary container are available on localhost.
+      # The service container is an instance of the second listed image which is run in a common network where ports exposed on the primary container are available on localhost.
       - image: mongo:4.2
     steps:
       # Reuse the workspace from the build job

--- a/docs/guides/modules/toolkit/pages/sample-config.adoc
+++ b/docs/guides/modules/toolkit/pages/sample-config.adoc
@@ -4,9 +4,9 @@
 :experimental:
 :page-aliases: example-configs.adoc
 
-This document provides sample `.circleci/config.yml` files that you can use as a starting point when setting up projects, or to better understand different ways to orchestrate jobs using workflows and filters. For information on all configuration elements available to you, see the xref:reference:ROOT:configuration-reference.adoc[Configuration reference] page.
+This document provides sample `.circleci/config.yml` files that you can use as a starting point when setting up projects, or to better understand different ways to orchestrate jobs using workflows and filters. For information on all configuration elements available to you, see the xref:reference:ROOT:configuration-reference.adoc[Configuration Reference] page.
 
-If you would like to get set up quickly, see our language-specific quickstart guides:
+If you would like to get set up right away, see our language-specific quickstart guides:
 
 * xref:getting-started:language-javascript.adoc[Node]
 * xref:getting-started:language-python.adoc[Python]
@@ -14,7 +14,7 @@ If you would like to get set up quickly, see our language-specific quickstart gu
 
 == Tools for editing configuration files
 
-CircleCI has created an xref:vs-code-extension-overview.adoc[extension for Visual Studio Code] that reduces context switching between the web app and VS Code through a set of helpful features.
+CircleCI has created an extension for xref:vs-code-extension-overview.adoc[Visual Studio Code] that reduces context switching between the web app and VS Code through a set of helpful features.
 
 The VS Code extension reduces the time to create, modify, and troubleshoot configuration files through real-time syntax validation, highlighting, and autocomplete suggestions. Authenticating the extension with your CircleCI account will also allow you to visualize and manage your CircleCI pipelines directly from your code editor, and be notified of workflow status changes.
 
@@ -35,6 +35,7 @@ The configuration example below shows a concurrent workflow in which the `build`
 
 This image shows the workflow view for the following configuration example:
 
+.Concurrent Workflow Graph
 image::guides:ROOT:concurrent-workflow-map.png[Concurrent Workflow Graph]
 
 [,yaml]
@@ -74,6 +75,7 @@ The configuration example below shows a sequential workflow where the `build` jo
 
 This image shows the workflow view for the following configuration example, in which jobs run sequentially (one after the other):
 
+.Sequential Workflow Graph
 image::guides:ROOT:sequential-workflow-map.png[Sequential Workflow Graph]
 
 [,yaml]
@@ -108,7 +110,7 @@ workflows:
 [#approval-job]
 === Approval job
 
-The example below shows a sequential workflow with an xref:reference:ROOT:configuration-reference.adoc#type[approval job]. Use an approval job to require manual approval before downstream jobs may proceed.
+The example below shows a sequential workflow with an xref:reference:ROOT:configuration-reference.adoc#type[Approval Job]. Use an approval job to require manual approval before downstream jobs may proceed.
 
 [,yaml]
 ----
@@ -155,19 +157,20 @@ workflows:
 
 The workflow runs as follows:
 
-. `build` job runs
-. `test` job runs
-. `hold` job, with `type: approval` ensures the workflow waits for manual approval in the CircleCI web app
-. Once `hold` job is approved the `deploy` job runs
+. `build` job runs.
+. `test` job runs.
+. `hold` job, with `type: approval` ensures the workflow waits for manual approval in the CircleCI web app.
+. Once `hold` job is approved the `deploy` job runs.
 
-An approval job can have any name. In the example above the approval job is named `hold`. The name you choose for an approval job should not be used to define a job in the main configuration. An approval job only exists as a workflow orchestration device.
+An approval job can have any name. In the example above the approval job is named `hold`. The name you choose for an approval job can not be used to define a job in the main configuration. An approval job only exists as a workflow orchestration device.
 
 The image below shows the workflow view for the following configuration example. This image has three parts to show:
 
-* The workflow graph with the `hold` job paused
-* The "Needs Approval" popup that appears when you click on a hold job
-* The workflow view again once the `hold` job has been approved and the `deploy` job has run
+* The workflow graph with the `hold` job paused.
+* The "Needs Approval" popup that appears when you click on a hold job.
+* The workflow view again once the `hold` job has been approved and the `deploy` job has run.
 
+.Approval Workflow Graph
 image::guides:ROOT:approval-workflow-map.png[Approval Workflow Graph]
 
 * Refer to the xref:orchestrate:workflows.adoc[Workflows] document for complete details about orchestrating job runs with concurrent, sequential, and manual approval workflows.
@@ -296,6 +299,7 @@ This example shows a sequential workflow with the `test` job configured to run o
 
 Below are two sample configurations for a Fan-in/Fan-out workflow.
 
+.Fan-in-out
 image::guides:ROOT:fan-in-out-example.png[Fan-in-out]
 
 [,yaml]
@@ -438,7 +442,7 @@ NOTE: A job can only run when its dependencies are satisfied therefore it requir
 [#sample-configuration-with-multiple-executor-types]
 == Sample configuration with multiple executor types
 
-It is possible to use multiple xref:execution-managed:executor-intro.adoc[executor types]
+It is possible to use multiple xref:execution-managed:executor-intro.adoc[Executor Types]
 in the same workflow.
 
 In Example 1 each push will build and test the project on Linux, Windows and macOS.
@@ -775,6 +779,6 @@ workflows:
 [#see-also]
 == See also
 
-* See the xref:about-circleci:concepts.adoc#configuration[Concepts document] and xref:orchestrate:workflows.adoc[Workflows] for more details of the concepts covered in this example.
+* See the xref:about-circleci:concepts.adoc#configuration[Concepts] page and xref:orchestrate:workflows.adoc[Workflows] for more details of the concepts covered in this example.
 * See the xref:reference:ROOT:configuration-reference.adoc[Configuration Reference] document for full details of each individual configuration key.
 * See the xref:examples-and-guides-overview.adoc[Example Public Repos] document for a list of public projects that use CircleCI.

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -1103,7 +1103,7 @@ This key is deprecated. Use <<jobfilters,workflows filtering>> to control which 
 [#resourceclass]
 == *`resource_class`*
 
-The `resource_class` feature allows you to configure CPU and RAM resources for each job. Resource classes are available for each execution environment, as described in the tables below.
+The `resource_class` feature allows you to configure CPU and RAM resources for each job. Resource classes are available for each execution environment, as described in the tables below. A resource class is also used as a label to identify a pool of self-hosted runners and to route a job to that pool. For full details on both uses, see the xref:guides:execution-managed:resource-class-overview.adoc[Resource Class Overview] page.
 
 We implement soft concurrency limits for each resource class to ensure our system remains stable for all customers. If you are on a Performance or Custom Plan and experience queuing for certain resource classes, it is possible you are hitting these limits. link:https://support.circleci.com/hc/en-us/requests/new[Contact CircleCI support] to request a raise on these limits for your account.
 

--- a/docs/reference/modules/ROOT/pages/glossary.adoc
+++ b/docs/reference/modules/ROOT/pages/glossary.adoc
@@ -21,10 +21,6 @@ A file or directory that persists after a <<job>> finishes, such as a compiled b
 
 A record of significant events in a CircleCI organization, available to organization admins for audit and forensic analysis. See the xref:guides:security:audit-logs.adoc[Audit Logs] page.
 
-== Branch filter
-
-A <<workflow>> configuration option that controls which branches run a given <<job>>. Branch filters use `only` and `ignore` keys with exact branch names or regular expressions. See the xref:guides:orchestrate:using-branch-filters.adoc[Using Branch Filters] page. Compare with <<tag-filter>>.
-
 [badge="Server v4+"]
 == Build agent
 
@@ -156,6 +152,10 @@ The type you assign to a <<job>> that defines the underlying technology used to 
 == Fan-out/fan-in
 
 A <<workflow>> pattern in which a single job branches into multiple jobs that run concurrently (fan-out), which then converge on a single downstream job (fan-in). This pattern is useful for running test suites in parallel after a build, then deploying once all tests pass. See the xref:guides:orchestrate:workflows.adoc[Workflows] page.
+
+== Filtering
+
+The mechanisms for controlling whether a <<job>>, <<workflow>>, or <<step>> runs, based on the git branch or tag, or on other conditions. You can filter a job by branch or tag using the `filters` key with `only` and `ignore` values, or set `filters` to an expression for finer control, for example `filters: pipeline.git.branch == "main"`. You can also gate a whole workflow or a single step with an expression in a `when` or `unless` condition. Expression-based conditions are the most flexible option and can reference pipeline values and parameters. See the xref:guides:orchestrate:using-branch-filters.adoc[Branch and Tag Filtering] page.
 
 == Flaky test
 
@@ -359,10 +359,6 @@ A single executable action within a <<job>>, such as a `run`, `checkout`, `save_
 == Setup workflow
 
 A <<workflow>> marked with `setup: true` that runs first in a <<dynamic-configuration,dynamic configuration>>. A setup workflow can compute pipeline parameters and select which configuration to continue with, enabling conditional execution of the rest of the pipeline. See the xref:guides:orchestrate:dynamic-config.adoc[Dynamic Configuration] page.
-
-== Tag filter
-
-A <<workflow>> configuration option that controls which git tags run a given <<job>>. Tag filters use `only` and `ignore` keys with exact tag names or regular expressions, and are often used to run deployment jobs on release tags. See the xref:guides:orchestrate:workflows.adoc[Workflows] page. Compare with <<branch-filter>>.
 
 [badge="Beta"]
 == Test impact analysis

--- a/docs/reference/modules/ROOT/pages/glossary.adoc
+++ b/docs/reference/modules/ROOT/pages/glossary.adoc
@@ -3,7 +3,7 @@
 :page-description: A glossary of CircleCI-specific and CI/CD terminology used across the CircleCI product and documentation.
 :experimental:
 
-This glossary defines terms used across the CircleCI product and documentation. It covers CircleCI-specific concepts as well as general CI/CD terms as CircleCI uses them. Entries marked with a *Server* badge apply to xref:guides:plans-pricing:plan-server.adoc[CircleCI Server], the self-hosted installation.
+This glossary defines terms used across the CircleCI product and documentation. It covers CircleCI-specific concepts as well as general CI/CD terms as CircleCI uses them.
 
 == Active user
 
@@ -21,10 +21,9 @@ A file or directory that persists after a <<job>> finishes, such as a compiled b
 
 A record of significant events in a CircleCI organization, available to organization admins for audit and forensic analysis. See the xref:guides:security:audit-logs.adoc[Audit Logs] page.
 
-[badge="Server v4+"]
 == Build agent
 
-On CircleCI Server, the CircleCI program that executes the steps within a job and reports the results. The build agent runs as the main process inside a Nomad job allocation. See <<nomad>> and the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
+On CircleCI Server, the CircleCI program that executes the steps within a job and reports the results. The build agent runs as the main process inside a Nomad job allocation. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
 
 == Built-in environment variable
 
@@ -38,24 +37,17 @@ A stored hierarchy of files that CircleCI restores into later <<job,jobs>> to sp
 
 A unique identifier that determines when CircleCI writes a new <<cache>> and which existing cache it restores. Cache keys can include templates, such as a checksum of a lock file or the branch name, that are evaluated at runtime. See the xref:guides:optimize:caching.adoc[Caching Dependencies] page.
 
-== CircleCI administrator
-
-On CircleCI Server, the first user to log in to a private installation. The administrator can add and remove users. For role-based access on cloud, see <<organization-role>> and the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
-
 == CircleCI CLI
 
-The command-line interface you install on your local machine to validate and debug configuration, run jobs locally, and manage orbs, contexts, and policies. See the xref:guides:toolkit:local-cli.adoc[CircleCI Local CLI] page. The CircleCI CLI is distinct from the in-pipeline `circleci` commands that run during a job.
+The command-line interface you install on your local machine to validate and debug configuration, run jobs locally, and manage orbs, contexts, and policies. See the xref:guides:toolkit:local-cli.adoc[CircleCI Local CLI] page. The CircleCI CLI is distinct from the environment CLI, which is available in your CircleCI pipelines.
 
-[badge="Server v4+"]
 == CircleCI Server
 
-The self-hosted CI/CD platform for organizations that must operate within their own firewall, private cloud, or data center. CircleCI Server runs in a Kubernetes cluster and provides the same core features as CircleCI Cloud. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
+CircleCI's on-premises CI/CD platform for organizations that must operate within their own firewall, private cloud, or data center. CircleCI Server runs in a Kubernetes cluster and provides the same core features as CircleCI Cloud. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
 
 == Command
 
 A reusable sequence of <<step,steps>> that can be invoked multiple times within a job, within other commands, or across jobs in a configuration file. Commands are a building block of reusable config and <<orbs>>. See the xref:reference:ROOT:reusing-config.adoc[Reusable Config Reference] page.
-
-NOTE: Not to be confused with a _release agent command_, a user-initiated release action (such as restore version or scale component) run by the <<release-agent>>. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page.
 
 == Component
 
@@ -143,11 +135,11 @@ A named value stored in CircleCI and injected at runtime into jobs, used for con
 
 == Execution environment
 
-The runtime in which a <<job>> runs, either a Docker container or a virtual machine. CircleCI offers the Docker, Linux VM, macOS, Windows, GPU, Android, and Arm VM execution environments. You do not select an execution environment directly: you choose an <<executor>> (`docker`, `machine`, or `macos`) and an image, and those determine the environment. This split between executor and execution environment is specific to CircleCI. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
+The runtime in which a <<job>> runs, either a Docker container or a virtual machine. CircleCI offers the Docker, Linux VM, macOS, Windows, GPU, Android, and Arm VM execution environments. You choose an <<executor>> (`docker`, `machine`, or `macos`) and an image, and those together determine the environment. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
 
 == Executor
 
-The type you assign to a <<job>> that defines the underlying technology used to run it. CircleCI has three executors: `docker`, `machine`, and `macos`. The executor is not the same as the <<execution-environment>>: the executor you choose, together with the image you specify, determines which execution environment the job runs in. For example, the `machine` executor can run a job in the Linux VM, Windows, GPU, Android, or Arm VM environment. In reusable config and orbs, an executor is also a named, parameterizable definition that multiple jobs can share. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] and xref:reference:ROOT:reusing-config.adoc[Reusable Config Reference] pages.
+The type you assign to a <<job>> that defines the underlying technology used to run it. CircleCI has three executors: `docker`, `machine`, and `macos`. For example, the `machine` executor can run a job in the Linux VM, Windows, GPU, Android, or Arm VM execution environment. In configuration an `executor` is also a named, parameterizable definition that multiple jobs can share. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] and xref:reference:ROOT:reusing-config.adoc[Reusable Config Reference] pages.
 
 == Fan-out/fan-in
 
@@ -160,10 +152,6 @@ The mechanisms for controlling whether a <<job>>, <<workflow>>, or <<step>> runs
 == Flaky test
 
 A test that passes and fails inconsistently without changes to the code under test. CircleCI identifies a test as flaky when it both fails and passes on the same commit within a set time window. See the xref:guides:test:fix-flaky-tests.adoc[Identify and Fix Flaky Tests] page.
-
-== Group
-
-A collection of users that can be assigned roles together, so administrators can manage access for many users at once. Groups can be mapped automatically from an identity provider. See the xref:guides:permissions-authentication:manage-groups.adoc[Manage Groups] and xref:guides:permissions-authentication:sso-group-mapping.adoc[SSO Group Mapping] pages.
 
 == Image
 
@@ -181,10 +169,6 @@ A feature that routes a job's traffic through a set of well-defined CircleCI IP 
 
 A collection of <<step,steps>> that run in a single <<execution-environment>>. Each job declares an <<executor>>, and jobs are orchestrated by <<workflow,workflows>>. See the xref:guides:orchestrate:jobs-steps.adoc[Jobs and Steps] page.
 
-== Job space
-
-All the containers being run by an <<executor>> for the current job.
-
 == Machine executor
 
 The <<executor>> (`machine`) that runs a job in a dedicated, ephemeral virtual machine with full operating-system access. Depending on the image you specify, the machine executor provides the Linux VM, Windows, GPU, Android, or Arm VM <<execution-environment,execution environment>>. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
@@ -193,7 +177,6 @@ The <<executor>> (`machine`) that runs a job in a dedicated, ephemeral virtual m
 
 A prebuilt virtual machine image for the <<machine-executor>>, available for Linux, macOS, Windows, Android, and GPU environments. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
 
-[badge="Server v4+"]
 == Machine provisioner
 
 On CircleCI Server, the service that dynamically provisions and manages the virtual machines used by jobs configured for the machine execution environment, as well as Remote Docker jobs. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
@@ -223,11 +206,6 @@ An additional layer of account security that requires a second verification fact
 
 A unique, immutable identifier that groups an organization's resources under a single owner. Each user or organization claims one namespace, typically the lowercase VCS organization name. The same namespace is used to group your registry <<orbs>> by author and to identify your <<self-hosted-runner,self-hosted runners>>, where it is combined with a resource-class name to form the full runner <<resource-class>> label. See the xref:orbs:use:orb-concepts.adoc[Orb Concepts] and xref:guides:execution-runner:runner-concepts.adoc[Runner Concepts] pages.
 
-[badge="Server v4+"]
-== Nomad
-
-On CircleCI Server, the HashiCorp workload orchestrator that schedules and runs CI/CD jobs. It consists of a Nomad control plane (server) that runs in the Kubernetes cluster and Nomad clients, provisioned outside the cluster, that execute jobs. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
-
 [#oidc-token]
 == OpenID Connect (OIDC) token
 
@@ -235,7 +213,7 @@ A token issued by CircleCI that lets a job authenticate with a cloud provider wi
 
 == Orbs
 
-Reusable packages of YAML configuration that bundle <<job,jobs>>, <<command,commands>>, and <<executor,executors>> to automate repeated processes and integrate with third-party tools. Orbs can be published to the orb registry as public or private, or defined inline in your configuration. Visit the https://circleci.com/developer/orbs[Orb Registry] to find orbs, and see the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
+Reusable packages of YAML configuration that bundle <<job,jobs>>, <<command,commands>>, and <<executor,executors>> to automate repeated processes and integrate with third-party tools. Orbs come in three forms. Registry orbs are published to the orb registry and can be public or private. Inline orbs are defined directly in your configuration. URL orbs are a single YAML file imported by HTTPS URL, subject to the organization's allow list. Visit the https://circleci.com/developer/orbs[Orb Registry] to find orbs, and see the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
 
 == Orb registry
 
@@ -247,11 +225,7 @@ The top-level account in CircleCI that contains a team's projects, settings, per
 
 == Organization role
 
-In a `circleci` type <<organization>>, a role assigned at the organization level that determines a user's permissions across the whole organization. The organization roles are admin, contributor, and viewer. (In `github` and `bitbucket` OAuth organizations, access follows the VCS <<owner>> model instead.) See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page. Compare with <<project-role>>.
-
-== Owner
-
-In a `github` or `bitbucket` (OAuth) <<organization>>, the owner of the team's VCS organization, who has full administrative control over the organization's CircleCI resources. In a `circleci` type organization, access is governed instead by an <<organization-role>>. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
+In a `circleci` type <<organization>>, a role assigned at the organization level that determines a user's permissions across the whole organization. The organization roles are admin, contributor, and viewer. In `github` and `bitbucket` OAuth organizations, access follows the VCS <<owner>> model instead. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page. Compare with <<project-role>>.
 
 == Parallelism
 
@@ -291,14 +265,6 @@ For `circleci` type organizations, a CircleCI project is a standalone entity tha
 
 After a project is set up, you can configure settings, contexts, environment variables, and the team members who may follow it. See the xref:guides:getting-started:create-project.adoc[Create a Project] page.
 
-== Project administrator
-
-In a `github` or `bitbucket` (OAuth) <<organization>>, the user who adds a repository in the VCS to CircleCI as a project. In a `circleci` type organization, project access is governed instead by a <<project-role>>. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
-
-== Project role
-
-In a `circleci` type <<organization>>, a role assigned at the project level that determines a user's permissions for a specific project, offering finer-grained control than an <<organization-role>>. The project roles are admin, contributor, and viewer. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
-
 == Registered user
 
 A user who has created a CircleCI account. Registered users can access the web app, view pipelines and build history, trigger and rerun builds, and have organization access based on their role. See the xref:guides:plans-pricing:user-types-and-registration.adoc[User Types and Registration] page. Compare with <<unregistered-user>>.
@@ -329,7 +295,7 @@ Reverting an application to a previous stable version when an issue is detected,
 
 == Schedule trigger
 
-A <<trigger>> that runs a pipeline on a defined schedule, using cron syntax, rather than on each commit. Schedule triggers are the recommended way to run scheduled work. Use them instead of scheduled workflows unless your setup requires the older approach. See the xref:guides:orchestrate:schedule-triggers.adoc[Schedule Triggers] page.
+A <<trigger>> that runs a pipeline on a defined schedule, using cron syntax, rather than on each commit. Schedule triggers are the recommended way to run scheduled work. Use them instead of scheduled workflows unless your setup requires that approach. See the xref:guides:orchestrate:schedule-triggers.adoc[Schedule Triggers] page.
 
 == Secrets masking
 
@@ -358,7 +324,7 @@ A single executable action within a <<job>>, such as a `run`, `checkout`, `save_
 
 == Setup workflow
 
-A <<workflow>> marked with `setup: true` that runs first in a <<dynamic-configuration,dynamic configuration>>. A setup workflow can compute pipeline parameters and select which configuration to continue with, enabling conditional execution of the rest of the pipeline. See the xref:guides:orchestrate:dynamic-config.adoc[Dynamic Configuration] page.
+A <<workflow,workflow>> marked with `setup: true` that runs first in a <<dynamic-configuration,dynamic configuration>>. A setup workflow can compute pipeline parameters and select which configuration to continue with, enabling conditional execution of the rest of the pipeline. See the xref:guides:orchestrate:dynamic-config.adoc[Dynamic Configuration] page.
 
 [badge="Beta"]
 == Test impact analysis
@@ -376,14 +342,6 @@ A mechanism that initiates a <<pipeline>>. Triggers can be automatic, based on V
 == Unregistered user
 
 Someone who has triggered builds in a CircleCI organization but has not created a CircleCI account. Unregistered users count as <<active-user,active users>> for billing. See the xref:guides:plans-pricing:user-types-and-registration.adoc[User Types and Registration] page.
-
-== URL orb
-
-A single YAML file of shared <<orbs,orb>> configuration, stored somewhere accessible over HTTPS, such as a GitHub repository, and imported by its URL rather than from the orb registry. The URL must be allowed by the organization's allow list. URL orbs let you share configuration across an organization while keeping direct control over updates. See the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
-
-== User
-
-An individual who can log in to the CircleCI platform. A user must be part of an organization to view or follow its projects. Access is governed by an <<organization-role>> and <<project-role>> in `circleci` type organizations, or by the VCS <<owner>> and <<project-administrator>> model in `github` and `bitbucket` OAuth organizations. Users may *not* view project data stored in environment variables. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
 
 == Version promotion
 

--- a/docs/reference/modules/ROOT/pages/glossary.adoc
+++ b/docs/reference/modules/ROOT/pages/glossary.adoc
@@ -5,262 +5,211 @@
 
 This glossary defines terms used across the CircleCI product and documentation. It covers CircleCI-specific concepts as well as general CI/CD terms as CircleCI uses them. Entries marked with a *Server* badge apply to xref:guides:plans-pricing:plan-server.adoc[CircleCI Server], the self-hosted installation.
 
-[#active-user]
 == Active user
 
 Any user, registered or unregistered, who triggers the use of compute resources on projects that are not open source during a billing period. Commits, reruns, approvals, scheduled pipelines, and machine users can all make a user active. Active users are counted for billing. See the xref:guides:plans-pricing:user-types-and-registration.adoc[User Types and Registration] page.
 
-[#approval-job]
 == Approval job
 
 A special job, configured with `type: approval`, that pauses a <<workflow>> until a user with the required permissions manually approves it. An approval job runs no steps of its own. It acts as a manual gate before downstream jobs continue. See the xref:guides:orchestrate:workflows.adoc[Workflows] page.
 
-[#artifact]
 == Artifact
 
 A file or directory that persists after a <<job>> finishes, such as a compiled binary, a coverage report, or a screenshot. Artifacts remain available for download long after a workflow completes, subject to a storage retention period. See the xref:guides:optimize:artifacts.adoc[Storing Build Artifacts] page. Compare with <<cache>> and <<workspace>>, which serve different purposes.
 
-[#audit-log]
 == Audit log
 
 A record of significant events in a CircleCI organization, available to organization admins for audit and forensic analysis. See the xref:guides:security:audit-logs.adoc[Audit Logs] page.
 
-[#branch-filter]
 == Branch filter
 
 A <<workflow>> configuration option that controls which branches run a given <<job>>. Branch filters use `only` and `ignore` keys with exact branch names or regular expressions. See the xref:guides:orchestrate:using-branch-filters.adoc[Using Branch Filters] page. Compare with <<tag-filter>>.
 
 [badge="Server v4+"]
-[#build-agent]
 == Build agent
 
 On CircleCI Server, the CircleCI program that executes the steps within a job and reports the results. The build agent runs as the main process inside a Nomad job allocation. See <<nomad>> and the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
 
-[#built-in-environment-variable]
 == Built-in environment variable
 
 A predefined <<environment-variable>> that CircleCI makes available in every job, containing information about the project, pipeline, and job being run (for example `CIRCLE_BRANCH`, `CIRCLE_JOB`, `CIRCLE_BUILD_NUM`). Built-in environment variables are scoped to the job. See the xref:reference:ROOT:variables.adoc[Project Values and Variables] page.
 
-[#cache]
 == Cache
 
 A stored hierarchy of files that CircleCI restores into later <<job,jobs>> to speed up repetitive operations, such as downloading dependencies. A cache is immutable once written and is identified by a <<cache-key>>. See the xref:guides:optimize:caching.adoc[Caching Dependencies] page. Compare with <<workspace>> and <<artifact>>.
 
-[#cache-key]
 == Cache key
 
 A unique identifier that determines when CircleCI writes a new <<cache>> and which existing cache it restores. Cache keys can include templates, such as a checksum of a lock file or the branch name, that are evaluated at runtime. See the xref:guides:optimize:caching.adoc[Caching Dependencies] page.
 
-[#circleci-administrator]
 == CircleCI administrator
 
 On CircleCI Server, the first user to log in to a private installation. The administrator can add and remove users. For role-based access on cloud, see <<organization-role>> and the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
 
-[#circleci-cli]
 == CircleCI CLI
 
 The command-line interface you install on your local machine to validate and debug configuration, run jobs locally, and manage orbs, contexts, and policies. See the xref:guides:toolkit:local-cli.adoc[CircleCI Local CLI] page. The CircleCI CLI is distinct from the in-pipeline `circleci` commands that run during a job.
 
 [badge="Server v4+"]
-[#circleci-server]
 == CircleCI Server
 
 The self-hosted CI/CD platform for organizations that must operate within their own firewall, private cloud, or data center. CircleCI Server runs in a Kubernetes cluster and provides the same core features as CircleCI Cloud. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
 
-[#command]
 == Command
 
 A reusable sequence of <<step,steps>> that can be invoked multiple times within a job, within other commands, or across jobs in a configuration file. Commands are a building block of reusable config and <<orbs>>. See the xref:reference:ROOT:reusing-config.adoc[Reusable Config Reference] page.
 
 NOTE: Not to be confused with a _release agent command_, a user-initiated release action (such as restore version or scale component) run by the <<release-agent>>. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page.
 
-[#component]
 == Component
 
 In the context of <<deployment,deployments>>, a collection of code and configuration that is deployed and released as a single unit. In Kubernetes terms, a component corresponds to a Deployment or Rollout object and its related objects that share a common `circleci.com/component-name` label. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page.
 
-[#concurrency]
 == Concurrency
 
 Running multiple jobs at the same time, either multiple jobs within a single <<workflow>> or multiple workflows running across an organization. Concurrency is limited by soft limits on each <<resource-class>>. Concurrency is _not_ the same as <<parallelism>>, which splits the tests of a single job across multiple containers. See the xref:guides:optimize:concurrency.adoc[Concurrency] page.
 
-[#config-policies]
 == Config policies
 
 Organization-level rules that govern which configuration elements are required, allowed, or disallowed in project configurations. CircleCI evaluates config policies with the Open Policy Agent (OPA) decision engine, using policies written in the Rego language. See the xref:guides:config-policies:config-policy-management-overview.adoc[Config Policy Management Overview] page.
 
-[#configuration]
 == Configuration
 
 The YAML file that defines your entire CI/CD process as code. The configuration file declares the <<pipeline>>, <<workflow,workflows>>, <<job,jobs>>, and <<step,steps>> that run when work is triggered. It is most often stored at `.circleci/config.yml` in the root of a repository, but a project is not limited to that name or location and can use a configuration file stored elsewhere. See the xref:guides:getting-started:config-intro.adoc[Configuration Introduction] page and the xref:reference:ROOT:configuration-reference.adoc[Configuration Reference].
 
-[#container]
 == Container
 
 A running instance of an <<image>>.
 
-[#container-runner]
 == Container runner
 
 A type of <<self-hosted-runner>> installed in a Kubernetes cluster that runs containerized jobs in ephemeral pods. Container runner complements the <<machine-runner>> for high-concurrency, container-based workloads. See the xref:guides:execution-runner:container-runner.adoc[Container Runner] page.
 
-[#context]
 == Context
 
 A mechanism for securing and sharing <<environment-variable,environment variables>> across projects at the organization level. Environment variables in a context are defined as name/value pairs and injected at runtime. After you create a context, you can reference it in the `workflows` section of a project's <<configuration,configuration file>> to give jobs access to its variables. Context access can be restricted with security groups, project restrictions, or expression restrictions. See the xref:guides:security:contexts.adoc[Using Contexts] page.
 
-[#convenience-image]
 == Convenience image
 
 A prebuilt Docker <<image>> maintained by CircleCI with popular languages and tools preinstalled. Next-generation convenience images use the `cimg/` namespace on Docker Hub and offer faster spin-up and improved stability over legacy images. See the xref:guides:execution-managed:circleci-images.adoc[CircleCI Images] page. Compare with <<custom-image>> and <<machine-image>>.
 
-[#credit]
 == Credit
 
 The unit of compute consumption in CircleCI. Credits are consumed by the second, at rates that vary by machine type and <<resource-class>>. Larger resource classes consume credits at higher rates. See the xref:guides:plans-pricing:plan-overview.adoc[Plan Overview] page.
 
-[#cross-repo-trigger]
 == Cross-repo trigger
 
 A <<trigger>> that runs a pipeline in one repository when an event, such as a tag push, occurs in another. Cross-repo triggers help you test library consumers. See the xref:guides:orchestrate:set-up-cross-repo-triggers-for-library-consumers.adoc[Set up Cross-Repo Triggers] page.
 
-[#custom-image]
 == Custom image
 
 A Docker <<image>> that you build and maintain yourself, typically from a Dockerfile stored in a registry, for use with the <<docker-executor>> when convenience images do not meet your needs. See the xref:guides:execution-managed:custom-images.adoc[Using Custom-Built Docker Images] page.
 
-[#custom-webhook]
 == Custom webhook
 
 An inbound webhook that lets any third-party service capable of sending an HTTP request trigger a CircleCI <<pipeline>>. See the xref:guides:orchestrate:custom-webhooks.adoc[Custom Webhooks] page. Compare with <<outbound-webhook>>.
 
-[#delivery]
 == Delivery
 
 The act of packaging code changes and making them available for <<deployment>>. _Continuous delivery_ produces deployable executables from code that can be deployed at a later time. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page.
 
-[#deploy-marker]
 == Deploy marker
 
 A lightweight logging mechanism, configured as steps in your pipeline, that records a timeline of deployments in one place. Deploy markers let you track deployment status, roll back, and promote versions through environments. See the xref:guides:deploy:configure-deploy-markers.adoc[Configure Deploy Markers] page.
 
-[#deployment]
 == Deployment
 
 The act of putting a new <<component>> version into an <<environment>>, regardless of whether traffic is yet routed to it. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page. Compare with <<release>> and <<delivery>>, which CircleCI defines as distinct steps.
 
-[#docker-executor]
 == Docker executor
 
 The <<executor>> (`docker`) that runs a job inside one or more Docker containers, providing the Docker <<execution-environment,execution environment>>. The Docker executor is resource-efficient and well suited to most build and test jobs. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
 
-[#docker-layer-caching]
 == Docker layer caching
 
 Docker Layer Caching (DLC) lets builds reuse Docker image layers from previous builds so that jobs which build Docker images run faster on subsequent runs. Layers can only be reused by builds from the same project. See the xref:guides:optimize:docker-layer-caching.adoc[Docker Layer Caching] and xref:guides:execution-managed:building-docker-images.adoc[Running Docker Commands] pages.
 
-[#dynamic-configuration]
 == Dynamic configuration
 
 A feature that lets a pipeline determine the work it runs at runtime, based on pipeline parameters, changed file paths, or other conditions, rather than using fully static configuration. Dynamic configuration is enabled with a <<setup-workflow>> (`setup: true`). See the xref:guides:orchestrate:dynamic-config.adoc[Dynamic Configuration] page.
 
-[#environment]
 == Environment
 
 In the Deploys feature, a named deployment target represented in the CircleCI UI, such as staging or production. Environments can be a custom type or a Kubernetes cluster type. Ordered into an <<environment-hierarchy>>, they define a promotion path. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page.
 
-[#environment-hierarchy]
 == Environment hierarchy
 
 An ordered sequence of <<environment,environments>> that defines a promotion path. You can configure hierarchies at the organization, project, or component level to support different promotion workflows. See the xref:guides:deploy:environment-hierarchy-and-version-promotion.adoc[Environment Hierarchy and Version Promotion] page.
 
-[#environment-variable]
 == Environment variable
 
 A named value stored in CircleCI and injected at runtime into jobs, used for configuration, secrets, and credentials. Environment variables can be set at the context, project, job, or step level, and follow an order of precedence. Values are encrypted at rest and masked in job output. See the xref:guides:security:env-vars.adoc[Using Environment Variables] page. Compare with <<built-in-environment-variable>>.
 
-[#execution-environment]
 == Execution environment
 
 The runtime in which a <<job>> runs, either a Docker container or a virtual machine. CircleCI offers the Docker, Linux VM, macOS, Windows, GPU, Android, and Arm VM execution environments. You do not select an execution environment directly: you choose an <<executor>> (`docker`, `machine`, or `macos`) and an image, and those determine the environment. This split between executor and execution environment is specific to CircleCI. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
 
-[#executor]
 == Executor
 
 The type you assign to a <<job>> that defines the underlying technology used to run it. CircleCI has three executors: `docker`, `machine`, and `macos`. The executor is not the same as the <<execution-environment>>: the executor you choose, together with the image you specify, determines which execution environment the job runs in. For example, the `machine` executor can run a job in the Linux VM, Windows, GPU, Android, or Arm VM environment. In reusable config and orbs, an executor is also a named, parameterizable definition that multiple jobs can share. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] and xref:reference:ROOT:reusing-config.adoc[Reusable Config Reference] pages.
 
-[#fan-out-fan-in]
 == Fan-out/fan-in
 
 A <<workflow>> pattern in which a single job branches into multiple jobs that run concurrently (fan-out), which then converge on a single downstream job (fan-in). This pattern is useful for running test suites in parallel after a build, then deploying once all tests pass. See the xref:guides:orchestrate:workflows.adoc[Workflows] page.
 
-[#flaky-test]
 == Flaky test
 
 A test that passes and fails inconsistently without changes to the code under test. CircleCI identifies a test as flaky when it both fails and passes on the same commit within a set time window. See the xref:guides:test:fix-flaky-tests.adoc[Identify and Fix Flaky Tests] page.
 
-[#group]
 == Group
 
 A collection of users that can be assigned roles together, so administrators can manage access for many users at once. Groups can be mapped automatically from an identity provider. See the xref:guides:permissions-authentication:manage-groups.adoc[Manage Groups] and xref:guides:permissions-authentication:sso-group-mapping.adoc[SSO Group Mapping] pages.
 
-[#image]
 == Image
 
 A packaged system that includes the instructions for creating a running <<container>>. The <<primary-container>> is defined by the first image listed in your <<configuration,configuration file>>. Visit the https://circleci.com/developer/images[CircleCI Developer Hub] to browse available convenience and machine images. See also <<convenience-image>>, <<machine-image>>, and <<custom-image>>.
 
-[#insights]
 == Insights
 
 CircleCI's dashboards that report time-series and aggregated data on credit usage, success rates, duration, and test performance across your projects, workflows, jobs, and tests. See the xref:guides:insights:insights.adoc[Insights] page and the xref:guides:insights:insights-glossary.adoc[Insights Metrics Glossary] for metric definitions such as throughput, P95 duration, and mean time to recovery.
 
-[#ip-ranges]
 == IP ranges
 
 A feature that routes a job's traffic through a set of well-defined CircleCI IP addresses, so jobs can reach systems protected by IP allow lists. See the xref:guides:security:ip-ranges.adoc[IP Ranges] page.
 
-[#job]
 == Job
 
 A collection of <<step,steps>> that run in a single <<execution-environment>>. Each job declares an <<executor>>, and jobs are orchestrated by <<workflow,workflows>>. See the xref:guides:orchestrate:jobs-steps.adoc[Jobs and Steps] page.
 
-[#job-space]
 == Job space
 
 All the containers being run by an <<executor>> for the current job.
 
-[#machine-executor]
 == Machine executor
 
 The <<executor>> (`machine`) that runs a job in a dedicated, ephemeral virtual machine with full operating-system access. Depending on the image you specify, the machine executor provides the Linux VM, Windows, GPU, Android, or Arm VM <<execution-environment,execution environment>>. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
 
-[#machine-image]
 == Machine image
 
 A prebuilt virtual machine image for the <<machine-executor>>, available for Linux, macOS, Windows, Android, and GPU environments. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
 
 [badge="Server v4+"]
-[#machine-provisioner]
 == Machine provisioner
 
 On CircleCI Server, the service that dynamically provisions and manages the virtual machines used by jobs configured for the machine execution environment, as well as Remote Docker jobs. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
 
-[#machine-runner]
 == Machine runner
 
 A type of <<self-hosted-runner>> installed directly on a Linux, macOS, or Windows machine, where it executes jobs in the same environment the runner binary is installed in. The current version is machine runner 3, which replaces the deprecated launch agent. See the xref:guides:execution-runner:runner-overview.adoc[CircleCI Runner Overview] page.
 
-[#macos-executor]
 == macOS executor
 
 The <<executor>> (`macos`) that runs a job in a macOS virtual machine with Xcode available, providing the macOS <<execution-environment,execution environment>>. Used for iOS and macOS development and testing. See the xref:guides:execution-managed:using-macos.adoc[Using the macOS Execution Environment] page.
 
-[#matrix-job]
 == Matrix job
 
 A <<job>> that runs multiple times with different combinations of parameter values, configured with the `matrix` key. Matrix jobs let you test across multiple language versions, platforms, or other variables without defining each job by hand. See the xref:guides:orchestrate:using-matrix-jobs.adoc[Using Matrix Jobs] page.
 
-[#mcp-server]
 == MCP server
 
 The CircleCI Model Context Protocol (MCP) server, which lets AI coding assistants diagnose build failures, fix issues, and manage pipelines through natural language without leaving the development environment. See the xref:guides:toolkit:using-the-circleci-mcp-server.adoc[Using the CircleCI Model Context Protocol Server] page.
@@ -270,13 +219,11 @@ The CircleCI Model Context Protocol (MCP) server, which lets AI coding assistant
 
 An additional layer of account security that requires a second verification factor, such as a one-time password from an authenticator app, in addition to a password. See the xref:guides:permissions-authentication:mfa.adoc[Manage Multi-Factor Authentication] page.
 
-[#namespace]
 == Namespace
 
 A unique, immutable identifier that groups an organization's resources under a single owner. Each user or organization claims one namespace, typically the lowercase VCS organization name. The same namespace is used to group your registry <<orbs>> by author and to identify your <<self-hosted-runner,self-hosted runners>>, where it is combined with a resource-class name to form the full runner <<resource-class>> label. See the xref:orbs:use:orb-concepts.adoc[Orb Concepts] and xref:guides:execution-runner:runner-concepts.adoc[Runner Concepts] pages.
 
 [badge="Server v4+"]
-[#nomad]
 == Nomad
 
 On CircleCI Server, the HashiCorp workload orchestrator that schedules and runs CI/CD jobs. It consists of a Nomad control plane (server) that runs in the Kubernetes cluster and Nomad clients, provisioned outside the cluster, that execute jobs. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
@@ -286,67 +233,54 @@ On CircleCI Server, the HashiCorp workload orchestrator that schedules and runs 
 
 A token issued by CircleCI that lets a job authenticate with a cloud provider without storing long-lived credentials. CircleCI provides OIDC tokens in the `CIRCLE_OIDC_TOKEN` and `CIRCLE_OIDC_TOKEN_V2` environment variables, with claims identifying the organization, project, and job. See the xref:guides:permissions-authentication:openid-connect-tokens.adoc[Using OpenID Connect Tokens] page.
 
-[#orbs]
 == Orbs
 
 Reusable packages of YAML configuration that bundle <<job,jobs>>, <<command,commands>>, and <<executor,executors>> to automate repeated processes and integrate with third-party tools. Orbs can be published to the orb registry as public or private, or defined inline in your configuration. Visit the https://circleci.com/developer/orbs[Orb Registry] to find orbs, and see the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
 
-[#orb-registry]
 == Orb registry
 
 The open repository of published registry <<orbs>> that you can search and import into your projects. Orbs in the registry are designated as certified (written by CircleCI), partner, or community. See the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
 
-[#organization]
 == Organization
 
 The top-level account in CircleCI that contains a team's projects, settings, permissions, and billing. An organization is one of three types: `circleci`, `github`, or `bitbucket`. See the xref:guides:permissions-authentication:users-organizations-and-integrations-guide.adoc[Users, Organizations, and Integrations Guide] page.
 
-[#organization-role]
 == Organization role
 
 In a `circleci` type <<organization>>, a role assigned at the organization level that determines a user's permissions across the whole organization. The organization roles are admin, contributor, and viewer. (In `github` and `bitbucket` OAuth organizations, access follows the VCS <<owner>> model instead.) See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page. Compare with <<project-role>>.
 
-[#owner]
 == Owner
 
 In a `github` or `bitbucket` (OAuth) <<organization>>, the owner of the team's VCS organization, who has full administrative control over the organization's CircleCI resources. In a `circleci` type organization, access is governed instead by an <<organization-role>>. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
 
-[#parallelism]
 == Parallelism
 
 Running a single job's steps across multiple identical execution environments at the same time, set with the `parallelism` key, to reduce job time. Parallelism is most often used with <<test-splitting>>. Parallelism is _not_ the same as <<concurrency>>, which is running multiple jobs at once. See the xref:guides:optimize:parallelism-faster-jobs.adoc[Running Tests in Parallel] page.
 
-[#parameter]
 == Parameter
 
 A named, typed value passed to a <<command>>, <<job>>, or <<executor>> to make reusable configuration flexible. Parameters support types such as string, boolean, integer, and enum. See the xref:reference:ROOT:reusing-config.adoc[Reusable Config Reference] page. Compare with <<pipeline-parameter>>.
 
-[#pipeline]
 == Pipeline
 
 The full set of processes you run when you trigger work on a project. A pipeline encompasses your <<workflow,workflows>>, which in turn coordinate your <<job,jobs>>, and is defined in your project's <<configuration,configuration file>>. See the xref:guides:orchestrate:pipelines.adoc[Pipelines] page.
 
-[#pipeline-parameter]
 == Pipeline parameter
 
 A typed <<parameter>> declared at the top level of a configuration file and passed when a <<pipeline>> is triggered through the API or web app. Pipeline parameters are referenced with `pipeline.parameters.<name>`. See the xref:guides:orchestrate:pipeline-variables.adoc[Pipeline Values and Parameters] page.
 
-[#pipeline-value]
 == Pipeline value
 
 Metadata about a pipeline that CircleCI makes available automatically, without declaration, such as `pipeline.id`, `pipeline.number`, and `pipeline.git.branch`. See the xref:guides:orchestrate:pipeline-variables.adoc[Pipeline Values and Parameters] page. Compare with <<pipeline-parameter>> and <<built-in-environment-variable>>.
 
-[#primary-container]
 == Primary container
 
 The first <<image>> listed in your <<configuration,configuration file>> for a Docker job. The job's steps run in the primary container. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page. Compare with <<service-container,service container>>.
 
-[#private-orb]
 == Private orb
 
 A registry <<orbs,orb>> available only within the organization that owns it. A private orb is findable in the registry only with a direct URL and when authenticated, and cannot be used by other organizations. See the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
 
-[#project]
 == Project
 
 include::guides:ROOT:partial$tips/check-org-type.adoc[]
@@ -357,67 +291,54 @@ For `circleci` type organizations, a CircleCI project is a standalone entity tha
 
 After a project is set up, you can configure settings, contexts, environment variables, and the team members who may follow it. See the xref:guides:getting-started:create-project.adoc[Create a Project] page.
 
-[#project-administrator]
 == Project administrator
 
 In a `github` or `bitbucket` (OAuth) <<organization>>, the user who adds a repository in the VCS to CircleCI as a project. In a `circleci` type organization, project access is governed instead by a <<project-role>>. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
 
-[#project-role]
 == Project role
 
 In a `circleci` type <<organization>>, a role assigned at the project level that determines a user's permissions for a specific project, offering finer-grained control than an <<organization-role>>. The project roles are admin, contributor, and viewer. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
 
-[#registered-user]
 == Registered user
 
 A user who has created a CircleCI account. Registered users can access the web app, view pipelines and build history, trigger and rerun builds, and have organization access based on their role. See the xref:guides:plans-pricing:user-types-and-registration.adoc[User Types and Registration] page. Compare with <<unregistered-user>>.
 
-[#release]
 == Release
 
 A version of a <<component>> becoming available to an audience of users and other services. A release occurs when an existing component is updated or when the first version of a new component is deployed. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page. Compare with <<deployment>>.
 
-[#release-agent]
 == Release agent
 
 A tool installed in a Kubernetes cluster that lets you manage deployments through CircleCI, providing visibility and control over releases, including support for Kubernetes Deployments and Argo Rollouts. See the xref:guides:deploy:release-agent-overview.adoc[Release Agent Overview] page.
 
-[#remote-docker]
 == Remote Docker
 
 A feature that enables building, running, and pushing Docker images to registries from within a <<docker-executor>> job, using the `setup_remote_docker` key. See the xref:guides:execution-managed:building-docker-images.adoc[Running Docker Commands] page.
 
-[#rerun]
 == Rerun
 
 Re-executing a failed <<workflow>>, or individual failed <<job,jobs>> within it, to recover from transient failures without triggering a new pipeline. See the xref:guides:orchestrate:workflows.adoc[Workflows] page. For tests specifically, see <<test-splitting>> and the xref:guides:test:rerun-failed-tests.adoc[Rerun Failed Tests] page.
 
-[#resource-class]
 == Resource class
 
 A configuration option that specifies the compute resources, such as CPU and RAM, allocated to a <<job>>. A resource class is also used as a label to identify a pool of <<self-hosted-runner,self-hosted runners>> and to route a job to that pool. See the xref:guides:execution-managed:resource-class-overview.adoc[Resource Class Overview] page.
 
-[#rollback]
 == Rollback
 
 Reverting an application to a previous stable version when an issue is detected, either through a dedicated rollback pipeline or by rerunning a prior workflow. See the xref:guides:deploy:rollback-a-deployment.adoc[Roll Back a Deployment] page.
 
-[#schedule-trigger]
 == Schedule trigger
 
 A <<trigger>> that runs a pipeline on a defined schedule, using cron syntax, rather than on each commit. Schedule triggers are the recommended way to run scheduled work. Use them instead of scheduled workflows unless your setup requires the older approach. See the xref:guides:orchestrate:schedule-triggers.adoc[Schedule Triggers] page.
 
-[#secrets-masking]
 == Secrets masking
 
 A security feature that obscures environment variable and context values in job output, providing an additional layer of protection against accidental exposure of secrets. See the xref:guides:security:env-vars.adoc[Using Environment Variables] page.
 
-[#self-hosted-runner]
 == Self-hosted runner
 
 A CircleCI agent installed on your own infrastructure, such as Kubernetes, virtual machines, or physical hardware, that claims and executes jobs on hardware or architectures you control. The two types are <<container-runner>> and <<machine-runner>>. See the xref:guides:execution-runner:runner-overview.adoc[CircleCI Runner Overview] page.
 
-[#service-container]
 == Service container
 
 An additional <<image>> listed in a job's configuration that runs alongside the <<primary-container>>, typically to provide a service such as a database. Also called a secondary container. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
@@ -427,53 +348,47 @@ An additional <<image>> listed in a job's configuration that runs alongside the 
 
 An authentication method that lets users authenticate once through an identity provider, using the SAML 2.0 protocol, to access an organization's CircleCI resources. See the xref:guides:permissions-authentication:sso-overview.adoc[SSO Overview] page.
 
-[#ssh-key]
 == SSH key
 
 A cryptographic key pair used for authentication in CircleCI. A deploy key gives CircleCI access to check out a single repository. A user key is associated with a user account and can give access to multiple repositories. See the xref:guides:security:rotate-project-ssh-keys.adoc[Rotate Project SSH Keys] page.
 
-[#step]
 == Step
 
 A single executable action within a <<job>>, such as a `run`, `checkout`, `save_cache`, or `store_artifacts` command. Steps run in the order they are defined under the `steps` key. See the xref:guides:orchestrate:jobs-steps.adoc[Jobs and Steps] page.
 
-[#setup-workflow]
 == Setup workflow
 
 A <<workflow>> marked with `setup: true` that runs first in a <<dynamic-configuration,dynamic configuration>>. A setup workflow can compute pipeline parameters and select which configuration to continue with, enabling conditional execution of the rest of the pipeline. See the xref:guides:orchestrate:dynamic-config.adoc[Dynamic Configuration] page.
 
+== Tag filter
+
+A <<workflow>> configuration option that controls which git tags run a given <<job>>. Tag filters use `only` and `ignore` keys with exact tag names or regular expressions, and are often used to run deployment jobs on release tags. See the xref:guides:orchestrate:workflows.adoc[Workflows] page. Compare with <<branch-filter>>.
+
 [badge="Beta"]
-[#test-impact-analysis]
 == Test impact analysis
 
 A feature that runs only the tests affected by a code change. Test impact analysis maps which tests exercise which source files and skips tests covering unchanged files, to speed up CI. See the xref:guides:test:set-up-test-impact-analysis.adoc[Set up Test Impact Analysis] page.
 
-[#test-splitting]
 == Test splitting
 
 Dividing a test suite across multiple parallel execution environments, by name, file size, or historical timing data, to reduce overall test time. Test splitting works together with <<parallelism>>. See the xref:guides:optimize:parallelism-faster-jobs.adoc[Running Tests in Parallel] page.
 
-[#trigger]
 == Trigger
 
 A mechanism that initiates a <<pipeline>>. Triggers can be automatic, based on VCS events, schedules, or custom webhooks, or manual, through the web app, API, or CLI. See the xref:guides:orchestrate:triggers-overview.adoc[Triggers Overview] page. See also <<schedule-trigger>>, <<custom-webhook>>, and <<cross-repo-trigger>>.
 
-[#unregistered-user]
 == Unregistered user
 
 Someone who has triggered builds in a CircleCI organization but has not created a CircleCI account. Unregistered users count as <<active-user,active users>> for billing. See the xref:guides:plans-pricing:user-types-and-registration.adoc[User Types and Registration] page.
 
-[#url-orb]
 == URL orb
 
 A single YAML file of shared <<orbs,orb>> configuration, stored somewhere accessible over HTTPS, such as a GitHub repository, and imported by its URL rather than from the orb registry. The URL must be allowed by the organization's allow list. URL orbs let you share configuration across an organization while keeping direct control over updates. See the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
 
-[#user]
 == User
 
 An individual who can log in to the CircleCI platform. A user must be part of an organization to view or follow its projects. Access is governed by an <<organization-role>> and <<project-role>> in `circleci` type organizations, or by the VCS <<owner>> and <<project-administrator>> model in `github` and `bitbucket` OAuth organizations. Users may *not* view project data stored in environment variables. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
 
-[#version-promotion]
 == Version promotion
 
 Deploying a specific <<component>> version to the next <<environment>> in an <<environment-hierarchy>>, often with a single action from the CircleCI UI. See the xref:guides:deploy:environment-hierarchy-and-version-promotion.adoc[Environment Hierarchy and Version Promotion] page.
@@ -488,12 +403,10 @@ The platform where your code is stored and that CircleCI integrates with, such a
 
 An HTTP POST request that CircleCI sends to an external service when a specified event occurs, such as a workflow or job completing. Outbound webhooks let other services react in real time without polling. See the xref:guides:integration:outbound-webhooks.adoc[Outbound Webhooks] page. Compare with <<custom-webhook>>, which triggers CircleCI.
 
-[#workflow]
 == Workflow
 
 A set of rules that defines a collection of <<job,jobs>> and their run order. Workflows can run jobs concurrently, sequentially, on a schedule, or with a manual gate using an <<approval-job>>. See the xref:guides:orchestrate:workflows.adoc[Workflows] page.
 
-[#workspace]
 == Workspace
 
 A workflow-aware storage mechanism that passes data between <<job,jobs>> in the same <<workflow>>. A job persists files with `persist_to_workspace`, and downstream jobs access them with `attach_workspace`. On CircleCI Cloud, workspace storage is retained for 15 days by default, which is also the maximum. You can set a shorter period (1 to 15 days) under menu:Plan[Usage Controls] in the web app. See the xref:guides:orchestrate:workspaces.adoc[Using Workspaces to Share Data Between Jobs] page. Compare with <<cache>> and <<artifact>>.

--- a/docs/reference/modules/ROOT/pages/glossary.adoc
+++ b/docs/reference/modules/ROOT/pages/glossary.adoc
@@ -13,7 +13,7 @@ Any user, registered or unregistered, who triggers the use of compute resources 
 [#approval-job]
 == Approval job
 
-A special job, configured with `type: approval`, that pauses a <<workflow>> until a user with the required permissions manually approves it. An approval job runs no steps of its own; it acts as a manual gate before downstream jobs continue. See the xref:guides:orchestrate:workflows.adoc[Workflows] page.
+A special job, configured with `type: approval`, that pauses a <<workflow>> until a user with the required permissions manually approves it. An approval job runs no steps of its own. It acts as a manual gate before downstream jobs continue. See the xref:guides:orchestrate:workflows.adoc[Workflows] page.
 
 [#artifact]
 == Artifact
@@ -405,7 +405,7 @@ Reverting an application to a previous stable version when an issue is detected,
 [#schedule-trigger]
 == Schedule trigger
 
-A <<trigger>> that runs a pipeline on a defined schedule, using cron syntax, rather than on each commit. Schedule triggers are the recommended way to run scheduled work; use them instead of scheduled workflows unless your setup requires the older approach. See the xref:guides:orchestrate:schedule-triggers.adoc[Schedule Triggers] page.
+A <<trigger>> that runs a pipeline on a defined schedule, using cron syntax, rather than on each commit. Schedule triggers are the recommended way to run scheduled work. Use them instead of scheduled workflows unless your setup requires the older approach. See the xref:guides:orchestrate:schedule-triggers.adoc[Schedule Triggers] page.
 
 [#secrets-masking]
 == Secrets masking
@@ -430,7 +430,7 @@ An authentication method that lets users authenticate once through an identity p
 [#ssh-key]
 == SSH key
 
-A cryptographic key pair used for authentication in CircleCI. A deploy key gives CircleCI access to check out a single repository; a user key is associated with a user account and can give access to multiple repositories. See the xref:guides:security:rotate-project-ssh-keys.adoc[Rotate Project SSH Keys] page.
+A cryptographic key pair used for authentication in CircleCI. A deploy key gives CircleCI access to check out a single repository. A user key is associated with a user account and can give access to multiple repositories. See the xref:guides:security:rotate-project-ssh-keys.adoc[Rotate Project SSH Keys] page.
 
 [#step]
 == Step
@@ -496,4 +496,4 @@ A set of rules that defines a collection of <<job,jobs>> and their run order. Wo
 [#workspace]
 == Workspace
 
-A workflow-aware storage mechanism that passes data between <<job,jobs>> in the same <<workflow>>. A job persists files with `persist_to_workspace`, and downstream jobs access them with `attach_workspace`. On CircleCI Cloud, workspace storage is retained for 15 days by default, which is also the maximum; you can set a shorter period (1 to 15 days) under menu:Plan[Usage Controls] in the web app. See the xref:guides:orchestrate:workspaces.adoc[Using Workspaces to Share Data Between Jobs] page. Compare with <<cache>> and <<artifact>>.
+A workflow-aware storage mechanism that passes data between <<job,jobs>> in the same <<workflow>>. A job persists files with `persist_to_workspace`, and downstream jobs access them with `attach_workspace`. On CircleCI Cloud, workspace storage is retained for 15 days by default, which is also the maximum. You can set a shorter period (1 to 15 days) under menu:Plan[Usage Controls] in the web app. See the xref:guides:orchestrate:workspaces.adoc[Using Workspaces to Share Data Between Jobs] page. Compare with <<cache>> and <<artifact>>.

--- a/docs/reference/modules/ROOT/pages/glossary.adoc
+++ b/docs/reference/modules/ROOT/pages/glossary.adoc
@@ -226,7 +226,7 @@ The top-level account in CircleCI that contains a team's projects, settings, per
 
 == Organization role
 
-In a `circleci` type <<organization>>, a role assigned at the organization level that determines a user's permissions across the whole organization. The organization roles are admin, contributor, and viewer. In `github` and `bitbucket` OAuth organizations, access follows the VCS <<owner>> model instead. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page. Compare with <<project-role>>.
+In a `circleci` type <<organization>>, a role assigned at the organization level that determines a user's permissions across the whole organization. The organization roles are admin, contributor, and viewer. In `github` and `bitbucket` OAuth organizations, access follows the VCS permissions model instead. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
 
 == Parallelism
 

--- a/docs/reference/modules/ROOT/pages/glossary.adoc
+++ b/docs/reference/modules/ROOT/pages/glossary.adoc
@@ -63,7 +63,7 @@ Organization-level rules that govern which configuration elements are required, 
 
 == Configuration
 
-The YAML file that defines your entire CI/CD process as code. The configuration file declares the <<pipeline>>, <<workflow,workflows>>, <<job,jobs>>, and <<step,steps>> that run when work is triggered. It is most often stored at `.circleci/config.yml` in the root of a repository, but a project is not limited to that name or location and can use a configuration file stored elsewhere. See the xref:guides:getting-started:config-intro.adoc[Configuration Introduction] page and the xref:reference:ROOT:configuration-reference.adoc[Configuration Reference].
+The YAML file that defines your entire CI/CD process as code. The configuration file declares the <<pipeline>>, <<workflow,workflows>>, <<job,jobs>>, and <<step,steps>> that run when work is triggered. It is most often stored at `.circleci/config.yml` in the root of a repository, but a project is not limited to that name or location. See the xref:guides:getting-started:config-intro.adoc[Configuration Introduction] page and the xref:reference:ROOT:configuration-reference.adoc[Configuration Reference].
 
 == Container
 
@@ -91,7 +91,7 @@ A <<trigger>> that runs a pipeline in one repository when an event, such as a ta
 
 == Custom image
 
-A Docker <<image>> that you build and maintain yourself, typically from a Dockerfile stored in a registry, for use with the <<docker-executor>> when convenience images do not meet your needs. See the xref:guides:execution-managed:custom-images.adoc[Using Custom-Built Docker Images] page.
+A Docker <<image>> that you build and maintain yourself, typically from a Dockerfile stored in a registry. Use a custom image with the <<docker-executor>> when convenience images do not meet your needs. See the xref:guides:execution-managed:custom-images.adoc[Using Custom-Built Docker Images] page.
 
 == Custom webhook
 
@@ -109,6 +109,7 @@ A lightweight logging mechanism, configured as steps in your pipeline, that reco
 
 The act of putting a new <<component>> version into an <<environment>>, regardless of whether traffic is yet routed to it. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page. Compare with <<release>> and <<delivery>>, which CircleCI defines as distinct steps.
 
+[#docker-executor]
 == Docker executor
 
 The <<executor>> (`docker`) that runs a job inside one or more Docker containers, providing the Docker <<execution-environment,execution environment>>. The Docker executor is resource-efficient and well suited to most build and test jobs. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
@@ -147,7 +148,7 @@ A <<workflow>> pattern in which a single job branches into multiple jobs that ru
 
 == Filtering
 
-The mechanisms for controlling whether a <<job>>, <<workflow>>, or <<step>> runs, based on the git branch or tag, or on other conditions. You can filter a job by branch or tag using the `filters` key with `only` and `ignore` values, or set `filters` to an expression for finer control, for example `filters: pipeline.git.branch == "main"`. You can also gate a whole workflow or a single step with an expression in a `when` or `unless` condition. Expression-based conditions are the most flexible option and can reference pipeline values and parameters. See the xref:guides:orchestrate:using-branch-filters.adoc[Branch and Tag Filtering] page.
+The mechanisms for controlling whether a <<job>>, <<workflow>>, or <<step>> runs, based on the git branch or tag, or on other conditions. You can filter a job by branch or tag using the `filters` key with `only` and `ignore` values. For finer control, set `filters` to an expression, for example `filters: pipeline.git.branch == "main"`. You can also gate a whole workflow or a single step with an expression in a `when` or `unless` condition. Expression-based conditions are the most flexible option and can reference pipeline values and parameters. See the xref:guides:orchestrate:using-branch-filters.adoc[Branch and Tag Filtering] page.
 
 == Flaky test
 
@@ -204,7 +205,7 @@ An additional layer of account security that requires a second verification fact
 
 == Namespace
 
-A unique, immutable identifier that groups an organization's resources under a single owner. Each user or organization claims one namespace, typically the lowercase VCS organization name. The same namespace is used to group your registry <<orbs>> by author and to identify your <<self-hosted-runner,self-hosted runners>>, where it is combined with a resource-class name to form the full runner <<resource-class>> label. See the xref:orbs:use:orb-concepts.adoc[Orb Concepts] and xref:guides:execution-runner:runner-concepts.adoc[Runner Concepts] pages.
+A unique, immutable identifier that groups an organization's resources under a single owner. Each user or organization claims one namespace, typically the lowercase VCS organization name. The same namespace groups your registry <<orbs>> by author and identifies your <<self-hosted-runner,self-hosted runners>>. For runners, it is combined with a resource-class name to form the full runner <<resource-class>> label. See the xref:orbs:use:orb-concepts.adoc[Orb Concepts] and xref:guides:execution-runner:runner-concepts.adoc[Runner Concepts] pages.
 
 [#oidc-token]
 == OpenID Connect (OIDC) token

--- a/docs/reference/modules/ROOT/pages/glossary.adoc
+++ b/docs/reference/modules/ROOT/pages/glossary.adoc
@@ -1,114 +1,499 @@
 = Glossary
 :page-platform: Cloud, Server v4+
-:page-description: A glossary of terms used for the CircleCI product.
+:page-description: A glossary of CircleCI-specific and CI/CD terminology used across the CircleCI product and documentation.
 :experimental:
+
+This glossary defines terms used across the CircleCI product and documentation. It covers CircleCI-specific concepts as well as general CI/CD terms as CircleCI uses them. Entries marked with a *Server* badge apply to xref:guides:plans-pricing:plan-server.adoc[CircleCI Server], the self-hosted installation.
+
+[#active-user]
+== Active user
+
+Any user, registered or unregistered, who triggers the use of compute resources on projects that are not open source during a billing period. Commits, reruns, approvals, scheduled pipelines, and machine users can all make a user active. Active users are counted for billing. See the xref:guides:plans-pricing:user-types-and-registration.adoc[User Types and Registration] page.
+
+[#approval-job]
+== Approval job
+
+A special job, configured with `type: approval`, that pauses a <<workflow>> until a user with the required permissions manually approves it. An approval job runs no steps of its own; it acts as a manual gate before downstream jobs continue. See the xref:guides:orchestrate:workflows.adoc[Workflows] page.
+
+[#artifact]
+== Artifact
+
+A file or directory that persists after a <<job>> finishes, such as a compiled binary, a coverage report, or a screenshot. Artifacts remain available for download long after a workflow completes, subject to a storage retention period. See the xref:guides:optimize:artifacts.adoc[Storing Build Artifacts] page. Compare with <<cache>> and <<workspace>>, which serve different purposes.
+
+[#audit-log]
+== Audit log
+
+A record of significant events in a CircleCI organization, available to organization admins for audit and forensic analysis. See the xref:guides:security:audit-logs.adoc[Audit Logs] page.
+
+[#branch-filter]
+== Branch filter
+
+A <<workflow>> configuration option that controls which branches run a given <<job>>. Branch filters use `only` and `ignore` keys with exact branch names or regular expressions. See the xref:guides:orchestrate:using-branch-filters.adoc[Using Branch Filters] page. Compare with <<tag-filter>>.
+
+[badge="Server v4+"]
+[#build-agent]
+== Build agent
+
+On CircleCI Server, the CircleCI program that executes the steps within a job and reports the results. The build agent runs as the main process inside a Nomad job allocation. See <<nomad>> and the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
+
+[#built-in-environment-variable]
+== Built-in environment variable
+
+A predefined <<environment-variable>> that CircleCI makes available in every job, containing information about the project, pipeline, and job being run (for example `CIRCLE_BRANCH`, `CIRCLE_JOB`, `CIRCLE_BUILD_NUM`). Built-in environment variables are scoped to the job. See the xref:reference:ROOT:variables.adoc[Project Values and Variables] page.
+
+[#cache]
+== Cache
+
+A stored hierarchy of files that CircleCI restores into later <<job,jobs>> to speed up repetitive operations, such as downloading dependencies. A cache is immutable once written and is identified by a <<cache-key>>. See the xref:guides:optimize:caching.adoc[Caching Dependencies] page. Compare with <<workspace>> and <<artifact>>.
+
+[#cache-key]
+== Cache key
+
+A unique identifier that determines when CircleCI writes a new <<cache>> and which existing cache it restores. Cache keys can include templates, such as a checksum of a lock file or the branch name, that are evaluated at runtime. See the xref:guides:optimize:caching.adoc[Caching Dependencies] page.
 
 [#circleci-administrator]
 == CircleCI administrator
 
-The first user to log into a private installation of CircleCI. Administrators have the ability to add and remove users.
+On CircleCI Server, the first user to log in to a private installation. The administrator can add and remove users. For role-based access on cloud, see <<organization-role>> and the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
+
+[#circleci-cli]
+== CircleCI CLI
+
+The command-line interface you install on your local machine to validate and debug configuration, run jobs locally, and manage orbs, contexts, and policies. See the xref:guides:toolkit:local-cli.adoc[CircleCI Local CLI] page. The CircleCI CLI is distinct from the in-pipeline `circleci` commands that run during a job.
+
+[badge="Server v4+"]
+[#circleci-server]
+== CircleCI Server
+
+The self-hosted CI/CD platform for organizations that must operate within their own firewall, private cloud, or data center. CircleCI Server runs in a Kubernetes cluster and provides the same core features as CircleCI Cloud. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
+
+[#command]
+== Command
+
+A reusable sequence of <<step,steps>> that can be invoked multiple times within a job, within other commands, or across jobs in a configuration file. Commands are a building block of reusable config and <<orbs>>. See the xref:reference:ROOT:reusing-config.adoc[Reusable Config Reference] page.
+
+NOTE: Not to be confused with a _release agent command_, a user-initiated release action (such as restore version or scale component) run by the <<release-agent>>. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page.
+
+[#component]
+== Component
+
+In the context of <<deployment,deployments>>, a collection of code and configuration that is deployed and released as a single unit. In Kubernetes terms, a component corresponds to a Deployment or Rollout object and its related objects that share a common `circleci.com/component-name` label. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page.
+
+[#concurrency]
+== Concurrency
+
+Running multiple jobs at the same time, either multiple jobs within a single <<workflow>> or multiple workflows running across an organization. Concurrency is limited by soft limits on each <<resource-class>>. Concurrency is _not_ the same as <<parallelism>>, which splits the tests of a single job across multiple containers. See the xref:guides:optimize:concurrency.adoc[Concurrency] page.
+
+[#config-policies]
+== Config policies
+
+Organization-level rules that govern which configuration elements are required, allowed, or disallowed in project configurations. CircleCI evaluates config policies with the Open Policy Agent (OPA) decision engine, using policies written in the Rego language. See the xref:guides:config-policies:config-policy-management-overview.adoc[Config Policy Management Overview] page.
+
+[#configuration]
+== Configuration
+
+The YAML file that defines your entire CI/CD process as code. The configuration file declares the <<pipeline>>, <<workflow,workflows>>, <<job,jobs>>, and <<step,steps>> that run when work is triggered. It is most often stored at `.circleci/config.yml` in the root of a repository, but a project is not limited to that name or location and can use a configuration file stored elsewhere. See the xref:guides:getting-started:config-intro.adoc[Configuration Introduction] page and the xref:reference:ROOT:configuration-reference.adoc[Configuration Reference].
 
 [#container]
 == Container
 
-A container is a running instance of an image.
+A running instance of an <<image>>.
+
+[#container-runner]
+== Container runner
+
+A type of <<self-hosted-runner>> installed in a Kubernetes cluster that runs containerized jobs in ephemeral pods. Container runner complements the <<machine-runner>> for high-concurrency, container-based workloads. See the xref:guides:execution-runner:container-runner.adoc[Container Runner] page.
 
 [#context]
 == Context
 
-xref:guides:security:contexts.adoc[Contexts] provide a mechanism for securing and sharing environment variables across projects. The environment variables are defined as name/value pairs and are injected at runtime. After a context has been created, you can use the context key in the workflows section of a project `.circleci/config.yml` file to give any job(s) access to the environment variables associated with the context.
+A mechanism for securing and sharing <<environment-variable,environment variables>> across projects at the organization level. Environment variables in a context are defined as name/value pairs and injected at runtime. After you create a context, you can reference it in the `workflows` section of a project's <<configuration,configuration file>> to give jobs access to its variables. Context access can be restricted with security groups, project restrictions, or expression restrictions. See the xref:guides:security:contexts.adoc[Using Contexts] page.
+
+[#convenience-image]
+== Convenience image
+
+A prebuilt Docker <<image>> maintained by CircleCI with popular languages and tools preinstalled. Next-generation convenience images use the `cimg/` namespace on Docker Hub and offer faster spin-up and improved stability over legacy images. See the xref:guides:execution-managed:circleci-images.adoc[CircleCI Images] page. Compare with <<custom-image>> and <<machine-image>>.
+
+[#credit]
+== Credit
+
+The unit of compute consumption in CircleCI. Credits are consumed by the second, at rates that vary by machine type and <<resource-class>>. Larger resource classes consume credits at higher rates. See the xref:guides:plans-pricing:plan-overview.adoc[Plan Overview] page.
+
+[#cross-repo-trigger]
+== Cross-repo trigger
+
+A <<trigger>> that runs a pipeline in one repository when an event, such as a tag push, occurs in another. Cross-repo triggers help you test library consumers. See the xref:guides:orchestrate:set-up-cross-repo-triggers-for-library-consumers.adoc[Set up Cross-Repo Triggers] page.
+
+[#custom-image]
+== Custom image
+
+A Docker <<image>> that you build and maintain yourself, typically from a Dockerfile stored in a registry, for use with the <<docker-executor>> when convenience images do not meet your needs. See the xref:guides:execution-managed:custom-images.adoc[Using Custom-Built Docker Images] page.
+
+[#custom-webhook]
+== Custom webhook
+
+An inbound webhook that lets any third-party service capable of sending an HTTP request trigger a CircleCI <<pipeline>>. See the xref:guides:orchestrate:custom-webhooks.adoc[Custom Webhooks] page. Compare with <<outbound-webhook>>.
+
+[#delivery]
+== Delivery
+
+The act of packaging code changes and making them available for <<deployment>>. _Continuous delivery_ produces deployable executables from code that can be deployed at a later time. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page.
+
+[#deploy-marker]
+== Deploy marker
+
+A lightweight logging mechanism, configured as steps in your pipeline, that records a timeline of deployments in one place. Deploy markers let you track deployment status, roll back, and promote versions through environments. See the xref:guides:deploy:configure-deploy-markers.adoc[Configure Deploy Markers] page.
+
+[#deployment]
+== Deployment
+
+The act of putting a new <<component>> version into an <<environment>>, regardless of whether traffic is yet routed to it. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page. Compare with <<release>> and <<delivery>>, which CircleCI defines as distinct steps.
+
+[#docker-executor]
+== Docker executor
+
+The <<executor>> (`docker`) that runs a job inside one or more Docker containers, providing the Docker <<execution-environment,execution environment>>. The Docker executor is resource-efficient and well suited to most build and test jobs. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
 
 [#docker-layer-caching]
 == Docker layer caching
 
-The CircleCI Docker Layer Caching (DLC) feature allows builds to reuse Docker image layers from previous builds. Use DLC to speed up workflows. Jobs that are configured to build Docker images run in a shorter time on subsequent runs. Layers may only be used by builds from the same project. For more information and usage examples, see the xref:guides:optimize:docker-layer-caching.adoc[Docker Layer Caching] and xref:guides:execution-managed:building-docker-images.adoc[Running Docker Commands] pages.
+Docker Layer Caching (DLC) lets builds reuse Docker image layers from previous builds so that jobs which build Docker images run faster on subsequent runs. Layers can only be reused by builds from the same project. See the xref:guides:optimize:docker-layer-caching.adoc[Docker Layer Caching] and xref:guides:execution-managed:building-docker-images.adoc[Running Docker Commands] pages.
 
-[#environment-variables]
-== Environment variables
+[#dynamic-configuration]
+== Dynamic configuration
 
-xref:guides:security:env-vars.adoc[Environment variables] store customer data that is used by a project. Only project administrators and owners are allowed to view or modify environment variables. The values are transmitted using secure protocols, for example, HTTPS and SSH, encrypted at rest, and hashed/salted to prevent CircleCI employees from viewing them.
+A feature that lets a pipeline determine the work it runs at runtime, based on pipeline parameters, changed file paths, or other conditions, rather than using fully static configuration. Dynamic configuration is enabled with a <<setup-workflow>> (`setup: true`). See the xref:guides:orchestrate:dynamic-config.adoc[Dynamic Configuration] page.
+
+[#environment]
+== Environment
+
+In the Deploys feature, a named deployment target represented in the CircleCI UI, such as staging or production. Environments can be a custom type or a Kubernetes cluster type. Ordered into an <<environment-hierarchy>>, they define a promotion path. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page.
+
+[#environment-hierarchy]
+== Environment hierarchy
+
+An ordered sequence of <<environment,environments>> that defines a promotion path. You can configure hierarchies at the organization, project, or component level to support different promotion workflows. See the xref:guides:deploy:environment-hierarchy-and-version-promotion.adoc[Environment Hierarchy and Version Promotion] page.
+
+[#environment-variable]
+== Environment variable
+
+A named value stored in CircleCI and injected at runtime into jobs, used for configuration, secrets, and credentials. Environment variables can be set at the context, project, job, or step level, and follow an order of precedence. Values are encrypted at rest and masked in job output. See the xref:guides:security:env-vars.adoc[Using Environment Variables] page. Compare with <<built-in-environment-variable>>.
+
+[#execution-environment]
+== Execution environment
+
+The runtime in which a <<job>> runs, either a Docker container or a virtual machine. CircleCI offers the Docker, Linux VM, macOS, Windows, GPU, Android, and Arm VM execution environments. You do not select an execution environment directly: you choose an <<executor>> (`docker`, `machine`, or `macos`) and an image, and those determine the environment. This split between executor and execution environment is specific to CircleCI. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
 
 [#executor]
 == Executor
 
-xref:guides:execution-managed:executor-intro.adoc[Executors] define the underlying technology to run a job. Can be either `docker` to run your job inside a Docker container with a specified image, or `machine` to run your job inside a full virtual machine.
+The type you assign to a <<job>> that defines the underlying technology used to run it. CircleCI has three executors: `docker`, `machine`, and `macos`. The executor is not the same as the <<execution-environment>>: the executor you choose, together with the image you specify, determines which execution environment the job runs in. For example, the `machine` executor can run a job in the Linux VM, Windows, GPU, Android, or Arm VM environment. In reusable config and orbs, an executor is also a named, parameterizable definition that multiple jobs can share. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] and xref:reference:ROOT:reusing-config.adoc[Reusable Config Reference] pages.
+
+[#fan-out-fan-in]
+== Fan-out/fan-in
+
+A <<workflow>> pattern in which a single job branches into multiple jobs that run concurrently (fan-out), which then converge on a single downstream job (fan-in). This pattern is useful for running test suites in parallel after a build, then deploying once all tests pass. See the xref:guides:orchestrate:workflows.adoc[Workflows] page.
+
+[#flaky-test]
+== Flaky test
+
+A test that passes and fails inconsistently without changes to the code under test. CircleCI identifies a test as flaky when it both fails and passes on the same commit within a set time window. See the xref:guides:test:fix-flaky-tests.adoc[Identify and Fix Flaky Tests] page.
+
+[#group]
+== Group
+
+A collection of users that can be assigned roles together, so administrators can manage access for many users at once. Groups can be mapped automatically from an identity provider. See the xref:guides:permissions-authentication:manage-groups.adoc[Manage Groups] and xref:guides:permissions-authentication:sso-group-mapping.adoc[SSO Group Mapping] pages.
 
 [#image]
 == Image
 
-An image is a packaged system that includes instructions for creating a running container. The primary container is defined by the first image listed in a `.circleci/config.yml` file. This is where commands are executed for jobs, using the Docker or machine executor. Visit the https://circleci.com/developer/images[CircleCI Developer Hub] to see available convenience and machine images.
+A packaged system that includes the instructions for creating a running <<container>>. The <<primary-container>> is defined by the first image listed in your <<configuration,configuration file>>. Visit the https://circleci.com/developer/images[CircleCI Developer Hub] to browse available convenience and machine images. See also <<convenience-image>>, <<machine-image>>, and <<custom-image>>.
+
+[#insights]
+== Insights
+
+CircleCI's dashboards that report time-series and aggregated data on credit usage, success rates, duration, and test performance across your projects, workflows, jobs, and tests. See the xref:guides:insights:insights.adoc[Insights] page and the xref:guides:insights:insights-glossary.adoc[Insights Metrics Glossary] for metric definitions such as throughput, P95 duration, and mean time to recovery.
+
+[#ip-ranges]
+== IP ranges
+
+A feature that routes a job's traffic through a set of well-defined CircleCI IP addresses, so jobs can reach systems protected by IP allow lists. See the xref:guides:security:ip-ranges.adoc[IP Ranges] page.
+
+[#job]
+== Job
+
+A collection of <<step,steps>> that run in a single <<execution-environment>>. Each job declares an <<executor>>, and jobs are orchestrated by <<workflow,workflows>>. See the xref:guides:orchestrate:jobs-steps.adoc[Jobs and Steps] page.
 
 [#job-space]
 == Job space
 
 All the containers being run by an <<executor>> for the current job.
 
-[#job]
-== Job
+[#machine-executor]
+== Machine executor
 
-xref:guides:orchestrate:jobs-steps.adoc[Jobs] are collections of steps, which run commands/scripts as required. Each job must declare an executor that is either `docker`, `machine`, `windows`, or `macos`.
+The <<executor>> (`machine`) that runs a job in a dedicated, ephemeral virtual machine with full operating-system access. Depending on the image you specify, the machine executor provides the Linux VM, Windows, GPU, Android, or Arm VM <<execution-environment,execution environment>>. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
+
+[#machine-image]
+== Machine image
+
+A prebuilt virtual machine image for the <<machine-executor>>, available for Linux, macOS, Windows, Android, and GPU environments. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
+
+[badge="Server v4+"]
+[#machine-provisioner]
+== Machine provisioner
+
+On CircleCI Server, the service that dynamically provisions and manages the virtual machines used by jobs configured for the machine execution environment, as well as Remote Docker jobs. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
+
+[#machine-runner]
+== Machine runner
+
+A type of <<self-hosted-runner>> installed directly on a Linux, macOS, or Windows machine, where it executes jobs in the same environment the runner binary is installed in. The current version is machine runner 3, which replaces the deprecated launch agent. See the xref:guides:execution-runner:runner-overview.adoc[CircleCI Runner Overview] page.
+
+[#macos-executor]
+== macOS executor
+
+The <<executor>> (`macos`) that runs a job in a macOS virtual machine with Xcode available, providing the macOS <<execution-environment,execution environment>>. Used for iOS and macOS development and testing. See the xref:guides:execution-managed:using-macos.adoc[Using the macOS Execution Environment] page.
+
+[#matrix-job]
+== Matrix job
+
+A <<job>> that runs multiple times with different combinations of parameter values, configured with the `matrix` key. Matrix jobs let you test across multiple language versions, platforms, or other variables without defining each job by hand. See the xref:guides:orchestrate:using-matrix-jobs.adoc[Using Matrix Jobs] page.
+
+[#mcp-server]
+== MCP server
+
+The CircleCI Model Context Protocol (MCP) server, which lets AI coding assistants diagnose build failures, fix issues, and manage pipelines through natural language without leaving the development environment. See the xref:guides:toolkit:using-the-circleci-mcp-server.adoc[Using the CircleCI Model Context Protocol Server] page.
+
+[#mfa]
+== Multi-factor authentication (MFA)
+
+An additional layer of account security that requires a second verification factor, such as a one-time password from an authenticator app, in addition to a password. See the xref:guides:permissions-authentication:mfa.adoc[Manage Multi-Factor Authentication] page.
+
+[#namespace]
+== Namespace
+
+A unique, immutable identifier that groups an organization's resources under a single owner. Each user or organization claims one namespace, typically the lowercase VCS organization name. The same namespace is used to group your registry <<orbs>> by author and to identify your <<self-hosted-runner,self-hosted runners>>, where it is combined with a resource-class name to form the full runner <<resource-class>> label. See the xref:orbs:use:orb-concepts.adoc[Orb Concepts] and xref:guides:execution-runner:runner-concepts.adoc[Runner Concepts] pages.
+
+[badge="Server v4+"]
+[#nomad]
+== Nomad
+
+On CircleCI Server, the HashiCorp workload orchestrator that schedules and runs CI/CD jobs. It consists of a Nomad control plane (server) that runs in the Kubernetes cluster and Nomad clients, provisioned outside the cluster, that execute jobs. See the xref:guides:plans-pricing:plan-server.adoc[CircleCI Server] page.
+
+[#oidc-token]
+== OpenID Connect (OIDC) token
+
+A token issued by CircleCI that lets a job authenticate with a cloud provider without storing long-lived credentials. CircleCI provides OIDC tokens in the `CIRCLE_OIDC_TOKEN` and `CIRCLE_OIDC_TOKEN_V2` environment variables, with claims identifying the organization, project, and job. See the xref:guides:permissions-authentication:openid-connect-tokens.adoc[Using OpenID Connect Tokens] page.
 
 [#orbs]
 == Orbs
 
-xref:orbs:use:orb-concepts.adoc[Orbs] are reusable snippets of code that help automate repeated processes, accelerate project setup, and make it straightforward to integrate with third-party tools. Visit the https://circleci.com/developer/orbs[Orbs Registry] on the CircleCI Developer Hub to search for orbs to help simplify your config.
+Reusable packages of YAML configuration that bundle <<job,jobs>>, <<command,commands>>, and <<executor,executors>> to automate repeated processes and integrate with third-party tools. Orbs can be published to the orb registry as public or private, or defined inline in your configuration. Visit the https://circleci.com/developer/orbs[Orb Registry] to find orbs, and see the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
+
+[#orb-registry]
+== Orb registry
+
+The open repository of published registry <<orbs>> that you can search and import into your projects. Orbs in the registry are designated as certified (written by CircleCI), partner, or community. See the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
+
+[#organization]
+== Organization
+
+The top-level account in CircleCI that contains a team's projects, settings, permissions, and billing. An organization is one of three types: `circleci`, `github`, or `bitbucket`. See the xref:guides:permissions-authentication:users-organizations-and-integrations-guide.adoc[Users, Organizations, and Integrations Guide] page.
+
+[#organization-role]
+== Organization role
+
+In a `circleci` type <<organization>>, a role assigned at the organization level that determines a user's permissions across the whole organization. The organization roles are admin, contributor, and viewer. (In `github` and `bitbucket` OAuth organizations, access follows the VCS <<owner>> model instead.) See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page. Compare with <<project-role>>.
 
 [#owner]
 == Owner
 
-The owner of the team's VCS organization.
+In a `github` or `bitbucket` (OAuth) <<organization>>, the owner of the team's VCS organization, who has full administrative control over the organization's CircleCI resources. In a `circleci` type organization, access is governed instead by an <<organization-role>>. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
+
+[#parallelism]
+== Parallelism
+
+Running a single job's steps across multiple identical execution environments at the same time, set with the `parallelism` key, to reduce job time. Parallelism is most often used with <<test-splitting>>. Parallelism is _not_ the same as <<concurrency>>, which is running multiple jobs at once. See the xref:guides:optimize:parallelism-faster-jobs.adoc[Running Tests in Parallel] page.
+
+[#parameter]
+== Parameter
+
+A named, typed value passed to a <<command>>, <<job>>, or <<executor>> to make reusable configuration flexible. Parameters support types such as string, boolean, integer, and enum. See the xref:reference:ROOT:reusing-config.adoc[Reusable Config Reference] page. Compare with <<pipeline-parameter>>.
 
 [#pipeline]
 == Pipeline
 
-A xref:guides:orchestrate:pipelines.adoc[CircleCI pipeline] is the full set of processes you run when you trigger work on your projects. Pipelines encompass your workflows, which in turn coordinate your jobs. Pipelines are defined in your project `.circleci/config.yml` file.
+The full set of processes you run when you trigger work on a project. A pipeline encompasses your <<workflow,workflows>>, which in turn coordinate your <<job,jobs>>, and is defined in your project's <<configuration,configuration file>>. See the xref:guides:orchestrate:pipelines.adoc[Pipelines] page.
+
+[#pipeline-parameter]
+== Pipeline parameter
+
+A typed <<parameter>> declared at the top level of a configuration file and passed when a <<pipeline>> is triggered through the API or web app. Pipeline parameters are referenced with `pipeline.parameters.<name>`. See the xref:guides:orchestrate:pipeline-variables.adoc[Pipeline Values and Parameters] page.
+
+[#pipeline-value]
+== Pipeline value
+
+Metadata about a pipeline that CircleCI makes available automatically, without declaration, such as `pipeline.id`, `pipeline.number`, and `pipeline.git.branch`. See the xref:guides:orchestrate:pipeline-variables.adoc[Pipeline Values and Parameters] page. Compare with <<pipeline-parameter>> and <<built-in-environment-variable>>.
 
 [#primary-container]
 == Primary container
 
-The first image listed in `.circleci/config.yml`. This is where commands are executed for jobs using the Docker executor.
+The first <<image>> listed in your <<configuration,configuration file>> for a Docker job. The job's steps run in the primary container. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page. Compare with <<service-container,service container>>.
 
-[#project-administrator]
-== Project administrator
+[#private-orb]
+== Private orb
 
-The user who adds a repository in the VCS to CircleCI as a project.
+A registry <<orbs,orb>> available only within the organization that owns it. A private orb is findable in the registry only with a direct URL and when authenticated, and cannot be used by other organizations. See the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
 
 [#project]
 == Project
 
 include::guides:ROOT:partial$tips/check-org-type.adoc[]
 
-For `github` and `bitbucket` type organizations, a CircleCI project shares the name of the code repository for which it automates workflows, tests, and deployment. A project is visible on the **Projects** page of the https://app.circleci.com/[CircleCI web app] and must be added with the **Set Up Project** button.
+For `github` and `bitbucket` type organizations, a CircleCI project shares the name of the code repository whose workflows, tests, and deployments it automates. A project is visible on the *Projects* page of the https://app.circleci.com/[CircleCI web app] and must be added with the *Set Up Project* button.
 
-For `circleci` type organizations, a CircleCI project is a standalone entity that you first create, and then associate with a code repository. You can create projects and connect your code in the link:https://app.circleci.com/[CircleCI web app].
+For `circleci` type organizations, a CircleCI project is a standalone entity that you create first, and then associate with a code repository. You can create projects and connect your code in the https://app.circleci.com/[CircleCI web app].
 
-After a project is set up or created, it is possible to configure settings, contexts, environment variables, and team members who may follow the project. Following a project enables you to subscribe to email notifications for the project's build status, and adds the project to your CircleCI dashboard.
+After a project is set up, you can configure settings, contexts, environment variables, and the team members who may follow it. See the xref:guides:getting-started:create-project.adoc[Create a Project] page.
+
+[#project-administrator]
+== Project administrator
+
+In a `github` or `bitbucket` (OAuth) <<organization>>, the user who adds a repository in the VCS to CircleCI as a project. In a `circleci` type organization, project access is governed instead by a <<project-role>>. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
+
+[#project-role]
+== Project role
+
+In a `circleci` type <<organization>>, a role assigned at the project level that determines a user's permissions for a specific project, offering finer-grained control than an <<organization-role>>. The project roles are admin, contributor, and viewer. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
+
+[#registered-user]
+== Registered user
+
+A user who has created a CircleCI account. Registered users can access the web app, view pipelines and build history, trigger and rerun builds, and have organization access based on their role. See the xref:guides:plans-pricing:user-types-and-registration.adoc[User Types and Registration] page. Compare with <<unregistered-user>>.
+
+[#release]
+== Release
+
+A version of a <<component>> becoming available to an audience of users and other services. A release occurs when an existing component is updated or when the first version of a new component is deployed. See the xref:guides:deploy:deployment-overview.adoc[Deployment Overview] page. Compare with <<deployment>>.
+
+[#release-agent]
+== Release agent
+
+A tool installed in a Kubernetes cluster that lets you manage deployments through CircleCI, providing visibility and control over releases, including support for Kubernetes Deployments and Argo Rollouts. See the xref:guides:deploy:release-agent-overview.adoc[Release Agent Overview] page.
 
 [#remote-docker]
 == Remote Docker
 
-A feature that enables building, running, and pushing images to Docker registries from within a Docker <<executor>> job. Visit the xref:guides:execution-managed:building-docker-images.adoc[Runner Docker Commands] page to learn more.
+A feature that enables building, running, and pushing Docker images to registries from within a <<docker-executor>> job, using the `setup_remote_docker` key. See the xref:guides:execution-managed:building-docker-images.adoc[Running Docker Commands] page.
+
+[#rerun]
+== Rerun
+
+Re-executing a failed <<workflow>>, or individual failed <<job,jobs>> within it, to recover from transient failures without triggering a new pipeline. See the xref:guides:orchestrate:workflows.adoc[Workflows] page. For tests specifically, see <<test-splitting>> and the xref:guides:test:rerun-failed-tests.adoc[Rerun Failed Tests] page.
 
 [#resource-class]
 == Resource class
-A configuration option for specifying compute resource sizing for a job. Also used as a label to identify a pool of self-hosted runners and to configure a job to run on a self-hosted runner from that pool. Read more on the xref:guides:execution-managed:resource-class-overview.adoc[resource class overview] page.
+
+A configuration option that specifies the compute resources, such as CPU and RAM, allocated to a <<job>>. A resource class is also used as a label to identify a pool of <<self-hosted-runner,self-hosted runners>> and to route a job to that pool. See the xref:guides:execution-managed:resource-class-overview.adoc[Resource Class Overview] page.
+
+[#rollback]
+== Rollback
+
+Reverting an application to a previous stable version when an issue is detected, either through a dedicated rollback pipeline or by rerunning a prior workflow. See the xref:guides:deploy:rollback-a-deployment.adoc[Roll Back a Deployment] page.
+
+[#schedule-trigger]
+== Schedule trigger
+
+A <<trigger>> that runs a pipeline on a defined schedule, using cron syntax, rather than on each commit. Schedule triggers are the recommended way to run scheduled work; use them instead of scheduled workflows unless your setup requires the older approach. See the xref:guides:orchestrate:schedule-triggers.adoc[Schedule Triggers] page.
+
+[#secrets-masking]
+== Secrets masking
+
+A security feature that obscures environment variable and context values in job output, providing an additional layer of protection against accidental exposure of secrets. See the xref:guides:security:env-vars.adoc[Using Environment Variables] page.
+
+[#self-hosted-runner]
+== Self-hosted runner
+
+A CircleCI agent installed on your own infrastructure, such as Kubernetes, virtual machines, or physical hardware, that claims and executes jobs on hardware or architectures you control. The two types are <<container-runner>> and <<machine-runner>>. See the xref:guides:execution-runner:runner-overview.adoc[CircleCI Runner Overview] page.
+
+[#service-container]
+== Service container
+
+An additional <<image>> listed in a job's configuration that runs alongside the <<primary-container>>, typically to provide a service such as a database. Also called a secondary container. See the xref:guides:execution-managed:executor-intro.adoc[Introduction to Execution Environments] page.
+
+[#sso]
+== Single sign-on (SSO)
+
+An authentication method that lets users authenticate once through an identity provider, using the SAML 2.0 protocol, to access an organization's CircleCI resources. See the xref:guides:permissions-authentication:sso-overview.adoc[SSO Overview] page.
+
+[#ssh-key]
+== SSH key
+
+A cryptographic key pair used for authentication in CircleCI. A deploy key gives CircleCI access to check out a single repository; a user key is associated with a user account and can give access to multiple repositories. See the xref:guides:security:rotate-project-ssh-keys.adoc[Rotate Project SSH Keys] page.
 
 [#step]
 == Step
 
-A step is a collection of executable commands. Visit the xref:guides:toolkit:sample-config.adoc[Sample Configuration] page to learn more.
+A single executable action within a <<job>>, such as a `run`, `checkout`, `save_cache`, or `store_artifacts` command. Steps run in the order they are defined under the `steps` key. See the xref:guides:orchestrate:jobs-steps.adoc[Jobs and Steps] page.
+
+[#setup-workflow]
+== Setup workflow
+
+A <<workflow>> marked with `setup: true` that runs first in a <<dynamic-configuration,dynamic configuration>>. A setup workflow can compute pipeline parameters and select which configuration to continue with, enabling conditional execution of the rest of the pipeline. See the xref:guides:orchestrate:dynamic-config.adoc[Dynamic Configuration] page.
+
+[badge="Beta"]
+[#test-impact-analysis]
+== Test impact analysis
+
+A feature that runs only the tests affected by a code change. Test impact analysis maps which tests exercise which source files and skips tests covering unchanged files, to speed up CI. See the xref:guides:test:set-up-test-impact-analysis.adoc[Set up Test Impact Analysis] page.
+
+[#test-splitting]
+== Test splitting
+
+Dividing a test suite across multiple parallel execution environments, by name, file size, or historical timing data, to reduce overall test time. Test splitting works together with <<parallelism>>. See the xref:guides:optimize:parallelism-faster-jobs.adoc[Running Tests in Parallel] page.
+
+[#trigger]
+== Trigger
+
+A mechanism that initiates a <<pipeline>>. Triggers can be automatic, based on VCS events, schedules, or custom webhooks, or manual, through the web app, API, or CLI. See the xref:guides:orchestrate:triggers-overview.adoc[Triggers Overview] page. See also <<schedule-trigger>>, <<custom-webhook>>, and <<cross-repo-trigger>>.
+
+[#unregistered-user]
+== Unregistered user
+
+Someone who has triggered builds in a CircleCI organization but has not created a CircleCI account. Unregistered users count as <<active-user,active users>> for billing. See the xref:guides:plans-pricing:user-types-and-registration.adoc[User Types and Registration] page.
+
+[#url-orb]
+== URL orb
+
+A single YAML file of shared <<orbs,orb>> configuration, stored somewhere accessible over HTTPS, such as a GitHub repository, and imported by its URL rather than from the orb registry. The URL must be allowed by the organization's allow list. URL orbs let you share configuration across an organization while keeping direct control over updates. See the xref:orbs:use:orb-intro.adoc[Orbs Introduction] page.
 
 [#user]
 == User
 
-An individual user within an organization. A CircleCI user is anyone who can log in to the CircleCI platform with a username and password. Users must be added to a VCS organization to view or follow associated CircleCI projects. Users may **not** view project data that is stored in environment variables.
+An individual who can log in to the CircleCI platform. A user must be part of an organization to view or follow its projects. Access is governed by an <<organization-role>> and <<project-role>> in `circleci` type organizations, or by the VCS <<owner>> and <<project-administrator>> model in `github` and `bitbucket` OAuth organizations. Users may *not* view project data stored in environment variables. See the xref:guides:permissions-authentication:roles-and-permissions-overview.adoc[Roles and Permissions Overview] page.
+
+[#version-promotion]
+== Version promotion
+
+Deploying a specific <<component>> version to the next <<environment>> in an <<environment-hierarchy>>, often with a single action from the CircleCI UI. See the xref:guides:deploy:environment-hierarchy-and-version-promotion.adoc[Environment Hierarchy and Version Promotion] page.
+
+[#vcs]
+== Version control system (VCS)
+
+The platform where your code is stored and that CircleCI integrates with, such as GitHub, GitHub Enterprise, GitLab, GitLab self-managed, Bitbucket Cloud, or Bitbucket Data Center. See the xref:guides:integration:version-control-system-integration-overview.adoc[VCS Integration Overview] page.
+
+[#outbound-webhook]
+== Webhook (outbound)
+
+An HTTP POST request that CircleCI sends to an external service when a specified event occurs, such as a workflow or job completing. Outbound webhooks let other services react in real time without polling. See the xref:guides:integration:outbound-webhooks.adoc[Outbound Webhooks] page. Compare with <<custom-webhook>>, which triggers CircleCI.
 
 [#workflow]
 == Workflow
 
-xref:guides:orchestrate:workflows.adoc[Workflows] define a list of jobs and their run order. It is possible to run jobs concurrently, sequentially, on a schedule, or with a manual gate using an approval job.
+A set of rules that defines a collection of <<job,jobs>> and their run order. Workflows can run jobs concurrently, sequentially, on a schedule, or with a manual gate using an <<approval-job>>. See the xref:guides:orchestrate:workflows.adoc[Workflows] page.
 
 [#workspace]
 == Workspace
 
-A xref:guides:orchestrate:workspaces.adoc[workspace] is a workflows-aware storage mechanism. A workspace stores data unique to the job, which may be needed in downstream jobs.
+A workflow-aware storage mechanism that passes data between <<job,jobs>> in the same <<workflow>>. A job persists files with `persist_to_workspace`, and downstream jobs access them with `attach_workspace`. On CircleCI Cloud, workspace storage is retained for 15 days by default, which is also the maximum; you can set a shorter period (1 to 15 days) under menu:Plan[Usage Controls] in the web app. See the xref:guides:orchestrate:workspaces.adoc[Using Workspaces to Share Data Between Jobs] page. Compare with <<cache>> and <<artifact>>.


### PR DESCRIPTION
## What we did
Expand docs/reference glossary from 27 to ~95 entries covering CircleCI-specific and key CI/CD terminology, with verified xrefs and internal cross-links. Resolve conflicting/overlapping definitions found across the docs:

- Disambiguate "command" (reusable config vs. release agent action); rename the deploy action to "release agent command" in deployment-overview and release-agent-overview.
- Unify "namespace" as one org-level identifier for orbs and runners.
- Clarify executor (docker/machine/macos) vs. execution environment; drop the incorrect "Windows executor" entry and generic Arm/GPU entries.
- Standardize on "service container" (sweep guides; keep "secondary container" as a synonym).
- Frame Owner/Project administrator and org/project roles by organization type rather than as legacy terms.
- Add parallelism contrast to the concurrency concept; point resource-class definitions at the canonical overview.
- State workspace retention (15-day default/max, 1-15 via Plan > Usage Controls).
- Note schedule triggers are recommended over scheduled workflows (not deprecated).
- Make clear config files are not confined to .circleci/config.yml.
- Fix org-as-"workspace" overload in the users/orgs guide.

## Why
This work is a precursor to finalising and changing some definitions to fit along with new CLI and APIs. That work will be done in a new branch