### PR TITLE
[SC-236] Add GitHub OAuth to pipeline event and trigger type docs

### DIFF
--- a/docs/guides/modules/ROOT/partials/pipelines-and-triggers/pipeline-values.adoc
+++ b/docs/guides/modules/ROOT/partials/pipelines-and-triggers/pipeline-values.adoc
@@ -377,10 +377,11 @@ d| [.nowrap]#GitHub App# +
 | `pipeline.trigger.type`
 d| [.nowrap]#GitHub App# +
 [.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth# +
 [.nowrap]#Bitbucket Cloud# +
 [.nowrap]#Bitbucket Data Center#
 | String
-| The type of trigger that initiated the pipeline. Possible values: `github_app`, `bitbucket_dc`, `schedule`, `webhook`, `api`.
+| The type of trigger that initiated the pipeline. Possible values: `github_app`, `github_server`, `github_oauth`, `bitbucket_cloud`, `bitbucket_dc`, `schedule`, `webhook`, `api`.
 | [.circle-green]#**Yes**#
 | [.circle-red]#**No**#
 
@@ -435,7 +436,8 @@ d| [.nowrap]#GitHub App# +
 
 | `pipeline.event.github.after`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth#
 | String
 | The SHA of the most recent commit on the branch after the push. Corresponds to the `after` field on the link:https://docs.github.com/en/webhooks/webhook-events-and-payloads#push[GitHub push event payload]. Only populated for push events.
 | [.circle-green]#**Yes**#
@@ -443,7 +445,8 @@ d| [.nowrap]#GitHub App# +
 
 | `pipeline.event.github.head_commit.url`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth#
 | String
 | The URL of the most recent commit on the branch. Corresponds to the `head_commit.url` field on the link:https://docs.github.com/en/webhooks/webhook-events-and-payloads#push[GitHub push event payload]. Only populated for push events.
 | [.circle-green]#**Yes**#
@@ -451,7 +454,8 @@ d| [.nowrap]#GitHub App# +
 
 | `pipeline.event.github.ref`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth#
 | String
 | The full Git ref that was pushed. Corresponds to the `ref` field on the link:https://docs.github.com/en/webhooks/webhook-events-and-payloads#push[GitHub push event payload]. Only populated for push events.
 | [.circle-green]#**Yes**#
@@ -555,7 +559,8 @@ d| [.nowrap]#GitHub App# +
 
 | `pipeline.event.github.sender.type`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth#
 | String
 | The type of GitHub user that triggered the event. Corresponds to the `sender.type` field on GitHub event payloads. Possible values are `User`, `Organization`, and `Bot`.
 | [.circle-green]#**Yes**#
@@ -563,7 +568,8 @@ d| [.nowrap]#GitHub App# +
 
 | `pipeline.event.github.sender.avatar_url`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth#
 | String
 | The avatar URL of the GitHub user who triggered the event. Corresponds to the `sender.avatar_url` field on GitHub event payloads.
 | [.circle-green]#**Yes**#
@@ -571,7 +577,8 @@ d| [.nowrap]#GitHub App# +
 
 | `pipeline.event.github.sender.login`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth#
 | String
 | The VCS username of the GitHub user who triggered the event. Corresponds to the `sender.login` field on GitHub event payloads.
 | [.circle-green]#**Yes**#
@@ -579,7 +586,8 @@ d| [.nowrap]#GitHub App# +
 
 | `pipeline.event.github.repository.name`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth#
 | String
 | The name of the repository that triggered the event, without the owner prefix. Corresponds to the `repository.name` field on repository-related GitHub event payloads.
 | [.circle-green]#**Yes**#
@@ -587,7 +595,8 @@ d| [.nowrap]#GitHub App# +
 
 | `pipeline.event.github.repository.owner.login`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth#
 | String
 | The VCS username of the repository owner. Corresponds to the `repository.owner.login` field on repository-related GitHub event payloads.
 | [.circle-green]#**Yes**#
@@ -595,7 +604,8 @@ d| [.nowrap]#GitHub App# +
 
 | `pipeline.event.github.repository.url`
 d| [.nowrap]#GitHub App# +
-[.nowrap]#GitHub App Server#
+[.nowrap]#GitHub App Server# +
+[.nowrap]#GitHub OAuth#
 | String
 | The URL of the repository that triggered the event. Corresponds to the `repository.url` field on repository-related GitHub event payloads.
 | [.circle-green]#**Yes**#


### PR DESCRIPTION
# Description
Add GitHub OAuth to the pipeline values reference table. Updates `pipeline.trigger.type` to include GitHub OAuth as a supported pipeline type and adds missing `github_oauth`, `github_server`, and `bitbucket_cloud` values. Adds GitHub OAuth to the 9 push-related `pipeline.event.github.*` variables (after, head_commit.url, ref, sender.*, repository.*).

# Reasons
SC-236 populates `pipeline.event.*` and `pipeline.trigger.type` for GitHub OAuth (and Bitbucket Cloud) triggers. The docs need to reflect these newly available values. This also fixes existing discrepancies where `github_server` and `bitbucket_cloud` were missing from `pipeline.trigger.type` possible values.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).