### PR TITLE
fix: prevent page badge from wrapping on multi-line titles

### DIFF
--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -1552,6 +1552,7 @@
 .platform-badge {
   position: relative;
   cursor: default;
+  flex-shrink: 0;
 }
 
 /* Light mode tooltip - dark background with white text */

--- a/ui/src/partials/article.hbs
+++ b/ui/src/partials/article.hbs
@@ -3,7 +3,7 @@
 <h1 class="page flex items-center gap-2">
 {{{this}}}
 {{#if @root.page.attributes.badge}}
-  <span class="text-[10px] rounded-full py-1 px-1.5 {{#if @root.page.attributes.badge-classes}}{{@root.page.attributes.badge-classes}}{{else}}text-terminal-black border{{/if}}" {{#if @root.page.attributes.badge-bg}}style="font-family: 'Roboto', sans-serif; font-weight: 700; background-color: {{@root.page.attributes.badge-bg}}; {{#if @root.page.attributes.badge-border}}border: 1px solid {{@root.page.attributes.badge-border}};{{/if}}"{{else}}style="font-family: 'Roboto', sans-serif; font-weight: 700;"{{/if}}>{{@root.page.attributes.badge}}</span>
+  <span class="text-[10px] rounded-full py-1 px-1.5 shrink-0 whitespace-nowrap {{#if @root.page.attributes.badge-classes}}{{@root.page.attributes.badge-classes}}{{else}}text-terminal-black border{{/if}}" {{#if @root.page.attributes.badge-bg}}style="font-family: 'Roboto', sans-serif; font-weight: 700; background-color: {{@root.page.attributes.badge-bg}}; {{#if @root.page.attributes.badge-border}}border: 1px solid {{@root.page.attributes.badge-border}};{{/if}}"{{else}}style="font-family: 'Roboto', sans-serif; font-weight: 700;"{{/if}}>{{@root.page.attributes.badge}}</span>
 {{/if}}
 </h1>
 {{/with}}


### PR DESCRIPTION
## Summary

- Adds `shrink-0 whitespace-nowrap` to the badge `<span>` in `article.hbs` so the badge text never wraps regardless of title length
- Adds `flex-shrink: 0` to `.platform-badge` in `doc.css` for the same reason on platform badges

## Test plan

- [ ] Load a page with a badge whose title wraps to two lines (e.g. the PyPI trusted publishing guide) and confirm the badge stays on one line with correct size and text

🤖 Generated with [Claude Code](https://claude.com/claude-code)