### PR TITLE
[ONP-3448] - Document disk image size

### DIFF
--- a/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
@@ -603,7 +603,7 @@ $ docker rm extract-base
 $ qemu-img resize disk.qcow2 20G
 ----
 
-`qemu-img resize` only grows the virtual size recorded in the qcow2 header. The image stays sparse, so the file on disk and the pushed registry layer barely grow. The extra space only becomes real data once the guest OS writes to it. The resize itself has minimal impact on registry storage or node-side image pulls.
+The `qemu-img resize` command only grows the virtual size recorded in the qcow2 header. The image stays sparse, so the file on disk and the pushed registry layer barely grow. The extra space only becomes real data once the guest OS writes to it. The resize itself has minimal impact on registry storage or node-side image pulls.
 
 === Install dependencies in the image
 

--- a/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
@@ -618,16 +618,16 @@ Run additional `--run-command` or `--install` flags for any other packages the r
 
 === Package and push the custom image
 
-Package the resized, customized qcow2 as a new OCI image with the disk at `/disk`, matching the layout KubeVirt expects:
-
+. Package the resized, customized qcow2 as a new OCI image with the disk at `/disk`, matching the layout KubeVirt expects:
++
 [source,dockerfile]
 ----
 FROM scratch
 ADD disk.qcow2 /disk/
 ----
 
-Build and push the image to a registry your cluster can reach:
-
+. Build and push the image to a registry your cluster can reach:
++
 [source,console]
 ----
 $ docker build -t <your-registry>/<your-image>:<tag> .

--- a/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
@@ -586,6 +586,74 @@ The startup script performs the following steps on each VM:
 . Configures systemd to power off the VM after the runner process exits.
 . Starts the runner service.
 
+[#custom-containerdisk-image]
+== Building a custom containerDisk image
+
+The default base image, `quay.io/containerdisks/ubuntu:22.04`, has a root filesystem capped at 2.2 GiB. Installs that write a lot of data to `/usr` or `/`, such as a full Docker install, can fail with a disk full error. This limit is not configurable through Runner Provisioner or KubeVirt; it comes from the base image itself. To get more root space, build a custom containerDisk image with a larger virtual size and point your resource class at it.
+
+=== Resize the disk image
+
+A containerDisk image stores its disk file at `/disk` inside an OCI image. Extract the disk from the base image and resize it with `qemu-img`:
+
+[source,console]
+----
+$ docker create --name extract-base quay.io/containerdisks/ubuntu:22.04
+$ docker cp extract-base:/disk/disk.qcow2 ./disk.qcow2
+$ docker rm extract-base
+$ qemu-img resize disk.qcow2 20G
+----
+
+`qemu-img resize` only grows the virtual size recorded in the qcow2 header. The image stays sparse, so the file on disk and the pushed registry layer barely grow. The extra space only becomes real data once the guest OS writes to it. The resize itself has minimal impact on registry storage or node-side image pulls.
+
+=== Install dependencies in the image
+
+Bake dependencies like Docker into the image so VMs do not need to install them on every boot. Use `virt-customize` from the `libguestfs-tools` package to modify the qcow2 file directly, without booting a VM:
+
+[source,console]
+----
+$ virt-customize -a disk.qcow2 --run-command 'curl -fsSL https://get.docker.com | sh'
+----
+
+Run additional `--run-command` or `--install` flags for any other packages the resource class needs. `virt-customize` requires `libguestfs-tools`, available through most Linux package managers.
+
+=== Package and push the custom image
+
+Package the resized, customized qcow2 as a new OCI image with the disk at `/disk`, matching the layout KubeVirt expects:
+
+[source,dockerfile]
+----
+FROM scratch
+ADD disk.qcow2 /disk/
+----
+
+Build and push the image to a registry your cluster can reach:
+
+[source,console]
+----
+$ docker build -t <your-registry>/<your-image>:<tag> .
+$ docker push <your-registry>/<your-image>:<tag>
+----
+
+=== Point a resource class at the custom image
+
+Update `spec.volumes[].containerDisk.image` in `my-values.yaml` to reference the custom image instead of the default:
+
+.`my-values.yaml`
+[source,yaml]
+----
+provisioner:
+  resourceClass:
+    spec:
+      volumes:
+        - name: disk
+          containerDisk:
+            image: "<your-registry>/<your-image>:<tag>"
+----
+
+Run `helm upgrade` as described in <<upgrading,Upgrading>> to roll out the change. Existing VMs keep running on the old image until they are recreated.
+
+NOTE: A pre-built reference image with a larger root and Docker preinstalled is planned for a future release. Until then, build a custom image using the steps in this section.
+
 == Scaling behavior
 
 Desired replicas are calculated as unclaimed tasks plus running tasks, clamped to `[minReplicas, maxReplicas]`.
@@ -828,6 +896,11 @@ Common causes:
 * *Wrong resource class name*: The `resourceClass.name` in values must match the resource class your jobs target, in `namespace/name` format.
 * *CircleCI Server not reachable*: If using a self-hosted server, confirm `circleciAPIAddr` is set and that the VM can reach that address. Check runner agent logs for connection errors.
 * *Cloud-init did not run*: If the VM booted from a cached image state, cloud-init may have been skipped. Delete the VM and let the pool recreate it: `kubectl delete vm -n runner-provisioner <vm-name>`.
+
+[#disk-full-during-install]
+=== Package installs fail with a disk full error
+
+A disk full error while installing packages, such as Docker, means the root filesystem on the default base image ran out of space. The default image caps root at 2.2 GiB, inherited from the upstream Ubuntu cloud image, and this limit cannot be raised at runtime. Build a custom image with a larger root; see <<custom-containerdisk-image,Building a Custom containerDisk Image>>.
 
 [#scaling-not-responding]
 === Scaling is not responding to job demand

--- a/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
@@ -898,7 +898,7 @@ Common causes:
 [#disk-full-during-install]
 === Package installs fail with a disk full error
 
-A disk full error while installing packages, such as Docker, means the root filesystem on the default base image ran out of space. The default image caps root at 2.2 GiB, inherited from the upstream Ubuntu cloud image, and this limit cannot be raised at runtime. Build a custom image with a larger root. See <<custom-containerdisk-image,Building a Custom containerDisk Image>> for more infromation.
+A disk full error while installing packages, such as Docker, means the root filesystem on the default base image ran out of space. The default image caps root at 2.2 GiB, inherited from the upstream Ubuntu cloud image, and this limit cannot be raised at runtime. Build a custom image with a larger root. See <<custom-containerdisk-image,Building a Custom containerDisk Image>> for more information.
 
 [#scaling-not-responding]
 === Scaling is not responding to job demand

--- a/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
@@ -652,8 +652,6 @@ provisioner:
 
 . Run `helm upgrade` as described in <<upgrading>> to roll out the change. Existing VMs keep running on the old image until they are recreated.
 
-NOTE: A pre-built reference image with a larger root and Docker preinstalled is planned for a future release. Until then, build a custom image using the steps in this section.
-
 == Scaling behavior
 
 Desired replicas are calculated as unclaimed tasks plus running tasks, clamped to `[minReplicas, maxReplicas]`.

--- a/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
@@ -636,8 +636,8 @@ $ docker push <your-registry>/<your-image>:<tag>
 
 === Point a resource class at the custom image
 
-Update `spec.volumes[].containerDisk.image` in `my-values.yaml` to reference the custom image instead of the default:
-
+. Update `spec.volumes[].containerDisk.image` in `my-values.yaml` to reference the custom image instead of the default:
++
 .`my-values.yaml`
 [source,yaml]
 ----
@@ -650,7 +650,7 @@ provisioner:
             image: "<your-registry>/<your-image>:<tag>"
 ----
 
-Run `helm upgrade` as described in <<upgrading,Upgrading>> to roll out the change. Existing VMs keep running on the old image until they are recreated.
+. Run `helm upgrade` as described in <<upgrading>> to roll out the change. Existing VMs keep running on the old image until they are recreated.
 
 NOTE: A pre-built reference image with a larger root and Docker preinstalled is planned for a future release. Until then, build a custom image using the steps in this section.
 

--- a/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
@@ -900,7 +900,7 @@ Common causes:
 [#disk-full-during-install]
 === Package installs fail with a disk full error
 
-A disk full error while installing packages, such as Docker, means the root filesystem on the default base image ran out of space. The default image caps root at 2.2 GiB, inherited from the upstream Ubuntu cloud image, and this limit cannot be raised at runtime. Build a custom image with a larger root; see <<custom-containerdisk-image,Building a Custom containerDisk Image>>.
+A disk full error while installing packages, such as Docker, means the root filesystem on the default base image ran out of space. The default image caps root at 2.2 GiB, inherited from the upstream Ubuntu cloud image, and this limit cannot be raised at runtime. Build a custom image with a larger root. See <<custom-containerdisk-image,Building a Custom containerDisk Image>> for more infromation.
 
 [#scaling-not-responding]
 === Scaling is not responding to job demand

--- a/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
@@ -589,7 +589,7 @@ The startup script performs the following steps on each VM:
 [#custom-containerdisk-image]
 == Building a custom containerDisk image
 
-The default base image, `quay.io/containerdisks/ubuntu:22.04`, has a root filesystem capped at 2.2 GiB. Installs that write a lot of data to `/usr` or `/`, such as a full Docker install, can fail with a disk full error. This limit is not configurable through Runner Provisioner or KubeVirt; it comes from the base image itself. To get more root space, build a custom containerDisk image with a larger virtual size and point your resource class at it.
+The default base image, `quay.io/containerdisks/ubuntu:22.04`, has a root filesystem capped at 2.2 GiB. Installs that write a lot of data to `/usr` or `/`, such as a full Docker install, can fail with a disk full error. This limit is not configurable through Runner Provisioner or KubeVirt. The limit comes from the base image itself. To get more root space, build a custom containerDisk image with a larger virtual size and point your resource class at it.
 
 === Resize the disk image
 


### PR DESCRIPTION
https://linear.app/circleci/issue/ONP-3448/document-how-to-build-a-custom-containerdisk-image-for-runner
# Description
Updated `runner-provisioner` docs to document the image size limit, and how to resize it.

# Reasons
Why did you make these changes? What problem does this solve?

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
