### PR TITLE
TEST-216 Update file-mapper docs

### DIFF
--- a/docs/guides/modules/test/pages/testsuite-configuration-reference.adoc
+++ b/docs/guides/modules/test/pages/testsuite-configuration-reference.adoc
@@ -213,7 +213,7 @@ src/quz_test.py
 |===
 --
 
-.Example of file-mapper using << outputs.go-list-json >>
+.Example of file-mapper using `<< outputs.go-list-json >>`
 [%linenums,yaml]
 ----
 ---
@@ -221,7 +221,7 @@ name: go tests
 file-mapper: go list -json="Dir,ImportPath,TestGoFiles,XTestGoFiles" ./... > << outputs.go-list-json >>
 ----
 
-.Example of file-mapper using << outputs.circleci-list >>
+.Example of file-mapper using `<< outputs.circleci-list >>`
 [%linenums,yaml]
 ----
 ---

--- a/docs/guides/modules/test/pages/testsuite-configuration-reference.adoc
+++ b/docs/guides/modules/test/pages/testsuite-configuration-reference.adoc
@@ -135,20 +135,70 @@ run: go tool gotestsum --junitfile="<< outputs.junit >>" -- -race -count=1 << te
 [#file-mapper]
 == *`file-mapper`*
 
-When test atoms are not files, Smarter Testing cannot determine which test files belong to which test atom. The `file-mapper` creates a mapping of test atoms to related test files.
+When test atoms are not files, Smarter Testing cannot determine which test files belong to which test atom. The `file-mapper` command creates a mapping of test atoms to related test files.
 
 * During analysis, Smarter Testing can associate test files with their test atoms in impact data.
 * During selection, Smarter Testing can determine which test atom to run when a test file is modified.
 
-The test atom to map can be specified in one of two ways:
+File mapper maps all test atoms to test files in a single pass.
+
+The test atoms to map can be specified in one of two ways:
 
 * Use the template variable `<< test.atoms >>` in the `file-mapper` command.
-* If the template variable is not found in the `file-mapper` command, the test atom will be passed on stdin.
+* If the template variable is not found in the `file-mapper` command, the test atoms will be passed on stdin separated by newlines.
 
-File mapper can run in two modes:
+File mapper supports two different output formats:
 
-* *One test atom at a time.* This mode expects a list of files back for a passed in `<< test.atom >>`.
-* *All test atoms in a single pass.* This mode supports `<< outputs.go-list-json >>` to map all go test files to go packages.
+* *Go list JSON format* `<< outputs.go-list-json >>`.
+* *CircleCI list format* `<< outputs.circleci-list >>`.
+
+=== *Go list JSON format*
+
+Go list JSON format is the format produced by `go list -json="Dir,ImportPath,TestGoFiles,XTestGoFiles" ./\...`.
+
+It consists of one or more JSON documents separated by newlines. Note that each record is a separate JSON document.
+
+.Example showing Go list JSON format
+[source,json]
+----
+{
+	"Dir": "/home/user/dev/module-name/internal/foo",
+	"ImportPath": "github.com/org/module-name/internal/foo",
+	"TestGoFiles": [
+		"foo_test.go"
+	]
+}
+{
+	"Dir": "/home/user/dev/module-name/internal/bar",
+	"ImportPath": "github.com/org/module-name/internal/bar",
+	"XTestGoFiles": [
+		"bar_test.go",
+		"baz_test.go",
+		"shared_test.go"
+	]
+}
+----
+
+=== *CircleCI list format*
+
+CircleCI list format is a plain text, record oriented format. It consists of one or more records separated by newlines.
+
+Each record begins with a line starting with `TA:`, followed by the test atom name.
+
+Each subsequent line lists a file that contains code for the test atom.
+
+Each line must be fewer than 32,768 characters long.
+
+.Example showing CircleCI list format
+[source]
+----
+TA:TestFooClass
+src/foo_test.py
+src/bar_test.py
+
+TA:TestQuzClass
+src/quz_test.py
+----
 
 [.table-scroll]
 --
@@ -163,13 +213,20 @@ File mapper can run in two modes:
 |===
 --
 
-*Example:*
-
+.Example of file-mapper using << outputs.go-list-json >>
 [%linenums,yaml]
 ----
 ---
 name: go tests
 file-mapper: go list -json="Dir,ImportPath,TestGoFiles,XTestGoFiles" ./... > << outputs.go-list-json >>
+----
+
+.Example of file-mapper using << outputs.circleci-list >>
+[%linenums,yaml]
+----
+---
+name: python tests
+file-mapper: for _atom in << test.atoms >>; do echo "TA:${_atom}"; echo "${_atom}" | sed -E 's/::.*$//'; done > << outputs.circleci-list >>
 ----
 
 '''

--- a/styles/config/vocabularies/Docs/accept.txt
+++ b/styles/config/vocabularies/Docs/accept.txt
@@ -205,6 +205,7 @@ Jenkins
 JFrog
 Jira
 jq\b
+JSON
 \bJUnit\b
 junit
 JRuby


### PR DESCRIPTION
Changes:
* Running file-mapper for individual test atoms is no longer supported.
* Document the two available formats for file-mapper output.


**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
    - Vale complains about use of the word `JSON` in a heading not being sentence case but there's not much I can do about that.

[Preview](https://output.circle-artifacts.com/output/job/b83ed982-4048-4a38-a977-bd2e9af80270/artifacts/0/build/guides/test/testsuite-configuration-reference/index.html)