### PR TITLE
Improve markdown export: documentsConverted refactor, tables, tabs, images, code fences

### DIFF
--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -98,18 +98,18 @@ module.exports.register = function () {
     })
 
     /**
-     * KEEP DATA TABLES AS HTML
+     * KEEP COMPLEX TABLES AS HTML
      *
-     * Markdown table syntax can only hold single-line cells, but CircleCI
-     * tables frequently put lists, multiple paragraphs, and code blocks inside
-     * cells. Converting those to a markdown table would destroy their
-     * structure (Turndown's default flattens every cell onto its own line), so
-     * we keep real data tables as HTML instead.
+     * Markdown table syntax can only hold single-line cells. Simple tables are
+     * turned into GFM markdown tables in the per-page DOM pass below, but
+     * CircleCI tables frequently put lists, multiple paragraphs, or code blocks
+     * inside cells, and those can't be represented as a markdown table, so we
+     * keep them as HTML. Such tables are marked with data-md-keep in the DOM
+     * pass and emitted verbatim by this rule.
      *
-     * Only tables marked with data-md-keep in the per-page DOM pass below are
-     * kept. That marker is applied to Asciidoctor data tables (table.tableblock)
-     * but NOT to admonition blocks (NOTE/TIP/WARNING), which Asciidoctor also
-     * renders as <table> - those still flatten to text via the default rules.
+     * Admonition blocks (NOTE/TIP/WARNING), which Asciidoctor also renders as
+     * <table>, are never marked and have no table rule, so they flatten to text
+     * via Turndown's default handling.
      */
     turndownService.addRule('keepDataTables', {
       filter: function (node) {
@@ -120,6 +120,36 @@ module.exports.register = function () {
         return '\n\n' + node.outerHTML + '\n\n'
       }
     })
+
+    /**
+     * BUILD A GFM MARKDOWN TABLE
+     *
+     * Convert a simple data table (inline-only cells, with a heading row) to a
+     * GitHub-flavored markdown table. Each cell's inline content is converted
+     * with Turndown, collapsed to a single line, and pipe characters escaped so
+     * they don't break columns.
+     */
+    const buildGfmTable = (table) => {
+      const rowToMarkdown = (tr) => {
+        const cellsMd = tr.querySelectorAll('th, td').map(cellEl =>
+          turndownService
+            .turndown(cellEl.innerHTML)
+            .replace(/\s*\n+\s*/g, ' ')   // collapse any line breaks to a space
+            .replace(/\|/g, '\\|')         // escape pipes so columns survive
+            .trim()
+        )
+        return '| ' + cellsMd.join(' | ') + ' |'
+      }
+
+      const headRow = table.querySelector('thead tr')
+      const columnCount = headRow.querySelectorAll('th, td').length
+      const lines = [
+        rowToMarkdown(headRow),
+        '| ' + Array(columnCount).fill('---').join(' | ') + ' |'
+      ]
+      table.querySelectorAll('tbody tr').forEach(tr => lines.push(rowToMarkdown(tr)))
+      return lines.join('\n')
+    }
 
     /**
      * CUSTOM RULE: Replace Images With Alt Text
@@ -275,30 +305,36 @@ module.exports.register = function () {
       parsed.querySelectorAll('span.image').forEach(el => el.remove())
 
       /**
-       * TIDY DATA TABLES
+       * CONVERT DATA TABLES
        *
-       * Real data tables (table.tableblock) are kept as HTML (see the Turndown
-       * setup above); admonition blocks, which Asciidoctor also renders as
-       * <table>, are deliberately excluded so they still flatten to text. Here
-       * we tidy each data table's Asciidoctor markup:
+       * Each Asciidoctor data table (table.tableblock) is either converted to a
+       * GFM markdown table (if it is simple) or kept as HTML (if it is complex).
+       * Admonition blocks, which Asciidoctor also renders as <table>, are not
+       * table.tableblock, so they are left alone and flatten to text.
+       *
+       * Common tidy-up for both paths:
        * - remove <colgroup> column-width definitions
-       * - strip presentational class/style attributes (structural attributes
-       *   like colspan/rowspan are preserved)
-       * - unwrap cells whose only child is a <p>, so simple cells read cleanly
-       *   while cells with lists/blocks keep their structure
-       * - absolutize links, since links inside kept HTML don't pass through the
-       *   markdown link rewriting applied later
-       * - mark the table with data-md-keep so the Turndown rule keeps it
+       * - unwrap cells whose only child is a <p>, so a "simple" cell holds
+       *   inline content directly (which both markdown tables and the HTML
+       *   path render cleanly), while cells with lists/blocks keep them
+       *
+       * A table is "simple" when it has a heading row (GFM tables require one)
+       * and every cell holds only single-line inline content: no lists, nested
+       * tables, code blocks, multiple paragraphs, hard line breaks (<br>), or
+       * spanned cells (colspan/rowspan), none of which a markdown table cell can
+       * represent. Anything else is kept as HTML.
+       *
+       * Simple tables are converted to markdown now and stashed behind a
+       * placeholder, which is swapped back in after Turndown runs (so the cell
+       * markdown isn't re-escaped, and in-table links still get absolutized).
+       * Complex tables are kept as HTML: we strip presentational class/style
+       * (preserving structural colspan/rowspan), absolutize their links (kept
+       * HTML bypasses the markdown link rewriting), and mark them data-md-keep.
        */
+      const blockCellSelector = 'ul, ol, dl, pre, table, div, blockquote, h1, h2, h3, h4, h5, h6, hr, p, br'
+      const gfmTablePlaceholders = []
       parsed.querySelectorAll('table.tableblock').forEach(table => {
         table.querySelectorAll('colgroup').forEach(colgroup => colgroup.remove())
-
-        table.removeAttribute('class')
-        table.removeAttribute('style')
-        table.querySelectorAll('*').forEach(el => {
-          el.removeAttribute('class')
-          el.removeAttribute('style')
-        })
 
         table.querySelectorAll('th, td').forEach(cellEl => {
           const elementChildren = cellEl.childNodes.filter(n => n.nodeType === 1)
@@ -307,13 +343,34 @@ module.exports.register = function () {
           }
         })
 
+        const hasHeader = !!table.querySelector('thead')
+        const cells = table.querySelectorAll('th, td')
+        const isSimple = cells.every(cellEl =>
+          !cellEl.querySelector(blockCellSelector) &&
+          !cellEl.getAttribute('colspan') &&
+          !cellEl.getAttribute('rowspan'))
+
+        if (hasHeader && isSimple) {
+          // Convert to a markdown table now, swap back in after Turndown.
+          const token = `XGFMTABLE${gfmTablePlaceholders.length}X`
+          gfmTablePlaceholders.push({ token, markdown: buildGfmTable(table) })
+          table.replaceWith(`<p>${token}</p>`)
+          return
+        }
+
+        // Keep as cleaned HTML.
+        table.removeAttribute('class')
+        table.removeAttribute('style')
+        table.querySelectorAll('*').forEach(el => {
+          el.removeAttribute('class')
+          el.removeAttribute('style')
+        })
         table.querySelectorAll('a').forEach(a => {
           const href = a.getAttribute('href')
           if (href) {
             a.setAttribute('href', absolutizeUrl(href, page.pub.url))
           }
         })
-
         table.setAttribute('data-md-keep', '')
       })
 
@@ -375,6 +432,16 @@ module.exports.register = function () {
        * Use Turndown service with our custom rules to convert HTML to markdown.
        */
       let markdown = turndownService.turndown(htmlContent)
+
+      /**
+       * RESTORE SIMPLE TABLES
+       *
+       * Swap the markdown tables back in for their placeholders. Done before
+       * the link rewriting below so in-table links are absolutized too.
+       */
+      gfmTablePlaceholders.forEach(({ token, markdown: tableMd }) => {
+        markdown = markdown.replace(token, '\n\n' + tableMd + '\n\n')
+      })
 
       /**
        * ADD THE PAGE TITLE

--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -57,15 +57,23 @@ module.exports.register = function () {
     })
 
     /**
-     * CUSTOM RULE: Remove Images
+     * CUSTOM RULE: Replace Images With Alt Text
      *
-     * Images don't translate well to markdown exports, so we remove them.
-     * Users viewing the markdown online can see images on the actual site.
+     * By the time Turndown runs, inline images and icons have been removed from
+     * the DOM, so this only sees block images (image::foo[]). The image binary
+     * isn't useful in a markdown export, but its alt text usually describes what
+     * the image shows, so surface that as a labeled blockquote block for readers
+     * (and LLMs). Images without usable alt text are dropped, to avoid emitting
+     * empty "Image:" blocks.
      */
-    turndownService.addRule('removeImages', {
+    turndownService.addRule('imageAltText', {
       filter: 'img',
-      replacement: function () {
-        return '' // Replace all images with empty string
+      replacement: function (content, node) {
+        const alt = (node.getAttribute('alt') || '').trim()
+        if (!alt) {
+          return '' // No alt text to surface - drop the image
+        }
+        return '\n\n> **Image:** ' + alt + '\n\n'
       }
     })
 
@@ -189,6 +197,17 @@ module.exports.register = function () {
        * mermaid diagrams before handing it to Turndown.
        */
       const parsed = parseHTML(page.contents.toString())
+
+      /**
+       * REMOVE INLINE IMAGES AND ICONS
+       *
+       * Asciidoctor renders inline images (the image:foo[] macro, including the
+       * theme-aware icons from theme-icon-extension) as <span class="image">,
+       * while block images (image::foo[]) render as <div class="imageblock">.
+       * Inline images and icons are decorative in a markdown export, so drop
+       * them entirely. Block images are kept and surfaced as alt text below.
+       */
+      parsed.querySelectorAll('span.image').forEach(el => el.remove())
 
       /**
        * FLATTEN TABS

--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -1,7 +1,7 @@
 /**
  * Markdown Export Extension for Antora
  *
- * This Antora extension converts the generated HTML documentation pages into
+ * This Antora extension converts the generated documentation pages into
  * Markdown format, making each page available as a downloadable .md file.
  *
  * Purpose:
@@ -9,13 +9,18 @@
  * - Converts HTML to clean, readable markdown
  * - Preserves code blocks with language syntax highlighting
  * - Converts relative links to absolute URLs
- * - Removes UI elements (images, diagrams, metadata bars)
+ * - Removes UI elements (images, diagrams)
  *
  * How it works:
- * 1. Collects all pages during 'contentClassified' event
- * 2. Converts HTML to Markdown during 'beforePublish' event
- * 3. Writes .md files to temp directory
- * 4. Post-build script copies them to final output directory
+ * 1. Hooks the 'documentsConverted' event. At this point Antora has converted
+ *    each page's AsciiDoc into an *embeddable HTML body* (page.contents), but
+ *    has NOT yet wrapped it in the site layout (header, nav, footer, the
+ *    article info bar, toolbars, etc. — those are added later, at
+ *    'pagesComposed'). Working from the pre-composition body means we never
+ *    have to find and strip the site chrome by hand.
+ * 2. Converts each body to Markdown and writes .md files to a temp directory.
+ * 3. A post-build script (gulp.d/tasks/build-site.js) copies them to the final
+ *    output directory once Antora finishes publishing.
  */
 
 'use strict'
@@ -26,38 +31,13 @@ const { parse: parseHTML } = require('node-html-parser') // HTML parser
 
 module.exports.register = function () {
   /**
-   * EVENT 1: contentClassified
+   * EVENT: documentsConverted
    *
-   * This event fires after Antora has classified all content but before
-   * it starts generating the site. We use it to collect all pages that
-   * need to be converted to Markdown.
+   * Fires after every page's AsciiDoc has been converted to embeddable HTML
+   * but before the UI layout is applied. page.contents holds just the document
+   * body, so there is no site chrome to remove.
    */
-  this.on('contentClassified', ({ contentCatalog }) => {
-    // Initialize array to store all pages for later processing
-    this.pages = []
-
-    // Iterate through all components (guides, reference, orbs, etc.)
-    contentCatalog.getComponents().forEach(({ versions }) => {
-      // For each version of each component
-      versions.forEach(({ name: component, version }) => {
-        // Find all pages in this component/version that will be published
-        const pages = contentCatalog
-          .findBy({ component, version, family: 'page' })
-          .filter(page => page.pub) // Only include pages that will be published
-
-        // Add these pages to our collection
-        this.pages.push(...pages)
-      })
-    })
-  })
-
-  /**
-   * EVENT 2: beforePublish
-   *
-   * This event fires after HTML is generated but before the site is published.
-   * We use it to convert all collected pages to Markdown format.
-   */
-  this.on('beforePublish', ({ playbook }) => {
+  this.on('documentsConverted', ({ playbook, contentCatalog }) => {
     // Get the site URL and remove any trailing slashes
     const siteUrl = playbook.site.url.replace(/\/+$/, '')
 
@@ -88,7 +68,6 @@ module.exports.register = function () {
         return '' // Replace all images with empty string
       }
     })
-
 
     /**
      * CUSTOM RULE: Clean Up Headings
@@ -181,115 +160,87 @@ module.exports.register = function () {
     }
     fs.mkdirSync(tempDir, { recursive: true })
 
+    /**
+     * COLLECT PAGES
+     *
+     * Gather every publishable page across all components/versions. The `pub`
+     * property (and `pub.url`) is assigned during classification, which runs
+     * before this event, so it is available here.
+     */
+    const pages = contentCatalog
+      .findBy({ family: 'page' })
+      .filter(page => page.pub)
+
     console.log(`Generating markdown files to temp: ${tempDir}`)
-    console.log(`Pages to process: ${this.pages.length}`)
+    console.log(`Pages to process: ${pages.length}`)
     let markdownCount = 0
 
     /**
      * PROCESS ALL PAGES
      *
-     * Convert each HTML page to Markdown and write to temp directory.
+     * Convert each page's HTML body to Markdown and write to temp directory.
      */
-    this.pages.forEach((page) => {
+    pages.forEach((page) => {
       /**
-       * EXTRACT ARTICLE CONTENT
+       * PARSE THE DOCUMENT BODY
        *
-       * Parse the HTML and extract just the main article content,
-       * ignoring navigation, sidebars, footers, etc.
+       * page.contents is the embeddable HTML body (no site chrome). We still
+       * parse it so we can flatten interactive elements (tabs) and convert
+       * mermaid diagrams before handing it to Turndown.
        */
-      const fullHtml = page.contents.toString()
-      const parsed = parseHTML(fullHtml)
+      const parsed = parseHTML(page.contents.toString())
 
-      // Find the main article content (try multiple selectors)
-      const article = parsed.querySelector('article.doc') ||
-                      parsed.querySelector('.doc') ||
-                      parsed.querySelector('article') ||
-                      parsed.querySelector('main')
+      /**
+       * FLATTEN TABS
+       *
+       * Tabs are interactive UI that don't work in markdown. Convert them to
+       * sequential content with bold labels for each tab.
+       */
+      const tabBlocks = parsed.querySelectorAll('.openblock.tabs')
+      tabBlocks.forEach(tabBlock => {
+        // Get tab labels
+        const tabLabels = []
+        const tabItems = tabBlock.querySelectorAll('.tablist .tab')
+        tabItems.forEach(tab => {
+          tabLabels.push(tab.textContent.trim())
+        })
 
-      if (article) {
-        /**
-         * REMOVE METADATA ELEMENTS
-         *
-         * Remove the article info bar (last updated, reading time, etc.)
-         * and other UI elements that aren't relevant to markdown export.
-         */
-        const h1 = article.querySelector('h1.page')
-        if (h1) {
-          // Find the metadata bar (the div after the h1)
-          let nextElement = h1.nextElementSibling
-          while (nextElement) {
-            // Check if this is the info bar with Contribute link
-            if (nextElement.tagName === 'DIV' &&
-                (nextElement.rawText || nextElement.innerHTML).includes('Contribute')) {
-              nextElement.remove()
-              break
-            }
-            // Also check if it's the info bar with border-vapor styling
-            if (nextElement.tagName === 'DIV' && nextElement.classList &&
-                nextElement.classList.toString().includes('border-vapor')) {
-              nextElement.remove()
-              break
-            }
-            nextElement = nextElement.nextElementSibling
+        // Get tab panels and build replacement HTML
+        const tabPanels = tabBlock.querySelectorAll('.tabpanel')
+        let replacementHtml = '<div class="tabs-content">'
+
+        tabPanels.forEach((panel, index) => {
+          if (tabLabels[index]) {
+            replacementHtml += `<p><strong>${tabLabels[index]}:</strong></p>`
           }
-        }
-
-        // Remove toolbars and edit links
-        const toolbars = article.querySelectorAll('.toolbar, .page-versions, .edit-this-page')
-        toolbars.forEach(el => el.remove())
-
-        /**
-         * FLATTEN TABS
-         *
-         * Tabs are interactive UI that don't work in markdown. Convert them to
-         * sequential content with bold labels for each tab.
-         */
-        const tabBlocks = article.querySelectorAll('.openblock.tabs')
-        tabBlocks.forEach(tabBlock => {
-          // Get tab labels
-          const tabLabels = []
-          const tabItems = tabBlock.querySelectorAll('.tablist .tab')
-          tabItems.forEach(tab => {
-            tabLabels.push(tab.textContent.trim())
-          })
-
-          // Get tab panels and build replacement HTML
-          const tabPanels = tabBlock.querySelectorAll('.tabpanel')
-          let replacementHtml = '<div class="tabs-content">'
-
-          tabPanels.forEach((panel, index) => {
-            if (tabLabels[index]) {
-              replacementHtml += `<p><strong>${tabLabels[index]}:</strong></p>`
-            }
-            replacementHtml += panel.innerHTML
-          })
-
-          replacementHtml += '</div>'
-
-          // Replace the entire tab block with flattened content
-          tabBlock.replaceWith(replacementHtml)
+          replacementHtml += panel.innerHTML
         })
 
-        /**
-         * CONVERT MERMAID TO CODE BLOCKS
-         *
-         * Extract mermaid diagrams and convert them to proper <pre><code> blocks
-         * so Turndown's code block rule handles them with proper whitespace preservation.
-         */
-        const mermaidDivs = article.querySelectorAll('.mermaid.content')
-        mermaidDivs.forEach(mermaidDiv => {
-          // Get raw text which preserves newlines in node-html-parser
-          const mermaidCode = mermaidDiv.rawText || mermaidDiv.textContent || ''
+        replacementHtml += '</div>'
 
-          // Replace with a proper code block that Turndown knows how to handle
-          // Use <pre><code> structure so Turndown's code block rule processes it
-          const codeBlock = `<pre><code class="language-mermaid">${mermaidCode.trim()}</code></pre>`
-          mermaidDiv.replaceWith(codeBlock)
-        })
-      }
+        // Replace the entire tab block with flattened content
+        tabBlock.replaceWith(replacementHtml)
+      })
+
+      /**
+       * CONVERT MERMAID TO CODE BLOCKS
+       *
+       * Extract mermaid diagrams and convert them to proper <pre><code> blocks
+       * so Turndown's code block rule handles them with proper whitespace preservation.
+       */
+      const mermaidDivs = parsed.querySelectorAll('.mermaid.content')
+      mermaidDivs.forEach(mermaidDiv => {
+        // Get raw text which preserves newlines in node-html-parser
+        const mermaidCode = mermaidDiv.rawText || mermaidDiv.textContent || ''
+
+        // Replace with a proper code block that Turndown knows how to handle
+        // Use <pre><code> structure so Turndown's code block rule processes it
+        const codeBlock = `<pre><code class="language-mermaid">${mermaidCode.trim()}</code></pre>`
+        mermaidDiv.replaceWith(codeBlock)
+      })
 
       // Get the cleaned HTML content
-      const htmlContent = article ? article.innerHTML : fullHtml
+      const htmlContent = parsed.innerHTML
 
       /**
        * CONVERT HTML TO MARKDOWN
@@ -297,6 +248,28 @@ module.exports.register = function () {
        * Use Turndown service with our custom rules to convert HTML to markdown.
        */
       let markdown = turndownService.turndown(htmlContent)
+
+      /**
+       * ADD THE PAGE TITLE
+       *
+       * The document title (h1) is rendered by the UI layout, not by the
+       * AsciiDoc converter, so it is not part of page.contents at this stage.
+       * Reconstruct it from the parsed AsciiDoc metadata so the markdown export
+       * still leads with the page title.
+       *
+       * doctitle is converted inline HTML (typographic characters appear as
+       * entities such as &#8217;, and inline markup as tags), so we run it
+       * through Turndown to decode it the same way the rendered <h1> was.
+       * When a page declares a badge attribute (e.g. "Beta", "Preview"), the
+       * layout appends it to the heading, so we preserve it here too.
+       */
+      const doctitle = page.asciidoc && page.asciidoc.doctitle
+      if (doctitle) {
+        const badge = page.asciidoc.attributes && page.asciidoc.attributes['page-badge']
+        const titleHtml = badge ? `${doctitle} ${badge}` : doctitle
+        const titleMd = turndownService.turndown(`<h1>${titleHtml}</h1>`).trim()
+        markdown = `${titleMd}\n\n` + markdown
+      }
 
       /**
        * CONVERT RELATIVE LINKS TO ABSOLUTE URLS

--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -222,28 +222,24 @@ module.exports.register = function () {
         )
       },
       replacement: function (content, node, options) {
-        // Extract language from class name (e.g., "language-javascript")
-        var className = node.firstChild.className || ''
-        var language = (className.match(/language-(\S+)/) || [null, ''])[1]
+        var codeEl = node.firstChild
 
-        // Get the actual code content
-        var code = node.firstChild.textContent
-        var fenceChar = options.fence
-        var fenceSize = 3
+        // Asciidoctor/shiki put the language in data-lang (e.g. data-lang="yaml");
+        // fall back to a "language-xxx" class for any other source.
+        var className = codeEl.getAttribute('class') || ''
+        var language =
+          codeEl.getAttribute('data-lang') ||
+          (className.match(/language-(\S+)/) || [null, ''])[1] ||
+          ''
 
-        // Check if the code contains ``` and adjust fence size if needed
-        // (prevents breaking out of the code block)
-        var fenceInCodeRegex = new RegExp('^' + fenceChar + '{' + fenceSize + ',}', 'gm')
+        // Get the actual code content (textContent strips shiki's highlight spans)
+        var code = codeEl.textContent
 
-        var match
-        while ((match = fenceInCodeRegex.exec(code))) {
-          if (match[0].length >= fenceSize) {
-            fenceSize = match[0].length + 1
-          }
-        }
-
-        // Create fence with appropriate length
-        var fence = Array(fenceSize + 1).join(fenceChar)
+        // Use a backtick fence at least three long, widened if the code itself
+        // contains a longer run of backticks so it can't break out of the block.
+        var longestBacktickRun = (code.match(/`+/g) || [])
+          .reduce(function (max, run) { return Math.max(max, run.length) }, 0)
+        var fence = '`'.repeat(Math.max(3, longestBacktickRun + 1))
 
         // Return formatted code block with language
         return (

--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -126,18 +126,26 @@ module.exports.register = function () {
      *
      * Convert a simple data table (inline-only cells, with a heading row) to a
      * GitHub-flavored markdown table. Each cell's inline content is converted
-     * with Turndown, collapsed to a single line, and pipe characters escaped so
-     * they don't break columns.
+     * with Turndown and forced onto a single line: hard line breaks (<br>) are
+     * preserved as a literal <br> (which GFM renders as a line break within a
+     * cell), any other stray newlines are collapsed to spaces, and pipes are
+     * escaped so they don't break columns.
      */
     const buildGfmTable = (table) => {
+      const cellToMarkdown = (cellEl) => {
+        // Protect <br> from Turndown (which would turn it into a newline that
+        // breaks the row); restore it as a literal <br> after conversion.
+        const html = cellEl.innerHTML.replace(/<br\s*\/?>/gi, '{X-BR-X}')
+        return turndownService
+          .turndown(html)
+          .replace(/\s*\n+\s*/g, ' ')          // collapse stray line breaks to a space
+          .replace(/\s*\{X-BR-X\}\s*/g, '<br>') // restore hard line breaks (no padding)
+          .replace(/\|/g, '\\|')               // escape pipes so columns survive
+          .trim()
+      }
+
       const rowToMarkdown = (tr) => {
-        const cellsMd = tr.querySelectorAll('th, td').map(cellEl =>
-          turndownService
-            .turndown(cellEl.innerHTML)
-            .replace(/\s*\n+\s*/g, ' ')   // collapse any line breaks to a space
-            .replace(/\|/g, '\\|')         // escape pipes so columns survive
-            .trim()
-        )
+        const cellsMd = tr.querySelectorAll('th, td').map(cellToMarkdown)
         return '| ' + cellsMd.join(' | ') + ' |'
       }
 
@@ -319,10 +327,11 @@ module.exports.register = function () {
        *   path render cleanly), while cells with lists/blocks keep them
        *
        * A table is "simple" when it has a heading row (GFM tables require one)
-       * and every cell holds only single-line inline content: no lists, nested
-       * tables, code blocks, multiple paragraphs, hard line breaks (<br>), or
-       * spanned cells (colspan/rowspan), none of which a markdown table cell can
-       * represent. Anything else is kept as HTML.
+       * and every cell holds only inline content: no lists, nested tables, code
+       * blocks, multiple paragraphs, or spanned cells (colspan/rowspan), none of
+       * which a markdown table cell can represent. Hard line breaks (<br>) are
+       * allowed - buildGfmTable keeps them as literal <br>, which GFM renders as
+       * a line break inside a cell. Anything else is kept as HTML.
        *
        * Simple tables are converted to markdown now and stashed behind a
        * placeholder, which is swapped back in after Turndown runs (so the cell
@@ -331,7 +340,7 @@ module.exports.register = function () {
        * (preserving structural colspan/rowspan), absolutize their links (kept
        * HTML bypasses the markdown link rewriting), and mark them data-md-keep.
        */
-      const blockCellSelector = 'ul, ol, dl, pre, table, div, blockquote, h1, h2, h3, h4, h5, h6, hr, p, br'
+      const blockCellSelector = 'ul, ol, dl, pre, table, div, blockquote, h1, h2, h3, h4, h5, h6, hr, p'
       const gfmTablePlaceholders = []
       parsed.querySelectorAll('table.tableblock').forEach(table => {
         table.querySelectorAll('colgroup').forEach(colgroup => colgroup.remove())
@@ -440,7 +449,9 @@ module.exports.register = function () {
        * the link rewriting below so in-table links are absolutized too.
        */
       gfmTablePlaceholders.forEach(({ token, markdown: tableMd }) => {
-        markdown = markdown.replace(token, '\n\n' + tableMd + '\n\n')
+        // Use a replacement function so "$" sequences in the table (e.g. a `$`
+        // code span) aren't interpreted as String.replace special patterns.
+        markdown = markdown.replace(token, () => '\n\n' + tableMd + '\n\n')
       })
 
       /**

--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -42,6 +42,47 @@ module.exports.register = function () {
     const siteUrl = playbook.site.url.replace(/\/+$/, '')
 
     /**
+     * URL RESOLVER
+     *
+     * Resolve a possibly-relative link to an absolute docs URL so markdown
+     * files work when viewed outside the site. Already-absolute links (with a
+     * scheme such as http: or mailto:) and pure anchor links are returned
+     * unchanged. Used both for markdown links and for links inside HTML tables.
+     */
+    const absolutizeUrl = (url, pageUrl) => {
+      // Already absolute (http://, https://, mailto:, etc.) or a pure anchor
+      if (/^[a-z]+:/.test(url) || url.startsWith('#')) {
+        return url
+      }
+      // Root-relative - just prepend the site domain
+      if (url.startsWith('/')) {
+        return siteUrl + url
+      }
+      const pageDir = pageUrl.endsWith('/')
+        ? pageUrl
+        : pageUrl.substring(0, pageUrl.lastIndexOf('/') + 1)
+      if (url.startsWith('../') || url.startsWith('./')) {
+        // Relative path - walk up from the current page directory
+        let upCount = 0
+        let cleanUrl = url
+        while (cleanUrl.startsWith('../')) {
+          upCount++
+          cleanUrl = cleanUrl.substring(3)
+        }
+        if (cleanUrl.startsWith('./')) {
+          cleanUrl = cleanUrl.substring(2)
+        }
+        const basePath = pageDir.split('/').filter(p => p)
+        for (let i = 0; i < upCount; i++) {
+          basePath.pop()
+        }
+        return siteUrl + '/' + basePath.join('/') + (basePath.length > 0 ? '/' : '') + cleanUrl
+      }
+      // Bare relative URL - resolve against the current page directory
+      return siteUrl + pageDir + url
+    }
+
+    /**
      * TURNDOWN CONFIGURATION
      *
      * Turndown is the library that converts HTML to Markdown.
@@ -54,6 +95,30 @@ module.exports.register = function () {
       emDelimiter: '_',           // Use _ for emphasis (not *)
       strongDelimiter: '**',      // Use ** for bold
       linkStyle: 'inlined'        // Use [text](url) format (not reference style)
+    })
+
+    /**
+     * KEEP DATA TABLES AS HTML
+     *
+     * Markdown table syntax can only hold single-line cells, but CircleCI
+     * tables frequently put lists, multiple paragraphs, and code blocks inside
+     * cells. Converting those to a markdown table would destroy their
+     * structure (Turndown's default flattens every cell onto its own line), so
+     * we keep real data tables as HTML instead.
+     *
+     * Only tables marked with data-md-keep in the per-page DOM pass below are
+     * kept. That marker is applied to Asciidoctor data tables (table.tableblock)
+     * but NOT to admonition blocks (NOTE/TIP/WARNING), which Asciidoctor also
+     * renders as <table> - those still flatten to text via the default rules.
+     */
+    turndownService.addRule('keepDataTables', {
+      filter: function (node) {
+        return node.nodeName === 'TABLE' && node.hasAttribute('data-md-keep')
+      },
+      replacement: function (content, node) {
+        node.removeAttribute('data-md-keep')
+        return '\n\n' + node.outerHTML + '\n\n'
+      }
     })
 
     /**
@@ -210,6 +275,49 @@ module.exports.register = function () {
       parsed.querySelectorAll('span.image').forEach(el => el.remove())
 
       /**
+       * TIDY DATA TABLES
+       *
+       * Real data tables (table.tableblock) are kept as HTML (see the Turndown
+       * setup above); admonition blocks, which Asciidoctor also renders as
+       * <table>, are deliberately excluded so they still flatten to text. Here
+       * we tidy each data table's Asciidoctor markup:
+       * - remove <colgroup> column-width definitions
+       * - strip presentational class/style attributes (structural attributes
+       *   like colspan/rowspan are preserved)
+       * - unwrap cells whose only child is a <p>, so simple cells read cleanly
+       *   while cells with lists/blocks keep their structure
+       * - absolutize links, since links inside kept HTML don't pass through the
+       *   markdown link rewriting applied later
+       * - mark the table with data-md-keep so the Turndown rule keeps it
+       */
+      parsed.querySelectorAll('table.tableblock').forEach(table => {
+        table.querySelectorAll('colgroup').forEach(colgroup => colgroup.remove())
+
+        table.removeAttribute('class')
+        table.removeAttribute('style')
+        table.querySelectorAll('*').forEach(el => {
+          el.removeAttribute('class')
+          el.removeAttribute('style')
+        })
+
+        table.querySelectorAll('th, td').forEach(cellEl => {
+          const elementChildren = cellEl.childNodes.filter(n => n.nodeType === 1)
+          if (elementChildren.length === 1 && elementChildren[0].tagName === 'P') {
+            cellEl.set_content(elementChildren[0].innerHTML)
+          }
+        })
+
+        table.querySelectorAll('a').forEach(a => {
+          const href = a.getAttribute('href')
+          if (href) {
+            a.setAttribute('href', absolutizeUrl(href, page.pub.url))
+          }
+        })
+
+        table.setAttribute('data-md-keep', '')
+      })
+
+      /**
        * FLATTEN TABS
        *
        * Tabs are interactive UI that don't work in markdown. Convert them to
@@ -303,54 +411,9 @@ module.exports.register = function () {
        * - /docs/page -> https://circleci.com/docs/page
        */
       markdown = markdown.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, text, url) => {
-        // Skip if already absolute (http://, https://, mailto:, etc.)
-        if (/^[a-z]+:/.test(url)) {
-          return match
-        }
-
-        // Keep anchor links (e.g., #section-name) as-is
-        if (url.startsWith('#')) {
-          return match
-        }
-
-        // Convert relative URLs to absolute
-        let absoluteUrl = url
-        if (url.startsWith('/')) {
-          // URL starts with / - just prepend site domain
-          absoluteUrl = siteUrl + url
-        } else if (url.startsWith('../') || url.startsWith('./')) {
-          // Relative path - resolve based on current page URL
-          const pageUrl = page.pub.url
-          const pageDir = pageUrl.endsWith('/') ? pageUrl : pageUrl.substring(0, pageUrl.lastIndexOf('/') + 1)
-
-          // Count how many directories to go up (../)
-          let upCount = 0
-          let cleanUrl = url
-          while (cleanUrl.startsWith('../')) {
-            upCount++
-            cleanUrl = cleanUrl.substring(3)
-          }
-          // Remove leading ./
-          if (cleanUrl.startsWith('./')) {
-            cleanUrl = cleanUrl.substring(2)
-          }
-
-          // Navigate up from current page directory
-          let basePath = pageDir.split('/').filter(p => p)
-          for (let i = 0; i < upCount; i++) {
-            basePath.pop()
-          }
-
-          // Construct absolute URL
-          absoluteUrl = siteUrl + '/' + basePath.join('/') + (basePath.length > 0 ? '/' : '') + cleanUrl
-        } else {
-          // Relative URL without ./ or ../ - resolve relative to current page
-          const pageUrl = page.pub.url
-          const pageDir = pageUrl.endsWith('/') ? pageUrl : pageUrl.substring(0, pageUrl.lastIndexOf('/') + 1)
-          absoluteUrl = siteUrl + pageDir + url
-        }
-
-        return `[${text}](${absoluteUrl})`
+        const absoluteUrl = absolutizeUrl(url, page.pub.url)
+        // Leave the link untouched when nothing needed resolving
+        return absoluteUrl === url ? match : `[${text}](${absoluteUrl})`
       })
 
       /**

--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -342,6 +342,7 @@ module.exports.register = function () {
        */
       const blockCellSelector = 'ul, ol, dl, pre, table, div, blockquote, h1, h2, h3, h4, h5, h6, hr, p'
       const gfmTablePlaceholders = []
+      const tabPlaceholders = []
       parsed.querySelectorAll('table.tableblock').forEach(table => {
         table.querySelectorAll('colgroup').forEach(colgroup => colgroup.remove())
 
@@ -384,38 +385,6 @@ module.exports.register = function () {
       })
 
       /**
-       * FLATTEN TABS
-       *
-       * Tabs are interactive UI that don't work in markdown. Convert them to
-       * sequential content with bold labels for each tab.
-       */
-      const tabBlocks = parsed.querySelectorAll('.openblock.tabs')
-      tabBlocks.forEach(tabBlock => {
-        // Get tab labels
-        const tabLabels = []
-        const tabItems = tabBlock.querySelectorAll('.tablist .tab')
-        tabItems.forEach(tab => {
-          tabLabels.push(tab.textContent.trim())
-        })
-
-        // Get tab panels and build replacement HTML
-        const tabPanels = tabBlock.querySelectorAll('.tabpanel')
-        let replacementHtml = '<div class="tabs-content">'
-
-        tabPanels.forEach((panel, index) => {
-          if (tabLabels[index]) {
-            replacementHtml += `<p><strong>${tabLabels[index]}:</strong></p>`
-          }
-          replacementHtml += panel.innerHTML
-        })
-
-        replacementHtml += '</div>'
-
-        // Replace the entire tab block with flattened content
-        tabBlock.replaceWith(replacementHtml)
-      })
-
-      /**
        * CONVERT MERMAID TO CODE BLOCKS
        *
        * Extract mermaid diagrams and convert them to proper <pre><code> blocks
@@ -432,6 +401,41 @@ module.exports.register = function () {
         mermaidDiv.replaceWith(codeBlock)
       })
 
+      /**
+       * CONVERT TABS TO <Tabs>/<Tab> BLOCKS
+       *
+       * Tabs are interactive UI. Flattening them to paragraphs loses the link
+       * between a tab's label and its content, so instead emit an XML-style
+       * structure: <Tabs> wrapping one <Tab title="..."> per tab. This gives an
+       * ingesting model explicit, unambiguous boundaries and preserves the
+       * "these are alternatives" relationship between tabs.
+       *
+       * Each panel's content is converted to real markdown (so code blocks,
+       * lists, tables, and images survive) and stashed behind a placeholder that
+       * is swapped back in after Turndown runs, so the panel markdown isn't
+       * re-escaped. This runs after the table and mermaid passes so panel
+       * content containing those is already handled.
+       */
+      parsed.querySelectorAll('.openblock.tabs').forEach(tabBlock => {
+        const tabLabels = tabBlock
+          .querySelectorAll('.tablist .tab')
+          .map(tab => tab.textContent.trim())
+        const tabPanels = tabBlock.querySelectorAll('.tabpanel')
+
+        const parts = ['<Tabs>']
+        tabPanels.forEach((panel, index) => {
+          // Escape double quotes so they don't break the title attribute
+          const title = (tabLabels[index] || `Tab ${index + 1}`).replace(/"/g, "'")
+          const panelMarkdown = turndownService.turndown(panel.innerHTML).trim()
+          parts.push(`<Tab title="${title}">`, '', panelMarkdown, '', '</Tab>')
+        })
+        parts.push('</Tabs>')
+
+        const token = `XTABSBLOCK${tabPlaceholders.length}X`
+        tabPlaceholders.push({ token, markdown: parts.join('\n') })
+        tabBlock.replaceWith(`<p>${token}</p>`)
+      })
+
       // Get the cleaned HTML content
       const htmlContent = parsed.innerHTML
 
@@ -443,14 +447,20 @@ module.exports.register = function () {
       let markdown = turndownService.turndown(htmlContent)
 
       /**
-       * RESTORE SIMPLE TABLES
+       * RESTORE TABS AND TABLES
        *
-       * Swap the markdown tables back in for their placeholders. Done before
-       * the link rewriting below so in-table links are absolutized too.
+       * Swap the markdown tab blocks and tables back in for their placeholders.
+       * Done before the link rewriting below so links inside them are
+       * absolutized too. Tabs are restored first so a table nested inside a tab
+       * (its placeholder carried in the tab markdown) is then resolved by the
+       * table pass. A replacement function is used so "$" sequences in the
+       * content (e.g. a `$` code span) aren't interpreted as String.replace
+       * special patterns.
        */
+      tabPlaceholders.forEach(({ token, markdown: tabsMd }) => {
+        markdown = markdown.replace(token, () => '\n\n' + tabsMd + '\n\n')
+      })
       gfmTablePlaceholders.forEach(({ token, markdown: tableMd }) => {
-        // Use a replacement function so "$" sequences in the table (e.g. a `$`
-        // code span) aren't interpreted as String.replace special patterns.
         markdown = markdown.replace(token, () => '\n\n' + tableMd + '\n\n')
       })
 

--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -18,9 +18,31 @@
  *    article info bar, toolbars, etc. — those are added later, at
  *    'pagesComposed'). Working from the pre-composition body means we never
  *    have to find and strip the site chrome by hand.
- * 2. Converts each body to Markdown and writes .md files to a temp directory.
+ * 2. For each page: parse the body, run DOM pre-passes (remove inline images,
+ *    convert data tables, mermaid, and tabs), convert the result to Markdown
+ *    with Turndown, swap structured blocks back in, rewrite links, and write
+ *    the .md file to a temp directory.
  * 3. A post-build script (gulp.d/tasks/build-site.js) copies them to the final
  *    output directory once Antora finishes publishing.
+ *
+ * Tables and tabs use a "placeholder" pattern: the block is converted to
+ * Markdown during the DOM pass (calling Turndown on each cell/panel), stashed
+ * behind a token, and the token is swapped back in after the main Turndown pass
+ * so its Markdown isn't re-escaped. Complex tables are instead kept as HTML and
+ * emitted verbatim via the keepDataTables rule.
+ *
+ * MAINTAINER NOTE — possible future refactor:
+ * The placeholder pattern means Turndown is invoked many times per page (once
+ * for the whole body, plus once per simple-table cell, per tab panel, and for
+ * the title). It is correct and the full-site build time is fine, but if build
+ * time or readability ever becomes a concern, the cleaner design is to mark
+ * simple tables/tabs in the DOM and register *scoped* Turndown rules for
+ * table/tr/td (and the tab wrappers) that emit GFM in the single page-level
+ * Turndown pass — no per-cell calls, no placeholders. This is roughly what
+ * turndown-plugin-gfm does; we avoid that plugin because its global table rules
+ * and its keep() for header-less tables capture Asciidoctor admonition blocks
+ * (NOTE/TIP/WARNING, also rendered as <table>) and dump them as raw HTML, so a
+ * scoped/hand-rolled version would be required.
  */
 
 'use strict'

--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -349,14 +349,18 @@ module.exports.register = function () {
           }
         })
 
-        const hasHeader = !!table.querySelector('thead')
+        // GFM tables need exactly one header row and can't represent a footer,
+        // so anything else is kept as HTML (buildGfmTable only reads the single
+        // thead row and the tbody rows, so this also avoids dropping content).
+        const hasSingleHeader =
+          table.querySelectorAll('thead tr').length === 1 && !table.querySelector('tfoot')
         const cells = table.querySelectorAll('th, td')
         const isSimple = cells.every(cellEl =>
           !cellEl.querySelector(blockCellSelector) &&
           !cellEl.getAttribute('colspan') &&
           !cellEl.getAttribute('rowspan'))
 
-        if (hasHeader && isSimple) {
+        if (hasSingleHeader && isSimple) {
           // Convert to a markdown table now, swap back in after Turndown.
           const token = `XGFMTABLE${gfmTablePlaceholders.length}X`
           gfmTablePlaceholders.push({ token, markdown: buildGfmTable(table) })


### PR DESCRIPTION
## Overview

Reworks the markdown export extension (`extensions/markdown-export-extension.js`) — the Antora extension that generates the downloadable `.md` version of every docs page (the "View markdown" links and the content LLMs/agents ingest). It started as a refactor to the `documentsConverted` event and grew to fix several conversion-quality issues for tables, tabs, images, and code blocks.

All changes are in one file. Each was validated by building the affected content and diffing the generated `.md` against the previous behavior; a full-site build (634 pages) passes all integrity checks (see Validation).

## Changes (one per commit)

### 1. Refactor to the `documentsConverted` event
Hook `documentsConverted` instead of `beforePublish`. At that point `page.contents` is the pre-composition HTML body, before the UI layout wraps it in site chrome — so we no longer re-parse the fully composed page, find `article.doc`, and strip the info bar (by string-matching "Contribute"/`border-vapor`) and toolbars by hand. The page title is reconstructed from `page.asciidoc.doctitle` (with the `page-badge` re-appended), since the `<h1>` is layout-rendered. Net result: 250/251 pages byte-identical to the old output; the one change is the root landing page, which the old code mangled (it has no `article.doc` and fell back to dumping the full page HTML) and now exports cleanly. Also removes the already-dead `"Contribute"` string check.

### 2. Image alt text instead of dropping images
Block images (`image::`) now surface their alt text as a `> **Image:** <alt>` block instead of being dropped. Inline images and theme icons (`image:`, rendered as `<span class="image">`) are still stripped as decorative.

### 3 & 4. Tables: GFM markdown for simple, HTML for complex
Turndown's default flattened every table cell onto its own line, destroying structure. Now:
- **Simple** tables (heading row + every cell is single-line inline content) → **GFM markdown tables**.
- **Complex** tables (lists, multiple paragraphs, code blocks, spanned cells) → kept as **cleaned HTML**, which markdown viewers render and LLMs parse, preserving structure markdown can't represent.
- **Admonitions** (NOTE/TIP/WARNING — also `<table>` in Asciidoctor) are deliberately left to flatten to text.

Built by hand (per-cell Turndown + placeholder swap-back) rather than via `turndown-plugin-gfm`, because that plugin's global rules + header-less-table `keep` capture admonitions and dump them as raw HTML.

### 5. `<br>` support + `$`-substitution fix
- Hard line breaks (`<br>`) no longer force a table to HTML — they're preserved as a literal `<br>` (valid in GFM cells). This lets the searchable "datatable" tables (e.g. on the variables reference page) become markdown tables.
- Fixes cell corruption when a table contained a `$` sequence (e.g. a `` `$` `` code span): the placeholder swap-back used a string replacement, so `` $` `` was interpreted as a `String.replace` special pattern and injected unrelated page text. Now uses a replacement function.

### 6. Tabs → `<Tabs>`/`<Tab title="...">`
Tabbed content was flattened to a bold `**Label:**` paragraph plus loose paragraphs, losing the label↔content boundary. Now emits an XML-style structure (`<Tabs>` wrapping one `<Tab title="...">` per tab) that gives ingesting models explicit boundaries and preserves the "these are alternatives" relationship. Each panel is converted to real markdown (code, lists, tables, images survive). The tab pass runs after the table/mermaid passes so nested content is handled.

### 7. Code fence language + width
The `fencedCodeBlock` rule emitted 9-backtick fences with no language. Two bugs: language was read from a `language-xxx` class but Asciidoctor/shiki use `data-lang`; and the fence was built from `options.fence` (the 3-backtick string) × fenceSize = 9 backticks. Now reads `data-lang` and builds a normal ``` fence.

## Validation — full-site build (634 pages, exit 0)

Integrity checks all clean:
- Placeholder leaks: **0** · 9-backtick fences: **0** · `data-md-keep` leaks: **0** · raw admonition tables: **0**
- `<Tabs>` balanced 382/382 · `<Tab>` balanced 878/878
- Malformed GFM rows: **0 real** (20 flagged were literal AsciiDoc inside an ```` ```adoc ```` code block on the *using-tables* style-guide page)

Output: 493 GFM tables · 60 complex tables kept as HTML · 382 tab groups (878 tabs) · 4,770 language-tagged code blocks · 600 image alt blocks.

Per-change regression diffs confirmed each change is localized (e.g. the code-fence fix touched only code-fence lines across 169 files; the tabs change touched only tab-bearing pages).

## Reviewer notes
- The table/tab/code logic uses a placeholder mechanism (convert to markdown in the DOM pass, stash behind a token, swap back after Turndown so content isn't re-escaped and in-content links are still absolutized). Tabs are restored before tables so a table nested in a tab still resolves.
- Complex tables kept as HTML still carry some Asciidoctor wrapper `<div>`s in block cells (harmless, renders fine) — left rather than risk over-stripping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)