### PR TITLE
feat: update Xcode 26.6 to RC 2 (17F113) with macOS 26.5.1

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
@@ -18,12 +18,12 @@ a| `m4pro.medium` +
 | link:https://circleci.com/changelog/xcode-27-0-beta-1-available/[Release Notes]
 
 | `26.6`
-| Xcode 26.6 (17F109)
-| 26.3
+| Xcode 26.6 (17F113)
+| 26.5.1
 a| `m4pro.medium` +
    `m4pro.large`
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18595/manifest.txt[Installed software]
-| link:https://circleci.com/changelog/xcode-26-6-available/[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18807/manifest.txt[Installed software]
+| link:https://circleci.com/changelog/xcode-26-6-rc-2-available/[Release Notes]
 
 | `26.5`
 | Xcode 26.5 (17F42)


### PR DESCRIPTION
# Description
Update docs for Xcode 26.6.0 for RC 2 release.

# Reasons
Xcode 26.6.0 RC 2 was released

