### PR TITLE
[ONP-3275] Note that CircleCI Server is not compatible with DocumentDB

### DIFF
--- a/docs/server-admin-4.10/modules/operator/pages/configuring-external-services.adoc
+++ b/docs/server-admin-4.10/modules/operator/pages/configuring-external-services.adoc
@@ -204,7 +204,7 @@ The changes will take effect upon running `helm install/upgrade`. If you are com
 
 [#backing-up-postgresql]
 === Back up PostgreSQL
-PostgreSQL provides official documentation for backing up and restoring your PostgreSQL 12 install, which can be found link:https://www.postgresql.org/docs/12/backup.html[here].
+PostgreSQL provides link:https://www.postgresql.org/docs/12/backup.html[official documentation for backing up and restoring your PostgreSQL 12 install].
 
 We strongly recommend the following:
 
@@ -217,6 +217,8 @@ We strongly recommend the following:
 == MongoDB
 
 NOTE: If using your own MongoDB instance, it needs to be version 3.6 or higher.
+
+IMPORTANT: CircleCI Server is not currently compatible with DocumentDB.
 
 [#migrating-from-internal-mongodb]
 === Migrating from an internal MongoDB to an externalized source

--- a/docs/server-admin-4.8/modules/operator/pages/configuring-external-services.adoc
+++ b/docs/server-admin-4.8/modules/operator/pages/configuring-external-services.adoc
@@ -103,7 +103,7 @@ kubectl exec -it -n "$namespace" "$PG_POD" -- bash
 psql -h <your-external-postgres-host> -U postgres -p <your-external-postgres-port>
 ----
 
-You should be able to connect to your external PostgreSQL at this point. If not, resolve any issues before proceeding.
+You must be able to connect to your external PostgreSQL at this point. If not, resolve any issues before proceeding.
 
 TIP: You may use `helm upgrade ...` to restore your CircleCI Server instance to a running state.
 
@@ -205,7 +205,7 @@ The changes will take effect upon running `helm install/upgrade`. If you are com
 
 [#backing-up-postgresql]
 === Back up PostgreSQL
-PostgreSQL provides official documentation for backing up and restoring your PostgreSQL 12 install, which can be found link:https://www.postgresql.org/docs/12/backup.html[here].
+PostgreSQL provides link:https://www.postgresql.org/docs/12/backup.html[official documentation for backing up and restoring your PostgreSQL 12 install].
 
 We strongly recommend the following:
 
@@ -218,6 +218,8 @@ We strongly recommend the following:
 == MongoDB
 
 NOTE: If using your own MongoDB instance, it needs to be version 3.6 or higher.
+
+IMPORTANT: CircleCI Server is not currently compatible with DocumentDB.
 
 [#migrating-from-internal-mongodb]
 === Migrating from an internal MongoDB to an externalized source
@@ -259,7 +261,7 @@ kubectl exec -it -n "$namespace" "$MONGO_POD" -- bash
 mongo --username <username> --password --authenticationDatabase admin --host <external-mongodb-host> --port <external-mongodb-port>
 ----
 
-You should be able to connect to your external MongoDB at this point. If not, resolve any issues before proceeding.
+You must be able to connect to your external MongoDB at this point. If not, resolve any issues before proceeding.
 
 TIP: You may use `helm upgrade ...` to restore your CircleCI Server instance to a running state.
 

--- a/docs/server-admin-4.9/modules/operator/pages/configuring-external-services.adoc
+++ b/docs/server-admin-4.9/modules/operator/pages/configuring-external-services.adoc
@@ -204,7 +204,7 @@ The changes will take effect upon running `helm install/upgrade`. If you are com
 
 [#backing-up-postgresql]
 === Back up PostgreSQL
-PostgreSQL provides official documentation for backing up and restoring your PostgreSQL 12 install, which can be found link:https://www.postgresql.org/docs/12/backup.html[here].
+PostgreSQL provides link:https://www.postgresql.org/docs/12/backup.html[official documentation for backing up and restoring your PostgreSQL 12 install].
 
 We strongly recommend the following:
 
@@ -217,6 +217,8 @@ We strongly recommend the following:
 == MongoDB
 
 NOTE: If using your own MongoDB instance, it needs to be version 3.6 or higher.
+
+IMPORTANT: CircleCI Server is not currently compatible with DocumentDB.
 
 [#migrating-from-internal-mongodb]
 === Migrating from an internal MongoDB to an externalized source


### PR DESCRIPTION
# Description

Add a note to the MongoDB section of the **Configuring external services** guide stating that CircleCI Server is not currently compatible with DocumentDB.

- The note is placed at the `== MongoDB` section level (right after the existing MongoDB version requirement), so that **both** the migration path and the fresh-install path see it.
- Scoped to the server-admin versions that lint clean: **4.8, 4.9, and 4.10**.

While adding the note to 4.8, this also fixes three pre-existing Vale lint errors in that file (two `should` → `must`, and a non-descriptive `[here]` link), matching the wording already used in 4.9/4.10. The `[here]` link is likewise corrected in 4.9 and 4.10.

## Scope note

Older published versions (4.2–4.7) carry extensive pre-existing Vale debt (incorrect product-name casing, `Postgres` vs `PostgreSQL`, list punctuation, sentence length, etc.). Because the CI `vale/lint` job re-lints entire changed files, touching those pages would require a large, unrelated cleanup. That is intentionally left out of this change.

# Reasons

Operators configuring an external MongoDB sometimes reach for AWS DocumentDB as a managed, Mongo-compatible service, but CircleCI Server is not compatible with it. The warning needed to live where everyone configuring external MongoDB will see it — previously it would have been missed by fresh-install operators, who are explicitly told to skip the migration subsection.

Ticket: [ONP-3275](https://linear.app/circleci/issue/ONP-3275)

🤖 Generated with [Claude Code](https://claude.com/claude-code)