### PR TITLE
refactor(llms-txt): adopt Antora-recommended beforePublish pattern

### DIFF
--- a/extensions/llms-txt-generator-extension.js
+++ b/extensions/llms-txt-generator-extension.js
@@ -1,398 +1,360 @@
-const fs = require('fs');
-const fsPromises = fs.promises;
-const path = require('path');
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const File = require('vinyl')
 
 /**
  * An Antora extension that auto-generates llms.txt from the documentation structure.
- * Only generates in CI on main branch to avoid local build artifacts.
- * The build task will copy it to the build directory.
+ *
+ * Hooks into `beforePublish` to add llms.txt directly to the siteCatalog as a
+ * Vinyl file — no intermediate filesystem writes or post-build copy steps needed.
+ * Also creates a sitemap-llms.xml and registers it in the main sitemapindex so
+ * that crawlers and LLMs can discover the file.
+ *
+ * Set SKIP_LLMS_TXT=true to disable generation (e.g. for faster local builds).
  */
 module.exports.register = function () {
-  this.once('navigationBuilt', async ({ playbook, contentCatalog }) => {
-    try {
-      // Only generate llms.txt in CI on main branch
-      const isCI = process.env.CI === 'true';
-      const isMainBranch = process.env.CIRCLE_BRANCH === 'main';
+  const logger = this.getLogger('llms-txt-generator')
 
-      if (!isCI || !isMainBranch) {
-        console.log(`Skipping llms.txt generation (CI: ${isCI}, Branch: ${process.env.CIRCLE_BRANCH || 'unknown'})`);
-        return;
-      }
-
-      console.log('Generating llms.txt for main branch deployment...');
-      const llmsTxt = await generateLlmsTxt(playbook, contentCatalog);
-
-      // Write to repository root (visible on GitHub)
-      const rootPath = path.join(__dirname, '..', 'llms.txt');
-      await fsPromises.writeFile(rootPath, llmsTxt, 'utf8');
-      console.log(`Generated llms.txt at ${rootPath}`);
-
-      // Write metadata for gulp task to copy
-      const metaPath = path.join(__dirname, '.temp', 'llms-meta.json');
-      await fsPromises.mkdir(path.dirname(metaPath), { recursive: true });
-      await fsPromises.writeFile(metaPath, JSON.stringify({
-        sourceFile: rootPath,
-        outputDir: playbook.output.dir,
-        generated: new Date().toISOString()
-      }), 'utf8');
-    } catch (err) {
-      // Never break the build - log error and continue
-      console.error('Error generating llms.txt:', err);
-      console.error('Build will continue without llms.txt generation');
+  this.once('beforePublish', ({ playbook, contentCatalog, siteCatalog }) => {
+    if (process.env.SKIP_LLMS_TXT === 'true') {
+      logger.info('Skipping llms.txt generation (SKIP_LLMS_TXT=true)')
+      return
     }
-  });
-};
+
+    try {
+      logger.info('Generating llms.txt...')
+      const llmsTxt = generateLlmsTxt(playbook, contentCatalog)
+
+      siteCatalog.addFile(new File({
+        contents: Buffer.from(llmsTxt),
+        mediaType: 'text/plain',
+        out: { path: 'llms.txt' },
+        path: 'llms.txt',
+        pub: { url: '/llms.txt', rootPath: '' },
+        src: { stem: 'llms' },
+      }))
+
+      addToSitemap(siteCatalog, playbook)
+
+      logger.info('Successfully generated llms.txt')
+    } catch (err) {
+      // Never break the build — log and continue
+      logger.error(`Error generating llms.txt: ${err.message}`)
+    }
+  })
+}
 
 /**
- * Generate the complete llms.txt content
+ * Create sitemap-llms.xml and register it in the main sitemapindex.
  */
-async function generateLlmsTxt(playbook, contentCatalog) {
-  const sections = [];
+function addToSitemap (siteCatalog, playbook) {
+  const siteUrl = playbook.site.url.replace(/\/?$/, '/')
+  const now = new Date().toISOString()
+
+  const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>${siteUrl}llms.txt</loc>
+    <lastmod>${now}</lastmod>
+  </url>
+</urlset>
+`
+
+  siteCatalog.addFile(new File({
+    contents: Buffer.from(sitemapXml),
+    mediaType: 'text/xml',
+    out: { path: 'sitemap-llms.xml' },
+    path: 'sitemap-llms.xml',
+    pub: { url: '/sitemap-llms.xml', rootPath: '' },
+    src: { stem: 'sitemap-llms' },
+  }))
+
+  // Insert the new sub-sitemap into the main sitemapindex
+  const mainSiteMap = siteCatalog.getFiles().find(f => f?.out?.path === 'sitemap.xml')
+  if (mainSiteMap) {
+    let xml = mainSiteMap.contents.toString()
+    xml = xml.replace(
+      /<\/sitemapindex>/,
+      `  <sitemap>\n    <loc>${siteUrl}sitemap-llms.xml</loc>\n  </sitemap>\n</sitemapindex>`
+    )
+    mainSiteMap.contents = Buffer.from(xml)
+  }
+}
+
+/**
+ * Generate the complete llms.txt content.
+ */
+function generateLlmsTxt (playbook, contentCatalog) {
+  const siteUrl = playbook.site.url
+  const sections = []
 
   // Header
-  sections.push('# CircleCI Documentation\n');
-  sections.push('> Official technical documentation for CircleCI, a continuous integration and delivery platform\n');
-  sections.push(`> Generated: ${new Date().toISOString()}\n`);
+  sections.push('# CircleCI Documentation\n')
+  sections.push('> Official technical documentation for CircleCI, a continuous integration and delivery platform\n')
+  sections.push(`> Generated: ${new Date().toISOString()}\n`)
 
   // Site Information
-  sections.push('## Site Information\n');
-  sections.push(`- URL: ${playbook.site.url}`);
-  sections.push('- Repository: https://github.com/circleci/circleci-docs');
-  sections.push('- Generator: Antora (static site generator for technical documentation)');
-  sections.push('- Markup: AsciiDoc\n');
+  sections.push('## Site Information\n')
+  sections.push(`- URL: ${siteUrl}`)
+  sections.push('- Repository: https://github.com/circleci/circleci-docs')
+  sections.push('- Generator: Antora (static site generator for technical documentation)')
+  sections.push('- Markup: AsciiDoc\n')
 
   // Markdown Exports
-  sections.push('## Markdown Exports\n');
-  sections.push('All documentation pages are available in markdown format for easier parsing and processing.\n');
-  sections.push('### How to Access Markdown Versions\n');
-  sections.push('1. **Direct URL conversion**: Replace the HTML page URL with `/index.md`');
-  sections.push('   - HTML: https://circleci.com/docs/guides/getting-started/first-steps/');
-  sections.push('   - Markdown: https://circleci.com/docs/guides/getting-started/first-steps/index.md\n');
-  sections.push('2. **Inline links in this file**: Each page listing below includes a [md] link');
-  sections.push('   - Example: Page Title (https://circleci.com/docs/page/) [md](https://circleci.com/docs/page/index.md)\n');
-  sections.push('3. **HTML metadata**: Each page includes `<link rel="alternate" type="text/markdown" href="index.md">` in the HTML head\n');
-  sections.push('### About This File (llms.txt)\n');
-  sections.push('- **Location**: https://circleci.com/docs/llms.txt');
-  sections.push('- **Purpose**: Provides LLMs with complete site structure, navigation, and page descriptions');
-  sections.push('- **Updates**: Automatically regenerated on each deployment to main branch');
-  sections.push('- **Discovery**: Announced via `<link rel="alternate" type="text/plain" href="/docs/llms.txt">` in page headers');
-  sections.push('- **Format**: Plain text with markdown-style formatting for readability\n');
+  sections.push('## Markdown Exports\n')
+  sections.push('All documentation pages are available in markdown format for easier parsing and processing.\n')
+  sections.push('### How to Access Markdown Versions\n')
+  sections.push('1. **Direct URL conversion**: Replace the HTML page URL with `/index.md`')
+  sections.push('   - HTML: https://circleci.com/docs/guides/getting-started/first-steps/')
+  sections.push('   - Markdown: https://circleci.com/docs/guides/getting-started/first-steps/index.md\n')
+  sections.push('2. **Inline links in this file**: Each page listing below includes a [md] link')
+  sections.push('   - Example: Page Title (https://circleci.com/docs/page/) [md](https://circleci.com/docs/page/index.md)\n')
+  sections.push('3. **HTML metadata**: Each page includes `<link rel="alternate" type="text/markdown" href="index.md">` in the HTML head\n')
+  sections.push('### About This File (llms.txt)\n')
+  sections.push('- **Location**: https://circleci.com/docs/llms.txt')
+  sections.push('- **Purpose**: Provides LLMs with complete site structure, navigation, and page descriptions')
+  sections.push('- **Updates**: Automatically regenerated on each deployment')
+  sections.push('- **Discovery**: Announced via `<link rel="alternate" type="text/plain" href="/docs/llms.txt">` in page headers')
+  sections.push('- **Sitemap**: Listed in https://circleci.com/docs/sitemap-llms.xml\n')
 
   // Documentation Structure
-  sections.push('## Documentation Structure\n');
-  sections.push('This documentation is organized into the following Antora components:\n');
+  sections.push('## Documentation Structure\n')
+  sections.push('This documentation is organized into the following Antora components:\n')
 
-  const components = contentCatalog.getComponents();
+  const components = contentCatalog.getComponents()
 
-  // Sort components by a logical order
-  const componentOrder = ['root', 'guides', 'reference', 'orbs', 'server-admin', 'services', 'contributors'];
-  const sortedComponents = components.sort((a, b) => {
-    const indexA = componentOrder.indexOf(a.name);
-    const indexB = componentOrder.indexOf(b.name);
-    if (indexA === -1 && indexB === -1) return a.name.localeCompare(b.name);
-    if (indexA === -1) return 1;
-    if (indexB === -1) return -1;
-    return indexA - indexB;
-  });
+  const componentOrder = ['root', 'guides', 'reference', 'orbs', 'server-admin', 'services', 'contributors']
+  const sortedComponents = [...components].sort((a, b) => {
+    const indexA = componentOrder.indexOf(a.name)
+    const indexB = componentOrder.indexOf(b.name)
+    if (indexA === -1 && indexB === -1) return a.name.localeCompare(b.name)
+    if (indexA === -1) return 1
+    if (indexB === -1) return -1
+    return indexA - indexB
+  })
 
   for (const component of sortedComponents) {
-    // For server-admin, show all versions together
     if (component.name === 'server-admin') {
       const serverVersions = component.versions
         .map(v => v.version)
         .sort((a, b) => {
-          // Extract version numbers for proper sorting
-          const numA = parseFloat(a.replace('server-', ''));
-          const numB = parseFloat(b.replace('server-', ''));
-          return numB - numA; // Descending order (newest first)
-        });
+          const numA = parseFloat(a.replace('server-', ''))
+          const numB = parseFloat(b.replace('server-', ''))
+          return numB - numA
+        })
 
-      sections.push(`### ${component.title || component.name}`);
-      sections.push(`- Versions: ${serverVersions.join(', ')}`);
+      sections.push(`### ${component.title || component.name}`)
+      sections.push(`- Versions: ${serverVersions.join(', ')}`)
 
-      // Use the latest version for start page
-      const latestVersion = component.versions[0];
-      const startPage = getStartPage(latestVersion, playbook.site.url);
-      if (startPage) {
-        sections.push(`- Start: ${startPage}`);
-      }
+      // Show navigation from the latest version only
+      const latestVersion = component.versions[0]
+      const startPage = getStartPage(latestVersion, siteUrl)
+      if (startPage) sections.push(`- Start: ${startPage}`)
 
-      // Add navigation from the latest version
-      const nav = formatNavigation(latestVersion.navigation, playbook.site.url, contentCatalog);
-      if (nav) {
-        sections.push(nav);
-      }
-      sections.push('');
-      continue;
+      const nav = formatNavigation(latestVersion.navigation, siteUrl, contentCatalog)
+      if (nav) sections.push(nav)
+      sections.push('')
+      continue
     }
 
-    // For other components, show each version separately (if multiple versions exist)
     for (const version of component.versions) {
-      const title = version.title || component.title || component.name;
+      const title = version.title || component.title || component.name
       const versionLabel = version.version !== 'master' && version.version !== 'main'
         ? ` (${version.version})`
-        : '';
+        : ''
 
-      sections.push(`### ${title}${versionLabel}`);
+      sections.push(`### ${title}${versionLabel}`)
 
-      const startPage = getStartPage(version, playbook.site.url);
-      if (startPage) {
-        sections.push(`- Start: ${startPage}`);
-      }
+      const startPage = getStartPage(version, siteUrl)
+      if (startPage) sections.push(`- Start: ${startPage}`)
 
-      const nav = formatNavigation(version.navigation, playbook.site.url, contentCatalog);
-      if (nav) {
-        sections.push(nav);
-      }
-      sections.push('');
+      const nav = formatNavigation(version.navigation, siteUrl, contentCatalog)
+      if (nav) sections.push(nav)
+      sections.push('')
     }
   }
 
   // Content Statistics
-  sections.push('## Content Statistics\n');
-  const stats = calculateStatistics(contentCatalog);
-  sections.push(`- Total components: ${stats.componentCount}`);
-  sections.push(`- Total pages: ${stats.totalPages}`);
-  sections.push('\nPages by component:');
+  sections.push('## Content Statistics\n')
+  const stats = calculateStatistics(contentCatalog)
+  sections.push(`- Total components: ${stats.componentCount}`)
+  sections.push(`- Total pages: ${stats.totalPages}`)
+  sections.push('\nPages by component:')
   for (const [comp, count] of Object.entries(stats.pagesByComponent).sort((a, b) => b[1] - a[1])) {
-    sections.push(`  - ${comp}: ${count}`);
+    sections.push(`  - ${comp}: ${count}`)
   }
-  sections.push('');
+  sections.push('')
 
   // Technical Stack
-  sections.push('## Technical Stack\n');
-  const techStack = await getTechnicalStack();
+  sections.push('## Technical Stack\n')
+  const techStack = getTechnicalStack()
   for (const [name, version] of Object.entries(techStack)) {
-    sections.push(`- ${name}: ${version}`);
+    sections.push(`- ${name}: ${version}`)
   }
-  sections.push('');
+  sections.push('')
 
   // Platform Badges
-  sections.push('## Platform Badges\n');
-  sections.push('Documentation pages include platform badges that indicate feature availability:\n');
-  sections.push('- **Cloud**: The features and processes described on the page are available for CircleCI Cloud');
-  sections.push('- **Server Admin**: This guide is for CircleCI Server administrators');
-  sections.push('- **Server v4+**: The features and processes described on the page are available for CircleCI Server v4.x+');
-  sections.push('- **Server v4.x** (specific versions like v4.2, v4.3): This guide is for that specific CircleCI Server version');
-  sections.push('- **Server v3.x** (specific versions): This guide is for that specific CircleCI Server version');
-  sections.push('\nPages may show multiple badges if a feature is available on multiple platforms.');
-  sections.push('If no badge is shown, assume the feature is available on all platforms.\n');
+  sections.push('## Platform Badges\n')
+  sections.push('Documentation pages include platform badges that indicate feature availability:\n')
+  sections.push('- **Cloud**: The features and processes described on the page are available for CircleCI Cloud')
+  sections.push('- **Server Admin**: This guide is for CircleCI Server administrators')
+  sections.push('- **Server v4+**: The features and processes described on the page are available for CircleCI Server v4.x+')
+  sections.push('- **Server v4.x** (specific versions like v4.2, v4.3): This guide is for that specific CircleCI Server version')
+  sections.push('- **Server v3.x** (specific versions): This guide is for that specific CircleCI Server version')
+  sections.push('\nPages may show multiple badges if a feature is available on multiple platforms.')
+  sections.push('If no badge is shown, assume the feature is available on all platforms.\n')
 
   // Common URL Patterns
-  sections.push('## Common URL Patterns\n');
-  sections.push(`- Guides: ${playbook.site.url}/guides/<topic>/`);
-  sections.push(`- Reference: ${playbook.site.url}/reference/<topic>/`);
-  sections.push(`- Orbs: ${playbook.site.url}/orbs/<topic>/`);
-  sections.push(`- Server Admin: ${playbook.site.url}/server-admin-<version>/<topic>/`);
-  sections.push(`- API: ${playbook.site.url}/api/<version>/`);
-  sections.push('');
+  sections.push('## Common URL Patterns\n')
+  sections.push(`- Guides: ${siteUrl}/guides/<topic>/`)
+  sections.push(`- Reference: ${siteUrl}/reference/<topic>/`)
+  sections.push(`- Orbs: ${siteUrl}/orbs/<topic>/`)
+  sections.push(`- Server Admin: ${siteUrl}/server-admin-<version>/<topic>/`)
+  sections.push(`- API: ${siteUrl}/api/<version>/`)
+  sections.push('')
 
-  // API Documentation (LLM-friendly)
-  sections.push('## API Documentation\n');
-  sections.push('CircleCI API v2 documentation is available in LLM-friendly format:\n');
-  sections.push(`- **API Index for LLMs**: ${playbook.site.url}/api/v2/llms.txt`);
-  sections.push(`  - Structured index of all API endpoints`);
-  sections.push(`  - Tag-grouped operations with descriptions`);
-  sections.push(`  - Authentication and rate limiting information`);
-  sections.push(`- **Per-Endpoint Markdown**: ${playbook.site.url}/api/v2/operations/{operationId}.md`);
-  sections.push(`  - Individual markdown files for each API endpoint`);
-  sections.push(`  - Complete schemas, parameters, and examples`);
-  sections.push(`  - Example: ${playbook.site.url}/api/v2/operations/createContext.md`);
-  sections.push(`- **Machine-Readable Index**: ${playbook.site.url}/api/v2/operations/index.json`);
-  sections.push(`  - JSON index of all operations with metadata`);
-  sections.push(`- **Full OpenAPI Spec**: ${playbook.site.url}/api/v2/openapi.json`);
-  sections.push(`  - Complete OpenAPI 3.0 specification`);
-  sections.push(`- **Human-Readable Docs**: ${playbook.site.url}/api/v2/`);
-  sections.push(`  - Interactive Redocly documentation (requires JavaScript)`);
-  sections.push('');
+  // API Documentation
+  sections.push('## API Documentation\n')
+  sections.push('CircleCI API v2 documentation is available in LLM-friendly format:\n')
+  sections.push(`- **API Index for LLMs**: ${siteUrl}/api/v2/llms.txt`)
+  sections.push(`  - Structured index of all API endpoints`)
+  sections.push(`  - Tag-grouped operations with descriptions`)
+  sections.push(`  - Authentication and rate limiting information`)
+  sections.push(`- **Per-Endpoint Markdown**: ${siteUrl}/api/v2/operations/{operationId}.md`)
+  sections.push(`  - Individual markdown files for each API endpoint`)
+  sections.push(`  - Complete schemas, parameters, and examples`)
+  sections.push(`  - Example: ${siteUrl}/api/v2/operations/createContext.md`)
+  sections.push(`- **Machine-Readable Index**: ${siteUrl}/api/v2/operations/index.json`)
+  sections.push(`- **Full OpenAPI Spec**: ${siteUrl}/api/v2/openapi.json`)
+  sections.push(`- **Human-Readable Docs**: ${siteUrl}/api/v2/`)
+  sections.push('')
 
   // Server Versions
-  const serverVersions = extractServerVersions(playbook);
+  const serverVersions = extractServerVersions(playbook)
   if (Object.keys(serverVersions).length > 0) {
-    sections.push('## Server Versions\n');
+    sections.push('## Server Versions\n')
     for (const [version, number] of Object.entries(serverVersions).sort((a, b) => b[0].localeCompare(a[0]))) {
-      sections.push(`- ${version}: ${number}`);
+      sections.push(`- ${version}: ${number}`)
     }
-    sections.push('');
+    sections.push('')
   }
 
-  return sections.join('\n');
+  return sections.join('\n')
 }
 
-/**
- * Get the start page URL for a component version
- */
-function getStartPage(version, siteUrl) {
-  if (!version.startPage) return null;
-  return siteUrl + version.startPage;
+function getStartPage (version, siteUrl) {
+  if (!version.startPage) return null
+  return siteUrl + version.startPage
 }
 
-/**
- * Format navigation structure with proper indentation and markdown links
- */
-function formatNavigation(navigation, siteUrl, contentCatalog, indent = 0) {
-  if (!navigation || navigation.length === 0) return '';
+function formatNavigation (navigation, siteUrl, contentCatalog, indent = 0) {
+  if (!navigation || navigation.length === 0) return ''
 
-  const lines = [];
-  const prefix = '  '.repeat(indent);
+  const lines = []
+  const prefix = '  '.repeat(indent)
 
   for (const item of navigation) {
     if (item.content) {
-      // This is a navigation item with content
-      const bullet = indent === 0 ? '-' : '-';
-      const url = item.urlType === 'internal' ? siteUrl + item.url : item.url;
-
-      // Add URL and markdown link if available
-      let urlPart = '';
+      let urlPart = ''
       if (item.url) {
-        urlPart = ` (${url})`;
+        const url = item.urlType === 'internal' ? siteUrl + item.url : item.url
+        urlPart = ` (${url})`
 
-        // Add markdown link for internal URLs
         if (item.urlType === 'internal') {
-          const markdownUrl = getMarkdownUrl(item.url, siteUrl);
-          urlPart += ` [md](${markdownUrl})`;
+          urlPart += ` [md](${getMarkdownUrl(item.url, siteUrl)})`
         }
       }
 
-      // Add page description if available
-      let descriptionPart = '';
+      let descriptionPart = ''
       if (item.urlType === 'internal' && item.url) {
-        const page = findPageByUrl(contentCatalog, item.url);
-        if (page && page.asciidoc && page.asciidoc.attributes && page.asciidoc.attributes['page-description']) {
-          const description = page.asciidoc.attributes['page-description'];
-          descriptionPart = `\n${prefix}  ${description}`;
+        const page = findPageByUrl(contentCatalog, item.url)
+        if (page?.asciidoc?.attributes?.['page-description']) {
+          descriptionPart = `\n${prefix}  ${page.asciidoc.attributes['page-description']}`
         }
       }
 
-      lines.push(`${prefix}${bullet} ${item.content}${urlPart}${descriptionPart}`);
+      lines.push(`${prefix}- ${item.content}${urlPart}${descriptionPart}`)
 
-      // Recursively format child items
       if (item.items && item.items.length > 0) {
-        const childNav = formatNavigation(item.items, siteUrl, contentCatalog, indent + 1);
-        if (childNav) {
-          lines.push(childNav);
-        }
+        const childNav = formatNavigation(item.items, siteUrl, contentCatalog, indent + 1)
+        if (childNav) lines.push(childNav)
       }
     } else if (item.items && item.items.length > 0) {
-      // Group without content - just process children
-      const childNav = formatNavigation(item.items, siteUrl, contentCatalog, indent);
-      if (childNav) {
-        lines.push(childNav);
-      }
+      const childNav = formatNavigation(item.items, siteUrl, contentCatalog, indent)
+      if (childNav) lines.push(childNav)
     }
   }
 
-  return lines.join('\n');
+  return lines.join('\n')
 }
 
-/**
- * Find a page in the content catalog by its URL
- */
-function findPageByUrl(contentCatalog, url) {
-  // Antora URLs are like /component/module/page.html or /component/module/path/
-  // We need to find the corresponding page in the catalog
-  const pages = contentCatalog.getPages();
-
-  for (const page of pages) {
-    if (page.pub && page.pub.url === url) {
-      return page;
-    }
+function findPageByUrl (contentCatalog, url) {
+  for (const page of contentCatalog.getPages()) {
+    if (page.pub && page.pub.url === url) return page
   }
-
-  return null;
+  return null
 }
 
-/**
- * Convert HTML URL to markdown URL following the pattern from markdown-export-extension
- */
-function getMarkdownUrl(pageUrl, siteUrl) {
-  if (pageUrl.endsWith('/')) {
-    // Directory-style URL -> add index.md
-    return siteUrl + pageUrl + 'index.md';
-  } else if (pageUrl.endsWith('.html')) {
-    // HTML file -> replace .html with .md
-    return siteUrl + pageUrl.replace(/\.html$/, '.md');
-  } else {
-    // Other URLs -> add .md extension
-    return siteUrl + pageUrl + '.md';
-  }
+function getMarkdownUrl (pageUrl, siteUrl) {
+  if (pageUrl.endsWith('/')) return siteUrl + pageUrl + 'index.md'
+  if (pageUrl.endsWith('.html')) return siteUrl + pageUrl.replace(/\.html$/, '.md')
+  return siteUrl + pageUrl + '.md'
 }
 
-/**
- * Calculate content statistics
- */
-function calculateStatistics(contentCatalog) {
-  const components = contentCatalog.getComponents();
-  const pagesByComponent = {};
-  let totalPages = 0;
+function calculateStatistics (contentCatalog) {
+  const components = contentCatalog.getComponents()
+  const pagesByComponent = {}
+  let totalPages = 0
 
   for (const component of components) {
     for (const version of component.versions) {
       const pages = contentCatalog.findBy({
         component: component.name,
         version: version.version,
-        family: 'page'
-      }).filter(page => page.pub);
+        family: 'page',
+      }).filter(page => page.pub)
 
       const key = component.name === 'server-admin'
         ? `${component.name} (${version.version})`
-        : (component.title || component.name);
+        : (component.title || component.name)
 
-      pagesByComponent[key] = (pagesByComponent[key] || 0) + pages.length;
-      totalPages += pages.length;
+      pagesByComponent[key] = (pagesByComponent[key] || 0) + pages.length
+      totalPages += pages.length
     }
   }
 
-  return {
-    componentCount: components.length,
-    totalPages,
-    pagesByComponent
-  };
+  return { componentCount: components.length, totalPages, pagesByComponent }
 }
 
-/**
- * Extract technical stack versions from package.json
- */
-async function getTechnicalStack() {
+function getTechnicalStack () {
   try {
-    const packagePath = path.join(__dirname, '..', 'package.json');
-    const packageJson = JSON.parse(await fsPromises.readFile(packagePath, 'utf8'));
-
-    const stack = {
-      'Static Site Generator': `Antora ${packageJson.devDependencies['@antora/cli']?.replace('^', '') || 'unknown'}`,
+    const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
+    return {
+      'Static Site Generator': `Antora ${packageJson.devDependencies?.['@antora/cli']?.replace('^', '') || 'unknown'}`,
       'Markup Language': 'AsciiDoc',
-      'API Docs': `Redocly CLI ${packageJson.devDependencies['@redocly/cli']?.replace('^', '') || 'unknown'}`,
+      'API Docs': `Redocly CLI ${packageJson.devDependencies?.['@redocly/cli']?.replace('^', '') || 'unknown'}`,
       'Search': 'Algolia',
       'Build Tool': 'npm scripts with Gulp',
-    };
-
-    return stack;
-  } catch (err) {
-    console.error('Error reading package.json:', err);
-    return {
-      'Static Site Generator': 'Antora',
-      'Markup Language': 'AsciiDoc',
-    };
+    }
+  } catch {
+    return { 'Static Site Generator': 'Antora', 'Markup Language': 'AsciiDoc' }
   }
 }
 
-/**
- * Extract server version numbers from playbook attributes
- */
-function extractServerVersions(playbook) {
-  const versions = {};
-  const attrs = playbook.asciidoc?.attributes || {};
+function extractServerVersions (playbook) {
+  const versions = {}
+  const attrs = playbook.asciidoc?.attributes || {}
 
   for (const [key, value] of Object.entries(attrs)) {
     if (key.startsWith('serverversion')) {
-      // Convert serverversion49 -> Server 4.9
-      const versionNum = key.replace('serverversion', '');
-      const major = versionNum.charAt(0);
-      const minor = versionNum.substring(1) || '0';
-      versions[`Server ${major}.${minor}`] = value;
+      const versionNum = key.replace('serverversion', '')
+      const major = versionNum.charAt(0)
+      const minor = versionNum.substring(1) || '0'
+      versions[`Server ${major}.${minor}`] = value
     }
   }
 
-  return versions;
+  return versions
 }
-

--- a/gulp.d/tasks/build-site.js
+++ b/gulp.d/tasks/build-site.js
@@ -46,25 +46,6 @@ function copyMarkdownFiles() {
   console.log(`✅ Copied ${metadata.fileCount} markdown files to ${outputDir}`)
 }
 
-function copyLlmsTxt() {
-  const metaPath = path.join(__dirname, '../../extensions/.temp/llms-meta.json')
-  if (!fs.existsSync(metaPath)) {
-    console.log('No llms.txt metadata found, skipping copy')
-    return
-  }
-
-  const metadata = JSON.parse(fs.readFileSync(metaPath, 'utf8'))
-  const { sourceFile, outputDir } = metadata
-
-  if (!fs.existsSync(sourceFile)) {
-    console.log('llms.txt source file not found, skipping')
-    return
-  }
-
-  const destPath = path.join(outputDir, 'llms.txt')
-  fs.copyFileSync(sourceFile, destPath)
-  console.log(`✅ Copied llms.txt to ${destPath}`)
-}
 
 module.exports = function buildSite(cb) {
   console.log('Starting Antora build...')
@@ -93,9 +74,6 @@ module.exports = function buildSite(cb) {
     if (enableMarkdown) {
       copyMarkdownFiles()
     }
-
-    // Copy llms.txt to build directory
-    copyLlmsTxt()
 
     // After Antora build succeeds, build API docs
     console.log('Antora build completed, now building API docs...')


### PR DESCRIPTION
Switch the llms.txt extension from the navigationBuilt event to beforePublish, adding the file directly to the siteCatalog as a Vinyl file. This removes the fragile two-step workaround (write to repo root → metadata JSON → gulp copy) in favour of the approach recommended by the Antora maintainer.

Also adds sitemap-llms.xml and inserts it into the main sitemapindex for LLM/crawler discoverability, replaces console.log with the Antora logger, and removes the CI-only gate so local builds also generate the file (use SKIP_LLMS_TXT=true to opt out).

CHanges based on: https://antora.zulipchat.com/#narrow/channel/282400-users/topic/Generation.20of.20an.20llms.2Etxt.20file.20at.20root/with/605186516