### PR TITLE
Reduce llms.txt size by removing unnecessary sections

### DIFF
--- a/extensions/llms-txt-generator-extension.js
+++ b/extensions/llms-txt-generator-extension.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const File = require('vinyl')
 
 /**
@@ -98,9 +96,7 @@ function generateLlmsTxt (playbook, contentCatalog) {
   // Site Information
   sections.push('## Site Information\n')
   sections.push(`- URL: ${siteUrl}`)
-  sections.push('- Repository: https://github.com/circleci/circleci-docs')
-  sections.push('- Generator: Antora (static site generator for technical documentation)')
-  sections.push('- Markup: AsciiDoc\n')
+  sections.push('- Repository: https://github.com/circleci/circleci-docs\n')
 
   // Markdown Exports
   sections.push('## Markdown Exports\n')
@@ -125,15 +121,18 @@ function generateLlmsTxt (playbook, contentCatalog) {
 
   const components = contentCatalog.getComponents()
 
-  const componentOrder = ['root', 'guides', 'reference', 'orbs', 'server-admin', 'services', 'contributors']
-  const sortedComponents = [...components].sort((a, b) => {
-    const indexA = componentOrder.indexOf(a.name)
-    const indexB = componentOrder.indexOf(b.name)
-    if (indexA === -1 && indexB === -1) return a.name.localeCompare(b.name)
-    if (indexA === -1) return 1
-    if (indexB === -1) return -1
-    return indexA - indexB
-  })
+  const componentOrder = ['root', 'guides', 'reference', 'orbs', 'server-admin']
+  const excludedComponents = ['services', 'contributors']
+  const sortedComponents = [...components]
+    .filter(c => !excludedComponents.includes(c.name))
+    .sort((a, b) => {
+      const indexA = componentOrder.indexOf(a.name)
+      const indexB = componentOrder.indexOf(b.name)
+      if (indexA === -1 && indexB === -1) return a.name.localeCompare(b.name)
+      if (indexA === -1) return 1
+      if (indexB === -1) return -1
+      return indexA - indexB
+    })
 
   for (const component of sortedComponents) {
     if (component.name === 'server-admin') {
@@ -175,25 +174,6 @@ function generateLlmsTxt (playbook, contentCatalog) {
       sections.push('')
     }
   }
-
-  // Content Statistics
-  sections.push('## Content Statistics\n')
-  const stats = calculateStatistics(contentCatalog)
-  sections.push(`- Total components: ${stats.componentCount}`)
-  sections.push(`- Total pages: ${stats.totalPages}`)
-  sections.push('\nPages by component:')
-  for (const [comp, count] of Object.entries(stats.pagesByComponent).sort((a, b) => b[1] - a[1])) {
-    sections.push(`  - ${comp}: ${count}`)
-  }
-  sections.push('')
-
-  // Technical Stack
-  sections.push('## Technical Stack\n')
-  const techStack = getTechnicalStack()
-  for (const [name, version] of Object.entries(techStack)) {
-    sections.push(`- ${name}: ${version}`)
-  }
-  sections.push('')
 
   // Platform Badges
   sections.push('## Platform Badges\n')
@@ -301,46 +281,6 @@ function getMarkdownUrl (pageUrl, siteUrl) {
   if (pageUrl.endsWith('/')) return siteUrl + pageUrl + 'index.md'
   if (pageUrl.endsWith('.html')) return siteUrl + pageUrl.replace(/\.html$/, '.md')
   return siteUrl + pageUrl + '.md'
-}
-
-function calculateStatistics (contentCatalog) {
-  const components = contentCatalog.getComponents()
-  const pagesByComponent = {}
-  let totalPages = 0
-
-  for (const component of components) {
-    for (const version of component.versions) {
-      const pages = contentCatalog.findBy({
-        component: component.name,
-        version: version.version,
-        family: 'page',
-      }).filter(page => page.pub)
-
-      const key = component.name === 'server-admin'
-        ? `${component.name} (${version.version})`
-        : (component.title || component.name)
-
-      pagesByComponent[key] = (pagesByComponent[key] || 0) + pages.length
-      totalPages += pages.length
-    }
-  }
-
-  return { componentCount: components.length, totalPages, pagesByComponent }
-}
-
-function getTechnicalStack () {
-  try {
-    const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
-    return {
-      'Static Site Generator': `Antora ${packageJson.devDependencies?.['@antora/cli']?.replace('^', '') || 'unknown'}`,
-      'Markup Language': 'AsciiDoc',
-      'API Docs': `Redocly CLI ${packageJson.devDependencies?.['@redocly/cli']?.replace('^', '') || 'unknown'}`,
-      'Search': 'Algolia',
-      'Build Tool': 'npm scripts with Gulp',
-    }
-  } catch {
-    return { 'Static Site Generator': 'Antora', 'Markup Language': 'AsciiDoc' }
-  }
 }
 
 function extractServerVersions (playbook) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Modified the llms.txt generator to exclude unnecessary sections and reduce the file size to under 100k characters.

## Changes made:
- Exclude `services` and `contributors` components from the generated output
- Remove the "Content Statistics" section that showed page counts per component
- Remove the "Technical Stack" section that detailed the site build tools
- Simplify the "Site Information" section to remove generator and markup references
- Remove unused helper functions (`calculateStatistics`, `getTechnicalStack`) and imports (`fs`, `path`)

# Reasons
The llms.txt file was exceeding 100k characters. According to DOC-204, the purpose of llms.txt is to guide AI agents to use CircleCI, not to document contributor guidelines or internal services. The removed sections were:
- **Contributors and Services components**: Purely for humans, not needed for AI agents learning to use CircleCI
- **Content Statistics**: Not necessary for AI agents to understand the documentation
- **Technical Stack**: Information about the docs site build process, not relevant for using CircleCI

# Content checks
This is a code change to the build system, not documentation content, so most content checks don't apply.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and check the generated `llms.txt` file to verify the size reduction.

Fixes DOC-204
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-204](https://linear.app/circleci/issue/DOC-204/split-llmstxt)

<div><a href="https://cursor.com/agents/bc-c134eb5a-99c9-447b-a2a2-a9ae2d24869f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c134eb5a-99c9-447b-a2a2-a9ae2d24869f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

