### PR TITLE
Ignore GitHub auth-required links in external link checker

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -16,6 +16,8 @@ IgnoreURLs:
   - "\\[url\\]"                          # Escaped literal [url] placeholder in search templates
   - "^/docs/"                            # All absolute paths from 404 page (navigation + assets)
   - "llms\\.txt$"                        # llms.txt only generated on main branch, not PR builds
+  - "github\\.com/circleci/circleci-docs/commit/" # Per-page "last updated" commit links — require GitHub login
+  - "github\\.com/circleci/circleci-docs/edit/"   # Per-page "propose changes" edit links — require GitHub login
 IgnoreDirs:
   - "api"
 OutputDir: ".htmltest"


### PR DESCRIPTION
## Summary

- The daily external link checker was generating hundreds of spurious failures because GitHub returns 429 (rate limited) or times out on unauthenticated requests to the circleci-docs repo
- Two URL patterns appear on every single docs page: the per-page **"last updated" commit link** (`/commit/<hash>`) generated by `page-metadata-extension.js`, and the per-page **"propose changes" edit link** (`/edit/main/...`) generated by Antora and used in `article-footer.hbs`
- Adds both patterns to `IgnoreURLs` in `.htmltest.yml` so htmltest skips them — the links are valid and work fine for logged-in users

## Test plan

- [ ] Verify the next daily external-link-check pipeline run no longer fails on `github.com/circleci/circleci-docs/commit/` or `github.com/circleci/circleci-docs/edit/` URLs
- [ ] Confirm genuine broken links (404s on CLI docs, VS Code marketplace, etc.) are still reported

Made with [Cursor](https://cursor.com)