### PR TITLE
Fix page-description attribute not rendering as meta description

### DIFF
--- a/ui/src/partials/head-info.hbs
+++ b/ui/src/partials/head-info.hbs
@@ -11,7 +11,7 @@
     <link rel="next" href="{{{relativize ./url}}}">
     {{/with}}
     {{/unless}}
-    {{#with page.description}}
+    {{#with (or page.description page.attributes.description)}}
     <meta name="description" content="{{{detag this}}}">
     {{/with}}
     {{#with page.keywords}}


### PR DESCRIPTION
## Summary

- Pages set `:page-description:` but the `head-info.hbs` template was checking `page.description`, which Antora only populates from the bare `:description:` attribute — so the `<meta name="description">` tag was never emitted
- Root cause: Antora strips the `page-` prefix when building `page.attributes`, so `:page-description:` is stored as `page.attributes.description`, not `page.description`
- Updated the template to check `(or page.description page.attributes.description)` so it works with both the Antora-conventional `page-description` attribute our pages use and the bare `:description:` attribute

## Test plan

- [x] Rebuilt site locally and confirmed pages with `:page-description:` set now have `<meta name="description" content="...">` in their `<head>`
- [ ] Confirm pages without `:page-description:` still render without a description tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)