### PR TITLE
feat: add Xcode 27.0 Beta 1 to supported versions

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
@@ -9,6 +9,14 @@
 | VM Software Manifest
 | Release Notes
 
+| `27.0`
+| Xcode 27.0 (27A5194q)
+| 26.5.1
+a| `m4pro.medium` +
+   `m4pro.large`
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18748/manifest.txt[Installed software]
+| link:https://circleci.com/changelog/xcode-27-0-beta-1-available/[Release Notes]
+
 | `26.6`
 | Xcode 26.6 (17F109)
 | 26.3


### PR DESCRIPTION
## Summary

- Adds Xcode 27.0 Beta 1 (27A5194q) on macOS 26.5.1 to the supported Xcode versions table
- Manifest: [v18748](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18748/manifest.txt)
- Release notes: https://circleci.com/changelog/xcode-27-0-beta-1-available/

## Test plan

- [ ] Verify table renders correctly on the macOS executor page
- [ ] Confirm release notes URL is live before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)