### PR TITLE
feat: update Xcode 27.0 Beta to build 27A5209h and manifest v18905 (Beta 2)

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
@@ -10,12 +10,12 @@
 | Release Notes
 
 | `27.0`
-| Xcode 27.0 (27A5194q)
+| Xcode 27.0 (27A5209h)
 | 26.5.1
 a| `m4pro.medium` +
    `m4pro.large`
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18748/manifest.txt[Installed software]
-| link:https://circleci.com/changelog/xcode-27-0-beta-1-available/[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18905/manifest.txt[Installed software]
+| link:https://circleci.com/changelog/xcode-27-0-beta-2-available/[Release Notes]
 
 | `26.6`
 | Xcode 26.6 (17F113)


### PR DESCRIPTION
# Description
Update documentation for Xcode 27 now that the Beta 2 image has been released
