### PR TITLE
Fix Vale errors in api-intro.adoc

### DIFF
--- a/docs/guides/modules/toolkit/pages/api-developers-guide.adoc
+++ b/docs/guides/modules/toolkit/pages/api-developers-guide.adoc
@@ -814,5 +814,5 @@ The following information is returned for each job:
 [#reference]
 == Reference
 
-* Refer to xref:api-intro.adoc[API v2 Introduction] for high-level information about the CircleCI v2 API.
+* Refer to xref:api-intro.adoc[API Overview] for high-level information about the CircleCI v2 API.
 * Refer to link:https://circleci.com/docs/api/v2/[API v2 Reference Guide] for a detailed list of all endpoints that make up the CircleCI v2 API.

--- a/docs/guides/modules/toolkit/pages/api-intro.adoc
+++ b/docs/guides/modules/toolkit/pages/api-intro.adoc
@@ -3,7 +3,7 @@
 :page-description: Introduction to the CircleCI API
 :experimental:
 
-The CircleCI API may be used to make API calls to interact with your pipelines, projects, and orgs. This includes retrieving detailed information about users, jobs, workflows, and pipelines, as well as triggering pipelines. There are currently two supported API versions:
+The CircleCI API may be used to make API calls to interact with your pipelines, projects, and orgs. This includes retrieving detailed information about users, jobs, workflows, and pipelines, as well as triggering pipelines. CircleCI currently supports two API versions:
 
 * link:../../../api/v1/[API v1.1 Reference]
 * link:../../../api/v2/[API v2 Reference]
@@ -12,14 +12,14 @@ API v2 includes several powerful features (for example, support for pipelines an
 
 CircleCI API v1.1 and v2 are supported and generally available. CircleCI expects to eventually End-Of-Life (EOL) API v1.1 in favor of API v2. Further guidance on when CircleCI API v1.1 will be discontinued will be communicated at a future date.
 
-To get started with the API v2, see the xref:api-developers-guide.adoc[API developers guide].
+To get started with the API v2, see the xref:api-developers-guide.adoc[API Developers Guide].
 
 [#changes-in-endpoints]
 == Changes in endpoints
 
 The CircleCI API v2 release includes several new endpoints, and deprecates some others. The sections below list the endpoints added for this release, in addition to the endpoints that have been removed.
 
-For a complete list of all API v2 endpoints, refer to the link:../../../api/v2/[API v2 Reference Guide], which contains a detailed description of each individual endpoint, as well as information on required and optional parameters, HTTP status and error codes, and code samples you may use in your workflows.
+Refer to the link:../../../api/v2/[API v2 Reference Guide] for a complete list of all API v2 endpoints. The guide contains a detailed description of each individual endpoint, including required and optional parameters, HTTP status and error codes, and code samples.
 
 [#deprecated-endpoints]
 === Deprecated endpoints


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in `docs/guides/modules/toolkit/pages/api-intro.adoc`.

## Errors Fixed
- **Line 6**: [circleci-docs.ThereIs] - Rewrote sentence to avoid starting with 'There are'
- **Line 15**: [circleci-docs.XrefTitleCase] - Updated xref link text from `API developers guide` to `API Developers Guide`
- **Line 22**: [circleci-docs.SentenceLength] - Split long sentence (>30 words) into two shorter sentences

## Verification
Ran Vale after fixes - no errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review
- Changes preserve existing AsciiDoc structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)