### PR TITLE
Add GitLab tab to 'How CircleCI checks out your code' section

### DIFF
--- a/docs/guides/modules/permissions-authentication/pages/users-organizations-and-integrations-guide.adoc
+++ b/docs/guides/modules/permissions-authentication/pages/users-organizations-and-integrations-guide.adoc
@@ -579,6 +579,20 @@ Bitbucket Data Center::
 --
 When you connect a repository with your CircleCI project, behind the scenes, CircleCI is registering a webhook within your Bitbucket Data Center project. You may verify this once you have successfully created the project by navigating to your repository's menu:Project Settings[Webhooks] page.
 --
+GitLab::
++
+--
+When you create a GitLab-based project in CircleCI, an SSH key is created, which is used to check out code from your repository. Each pipeline configuration you create generates a new SSH key to access the code in the repository associated with that configuration.
+
+The private key is installed into the `.ssh` directory when CircleCI builds your project, and SSH is configured to communicate with GitLab. Therefore, the SSH key is used for:
+
+- Checking out the main project.
+- Checking out any GitLab-hosted submodules.
+- Checking out any GitLab-hosted private dependencies.
+- Automatic git merging/tagging/etc.
+
+For GitLab self-managed instances, you will need to provide SSH host keys during the integration setup. You can retrieve these keys by running `ssh-keyscan <instance_url>`. See the <<manage-vcs-integrations>> section for more information on configuring GitLab self-managed integrations.
+--
 ====
 
 === Custom checkout commands

--- a/docs/guides/modules/permissions-authentication/pages/users-organizations-and-integrations-guide.adoc
+++ b/docs/guides/modules/permissions-authentication/pages/users-organizations-and-integrations-guide.adoc
@@ -582,9 +582,9 @@ When you connect a repository with your CircleCI project, behind the scenes, Cir
 GitLab::
 +
 --
-When you create a GitLab-based project in CircleCI, an SSH key is created, which is used to check out code from your repository. Each pipeline configuration you create generates a new SSH key to access the code in the repository associated with that configuration.
+When you set up a new project with GitLab in CircleCI, an SSH key is created, which is used to check out code from your repository.
 
-The private key is installed into the `.ssh` directory when CircleCI builds your project, and SSH is configured to communicate with GitLab. Therefore, the SSH key is used for:
+When CircleCI builds your project, the private key is installed into the `.ssh` directory and SSH is configured to communicate with GitLab. Therefore, the SSH key is used for:
 
 - Checking out the main project.
 - Checking out any GitLab-hosted submodules.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
Added a GitLab tab to the "How CircleCI checks out your code" section in the users, organizations, and integrations guide. The new tab explains how CircleCI uses SSH keys to check out GitLab repositories.

# Reasons
The GitLab tab was missing from the "How CircleCI checks out your code" section at https://circleci.com/docs/guides/permissions-authentication/users-organizations-and-integrations-guide/#how-circleci-checks-out-your-code. This gap left GitLab users without documentation on how CircleCI checks out their code, while GitHub and Bitbucket users had this information available.

This PR resolves Linear issue DOC-16.

# Changes
- Added GitLab tab explaining SSH key creation and usage for code checkout
- Documented how SSH keys are used for checkout operations (main project, submodules, private dependencies, git operations)
- Included reference to GitLab self-managed SSH host key setup
- Fixed initial description to clarify SSH keys are created per project (not per configuration) to match GitHub and Bitbucket tabs

# Content checks

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-16](https://linear.app/circleci/issue/DOC-16/add-in-gitlab-tab-under-how-circleci-checks-out-your-code-section)

<div><a href="https://cursor.com/agents/bc-53edaaf0-612f-406a-8e09-537f21220c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53edaaf0-612f-406a-8e09-537f21220c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

