### PR TITLE
Fix Vale errors in local-cli.adoc

### DIFF
--- a/docs/guides/modules/toolkit/pages/local-cli.adoc
+++ b/docs/guides/modules/toolkit/pages/local-cli.adoc
@@ -7,13 +7,13 @@ The https://circleci-public.github.io/circleci-cli/[CircleCI local command line 
 
 Some of the things you can do with the CLI include:
 
-* xref:how-to-use-the-circleci-local-cli.adoc#validate-a-circleci-config[Debug and validate your CircleCI configuration]
-* xref:how-to-use-the-circleci-local-cli.adoc#run-a-job-in-a-container-on-your-machine[Run jobs locally]
+* xref:how-to-use-the-circleci-local-cli.adoc#validate-a-circleci-config[Debug and Validate Your CircleCI Configuration]
+* xref:how-to-use-the-circleci-local-cli.adoc#run-a-job-in-a-container-on-your-machine[Run Jobs Locally]
 * Query CircleCI's API
-* xref:how-to-use-the-circleci-local-cli.adoc#orb-development-kit[Create, publish, view, and manage orbs]
-* xref:how-to-use-the-circleci-local-cli.adoc#context-management[Manage contexts]
+* xref:how-to-use-the-circleci-local-cli.adoc#orb-development-kit[Create, Publish, View, and Manage Orbs]
+* xref:how-to-use-the-circleci-local-cli.adoc#context-management[Manage Contexts]
 
-This page covers the installation and usage of the CircleCI local CLI. The expectation is you have basic knowledge of CI/CD and xref:about-circleci:concepts.adoc[CircleCI's concepts]. You should already have a CircleCI account and an account with a supported VCS.
+This page covers the installation and usage of the CircleCI local CLI. The expectation is you have basic knowledge of CI/CD and xref:about-circleci:concepts.adoc[CircleCI's Concepts]. You need a CircleCI account and an account with a supported VCS.
 
 == The CircleCI CLI and the task runner
 
@@ -148,7 +148,7 @@ Before using the CLI, you need to generate a CircleCI API token from the https:/
 circleci setup
 ----
 
-The set up process will prompt you for configuration settings. If you are using the CLI with CircleCI cloud, use the default CircleCI host. If you are using CircleCI server, change the value to your installation address (for example, `circleci.your-org.com`).
+The set up process will prompt you for configuration settings. If you are using the CLI with CircleCI Cloud, use the default CircleCI host. If you are using CircleCI Server, change the value to your installation address (for example, `circleci.your-org.com`).
 
 [#telemetry]
 == Telemetry
@@ -159,8 +159,8 @@ Telemetry works on an opt-in basis. When running a command for the first time, y
 
 You can disable or enable telemetry any time in one of the following ways:
 
-* Run one of the following commands: `circleci telemetry enable` or `circleci telemetry disable`
-* To disable telemetry, set the `CIRCLECI_CLI_TELEMETRY_OPTOUT` environment variable to `1` or `true`
+* Run one of the following commands: `circleci telemetry enable` or `circleci telemetry disable`.
+* To disable telemetry, set the `CIRCLECI_CLI_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
 
 [#uninstallation]
 == Uninstall
@@ -193,10 +193,10 @@ choco uninstall circleci-cli -y --remove dependencies
 [#next-steps]
 == Next steps
 
-* xref:how-to-use-the-circleci-local-cli.adoc#validate-a-circleci-config[How to validate your CircleCI configuration]
-* xref:how-to-use-the-circleci-local-cli.adoc#run-a-job-in-a-container-on-your-machine[How to run a job in a container on your local machine]
-* xref:how-to-use-the-circleci-local-cli.adoc#orb-development-kit[How to create, publish, view, and manage orbs]
-* xref:how-to-use-the-circleci-local-cli.adoc#context-management[How to manage contexts]
+* xref:how-to-use-the-circleci-local-cli.adoc#validate-a-circleci-config[How to Validate Your CircleCI Configuration]
+* xref:how-to-use-the-circleci-local-cli.adoc#run-a-job-in-a-container-on-your-machine[How to Run a Job in a Container on Your Local Machine]
+* xref:how-to-use-the-circleci-local-cli.adoc#orb-development-kit[How to Create, Publish, View, and Manage Orbs]
+* xref:how-to-use-the-circleci-local-cli.adoc#context-management[How to Manage Contexts]
 
 '''
 
@@ -216,7 +216,7 @@ If you wish to suggest ways we could improve the CLI link:https://github.com/Cir
 * https://support.circleci.com/hc/en-us/articles/4407580027675-Docker-Layer-Caching-FAQ[Docker Layer Cache FAQ]
 * https://support.circleci.com/hc/en-us/articles/14031352897819-How-to-Rotate-your-Self-Hosted-Runner-Resource-Class-Tokens[How to rotate your self-hosted runner resource class tokens using the CircleCI CLI?]
 * https://support.circleci.com/hc/en-us/articles/360057144631-CircleCI-Runner-Error-Message-We-cannot-run-this-job-using-the-selected-resource-class-[How to use the CLI to verify namespaces and resource classes have been created correctly when installing the CircleCI runner?]
-* https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[How to use Reality Check to validate your CircleCI server installation for GitHub Enterprise via the CLI?]
+* https://support.circleci.com/hc/en-us/articles/360011235534-Using-realitycheck-to-validate-your-CircleCI-installation[How to use Reality Check to validate your CircleCI Server installation for GitHub Enterprise via the CLI?]
 
 [#troubleshooting]
 === Troubleshooting


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in \`docs/guides/modules/toolkit/pages/local-cli.adoc\`.

## Errors Fixed
- **Lines 10-14**: [circleci-docs.XrefTitleCase] - Capitalized xref link texts for feature list items
- **Line 16**: [circleci-docs.XrefTitleCase] - Capitalized 'CircleCI's Concepts'
- **Line 16**: [circleci-docs.Avoid] - Replaced 'should' with definitive language
- **Line 151**: [Vale.Terms] - Capitalized 'CircleCI Cloud' and 'CircleCI Server'
- **Lines 162-163**: [circleci-docs.ListPunctuation] - Added periods to telemetry list items
- **Lines 196-199**: [circleci-docs.XrefTitleCase] - Capitalized next steps xref link texts
- **Line 219**: [Vale.Terms] - Capitalized 'CircleCI Server' in support link text

## Verification
Ran Vale after fixes - no errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)