### PR TITLE
chore: replace go/install orb step with circleci/setup-go function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
             - ui/node_modules
       - run:
           name: Install Go
-          command: circleci run circleci/setup-go@0.0.5-bf6c59b -- --version 1.25.0 --go-cache-checksum '{{ checksum "go.sum" }}'
+          command: circleci run circleci/setup-go@0.0.6-2f4558a -- --version 1.25.0 --go-cache-checksum '{{ checksum "go.sum" }}'
       - run:
           name: Verify Go Installation
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,8 +140,9 @@ jobs:
           paths:
             - ui-bundle.zip
             - ui/node_modules
-      - go/install:
-          version: "1.25.0"
+      - run:
+          name: Install Go
+          command: circleci run circleci/setup-go@0.0.5-bf6c59b -- --version 1.25.0 --go-cache-checksum '{{ checksum "go.sum" }}'
       - run:
           name: Verify Go Installation
           command: |


### PR DESCRIPTION
## Context

We're in the middle of reworking how CircleCI orbs handle shared functionality — moving the logic out of shell-in-YAML and into compiled Go binaries we're calling [Functions](https://docs.google.com/document/d/1aTNdh26RtoICdyJ_9ECac8PGvx3eW3lfAiFutF16Ado). As part of that, we're migrating our own repos off the `circleci/go` orb's `go/install` step in favor of the new `setup-go` function ([PIE-86](https://linear.app/circleci/issue/PIE-86), [README](https://github.com/circleci/functions/blob/main/cmd/setup-go/README.md)). No public docs yet — we're dogfooding it across internal repos first before any wider rollout. This is a drop-in replacement — same behavior, CI passes on this branch.

## Summary

- Replaces `go/install: version: "1.25.0"` with `circleci run circleci/setup-go@0.0.6-2f4558a`
- Orb declaration kept — still used for `go/with-cache`

## Test plan

- [x] CI passed on `pie-86/setup-go` branch