### PR TITLE
Fix Vale errors in create-and-manage-config-policies.adoc

### DIFF
--- a/docs/guides/modules/config-policies/pages/create-and-manage-config-policies.adoc
+++ b/docs/guides/modules/config-policies/pages/create-and-manage-config-policies.adoc
@@ -3,12 +3,12 @@
 :page-description: Learn how to write and manage config policies for CircleCI project configurations.
 :experimental:
 
-NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI server v4.2. You must be an organization admin in order to create and manage config policies.
+NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI Server v4.2. You must be an organization admin in order to create and manage config policies.
 
 Follow the how-to guides on this page to manage, create, and use config policies.
 
 ****
-**Using server?** When using the `circleci policy` commands with CircleCI server, you will need to use the `policy-base-url` flag to provide your CircleCI server domain. For example:
+**Using server?** When using the `circleci policy` commands with CircleCI Server, you will need to use the `policy-base-url` flag to provide your CircleCI Server domain. For example:
 [source,shell]
 ----
 circleci policy settings --enabled=true --owner-id <your-organization-ID> --policy-base-url <your-circleci-server-domain>
@@ -57,11 +57,11 @@ include::ROOT:partial$notes/find-organization-id.adoc[]
 [#manage-policies-with-your-vcs]
 == Manage policies with your VCS
 
-CircleCI policies are managed by pushing directories of policies to CircleCI via the CLI. There are various ways to manage your policies but here is a list of recommended best practices:
+CircleCI policies are managed by pushing directories of policies to CircleCI via the CLI. The following lists recommended best practices for managing your policies:
 
 * Store your policies in a repository in your VCS, within your organization. This is how policies are managed internally at CircleCI. Pushing a policy bundle is done by triggering a CircleCI pipeline.
 
-* Create a bot account for pushing policies, and use its associated CircleCI personal API token for authentication. For maximum security the token should be stored as an environment variable within a context, and that context should be restricted to groups that are responsible for managing policies. For more information, see the xref:security:contexts.adoc[Using Contexts] page.
+* Create a bot account for pushing policies, and use its associated CircleCI personal API token for authentication. For maximum security, store the token as an environment variable within a context, and restrict that context to groups that are responsible for managing policies. For more information, see the xref:security:contexts.adoc[Using Contexts] page.
 
 The rest of the steps in this section show how to set up a CI/CD pipeline to manage your policies.
 
@@ -70,15 +70,15 @@ The rest of the steps in this section show how to set up a CI/CD pipeline to man
 
 For the config policies pipeline recommended in this guide you will need to securely manage some environment variables:
 
-* `CIRCLECI_CLI_TOKEN` with the value of a personal API token to authenticate the CLI
-* `ORG_ID` with the value of the organization ID
+* `CIRCLECI_CLI_TOKEN` with the value of a personal API token to authenticate the CLI.
+* `ORG_ID` with the value of the organization ID.
 
-You can do this using a context. For more information about setting up and using contexts to securely manage environment variables see the xref:security:contexts.adoc[Using contexts] page. You might already have a context set up for this or you might want to create a new one. For this example the context name `my-context` is used.
+You can do this using a context. For more information about setting up and using contexts to securely manage environment variables see the xref:security:contexts.adoc[Using Contexts] page. You might already have a context set up for this or you might want to create a new one. For this example the context name `my-context` is used.
 
 . In the CircleCI web app, select **Organization settings > Contexts**.
 . Select **Create Context** and enter a name for your context, for example `my-context`.
 . Select your new context name in the list to access options.
-. Select **Add Environment Variable** and enter `CIRCLECI_CLI_TOKEN` for the environment variable name, and your personal API token string for the value (For more information about this see the xref:toolkit:local-cli.adoc#configure-the-cli[Installing the CircleCI local CLI] page). Then click **Add Environment Variable** again to complete.
+. Select **Add Environment Variable** and enter `CIRCLECI_CLI_TOKEN` for the environment variable name, and your personal API token string for the value (For more information about this see the xref:toolkit:local-cli.adoc#configure-the-cli[Installing the CircleCI Local CLI] page). Then click **Add Environment Variable** again to complete.
 . Select **Add Environment Variable** and enter `ORG_ID` for the environment variable name, and your organization ID for the value.
 +
 include::ROOT:partial$notes/find-organization-id.adoc[]
@@ -140,7 +140,7 @@ jobs:
           command: circleci policy push ./config-policies --no-prompt --owner-id $ORG_ID # push the policy bundle to CircleCI
 ----
 +
-Your file structure should now look something like:
+Your file structure will now look something like:
 +
 [source,shell]
 ----
@@ -154,8 +154,8 @@ Your file structure should now look something like:
 ****
 The context for each job is shown as `my-context`. This context name is arbitrary, but it must be active and declare the following environment variables:
 
-* `CIRCLECI_CLI_TOKEN` with the value of a personal API token to authenticate the CLI
-* `ORG_ID` with the value of the organization ID
+* `CIRCLECI_CLI_TOKEN` with the value of a personal API token to authenticate the CLI.
+* `ORG_ID` with the value of the organization ID.
 
 For setup steps see the <<prerequisites>> on this page.
 ****
@@ -213,7 +213,7 @@ check_version = reason {
 
 You can now push your new policy to your organization for it to take effect. You have two options:
 
-* Push the policy manually using the CLI from your local environment
+* Push the policy manually using the CLI from your local environment.
 * Push your changes to your config policy repository if you are managing policies via your VCS as shown <<manage-policies-with-your-vcs,above>>.
 
 [tabs]
@@ -240,9 +240,9 @@ If the upload was successful, you will see something like the following:
 Push to VCS::
 +
 --
-If you have set up your config policies with the sample configuration shown <<manage-policies-with-your-vcs,above>>, push your changes to the `main` branch of your config policies repository, and head to the CircleCI web app to see your policy pipeline run.
+Set up your config policies using the sample configuration shown <<manage-policies-with-your-vcs,above>>. Push your changes to the `main` branch of your config policies repository. The CircleCI web app will then show your policy pipeline running.
 
-You can also push to a development branch, in which case you will get a diff of your policy bundle when you push your changes, rather than your new policy being pushed to your CircleCI organization. This is useful when developing your policies.
+You can also push to a development branch. Doing this gives you a diff of your policy bundle rather than pushing the new policy to your CircleCI organization. Pushing to a development branch is useful during policy development.
 --
 ====
 
@@ -286,16 +286,16 @@ If the upload was successful, you will see something like the following:
 }
 ----
 --
-Push to vcs::
+Push to VCS::
 +
 --
-Push your changes to the `main` branch of your config policies repository, and head to the CircleCI web app to see your policy pipeline run.
+Push your changes to the `main` branch of your config policies repository. The CircleCI web app will then show your policy pipeline running.
 
-You can also push to a development branch, in which case you will get a diff of your policy bundle when you push your changes, rather than your new policy being pushed to your CircleCI organization. This is useful when developing your policies.
+You can also push to a development branch. Doing this gives you a diff of your policy bundle rather than pushing the new policy to your CircleCI organization. Pushing to a development branch is useful during policy development.
 --
 ====
 
 [#next-steps]
 == Next steps
 
-If you would like to write tests for your policy, check out the xref:test-config-policies.adoc[Test config policies] guide.
+If you would like to write tests for your policy, check out the xref:test-config-policies.adoc[Test Config Policies] guide.


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in `docs/guides/modules/config-policies/pages/create-and-manage-config-policies.adoc`.

## Errors Fixed
- **Lines 6, 11**: `Vale.Terms` - Corrected 'CircleCI server' to 'CircleCI Server'
- **Line 60**: `circleci-docs.ThereIs` - Removed 'There are' sentence starter
- **Line 64**: `circleci-docs.Avoid` - Replaced 'should' passive constructions with active language
- **Lines 73-74, 157-158, 216**: `circleci-docs.ListPunctuation` - Added missing periods to list items
- **Lines 76, 81, 301**: `circleci-docs.XrefTitleCase` - Updated xref link text to title case
- **Line 143**: `circleci-docs.Avoid` - Replaced 'should' with definitive language
- **Lines 243, 245, 294**: `circleci-docs.SentenceLength` + `circleci-docs.UnclearAntecedent` - Shortened sentences and replaced vague 'This is' with explicit subjects
- **Line 289**: `Vale.Terms` - Fixed 'vcs' to 'VCS'

## Verification
Vale reports no errors remaining after fixes.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review
- Changes preserve existing AsciiDoc structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)