### PR TITLE
docs(server): document TLS 1.3 and pg_partman requirements for external PostgreSQL

### DIFF
--- a/docs/server-admin-4.10/modules/operator/pages/configuring-external-services.adoc
+++ b/docs/server-admin-4.10/modules/operator/pages/configuring-external-services.adoc
@@ -14,6 +14,10 @@ This page describes how to configure external services for use with a new Circle
 
 NOTE: Your externalized PostgreSQL instance needs to be version 12. While you can use PostgreSQL 13 and 14, the version we use for testing is 12.22, which is also the version we ship when using an internalized PostgreSQL. You can also use services that are fully compatible with PostgreSQL, such as Amazon RDS for PostgreSQL.
 
+IMPORTANT: CircleCI Server requires TLS 1.3 to authenticate with an externalized PostgreSQL instance.
+
+IMPORTANT: Your externalized PostgreSQL instance must use pg_partman 4.5.x. pg_partman 5.x is not currently supported.
+
 Consider running at least two PostgreSQL replicas to allow recovery from primary failure and for backups. The table below shows the recommended specifications for PostgreSQL machines:
 
 [.table.table-striped]

--- a/docs/server-admin-4.9/modules/operator/pages/configuring-external-services.adoc
+++ b/docs/server-admin-4.9/modules/operator/pages/configuring-external-services.adoc
@@ -14,6 +14,10 @@ This page describes how to configure external services for use with a new Circle
 
 NOTE: Your externalized PostgreSQL instance needs to be version 12. While you can use PostgreSQL 13 and 14, the version we use for testing is 12.22, which is also the version we ship when using an internalized PostgreSQL. You can also use services that are fully compatible with PostgreSQL, such as Amazon RDS for PostgreSQL.
 
+IMPORTANT: CircleCI Server requires TLS 1.3 to authenticate with an externalized PostgreSQL instance.
+
+IMPORTANT: Your externalized PostgreSQL instance must use pg_partman 4.5.x. pg_partman 5.x is not currently supported.
+
 Consider running at least two PostgreSQL replicas to allow recovery from primary failure and for backups. The table below shows the recommended specifications for PostgreSQL machines:
 
 [.table.table-striped]

--- a/styles/config/vocabularies/Docs/accept.txt
+++ b/styles/config/vocabularies/Docs/accept.txt
@@ -262,6 +262,7 @@ OPA
 [Pp]arsable
 [Pp]assphraseless
 [Pp]erformance
+pg_partman
 PHP
 PHPUnit
 Pipenv


### PR DESCRIPTION
## Summary

- Document that CircleCI Server requires TLS 1.3 to authenticate with an externalized PostgreSQL instance.
- Document that the externalized PostgreSQL instance must use pg_partman 4.5.x; pg_partman 5.x is not currently supported.
- Applied to both Server 4.9 and 4.10 admin docs.

Linear: https://linear.app/circleci/issue/ONP-3342/investigate-server-support-for-rds-and-document-requirements

## Test plan

- Visually confirm the two `IMPORTANT` admonitions render between the version `NOTE` and the PostgreSQL replicas paragraph in the "Best practices for PostgreSQL" section for both 4.9 and 4.10.