### PR TITLE
Fix Vale errors in api-developers-guide.adoc

### DIFF
--- a/docs/guides/modules/toolkit/pages/api-developers-guide.adoc
+++ b/docs/guides/modules/toolkit/pages/api-developers-guide.adoc
@@ -814,5 +814,5 @@ The following information is returned for each job:
 [#reference]
 == Reference
 
-* Refer to xref:api-intro.adoc[API v2 Introduction] for high-level information about the CircleCI v2 API.
+* Refer to xref:api-intro.adoc[API Overview] for high-level information about the CircleCI v2 API.
 * Refer to link:https://circleci.com/docs/api/v2/[API v2 Reference Guide] for a detailed list of all endpoints that make up the CircleCI v2 API.


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in `docs/guides/modules/toolkit/pages/api-developers-guide.adoc`.

## Errors Fixed
- **Line 817**: [circleci-docs.XrefTitleCase] - Updated xref link text from `API v2 Introduction` to `API Overview` to satisfy title case requirements

## Verification
Ran Vale after fixes - no errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review
- Changes preserve existing AsciiDoc structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)