### PR TITLE
remove test splitting tutorial from redirects

### DIFF
--- a/scripts/redirects_v2.yml
+++ b/scripts/redirects_v2.yml
@@ -1283,9 +1283,6 @@
 - old: /test-config-policies/
   new: /guides/config-policies/test-config-policies/
 
-- old: /test-splitting-tutorial/
-  new: /guides/test/test-splitting-tutorial/
-
 - old: /testing-ios/
   new: /guides/test/testing-ios/
 


### PR DESCRIPTION
The page is archived for now. Remove from redirects list.