### PR TITLE
Revise deprecation notice for trigger parameters

### DIFF
--- a/docs/guides/modules/ROOT/partials/pipelines-and-triggers/pipeline-values.adoc
+++ b/docs/guides/modules/ROOT/partials/pipelines-and-triggers/pipeline-values.adoc
@@ -348,7 +348,7 @@ These values describe how and why the pipeline was triggered, including the even
 
 [WARNING]
 ====
-All `+pipeline.trigger_parameters.circleci.*+` and `+pipeline.trigger_parameters.github_app.*+` values are deprecated and their presence is not guaranteed after **2026-08-01**. Use the replacement values listed in the table below.
+All `+pipeline.trigger_parameters.circleci.*+` and `+pipeline.trigger_parameters.github_app.*+` values are deprecated and their presence is not guaranteed after **2026-09-21**. Use the replacement values listed in the table below.
 ====
 
 [.table-scroll]


### PR DESCRIPTION
Updated deprecation date for CircleCI and GitHub App trigger parameters.

# Description
What did you change?

# Reasons
Why did you make these changes? What problem does this solve?

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
