### PR TITLE
DOC-211: Refactor UI root font-size to 16px and align header/nav/TOC to the redesign

### DIFF
--- a/planning/16px-root-refactor-review-checklist.md
+++ b/planning/16px-root-refactor-review-checklist.md
@@ -1,0 +1,91 @@
+# 16px root refactor — region-by-region review checklist
+
+**What changed:** root font-size 18px→16px (desktop), 17px→16px (mobile).
+**Effect:** every `rem`-based value scaled ×0.889 (desktop) / ×0.941 (mobile). Pinned
+`px` (`text-[16px]`, `w-[13px]`, `px-[32px]`…), keyword sizes (`large`/`medium`), and
+`em` values (relative to parent) are UNCHANGED. `calc(N/--rem-base*1rem)` dims keep
+exact px (navbar, nav/TOC width, doc max-width).
+
+**How to read this:** all-rem spacing scaled uniformly, so proportions are preserved —
+low risk. Focus on ⚠️ = a rem value sitting next to a pinned-px value, where the
+*relationship* shifted. px shown as old→new (desktop).
+
+---
+
+## 1. Left-side nav  (`left-side-nav.hbs`, `navigation-tree.hbs`)
+- [ ] Link text stays 16px (`text-[16px]`) — confirm unchanged
+- [ ] Row vertical padding `py-[8px]` — pinned px, unchanged
+- [ ] `space-x-2` gap toggle↔text: 9→8  ⚠️ sits next to `w-[6px]` chevron (px, unchanged)
+- [ ] `my-1` row gap: 4.5→4 · `p-1` toggle button: 4.5→4
+- [ ] `gap-1.5` link↔badge: 6.75→6 · badge `py-0.5 px-1.5`: 2.25→2 / 6.75→6
+- [ ] Child indent `pl-6`: 27→24 · `pr-2`: 9→8
+- [ ] `-ml-[1.3rem]` chevron offset: 23.4→20.8  ⚠️ chevron alignment vs text
+- [ ] Active-item `rounded-lg bg-fog` pill — check padding still wraps text cleanly
+
+## 2. Right-hand TOC  (`toc.css`)
+- [ ] Top-level `font-size: large`, sub `medium` — keywords, unchanged
+- [ ] Heading font `calc(15/16*1rem)` = 15px — preserved
+- [ ] Header row `height: 2.5rem`: 45→40  ⚠️ contains a fixed-size icon
+- [ ] `margin-top: -2.1rem`: 37.8→33.6 (negative pull-up — check it still aligns)
+- [ ] `margin-right: 0.75rem`: 13.5→12 · `margin-bottom: 1.2rem/1.25rem`: 21.6→19.2 / 22.5→20
+- [ ] Indent levels `padding-left` 1.25/2/2.75/3.5rem: 22.5→20 / 36→32 / 49.5→44 / 63→56
+- [ ] Item `padding: 0.6rem 0 0.6rem 0.8rem`: 10.8→9.6 / 14.4→12.8
+
+## 3. Tabs  (`tabs.css`)
+- [ ] Tab list `margin-bottom: 1.25rem`: 22.5→20
+- [ ] Tab `padding: 1rem 1px`: 18→16 vertical  ⚠️ 1px horizontal is pinned — vertical/horizontal ratio moved
+- [ ] Tab `margin-right: 1.5rem` / `margin: 0 1.5rem 0 0`: 27→24 (spacing between tabs)
+- [ ] Panel `padding: calc(40/16*1rem) 0 calc(20/16*1rem)`: stays 40/20px — preserved
+- [ ] Panel `margin-bottom: 1.25rem`: 22.5→20
+
+## 4. Page-navigation container  (`body.css`, ≥1200px)
+- [ ] aside `padding-top: 2.5rem`: 45→40 · `padding-bottom: 3rem`: 54→48
+
+## 5. Main layout / columns  (`main.css`)
+- [ ] Content `margin-top/bottom: 2.5rem`: 45→40
+- [ ] `width: calc(100% - var(--toc-width) - 5rem)`: the 5rem gutter 90→80  ⚠️ toc-width is
+      preserved px but the 5rem subtraction shrank — verify article/TOC column split at 1200px & 1600px
+- [ ] Comment at main.css:63 still says "5rem = ml-12 (3rem) + ~2rem gap" — that math
+      now resolves to 80px not 90px; sanity-check the toolbar left margin still lines up
+
+## 6. Article body  (`doc.css` `.doc`)
+- [ ] Article font-size 16px, headings (32/24/20/18/16px) — pinned, unchanged
+- [ ] `.doc padding: 0 1rem 4rem`: sides 18→16, bottom 72→64
+- [ ] Heading `gap: 0.5rem` (badge alignment): 9→8  ⚠️ badges often pinned px
+- [ ] Section spacing `margin-top` 1rem/2rem: 18→16 / 36→32
+- [ ] Inline SVG icons `w-5 h-5`: 22.5→20 · `w-4 h-4`: 18→16 · `w-7 h-7`: 31.5→28
+- [ ] Any `text-sm`: 15.75→14
+
+## 7. Admonitions (note/tip/warning)  (`doc.css` ~410, ~553–571)
+- [ ] Box `padding: 1rem`: 18→16 · outer `margin: 1.5rem …`: 27→24
+- [ ] Icon↔text `gap: 1rem`: 18→16  ⚠️ icon may be pinned px — check icon/text gap
+- [ ] Border/pointer `border-width: 0.5rem 0.3rem 0`: 9→8 / 5.4→4.8
+
+## 8. Code blocks  (`doc.css` ~973–998, ~1110)
+- [ ] `border-radius: 0.5rem`: 9→8
+- [ ] `padding: 0.75rem` / `1rem` / `1rem 1rem 0.75rem`: 13.5→12 / 18→16
+- [ ] Copy-button `top/right: 0.5rem`: 9→8  ⚠️ button itself likely pinned px — check inset
+- [ ] Code font-size `calc(13/16*1rem)` etc. = 13 / 13.5 / 12px — preserved
+- [ ] `code/kbd/pre` base `font-size: 16px` (base.css) — pinned, unchanged
+
+## 9. Tables  (`doc.css` ~734–768)
+- [ ] Cell `padding: 0.25rem 2rem 1.25rem`: 4.5→4 / 36→32 / 22.5→20
+- [ ] `padding: 1rem 2rem`: 18→16 / 36→32
+- [ ] Wide-table horizontal scroll container still clips correctly (layout unchanged)
+
+## 10. Footer  (`footer.hbs`)
+- [ ] Named-scale utilities (gap-*, py-*, space-*) shrink ×0.889; pinned `px-[32px]`,
+      `w-[1440px]` etc. unchanged — check column gaps & link spacing balance
+- [ ] Social-icon row gaps vs pinned icon sizes  ⚠️
+
+---
+
+## Cross-cutting checks
+- [ ] Mobile (<768px): everything scaled ×0.941 not ×0.889, and the old "17px-root
+      quirk" is fixed — spacings that were ~5.5% small are now correct. Compare mobile
+      vs desktop feels consistent.
+- [ ] Browser zoom / larger default font: root is now `100%` (was `em`), still scales
+      with user preference — bump browser font size and confirm layout scales.
+- [ ] Print stylesheet unchanged (root still 15px in print) — spot-check a print preview.
+- [ ] No horizontal scroll on body at any breakpoint (the `min-width:0` / `width:100%`
+      flex guards in doc.css are unaffected but worth a glance).

--- a/planning/rem-base-to-tailwind-theme-migration-plan.md
+++ b/planning/rem-base-to-tailwind-theme-migration-plan.md
@@ -1,0 +1,91 @@
+# Plan: retire `--rem-base` by migrating structural dimensions to the Tailwind v4 theme (Option C)
+
+## Is this the right option?
+
+**It's the idiomatic end-state, but it's a discretionary refactor, not a bug fix.** After the 16px-root work, the `--rem-base` calc layer is *correct* — it just duplicates a system Tailwind already provides. So this is worth doing **if** the team wants to standardise sizing on Tailwind v4 tokens (one source of truth, self-documenting utilities, no bespoke px→rem math). If you only want to remove the footgun cheaply, **Option A** (inline the calcs to plain rem literals and delete `--rem-base`) gets ~80% of the benefit for ~20% of the effort. This plan is the full Option C.
+
+**Do it as its own PR**, after/independent of the font-size branch — it's a pure refactor with a "renders pixel-identical" acceptance bar, so it should be reviewable on its own.
+
+## Why (recap)
+
+`ui/` runs **Tailwind v4** (`tailwindcss@^4.1.4`, `@tailwindcss/postcss`), which is CSS-first: a `@theme {}` block in `src/css/site.css` generates **both** utility classes **and** `:root` CSS variables. There is already a `@theme` block there mapping colours + `--breakpoint-lg`.
+
+The bespoke layer we want to remove:
+- `--rem-base: 16` plus ~22 `calc(N / var(--rem-base) * 1rem)` sites.
+- The problems (see the branch discussion): a hidden invariant that `--rem-base` must mirror the root font-size (the exact trap that caused the original 17/18px bug), redundant indirection now that root = rem-base = 16, and a second sizing system running parallel to Tailwind's.
+
+## Current state — inventory
+
+### A. Structural dimension vars in `vars.css` (token candidates)
+| Var | Value | px | Consumers |
+|---|---|---|---|
+| `--navbar-height` | `calc(63 / rem-base * 1rem)` | 63 | vestigial (feeds only dead vars) |
+| `--toolbar-height` | `calc(45 / rem-base * 1rem)` | 45 | vestigial (feeds only dead vars) |
+| `--header-height` | `9.5rem` | 152 | body.css ×2, doc.css ×1, vars.css ×1 |
+| `--nav-width` | `calc(270 / rem-base * 1rem)` | 270 | none found (semi-dead) |
+| `--toc-width` | `calc(265 / rem-base * 1rem)` | 265 | main.css ×3, doc.css ×1 |
+| `--toc-width--widescreen` | `calc(474 / rem-base * 1rem)` | 474 | main.css ×3, doc.css ×1 |
+| `--doc-max-width` | `calc(720 / rem-base * 1rem)` | 720 | none found (semi-dead) |
+| `--doc-max-width--desktop` | `calc(888 / rem-base * 1rem)` | 888 | doc.css ×4, main.css ×2, article-toolbar.hbs ×1 |
+
+### B. One-off `calc(N / rem-base * 1rem)` values (not reusable tokens)
+- `doc.css`: font-sizes 18, 22.5, 13, 13.5, 12, 15 px; margins 40 (×3), 32, 20 px.
+- `toc.css`: font-size 15px.
+- `tabs.css`: padding 40px / 20px.
+
+These are specific values, not a shared scale — they should become **plain rem/px** (or Tailwind utilities where the element lives in a template), *not* new tokens, unless a coherent type scale emerges (see Phase 3).
+
+### C. Already-dead vars (defined, zero consumers) — clean up while here
+`--body-top`, `--body-min-height`, `--nav-height`, `--nav-height--desktop`, `--drawer-height`, `--nav-panel-menu-height`, `--nav-panel-explore-height`. These currently keep `--navbar-height`/`--toolbar-height` "alive." Removing them lets those two go too.
+
+## Target state
+
+Define the reusable dimensions as Tailwind v4 theme tokens in the `@theme` block of `site.css` (literal rem values, so utilities generate at build):
+
+```css
+@theme {
+  /* … existing colours … */
+
+  /* Layout dimensions (were calc(N / --rem-base * 1rem)) */
+  --container-doc:          45rem;     /* 720px  → max-w-doc */
+  --container-doc-desktop:  55.5rem;   /* 888px  → max-w-doc-desktop */
+  --container-toc:          16.5625rem;/* 265px  → max-w-toc  (also used as a width) */
+  --container-toc-wide:     29.625rem; /* 474px  → max-w-toc-wide */
+  --spacing-nav:            16.875rem; /* 270px  → w-nav / etc. */
+  --spacing-header:         9.5rem;    /* 152px  → h-header, and the sticky-clearance source of truth */
+}
+```
+
+> **Verify the namespace→utility mapping against the Tailwind v4 docs before writing values** — `--container-*` → `max-w-*`; `--spacing-*` extends the spacing scale (`w-*`/`h-*`/`p-*`/`m-*`/`gap-*`); `--text-*` → `text-*` font-size (may pair a line-height). Use literal values (not `var(--…)` references) for anything that must generate a *sized* utility, unlike the colour tokens which can reference runtime vars.
+
+Then:
+- Hand-written CSS references the generated vars: `var(--doc-max-width--desktop)` → `var(--container-doc-desktop)`, `var(--toc-width)` → `var(--container-toc)`, etc.
+- Templates use utilities: `max-w-[var(--doc-max-width--desktop)]` → `max-w-doc-desktop`.
+- `--header-height` becomes `--spacing-header` (single source of truth preserved; `body.css`/`doc.css` refer to `var(--spacing-header)`).
+- `--rem-base` and the old dimension vars are deleted from `vars.css`.
+
+## Phased steps
+
+**Phase 0 — Baseline.** Build UI (`npm run build:ui` in `ui/`), capture screenshots of: header, left nav (≥1200px), TOC, article at 720/888px widths, an anchor jump. This is the pixel-identical acceptance reference.
+
+**Phase 1 — Add tokens (additive, no removals).** Add the dimension tokens to `@theme` in `site.css`. Confirm the expected utilities and `:root` vars are generated in `build/`. No behaviour change yet.
+
+**Phase 2 — Repoint structural consumers.**
+- CSS: swap `var(--nav-width|toc-width|toc-width--widescreen|doc-max-width|doc-max-width--desktop|header-height)` → the generated token vars in `main.css`, `doc.css`, `body.css`, `vars.css`.
+- Template: `article-toolbar.hbs` `max-w-[var(--doc-max-width--desktop)]` → `max-w-doc-desktop`.
+
+**Phase 3 — Convert the one-off calcs (Section B).** Replace `calc(N / var(--rem-base) * 1rem)` with plain rem (e.g. `calc(18 / rem-base * 1rem)` → `1.125rem`) in `doc.css`/`toc.css`/`tabs.css`. If the font-sizes (12/13/13.5/15/18/22.5px) form a coherent scale, optionally promote them to `--text-*` tokens instead; otherwise literals + a `/* Npx */` comment.
+
+**Phase 4 — Delete the old layer.** Remove `--rem-base` and the migrated/dead vars from `vars.css` (`--nav-width`, `--toc-width*`, `--doc-max-width*`, `--navbar-height`, `--toolbar-height`, plus the Section C dead vars). Update `COLOR_SYSTEM.md`'s FONTS/DIMENSIONS notes if they reference removed vars.
+
+**Phase 5 — Verify.** Rebuild; diff against Phase 0 screenshots (must be pixel-identical at default zoom). Run stylelint. Grep for stragglers: `grep -rn "rem-base\|--nav-width\|--doc-max-width\|--toc-width" ui/src`.
+
+## Risks & notes
+- **v4 namespace correctness** is the main risk — a token under the wrong namespace generates no (or the wrong) utility. Mitigate by verifying against the v4 docs and inspecting `build/` output after Phase 1.
+- **Pixel parity**: every value converts to the same rem it computes to today (root = 16px), so rendering should be identical. Zoom-scaling behaviour is also preserved (still rem).
+- **`--header-height` stays an estimate** — migrating it to `--spacing-header` keeps it as the documented single source of truth; the anchor-jump JS (`03-fragment-jumper.js`) still measures the header live and is unaffected.
+- **Semi-dead vars** (`--nav-width`, `--doc-max-width`): confirm truly unused before deleting (grep incl. `.hbs` arbitrary values) — safe to drop if so, saving migration work.
+- Keep this **separate from the font-size PR**.
+
+## Effort
+Roughly a focused half-day: Phase 1–2 are mechanical, Phase 3 is find-replace, Phase 4 is deletion, Phase 5 is the screenshot diff. The reusable checklist in `planning/16px-root-refactor-review-checklist.md` covers the visual-regression surface.

--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -22,21 +22,29 @@ body {
   overflow-wrap: anywhere; /* aka overflow-wrap; used when hyphens are disabled or aren't sufficient */
 }
 
-/* Desktop "tray": the page content sits in a white panel with rounded corners,
-   floating on a grey (--color-fog, theme-aware) backdrop inset by --tray-inset on
-   all sides — matches the redesign frame. Uses margin + border-radius rather than an
-   overflow-clip wrapper so the sticky header/nav/TOC keep working (sticky breaks
-   inside a clipped ancestor). The header carries the same rounded top corners
-   (lg:rounded-t-[16px]) and sticks at top:--tray-inset so the top gutter stays visible
-   when scrolled; without the matching radius its square corners would cover the notch. */
+/* Desktop "tray": the page is a white panel with 16px rounded corners, framed by an
+   even grey (--color-fog, theme-aware) --tray-inset gutter on all four sides. The
+   gutter is html PADDING (not body margin): a body bottom-margin isn't reachable by
+   scroll — browsers clamp to the content — so it never shows at the page end, whereas
+   html's padding-bottom sits at the true content end and is scrollable-to. height:auto
+   is needed for that (with the base height:100% the padding-bottom would sit a viewport
+   up, not at the content end); body min-height keeps short pages filling the viewport.
+   The panel scrolls and rubber-band-bounces with the document, so its rounded corners
+   move against the fixed grey backdrop.
+   Trade-off: the header's rounded top corners read as round at the top / during the top
+   bounce (grey behind them); mid-scroll the sticky header has white content behind, so
+   they look square. Keeping them round mid-scroll needs a fixed overlay, which kills the
+   bounce. */
 @media screen and (min-width: 1200px) {
   html {
     background: var(--color-fog);
+    padding: var(--tray-inset);
+    height: auto;
   }
 
   body {
-    margin: var(--tray-inset);
     border-radius: 16px;
+    min-height: calc(100vh - 2 * var(--tray-inset));
   }
 }
 

--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -12,16 +12,6 @@ html {
   color-scheme: light dark; /* Support both light and dark modes */
 }
 
-/* Type scale matches desktop from the tablet breakpoint up; only mobile drops
-   down (the design has one mobile type scale and a shared tablet/desktop scale).
-   Kept at 768px (md) to align with the heading sizes in doc.css. The structural
-   reflow to sidebars stays at 1200px (lg) — see main.css. */
-@media screen and (min-width: 768px) {
-  html {
-    font-size: var(--body-font-size--desktop);
-  }
-}
-
 body {
   background: var(--body-background);
   color: var(--body-font-color);

--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -22,6 +22,24 @@ body {
   overflow-wrap: anywhere; /* aka overflow-wrap; used when hyphens are disabled or aren't sufficient */
 }
 
+/* Desktop "tray": the page content sits in a white panel with rounded corners,
+   floating on a grey (--color-fog, theme-aware) backdrop inset by --tray-inset on
+   all sides — matches the redesign frame. Uses margin + border-radius rather than an
+   overflow-clip wrapper so the sticky header/nav/TOC keep working (sticky breaks
+   inside a clipped ancestor). The header carries the same rounded top corners
+   (lg:rounded-t-[16px]) and sticks at top:--tray-inset so the top gutter stays visible
+   when scrolled; without the matching radius its square corners would cover the notch. */
+@media screen and (min-width: 1200px) {
+  html {
+    background: var(--color-fog);
+  }
+
+  body {
+    margin: var(--tray-inset);
+    border-radius: 16px;
+  }
+}
+
 a {
   text-decoration: none;
 }

--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -22,32 +22,6 @@ body {
   overflow-wrap: anywhere; /* aka overflow-wrap; used when hyphens are disabled or aren't sufficient */
 }
 
-/* Desktop "tray": the page is a white panel with 16px rounded corners, framed by an
-   even grey (--color-fog, theme-aware) --tray-inset gutter on all four sides. The
-   gutter is html PADDING (not body margin): a body bottom-margin isn't reachable by
-   scroll — browsers clamp to the content — so it never shows at the page end, whereas
-   html's padding-bottom sits at the true content end and is scrollable-to. height:auto
-   is needed for that (with the base height:100% the padding-bottom would sit a viewport
-   up, not at the content end); body min-height keeps short pages filling the viewport.
-   The panel scrolls and rubber-band-bounces with the document, so its rounded corners
-   move against the fixed grey backdrop.
-   Trade-off: the header's rounded top corners read as round at the top / during the top
-   bounce (grey behind them); mid-scroll the sticky header has white content behind, so
-   they look square. Keeping them round mid-scroll needs a fixed overlay, which kills the
-   bounce. */
-@media screen and (min-width: 1200px) {
-  html {
-    background: var(--color-fog);
-    padding: var(--tray-inset);
-    height: auto;
-  }
-
-  body {
-    border-radius: 16px;
-    min-height: calc(100vh - 2 * var(--tray-inset));
-  }
-}
-
 a {
   text-decoration: none;
 }

--- a/ui/src/css/body.css
+++ b/ui/src/css/body.css
@@ -9,8 +9,8 @@
   /* Keep navigation sticky so it participates in page overscroll */
   [data-page-navigation] {
     position: sticky;
-    top: calc(var(--header-height) + var(--tray-inset));
-    height: calc(100vh - var(--header-height) - var(--tray-inset));
+    top: var(--header-height);
+    height: calc(100vh - var(--header-height));
   }
 
   /* Make aside independently scrollable */

--- a/ui/src/css/body.css
+++ b/ui/src/css/body.css
@@ -9,8 +9,8 @@
   /* Keep navigation sticky so it participates in page overscroll */
   [data-page-navigation] {
     position: sticky;
-    top: var(--header-height);
-    height: calc(100vh - var(--header-height));
+    top: calc(var(--header-height) + var(--tray-inset));
+    height: calc(100vh - var(--header-height) - var(--tray-inset));
   }
 
   /* Make aside independently scrollable */

--- a/ui/src/css/body.css
+++ b/ui/src/css/body.css
@@ -9,8 +9,8 @@
   /* Keep navigation sticky so it participates in page overscroll */
   [data-page-navigation] {
     position: sticky;
-    top: calc(var(--navbar-height) + var(--toolbar-height));
-    height: calc(100vh - var(--navbar-height) - var(--toolbar-height));
+    top: var(--header-height);
+    height: calc(100vh - var(--header-height));
   }
 
   /* Make aside independently scrollable */

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -73,7 +73,7 @@
   margin: 16px 0;
   padding: 0;
   text-align: left;
-  scroll-margin-top: calc(var(--navbar-height) + var(--toolbar-height) + 1rem);
+  scroll-margin-top: calc(var(--header-height) + 1.5rem); /* No-JS fallback for anchor jumps; the active offset is set in js/03-fragment-jumper.js (HEADER_GAP). Keep the gap in sync (1.5rem = 24px). */
   /* Flex layout for badge vertical alignment */
   display: flex;
   align-items: center;

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -101,18 +101,17 @@
   font-size: 16px;
 }
 
-/* Mobile heading sizes (below the tablet breakpoint). 767.5px pairs with the
-   768px html font-size bump in base.css so the whole type scale switches at one
-   boundary. */
+/* Mobile heading sizes (below the tablet breakpoint). The 767.5px boundary keeps
+   the whole type scale switching at one place; the root is a uniform 16px across
+   breakpoints (see base.css). */
 @media screen and (max-width: 767.5px) {
   .doc h1 {
     font-size: 24px;
   }
 
   /* Gives the breadcrumbs→title gap on mobile, matching the tablet/desktop rule.
-     Uses the same --rem-base calc as the ≥768 rule for consistency; note the root
-     is 17px below 768px, so this resolves to ~37.8px rather than a true 40px until
-     the 17px-root quirk is revisited. */
+     Uses the same --rem-base calc as the ≥768 rule; with the 16px root and
+     --rem-base:16 this resolves to a true 40px. */
   .doc h1.page {
     margin-top: calc(40 / var(--rem-base) * 1rem);
   }

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -234,8 +234,8 @@
   --nav-panel-menu-height: calc(100% - var(--drawer-height));
   --nav-panel-explore-height: calc(50% + var(--drawer-height));
   --nav-width: calc(270 / var(--rem-base) * 1rem);
-  --spacing: 0.25rem; /* Base spacing unit (0.25rem * 35 = 8.75rem for TOC positioning) */
-  --toc-top: calc(var(--spacing) * 35); /* Empirically determined position: navbar + toolbar + additional spacing (≈8.75rem vs logical 6rem) */
+  --spacing: 0.25rem; /* Base spacing unit (0.25rem * 40 = 10rem for TOC positioning) */
+  --toc-top: calc(var(--spacing) * 40); /* Empirically determined: clears the sticky header (logo row + component nav) plus a gap below its border. ≈10rem/160px at the 16px root; retune if the header height changes. */
   --toc-height: calc(100vh - var(--toc-top) - 6.2rem);
   --toc-width: calc(265 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(474 / var(--rem-base) * 1rem);

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -226,6 +226,7 @@
 
   --navbar-height: calc(63 / var(--rem-base) * 1rem);
   --toolbar-height: calc(45 / var(--rem-base) * 1rem);
+  --header-height: 9.5rem; /* ≈152px: rendered height of the sticky site header (pt-6 + logo row + mb-9 + component-nav row + border-b). Single source of truth for clearing the header — retune here if the header layout changes. */
   --drawer-height: var(--toolbar-height);
   --body-top: var(--navbar-height);
   --body-min-height: calc(100vh - var(--body-top));
@@ -234,8 +235,8 @@
   --nav-panel-menu-height: calc(100% - var(--drawer-height));
   --nav-panel-explore-height: calc(50% + var(--drawer-height));
   --nav-width: calc(270 / var(--rem-base) * 1rem);
-  --spacing: 0.25rem; /* Base spacing unit (0.25rem * 40 = 10rem for TOC positioning) */
-  --toc-top: calc(var(--spacing) * 40); /* Empirically determined: clears the sticky header (logo row + component nav) plus a gap below its border. ≈10rem/160px at the 16px root; retune if the header height changes. */
+  --spacing: 0.25rem; /* Base spacing unit */
+  --toc-top: calc(var(--header-height) + var(--spacing) * 2); /* Sticky TOC sits below the header with an 8px gap (≈10rem/160px). */
   --toc-height: calc(100vh - var(--toc-top) - 6.2rem);
   --toc-width: calc(265 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(474 / var(--rem-base) * 1rem);

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -227,7 +227,7 @@
   --navbar-height: calc(63 / var(--rem-base) * 1rem);
   --toolbar-height: calc(45 / var(--rem-base) * 1rem);
   --header-height: 9.5rem; /* ≈152px: rendered height of the sticky site header (pt-6 + logo row + mb-9 + component-nav row + border-b). Single source of truth for clearing the header — retune here if the header layout changes. */
-  --tray-inset: 4px; /* Desktop "tray": width of the grey gutter framing the white page panel (see base.css). Also offsets the sticky header/nav/TOC so they clear the gutter. */
+  --tray-inset: 4px; /* Desktop "tray": width of the grey gutter framing the page panel on all four sides (see base.css). */
   --drawer-height: var(--toolbar-height);
   --body-top: var(--navbar-height);
   --body-min-height: calc(100vh - var(--body-top));
@@ -237,7 +237,7 @@
   --nav-panel-explore-height: calc(50% + var(--drawer-height));
   --nav-width: calc(270 / var(--rem-base) * 1rem);
   --spacing: 0.25rem; /* Base spacing unit */
-  --toc-top: calc(var(--header-height) + var(--tray-inset) + var(--spacing) * 2); /* Sticky TOC sits below the header (offset by the tray inset) with an 8px gap. */
+  --toc-top: calc(var(--header-height) + var(--spacing) * 2); /* Sticky TOC sits below the header with an 8px gap (≈10rem/160px). */
   --toc-height: calc(100vh - var(--toc-top) - 6.2rem);
   --toc-width: calc(265 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(474 / var(--rem-base) * 1rem);

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -227,6 +227,7 @@
   --navbar-height: calc(63 / var(--rem-base) * 1rem);
   --toolbar-height: calc(45 / var(--rem-base) * 1rem);
   --header-height: 9.5rem; /* ≈152px: rendered height of the sticky site header (pt-6 + logo row + mb-9 + component-nav row + border-b). Single source of truth for clearing the header — retune here if the header layout changes. */
+  --tray-inset: 4px; /* Desktop "tray": width of the grey gutter framing the white page panel (see base.css). Also offsets the sticky header/nav/TOC so they clear the gutter. */
   --drawer-height: var(--toolbar-height);
   --body-top: var(--navbar-height);
   --body-min-height: calc(100vh - var(--body-top));
@@ -236,7 +237,7 @@
   --nav-panel-explore-height: calc(50% + var(--drawer-height));
   --nav-width: calc(270 / var(--rem-base) * 1rem);
   --spacing: 0.25rem; /* Base spacing unit */
-  --toc-top: calc(var(--header-height) + var(--spacing) * 2); /* Sticky TOC sits below the header with an 8px gap (≈10rem/160px). */
+  --toc-top: calc(var(--header-height) + var(--tray-inset) + var(--spacing) * 2); /* Sticky TOC sits below the header (offset by the tray inset) with an 8px gap. */
   --toc-height: calc(100vh - var(--toc-top) - 6.2rem);
   --toc-width: calc(265 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(474 / var(--rem-base) * 1rem);

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -202,9 +202,8 @@
      FONTS
      ============================================ */
 
-  --rem-base: 18; /* used to compute rem value from desired pixel value (e.g., calc(18 / var(--rem-base) * 1rem) = 18px) */
-  --body-font-size: 1.0625em; /* 17px */
-  --body-font-size--desktop: 1.125em; /* 18px */
+  --rem-base: 16; /* matches the 16px root; used to compute rem from px (e.g., calc(40 / var(--rem-base) * 1rem) = 40px) */
+  --body-font-size: 100%; /* 16px root (browser default); respects the user's font-size preference */
   --body-font-size--print: 0.9375em; /* 15px */
   --body-line-height: 1.6;
   --body-font-family: "Inter", "Inter Fallback", sans-serif;

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -227,7 +227,6 @@
   --navbar-height: calc(63 / var(--rem-base) * 1rem);
   --toolbar-height: calc(45 / var(--rem-base) * 1rem);
   --header-height: 9.5rem; /* ≈152px: rendered height of the sticky site header (pt-6 + logo row + mb-9 + component-nav row + border-b). Single source of truth for clearing the header — retune here if the header layout changes. */
-  --tray-inset: 4px; /* Desktop "tray": width of the grey gutter framing the page panel on all four sides (see base.css). */
   --drawer-height: var(--toolbar-height);
   --body-top: var(--navbar-height);
   --body-min-height: calc(100vh - var(--body-top));

--- a/ui/src/js/03-fragment-jumper.js
+++ b/ui/src/js/03-fragment-jumper.js
@@ -5,6 +5,7 @@
   if (!article) return
   var toolbar = document.querySelector('header') || document.querySelector('.toolbar')
   var supportsScrollToOptions = 'scrollTo' in document.documentElement
+  var HEADER_GAP = 24 // px of breathing room below the sticky header on anchor jumps; keep in sync with .doc heading scroll-margin-top in doc.css
 
   function decodeFragment (hash) {
     return hash && (~hash.indexOf('%') ? decodeURIComponent(hash) : hash).slice(1)
@@ -20,7 +21,7 @@
       window.location.hash = '#' + this.id
       e.preventDefault()
     }
-    var y = computePosition(this, 0) - toolbar.getBoundingClientRect().bottom
+    var y = computePosition(this, 0) - toolbar.getBoundingClientRect().bottom - HEADER_GAP
     var instant = e === false && supportsScrollToOptions
     instant ? window.scrollTo({ left: 0, top: y, behavior: 'instant' }) : window.scrollTo(0, y)
   }

--- a/ui/src/partials/article-footer.hbs
+++ b/ui/src/partials/article-footer.hbs
@@ -1,4 +1,4 @@
-<footer class="mt-10 mb-12 border-t border-vapor w-full text-sm px-12 pt-6">
+<footer class="mt-10 mb-12 border-t border-vapor w-full text-base px-12 pt-6">
   <!--
   <div class="flex flex-col md:flex-row md:items-center">
     <h4 class="text-xl font-normal">

--- a/ui/src/partials/article-toolbar.hbs
+++ b/ui/src/partials/article-toolbar.hbs
@@ -1,3 +1,3 @@
-<div role="navigation" aria-label="Article Toolbar" class="article-toolbar flex flex-col max-w-[var(--doc-max-width--desktop)] md:items-center ml-auto mr-auto px-[var(--doc-padding-x)] lg:ml-12 lg:mr-0 lg:px-0 mt-6 md:mt-12 md:flex-row text-sm font-normal" >
+<div role="navigation" aria-label="Article Toolbar" class="article-toolbar flex flex-col max-w-[var(--doc-max-width--desktop)] md:items-center ml-auto mr-auto px-[var(--doc-padding-x)] lg:ml-12 lg:mr-0 lg:px-0 mt-6 md:mt-12 md:flex-row text-base font-normal" >
   {{> breadcrumbs}}
 </div>

--- a/ui/src/partials/breadcrumbs.hbs
+++ b/ui/src/partials/breadcrumbs.hbs
@@ -3,19 +3,19 @@
   <ul>
     {{#if site.homeUrl}}
     <li class="inline after:text-[var(--breadcrumb-separator-color)] after:content-['/'] after:px-2">
-      <a class="font-normal" style="color: var(--breadcrumb-link-color)" href="{{{relativize site.homeUrl}}}">Home</a>
+      <a class="font-medium" style="color: var(--breadcrumb-link-color)" href="{{{relativize site.homeUrl}}}">Home</a>
     </li>
     {{/if}}
     {{#with page.componentVersion}}
     {{#if (and ./title (ne ./title @root.page.breadcrumbs.0.content))}}
-    <li class="inline after:text-[var(--breadcrumb-separator-color)] after:content-['/'] after:px-2"><a class="font-normal" style="color: var(--breadcrumb-link-color)" href="{{{relativize ./url}}}">{{{./title}}}</a></li>
+    <li class="inline after:text-[var(--breadcrumb-separator-color)] after:content-['/'] after:px-2"><a class="font-medium" style="color: var(--breadcrumb-link-color)" href="{{{relativize ./url}}}">{{{./title}}}</a></li>
     {{/if}}
     {{/with}}
     {{#each page.breadcrumbs}}
     {{#unless @last}}
     <li class="inline after:text-[var(--breadcrumb-separator-color)] after:content-['/'] after:px-2">
       {{#if (and ./url (eq ./urlType 'internal'))}}
-        <a class="font-normal" style="color: var(--breadcrumb-link-color)" href="{{{relativize ./url}}}">{{{./content}}}</a>
+        <a class="font-medium" style="color: var(--breadcrumb-link-color)" href="{{{relativize ./url}}}">{{{./content}}}</a>
               {{else}}
           <span class="font-normal cursor-default" style="color: var(--breadcrumb-font-color)">{{{./content}}}</span>
         {{/if}}

--- a/ui/src/partials/component-explorer-nav.hbs
+++ b/ui/src/partials/component-explorer-nav.hbs
@@ -1,9 +1,9 @@
 <nav data-component-explorer-nav class="flex flex-col md:flex-row md:items-center justify-between text-terminal-black font-medium md:font-normal {{#if class}}{{class}}{{/if}} overflow-x-auto whitespace-nowrap gap-3">
 
-  <ul class="flex flex-col md:flex-row md:space-x-8">
+  <ul class="flex flex-col md:flex-row md:gap-6">
     {{#each options.navList}}
-      <li class="flex items-center mr-2">
-        <a href="{{{relativize ./url}}}" class="inline-block px-2 py-2 md:py-3 {{#if (eq ./name @root.page.component.name)}} text-accent-green md:text-inherit border-l-2 md:border-l-0 md:border-b-2 border-accent-green font-semibold {{/if}} ">
+      <li class="flex items-center">
+        <a href="{{{relativize ./url}}}" class="inline-block py-2 md:py-3 {{#if (eq ./name @root.page.component.name)}} text-accent-green md:text-inherit border-l-2 md:border-l-0 md:border-b-2 border-accent-green font-semibold {{/if}} ">
           {{{./label}}}
         </a>
       </li>

--- a/ui/src/partials/dropdown.hbs
+++ b/ui/src/partials/dropdown.hbs
@@ -1,8 +1,8 @@
-<div data-dropdown class="{{#if class}}{{class}}{{/if}} relative flex justify-center items-center text-sm font-normal">
+<div data-dropdown class="{{#if class}}{{class}}{{/if}} relative flex justify-center items-center text-base font-normal">
   <!-- Trigger Button -->
   <button
     data-dropdown-button
-    class="px-4 py-3 border rounded-full text-sm m-auto w-full text-left flex items-center justify-between focus:border-link-on-light hover:border-link-on-light"
+    class="px-4 py-3 border rounded-full text-base m-auto w-full text-left flex items-center justify-between focus:border-link-on-light hover:border-link-on-light"
     aria-haspopup="true"
     aria-expanded="false"
   >

--- a/ui/src/partials/header-content.hbs
+++ b/ui/src/partials/header-content.hbs
@@ -1,4 +1,4 @@
-<header class="flex flex-col max-w-full px-[32px] md:px-16 pt-6 border-b border-vapor bg-body-bg sticky top-0 z-10">
+<header class="flex flex-col max-w-full px-[32px] md:px-16 pt-6 border-b border-vapor bg-body-bg lg:rounded-t-[16px] sticky top-0 lg:top-[var(--tray-inset)] z-10">
   <div class="flex items-center justify-between mb-9">
     <!-- Logo + Title -->
     <div class="flex items-center space-x-2">

--- a/ui/src/partials/header-content.hbs
+++ b/ui/src/partials/header-content.hbs
@@ -1,4 +1,4 @@
-<header class="flex flex-col max-w-full px-[32px] md:px-16 pt-6 border-b border-vapor bg-body-bg lg:rounded-t-[16px] sticky top-0 z-10">
+<header class="flex flex-col max-w-full px-[32px] md:px-16 pt-6 border-b border-vapor bg-body-bg sticky top-0 z-10">
   <div class="flex items-center justify-between mb-9">
     <!-- Logo + Title -->
     <div class="flex items-center space-x-2">

--- a/ui/src/partials/header-content.hbs
+++ b/ui/src/partials/header-content.hbs
@@ -1,4 +1,4 @@
-<header class="flex flex-col max-w-full px-[32px] md:px-16 pt-6 border-b border-vapor bg-body-bg lg:rounded-t-[16px] sticky top-0 lg:top-[var(--tray-inset)] z-10">
+<header class="flex flex-col max-w-full px-[32px] md:px-16 pt-6 border-b border-vapor bg-body-bg lg:rounded-t-[16px] sticky top-0 z-10">
   <div class="flex items-center justify-between mb-9">
     <!-- Logo + Title -->
     <div class="flex items-center space-x-2">

--- a/ui/src/partials/header-content.hbs
+++ b/ui/src/partials/header-content.hbs
@@ -1,5 +1,5 @@
-<header class="flex flex-col max-w-full px-[32px] md:px-9 pt-6 border-b border-vapor bg-body-bg sticky top-0 z-10">
-  <div class="flex items-center justify-between mb-7">
+<header class="flex flex-col max-w-full px-[32px] md:px-16 pt-6 border-b border-vapor bg-body-bg sticky top-0 z-10">
+  <div class="flex items-center justify-between mb-9">
     <!-- Logo + Title -->
     <div class="flex items-center space-x-2">
       <a href="{{{relativize '/'}}}">

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -1,4 +1,4 @@
-<div data-page-navigation class="{{#if class}}{{class}}{{/if}} h-full border-r border-vapor fixed lg:sticky inset-0 lg:top-0 lg:h-screen transform -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 lg:z-auto bg-body-bg" {{#if page.component}} data-tcomponent="{{page.component.name}}" data-tversion="{{page.version}}"{{/if}}>
+<div data-page-navigation class="{{#if class}}{{class}}{{/if}} h-full border-r border-vapor fixed lg:sticky inset-0 lg:top-0 lg:h-screen transform -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 lg:z-auto bg-body-bg lg:rounded-bl-[16px]" {{#if page.component}} data-tcomponent="{{page.component.name}}" data-tversion="{{page.version}}"{{/if}}>
   <aside class="relative h-full py-6 px-9 lg:pl-16 overflow-y-scroll scrollbar-thin scrollbar-thumb-rounded-xl scrollbar-thumb-fog scrollbar-track-vapor scrollbar-track-border">
     <div class="flex items-center justify-between lg:hidden text-terminal-black mb-10">
       <img data-page-navigation-back-button src="{{{uiRootPath}}}/img/arrow-back.svg" alt="Arrow Back" class="invisible lg:hidden h-4 w-4">

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -1,5 +1,5 @@
 <div data-page-navigation class="{{#if class}}{{class}}{{/if}} h-full border-r border-vapor fixed lg:sticky inset-0 lg:top-0 lg:h-screen transform -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 lg:z-auto bg-body-bg" {{#if page.component}} data-tcomponent="{{page.component.name}}" data-tversion="{{page.version}}"{{/if}}>
-  <aside class="relative h-full py-6 px-9 overflow-y-scroll scrollbar-thin scrollbar-thumb-rounded-xl scrollbar-thumb-fog scrollbar-track-vapor scrollbar-track-border">
+  <aside class="relative h-full py-6 px-9 lg:pl-16 overflow-y-scroll scrollbar-thin scrollbar-thumb-rounded-xl scrollbar-thumb-fog scrollbar-track-vapor scrollbar-track-border">
     <div class="flex items-center justify-between lg:hidden text-terminal-black mb-10">
       <img data-page-navigation-back-button src="{{{uiRootPath}}}/img/arrow-back.svg" alt="Arrow Back" class="invisible lg:hidden h-4 w-4">
       <h3 class="font-medium"> {{page.component.title}}</h3>

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -1,4 +1,4 @@
-<div data-page-navigation class="{{#if class}}{{class}}{{/if}} h-full border-r border-vapor fixed lg:sticky inset-0 lg:top-0 lg:h-screen transform -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 lg:z-auto bg-body-bg lg:rounded-bl-[16px]" {{#if page.component}} data-tcomponent="{{page.component.name}}" data-tversion="{{page.version}}"{{/if}}>
+<div data-page-navigation class="{{#if class}}{{class}}{{/if}} h-full border-r border-vapor fixed lg:sticky inset-0 lg:top-0 lg:h-screen transform -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 lg:z-auto bg-body-bg" {{#if page.component}} data-tcomponent="{{page.component.name}}" data-tversion="{{page.version}}"{{/if}}>
   <aside class="relative h-full py-6 px-9 lg:pl-16 overflow-y-scroll scrollbar-thin scrollbar-thumb-rounded-xl scrollbar-thumb-fog scrollbar-track-vapor scrollbar-track-border">
     <div class="flex items-center justify-between lg:hidden text-terminal-black mb-10">
       <img data-page-navigation-back-button src="{{{uiRootPath}}}/img/arrow-back.svg" alt="Arrow Back" class="invisible lg:hidden h-4 w-4">


### PR DESCRIPTION
## What & why

The docs UI root font-size was set to **17px (mobile) / 18px (desktop)**, so `1rem` was not Tailwind's assumed 16px. This silently inflated every named-scale Tailwind utility in the chrome by ~12.5% (e.g. `w-5 h-5` icons rendered 22.5px instead of 20px), forced a mix of px-pinned workarounds, and caused a mobile spacing quirk (`--rem-base:18` ≠ the 17px mobile root).

This PR moves the root to a uniform **16px** and then aligns the header, left nav, and TOC to the redesign, and tidies a few weights/gaps that surfaced during review.

## Changes

**Root font-size → 16px**
- `html` set to `font-size: 100%` (16px, still honouring the user's browser font-size preference); dropped the responsive root bump.
- `--rem-base` retargeted `18 → 16` so the `calc(N / --rem-base * 1rem)` structural dims keep their exact px and gain correct mobile behaviour.
- Article content (16px) and headings (px) were already pinned, so they're unchanged; named-scale utilities and plain-`rem` values now resolve to their intended 16px-native sizes.

**Redesign alignment**
- Header padded to the **64px** content grid (`md:px-16`); logo-row margin → `mb-9` (36px).
- Component nav: **24px** gap between items, first item flush at the 64px edge.
- Left sidebar content aligned to the same 64px grid (`lg:pl-16`).
- Breadcrumb / footer / dropdown text `text-sm → text-base` (they were rendering ~15.75px against the old root and dropped to a true 14px at 16px; now a real 16px).
- Breadcrumb links → font-weight 500.

**Single source of truth for header clearance**
- New `--header-height` (~152px) feeds `--toc-top`, heading `scroll-margin-top`, and the sticky left-nav offset — previously three inconsistent approximations, which left anchored headings and the sidebar top tucked behind the header.
- Anchor click-jumps are actually driven by `js/03-fragment-jumper.js` (it `scrollTo`s and ignores `scroll-margin-top`); added `HEADER_GAP` there so clicked headings clear the header with breathing room.

**Docs**
- `planning/16px-root-refactor-review-checklist.md` — region-by-region visual-review checklist.
- `planning/rem-base-to-tailwind-theme-migration-plan.md` — plan to eventually retire `--rem-base` in favour of Tailwind v4 `@theme` tokens (follow-up, not in this PR).

> **Note:** an earlier revision of this branch added a desktop "tray" (rounded page panel on a grey backdrop). Design decided against it, so it has been removed — not part of this PR.

## Testing
- Reviewed via local preview (`npm run start:dev`) across mobile / tablet / desktop, light and dark mode, using the checklist above.
- Key checks: chrome utilities/icons at correct sizes, breadcrumb/nav/TOC/tabs spacing, anchor-jump landing position, and sticky header/nav/TOC behaviour.

## Follow-ups (not in this PR)
- `--rem-base` → Tailwind v4 theme migration (plan committed).
