### PR TITLE
Update testsuite working directory tip

### DIFF
--- a/docs/guides/modules/ROOT/partials/tips/testsuite-working-directory.adoc
+++ b/docs/guides/modules/ROOT/partials/tips/testsuite-working-directory.adoc
@@ -2,5 +2,5 @@
 ====
 Run the `circleci run testsuite` CLI tooling from the directory where your tests are located. This is typically your repository root, but for monorepos it can be the root of a subpackage (for example, `cd service-1 && circleci run testsuite "ci tests"`).
 
-The testsuite will automatically find the `.circleci/test-suites.yml` configuration file by walking up the directory tree. All commands (`discover`, `run`, `analysis`) execute relative to where you run the CLI, so avoid using `cd` or `--directory` flags within your commands.
+The testsuite will look for the `.circleci/test-suites.yml` configuration file in the repository root or the subpackage where the CLI is run. All commands (`discover`, `run`, `analysis`) execute relative to where you run the CLI, so avoid using `cd` or `--directory` flags within your commands.
 ====


### PR DESCRIPTION
The testsuite has changed to better support monorepos. Previously, it would walk the directory tree looking for `.circleci/test-suites.yml`. This forced monorepos into an opinionated project setup where the `.circleci/test-suites.yml` had to be at the root of the repo.

For some monorepos that would make the `test-suites.yml` difficult to deal with as all subpackages of that monorepo had to share the same configuration file.

Now, the testsuite will look in the repository root and the working directory where the CLI was run, allowing monorepos to choose between having a single config file at the root or have each subpackage define its own config file.
