### PR TITLE
removing refs to PG14 being required in server 4.10

### DIFF
--- a/docs/server-admin-4.10/modules/installation/pages/upgrade-server.adoc
+++ b/docs/server-admin-4.10/modules/installation/pages/upgrade-server.adoc
@@ -33,7 +33,6 @@ Customers that do not perform this step may have issues restoring Vault from bac
 * Ensure you have set up xref:operator:backup-and-restore.adoc#[Backup and Restore].
 * Ensure there is a recent backup. For more information, see the xref:operator:backup-and-restore.adoc#creating-backups[Backup and Restore] guide.
 * Server 4.10 requires mongoDB 7.0 or higher. If your Mongo DB is not externalized, ensure you are running MongoDB 7.0 or higher. Follow our xref:operator:upgrade-mongo.adoc#upgrade-mongodb-to-7[Upgrade MongoDB to 7.0] Guide for steps to upgrade your MongoDB instance.
-* Server 4.10 requires PostgreSQL 14 or higher. If your PostgreSQL database is not externalized, follow the xref:operator:upgrade-postgres.adoc[Upgrade PostgreSQL] guide for steps to upgrade your PostgreSQL instance.
 
 [#upgrade-steps]
 == Upgrade steps

--- a/docs/server-admin-4.10/modules/operator/pages/upgrade-postgres.adoc
+++ b/docs/server-admin-4.10/modules/operator/pages/upgrade-postgres.adoc
@@ -3,7 +3,7 @@
 :page-description: Learn how to upgrade the internal PostgreSQL database from version 12 to 14 in an installation of CircleCI Server 4.10.
 :experimental:
 
-PostgreSQL is a database service used by CircleCI Server. Server 4.10 ships PostgreSQL `14` so you must upgrade to PostgreSQL 14 before upgrading to Server 4.10. This page describes how to upgrade your internal PostgreSQL instance from version `12` to `14`.
+PostgreSQL is a database service used by CircleCI Server. This page describes how to upgrade your internal PostgreSQL instance from version `12` to `14`.
 
 == Important notes about upgrading PostgreSQL
 

--- a/docs/server-admin-4.10/modules/overview/pages/release-notes.adoc
+++ b/docs/server-admin-4.10/modules/overview/pages/release-notes.adoc
@@ -13,11 +13,10 @@ CircleCI Server 4.10 introduces enhanced security and infrastructure management 
 
 [IMPORTANT]
 ====
-Server 4.10 requires *mongoDB 7.0* or higher and *PostgreSQL 14* or higher.
+Server 4.10 requires *mongoDB 7.0* or higher
 
 * If your MongoDB instance is not externalized then follow our xref:operator:upgrade-mongo.adoc#upgrade-mongodb-to-7[Upgrade MongoDB to 7.0 Guide] before upgrading to Server 4.10.0.
 
-* If your PostgreSQL instance is not externalized then follow the xref:operator:upgrade-postgres.adoc[Upgrade PostgreSQL] guide before upgrading to Server 4.10.0.
 ====
 
 For upgrade steps see the xref:installation:upgrade-server.adoc#[Upgrade Server 4.10 Guide].


### PR DESCRIPTION
# Description
Removing references to PG 14 as a requirement for upgrading to server 4.10.

# Reasons
Server 4.10 does not ship with PG 14 installed so our docs stating that as a requirement are false.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
