### PR TITLE
Check external links in new pipeline

### DIFF
--- a/.circleci/external-link-check.yml
+++ b/.circleci/external-link-check.yml
@@ -1,0 +1,48 @@
+version: 2.1
+
+# Stripped-back pipeline whose only job is to validate EXTERNAL links once per day.
+#
+# The per-commit pipeline (.circleci/config.yml) skips external links for speed by
+# running htmltest with the -s flag. This pipeline builds the site and runs the full
+# htmltest check (no -s), so broken external links surface daily without slowing down
+# normal PR/commit validation.
+#
+# Wiring (done once in the CircleCI web UI, not in this file):
+#   Project Settings -> Pipelines -> add a pipeline definition that uses this config
+#   file path (.circleci/external-link-check.yml). Then add a Scheduled trigger on
+#   that pipeline that runs daily against the main branch. No VCS push trigger, so
+#   this pipeline only runs on the schedule.
+
+orbs:
+  go: circleci/go@3.0.4
+
+executors:
+  node_executor:
+    docker:
+      - image: cimg/node:24.16.0
+    resource_class: medium+.gen2
+    working_directory: ~/project
+
+jobs:
+  external-link-check:
+    executor: node_executor
+    steps:
+      - checkout
+      - run:
+          name: Install Node dependencies
+          command: npm ci
+      - go/install:
+          version: "1.25.0"
+      - run:
+          name: Build the documentation site
+          command: NODE_OPTIONS="--max-old-space-size=4096" npm run build:docs
+      - run:
+          name: Validate HTML including external links
+          command: go tool htmltest
+      - store_artifacts:
+          path: .htmltest
+
+workflows:
+  external-link-check:
+    jobs:
+      - external-link-check

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,5 +1,12 @@
 DirectoryPath: "build"
-CheckExternal: false
+# External links are checked by default. The per-commit pipeline skips them for
+# speed by passing htmltest's -s flag (see the validate-html task); the daily
+# external-link-check pipeline runs the full check with no flag.
+CheckExternal: true
+# Tuning that only takes effect when external links are checked (daily run):
+# give remote hosts a generous timeout and cache results so reruns are cheap.
+ExternalTimeout: 20
+CacheExpires: "6h"
 EnforceHTTPS: true
 CheckSelfReferencesAsInternal: true
 BaseURL: https://circleci.com/docs

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -76,7 +76,12 @@ tasks:
       - npm run build:docs
 
   validate-html:
-    desc: Validate HTML, links, etc
+    desc: Validate HTML and internal links (skips external links for speed)
+    cmds:
+      - go tool htmltest -s
+
+  validate-html-external:
+    desc: Validate HTML including external links (slower; used by the daily pipeline)
     cmds:
       - go tool htmltest
 


### PR DESCRIPTION
# Description
* New config file to run a pipeline periodically that just checks external linking
* Add new task for external link checking
* Check the way we opt out of external link checking to use the `-s` flag rather than hard coding the option in config

# Reasons
We are not currently checking any links that go outside the docs site itself. It takes a long time to check external links so I don't want to do this on every commit but it would be very useful to know if we get failures.


