### PR TITLE
Fix Vale errors in test-config-policies.adoc

### DIFF
--- a/docs/guides/modules/config-policies/pages/test-config-policies.adoc
+++ b/docs/guides/modules/config-policies/pages/test-config-policies.adoc
@@ -445,7 +445,7 @@ It is best-practice to use a file structure that allows you to write stable test
 │   │   ├── policy2_test.yaml
 ----
 
-Run tests against the entire production policy bundle, and also write stable tests against individual policies. Isolate each policy in its own subdirectory with its tests; each subdirectory will then run with a sub-bundle and its defined tests.
+Run tests against the entire production policy bundle, and also write stable tests against individual policies. Isolate each policy in its own subdirectory with its tests. Each subdirectory will then run with a sub-bundle and its defined tests.
 
 . Update the file structure:
 +

--- a/docs/guides/modules/config-policies/pages/test-config-policies.adoc
+++ b/docs/guides/modules/config-policies/pages/test-config-policies.adoc
@@ -3,27 +3,27 @@
 :page-description: Open preview of config policies for CircleCI. Learn about testing your policies.
 :experimental:
 
-NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI server v4.2.
+NOTE: The config policies feature is available on the **Scale** Plan and from CircleCI Server v4.2.
 
 Follow the how-to guides on this page to write and set up tests for your config policies.
 
 ****
-**Using server?** When using the `circleci policy` commands with CircleCI server, you will need to use the `policy-base-url` flag to provide your CircleCI server domain. For example:
+**Using server?** When using the `circleci policy` commands with CircleCI Server, you will need to use the `policy-base-url` flag to provide your CircleCI Server domain. For example:
 [source,shell]
 ----
 circleci policy test ./config-policies --policy-base-url <your-circleci-server-domain>
 ----
 ****
 
-This guide assumes you are familiar with writing config policies. If you would like more information on configuration policies, or the process of creating policies, see the xref:config-policy-management-overview.adoc[Config policies overview] and xref:create-and-manage-config-policies.adoc[Create and manage config policies] pages.
+This guide assumes you are familiar with writing config policies. If you would like more information on configuration policies, or the process of creating policies, see the xref:config-policy-management-overview.adoc[Config Policies Overview] and xref:create-and-manage-config-policies.adoc[Create and Manage Config Policies] pages.
 
 [#prerequisites]
 == Prerequisites
 
-The instructions on this page assume you have followed and completed the xref:create-and-manage-config-policies.adoc#create-a-policy[Create a policy] guide, through which you will have done the following:
+The instructions on this page assume you have followed and completed the xref:create-and-manage-config-policies.adoc#create-a-policy[Create a Policy] guide, through which you will have done the following:
 
-* Enabled config policies for your organization
-* Created a simple policy to check CircleCI config versions within your org. You will have the following file structure: `./config-policies/version.rego`
+* Enabled config policies for your organization.
+* Created a simple policy to check CircleCI config versions within your org. You will have the following file structure: `./config-policies/version.rego`.
 
 [#write-a-policy-test]
 == Write a policy test
@@ -243,7 +243,7 @@ Expected output:
 
 [#add-another-policy-and-test]
 == Add another policy and test
-Next, add a second policy and test to your `config-policies` directory. The steps below show how to add a policy that specifies the minimum Docker version for xref:execution-managed:building-docker-images.adoc[remote Docker], writing tests for that policy, and running those tests.
+Next, add a second policy and test to your `config-policies` directory. The steps below show how to add a policy that specifies the minimum Docker version for xref:execution-managed:building-docker-images.adoc[Remote Docker], writing tests for that policy, and running those tests.
 
 . Inside your `config-policies` directory, create a Rego file for a new policy, call it: `docker.rego`.
 . Copy the following policy definition into `docker.rego`:
@@ -445,7 +445,7 @@ It is best-practice to use a file structure that allows you to write stable test
 │   │   ├── policy2_test.yaml
 ----
 
-It is a good idea to have tests that run against the entire bundle that will be active in production, but we also want to be able to write stable tests against an individual policy. This is achieved by isolating each policy in its own subdirectory with its tests. This way each subdirectory will run with a sub-bundle and the tests defined within it.
+Run tests against the entire production policy bundle, and also write stable tests against individual policies. Isolate each policy in its own subdirectory with its tests; each subdirectory will then run with a sub-bundle and its defined tests.
 
 . Update the file structure:
 +
@@ -479,7 +479,7 @@ ok    config-policies/version    0.000s
 ----
 
 . To build more confidence, best practice is to create a top level test that will use the entire policy bundle, similar to an integration or end-to-end test.
-. Create a new test file: `./config-policies/policy_test.yaml`
+. Create a new test file: `./config-policies/policy_test.yaml`.
 . Copy the following into your `policy_test.yaml` file:
 +
 [source,yaml]
@@ -628,7 +628,7 @@ NOTE: Modifying the version policy will also affect the top level tests, so the 
 [#opa-tests]
 == OPA tests
 
-OPA also has a way of specifying tests directly within a rego document. Read more about it in the link:https://www.openpolicyagent.org/docs/latest/policy-testing/[OPA docs].
+OPA also has a way of specifying tests directly within a Rego document. Read more about it in the link:https://www.openpolicyagent.org/docs/latest/policy-testing/[OPA docs].
 
 OPA evaluates rules that start with `test_` and expects the output to be truthy. The `circleci policy test` command runs the OPA tests and reports them as `<opa.tests>`.
 
@@ -699,7 +699,7 @@ ok    <opa.tests>         0.001s
 3/3 tests passed (0.001s)
 ----
 
-. Run in verbose mode to see the OPA tests that were run by name:
+. Run in verbose mode to see the OPA tests that ran by name:
 +
 [source,shell]
 ----


### PR DESCRIPTION
## Summary
This PR fixes Vale error-level issues in `docs/guides/modules/config-policies/pages/test-config-policies.adoc`.

## Errors Fixed
- **Lines 6, 11**: `Vale.Terms` - Corrected 'CircleCI server' to 'CircleCI Server'
- **Lines 18, 23, 246**: `circleci-docs.XrefTitleCase` - Updated xref link text to title case
- **Lines 25-26, 482**: `circleci-docs.ListPunctuation` - Added missing periods to list items
- **Line 448**: `circleci-docs.SentenceLength` + `circleci-docs.UnclearAntecedent` - Shortened sentence and replaced vague 'This is achieved' antecedent with explicit subject
- **Line 631**: `Vale.Terms` - Fixed 'rego' to 'Rego'
- **Line 702**: `circleci-docs.Avoid` - Replaced passive 'were run' with active 'ran'

## Verification
Vale reports no errors remaining after fixes.

## Notes
- Only error-level issues were addressed
- Warnings and suggestions were left for human review
- Changes preserve existing AsciiDoc structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)