### PR TITLE
Fix external link check pipeline

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -16,6 +16,7 @@ IgnoreURLs:
   - "\\[url\\]"                          # Escaped literal [url] placeholder in search templates
   - "^/docs/"                            # All absolute paths from 404 page (navigation + assets)
   - "llms\\.txt$"                        # llms.txt only generated on main branch, not PR builds
+  - "^https://support\\.circleci\\.com"  # Support site returns 403 to automated checkers; links are valid
 IgnoreDirs:
   - "api"
 OutputDir: ".htmltest"


### PR DESCRIPTION
Currently when we check external links we get failures whenever we link to support with a 403. These links work fine so this change is just to ignore those URLS
