### PR TITLE
Fix Vale errors in get-started-with-the-vs-code-extension.adoc

### DIFF
--- a/docs/guides/modules/toolkit/pages/get-started-with-the-vs-code-extension.adoc
+++ b/docs/guides/modules/toolkit/pages/get-started-with-the-vs-code-extension.adoc
@@ -3,7 +3,7 @@
 :page-description: A quickstart tutorial for the CircleCI VS Code extension.
 :experimental:
 
-This tutorial is a quickstart guide to setting up and using the official CircleCI VS Code extension. You can read more about the extension's capabilities in the xref:vs-code-extension-overview.adoc[overview].
+This tutorial is a quickstart guide to setting up and using the official CircleCI VS Code extension. You can read more about the extension's capabilities in the xref:vs-code-extension-overview.adoc[Overview].
 
 [#prerequisites]
 == Prerequisites
@@ -14,14 +14,14 @@ Before starting this tutorial, make sure you have:
 
 * A CircleCI account (you can link:https://circleci.com/signup/[sign up for free]).
 
-* A xref:getting-started:create-project.adoc[project] you follow that is building on CircleCI.
+* A xref:getting-started:create-project.adoc[Project] you follow that is building on CircleCI.
 
-* CircleCI server users: your self-hosted server URL.
+* CircleCI Server users: your self-hosted server URL.
 
 [#install-the-extension]
 == 1. Install the extension
 
-There are two ways to install the CircleCI extension:
+You can install the CircleCI extension in two ways:
 
 * In VS Code, click the **Extensions** icon on the left-hand Activity Bar, or open **View > Extensions**.
 
@@ -30,12 +30,13 @@ There are two ways to install the CircleCI extension:
 [#authenticate-into-circleci]
 == 2. Authenticate into CircleCI
 
-. In VS Code, open the CircleCI panel by clicking on the CircleCI icon on the activity bar, then click “Log in”.
+. In VS Code, open the CircleCI panel by clicking on the CircleCI icon on the activity bar, then click **Log in**.
 
-. You will be prompted to enter a xref:managing-api-tokens.adoc#overview[personal API token]. You may create one in your CircleCI link:https://app.circleci.com/settings/user/tokens[**User Settings > Personal API Tokens**].
+. You will be prompted to enter a xref:managing-api-tokens.adoc#overview[Personal API Token]. You may create one in your CircleCI link:https://app.circleci.com/settings/user/tokens[**User Settings > Personal API Tokens**].
 +
-**CircleCI server**: Make sure to check **I'm a CircleCI server customer**, then enter your self-hosted server URL.
+**CircleCI Server**: Make sure to check **I'm a CircleCI Server customer**, then enter your self-hosted server URL.
 +
+.Log in to CircleCI from VS Code
 image::guides:ROOT:vs_code_extension_login.png[Log in to CircleCI from VS Code]
 
 [#set-up-your-project-in-vs-code]
@@ -43,10 +44,11 @@ image::guides:ROOT:vs_code_extension_login.png[Log in to CircleCI from VS Code]
 
 If your VS Code workspace contains one or more CircleCI projects, the extension will detect them automatically, and the pipelines panel will be populated with your most recent pipelines.
 
-If no project is detected, open the extension's settings page (either through the VS Code command `CircleCI: Open Settings`, or by clicking on the settings icon icon:settings[Settings icon] at the top of the pipelines panel), and select your projects manually. Only projects you follow are listed for selection.
+If no project is detected, open the extension settings page and select your projects manually. You can open it through the VS Code command `CircleCI: Open Settings`, or by clicking the settings icon icon:settings[Settings icon] at the top of the pipelines panel. Only projects you follow are listed.
 
-NOTE: **GitHub App and GitLab projects:** The pipelines manager does not yet support automatic detection for projects in a `circleci` type organization. Select your project manually from the settings page. For more information on organization types, see the xref:permissions-authentication:users-organizations-and-integrations-guide.adoc[Users, organizations, and integrations guide].
+NOTE: **GitHub App and GitLab projects:** The pipelines manager does not yet support automatic detection for projects in a `circleci` type organization. Select your project manually from the settings page. For more information on organization types, see the xref:permissions-authentication:users-organizations-and-integrations-guide.adoc[Users, Organizations, and Integrations Guide].
 
+.The Pipelines Panel
 image::guides:ROOT:vs_code_extension_pipelines_panel_zoomed.png[The pipelines panel displays pipelines you follow.]
 
 NOTE: Your manual selection will only persist if no projects are detected automatically.
@@ -73,10 +75,11 @@ You can configure specific workflow status changes you want to be notified for i
 [#configure-ssh-keys]
 == 6. Configure SSH keys
 
-The extension allows you to xref:execution-managed:ssh-access-jobs.adoc[rerun jobs with SSH] directly from within VS Code, either in the terminal or in a link:https://code.visualstudio.com/docs/remote/ssh[remote VS Code window].
+The extension allows you to xref:execution-managed:ssh-access-jobs.adoc[Rerun Jobs With SSH] directly from within VS Code, either in the terminal or in a link:https://code.visualstudio.com/docs/remote/ssh[remote VS Code window].
 
 The SSH functionality uses the same key that you use for your VCS. The easiest way to configure SSH keys for the extension is to try re-running a job with SSH, by clicking on the action icon next to the job.
 
+.Failed Job with Rerun With SSH
 image::guides:ROOT:vs_code_extension_rerun_job_ssh.png[Failed job with rerun with SSH icon]
 
 In the Command Palette, you will be asked to select whether you want to start an SSH session in the terminal or in a remote window. The extension will then try to find your key automatically. Follow the prompts to finish configuring your SSH key.
@@ -85,8 +88,9 @@ Alternatively, you can configure SSH keys for the extension manually through the
 
 To open an SSH session in a dedicated VS Code remote window, you need to install the link:https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-explorer[official Remote Explorer extension for VS Code].
 
-NOTE: **GitHub App and GitLab projects:** Re-run with SSH from VS Code is not yet available for projects in a `circleci` type organization. For more information on organization types, see the xref:permissions-authentication:users-organizations-and-integrations-guide.adoc[Users, organizations, and integrations guide].
+NOTE: **GitHub App and GitLab projects:** Re-run with SSH from VS Code is not yet available for projects in a `circleci` type organization. For more information on organization types, see the xref:permissions-authentication:users-organizations-and-integrations-guide.adoc[Users, Organizations, and Integrations Guide].
 
+.VS Code Remote Development Window
 image::guides:ROOT:vs_code_extension_ssh_remote_window.png[VS Code with remote development window]
 
 [#open-a-config-file-to-test-language-support-features]
@@ -96,16 +100,17 @@ The extension integrates a Language Server specific to CircleCI configuration fi
 
 . To verify that language support is working, open a `.yml` file in a `.circleci` directory.
 +
-Even without taking any further action, you should see:
+Even without taking any further action, you will see:
 
 * Syntax coloration is applied.
 * Red warnings appear if you introduce syntax errors.
 * You are able to use go-to-definition commands on the file.
 +
+.Go-to Definition in Config
 image::guides:ROOT:vs_code_extension_config_helper-overview-optimised.gif[Go-to definition in config]
 +
 TIP: If you do not see any syntax coloration, you might be using a VS Code theme that is not compatible with our syntax highlighting.
 
-. Open the "Problems" panel to access diagnostics. The panel lists warnings and issues detected by the extension.
+. Open the **Problems** panel to access diagnostics. The panel lists warnings and issues detected by the extension.
 
 TIP: If you do not see any of the above language support features, try running the command `CircleCI: Restart Language Server`.


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in \`docs/guides/modules/toolkit/pages/get-started-with-the-vs-code-extension.adoc\`.

## Errors Fixed
- **Lines 6, 17**: [circleci-docs.XrefTitleCase] - Capitalized single-word xref link texts
- **Line 19**: [Vale.Terms] - Capitalized 'CircleCI Server'
- **Line 24**: [circleci-docs.ThereIs] - Rephrased sentence starting with 'There are'
- **Line 33**: [circleci-docs.ListPunctuation] - Replaced quoted text with bold to fix list item ending
- **Line 35**: [circleci-docs.XrefTitleCase] - Capitalized 'Personal API Token'
- **Line 37**: [Vale.Terms] - Capitalized 'CircleCI Server' (two occurrences)
- **Lines 39, 50, 80, 90, 105**: [circleci-docs.ImageTitles] - Added descriptive titles before images
- **Line 46**: [circleci-docs.SentenceLength] - Split long sentence (>30 words) into shorter sentences
- **Lines 48, 88**: [circleci-docs.XrefTitleCase] - Capitalized 'Users, Organizations, and Integrations Guide'
- **Line 76**: [circleci-docs.XrefTitleCase] - Capitalized 'Rerun Jobs With SSH'
- **Line 99**: [circleci-docs.Avoid] - Replaced 'should' with 'will'
- **Line 109**: [circleci-docs.QuoteType] - Replaced inconsistent ASCII quotes with bold formatting

## Verification
Ran Vale after fixes - no errors remaining.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)