### PR TITLE
Deprecate job filters in docs

### DIFF
--- a/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
@@ -40,7 +40,7 @@ xref:reference:ROOT:configuration-reference.adoc#jobfilters[Branch and Tag Job F
 [#filter-a-workflow-with-an-expression]
 == Filter a workflow with an expression
 
-To run an entire workflow only when a condition is met, add a `when` clause (or the inverse `unless` clause) with a logic statement to the workflow declaration. Expressions can reference pipeline values and pipeline parameters and use comparison and logic operators.
+To run an entire workflow only when a condition is met, add a `when` clause (or the inverse `unless` clause) with an expression to the workflow declaration. Expressions can reference pipeline values and pipeline parameters and use comparison and logic operators.
 
 The following example runs the `integration_tests` workflow only when the pipeline is on the `main` branch:
 

--- a/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
@@ -5,7 +5,7 @@
 
 You can control whether a job, workflow, or step runs, based on the git branch or tag that triggered the pipeline. CircleCI provides several mechanisms, covered in the sections below. Choose one based on what you want to control:
 
-* Filter a *job* with an expression, for finer control than branch and tag filters allow.
+* Filter a *job* with an expression.
 * Run a whole *workflow* only when a condition is met, using an expression.
 * Run a single *step* only when a condition is met, using a `when` step.
 
@@ -35,7 +35,7 @@ workflows:
 
 For the full operator list and more examples, see the xref:reference:ROOT:configuration-reference.adoc#expression-based-job-filters[Expression-Based Job Filters] reference.
 
-xref:reference:ROOT:configuration-reference.adoc#jobfilters[Branch and tag job filters] are deprecated. If you have a job that uses them, you can replace them with expression-based job filters as described in this section.
+xref:reference:ROOT:configuration-reference.adoc#jobfilters[Branch and Tag Job Filters] are deprecated. If you have a job that uses them, you can replace them with expression-based job filters as described in this section.
 
 [#filter-a-workflow-with-an-expression]
 == Filter a workflow with an expression

--- a/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
@@ -14,7 +14,7 @@ Expression-based conditions are the most flexible option. They can reference pip
 [#filter-a-job-with-an-expression]
 == Filter a job with an expression
 
-For finer control than `branches` and `tags` allow, set the `filters` key on a job to an expression instead of a `branches` or `tags` map. The job runs only when the expression evaluates to true. Expressions can reference pipeline values and pipeline parameters and use comparison and logic operators. A single expression can replace conditions that would otherwise need several filters.
+Set the `filters` key on a job to an expression. The job runs only when the expression evaluates to true. Expressions can reference pipeline values and pipeline parameters and use comparison and logic operators.
 
 The following example runs `integration-test` on `main` or any branch starting with `integration-`, and runs `deploy` only on `main`:
 

--- a/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
@@ -5,40 +5,11 @@
 
 You can control whether a job, workflow, or step runs, based on the git branch or tag that triggered the pipeline. CircleCI provides several mechanisms, covered in the sections below. Choose one based on what you want to control:
 
-* Filter a *job* by branch or tag with workflow filters.
 * Filter a *job* with an expression, for finer control than branch and tag filters allow.
 * Run a whole *workflow* only when a condition is met, using an expression.
 * Run a single *step* only when a condition is met, using a `when` step.
 
 Expression-based conditions are the most flexible option. They can reference pipeline values and pipeline parameters and use comparison and logic operators, so they cover most cases where you previously needed branch filters.
-
-[#filter-a-job-by-branch-or-tag]
-== Filter a job by branch or tag
-
-To control which branches or tags run a job, add a `filters` key to the job in your workflow. The `filters` key takes `branches` and `tags` keys. Each accepts `only` and `ignore` values, which can be exact strings or regular expressions.
-
-[source,yaml]
-----
-version: 2.1
-
-workflows:
-  build-test-deploy:
-    jobs:
-      - test:
-          filters:
-            branches:
-              only:
-                - main
-                - /^feature-.*/ # any branch beginning feature-
-      - deploy:
-          filters:
-            branches:
-              ignore: main
-----
-
-NOTE: CircleCI does not run workflows for tags unless you specify a `tags` filter. If a job uses a tag filter, every job it depends on must specify the same tag filter.
-
-For regular-expression examples and tag-filtering detail, see the xref:workflows.adoc#using-filters-in-your-workflows[Using Filters in Your Workflows] section.
 
 [#filter-a-job-with-an-expression]
 == Filter a job with an expression
@@ -62,7 +33,9 @@ workflows:
           filters: pipeline.git.branch == "main"
 ----
 
-Use either the expression form or the `branches` and `tags` form for a given job, not both. For the full operator list and more examples, see the xref:reference:ROOT:configuration-reference.adoc#expression-based-job-filters[Expression-Based Job Filters] reference.
+For the full operator list and more examples, see the xref:reference:ROOT:configuration-reference.adoc#expression-based-job-filters[Expression-Based Job Filters] reference.
+
+xref:reference:ROOT:configuration-reference.adoc#jobfilters[Branch and tag job filters] are deprecated. If you have a job that uses them, you can replace them with expression-based job filters as described in this section.
 
 [#filter-a-workflow-with-an-expression]
 == Filter a workflow with an expression

--- a/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-branch-filters.adoc
@@ -40,7 +40,7 @@ xref:reference:ROOT:configuration-reference.adoc#jobfilters[Branch and Tag Job F
 [#filter-a-workflow-with-an-expression]
 == Filter a workflow with an expression
 
-To run an entire workflow only when a condition is met, add a `when` clause (or the inverse `unless` clause) with a logic statement to the workflow declaration. This approach is more flexible than `filters` because the condition can use pipeline values, pipeline parameters, and operators.
+To run an entire workflow only when a condition is met, add a `when` clause (or the inverse `unless` clause) with a logic statement to the workflow declaration. Expressions can reference pipeline values and pipeline parameters and use comparison and logic operators.
 
 The following example runs the `integration_tests` workflow only when the pipeline is on the `main` branch:
 
@@ -55,7 +55,7 @@ workflows:
       - mytestjob
 ----
 
-For the operators you can use in a condition, see the xref:reference:ROOT:configuration-reference.adoc#logic-statements[Logic Statements] reference.
+For the operators you can use in a condition, see the xref:reference:ROOT:configuration-reference.adoc#expression-operators[Expression Operators] reference.
 
 [#filter-a-step-with-when]
 == Filter a step with when

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -3700,6 +3700,93 @@ To use a pipeline parameter in an expression, the parameter name must follow the
 If a pipeline parameter has a name that does not follow these rules, CircleCI performs string replacement instead of evaluating an expression.
 ====
 
+[#logic-statements]
+== Using logic statements
+
+Certain dynamic configuration features accept logic statements as arguments.
+Logic statements are evaluated to boolean values at configuration compilation
+time, that is, before the workflow is run. The group of logic statements
+includes:
+
+[.table-scroll]
+--
+[cols="1,1,1,2", options="header"]
+|===
+| Type | Arguments | `true` if | Example
+
+| YAML literal
+| None
+| is truthy
+| `true`/`42`/`"a string"`
+
+| xref:guides:orchestrate:pipeline-variables.adoc#pipeline-values[Pipeline Value]
+| None
+| resolves to a truthy value
+| `<< pipeline.git.branch >>`
+
+| xref:guides:orchestrate:pipeline-variables.adoc#pipeline-parameters-in-configuration[Pipeline Parameter]
+| None
+| resolves to a truthy value
+| `<< pipeline.parameters.my-parameter >>`
+
+| `and`
+| N logic statements
+| all arguments are truthy
+| `and: [ true, true, false ]`
+
+| `or`
+| N logic statements
+| any argument is truthy
+| `or: [ false, true, false ]`
+
+| `not`
+| 1 logic statement
+| the argument is not truthy
+| `not: true`
+
+| `equal`
+| N values
+| all arguments evaluate to equal values
+| `equal: [ 42, << pipeline.number >>]`
+
+| `matches`
+| `pattern` and `value`
+| `value` matches the `pattern`
+| `+matches: { pattern: "^feature-.+$", value: << pipeline.git.branch >> }+`
+|===
+--
+
+The following logic values are considered falsy:
+
+* false.
+* null.
+* 0
+* NaN
+* empty strings ("").
+* statements with no arguments.
+
+All other values are truthy. Also note that using logic with an empty list will cause a validation error.
+
+Logic statements always evaluate to a boolean value at the top level, and coerce
+as necessary. They can be nested in an arbitrary fashion, according to their
+argument specifications, and to a maximum depth of 100 levels.
+
+`matches` uses link:https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html[Java regular expressions] for its `pattern`. A full match pattern must be provided, prefix matching is not an option. It is recommended to enclose a pattern in `^` and `$` to avoid accidental partial matches.
+
+NOTE: When using logic statements at the workflow level, do not include the `condition:` key (the `condition` key is only needed for `job` level logic statements).
+
+*Example:*
+
+[,yaml]
+----
+workflows:
+  my-workflow:
+    when:
+      or:
+        - equal: [ main, << pipeline.git.branch >> ]
+        - equal: [ staging, << pipeline.git.branch >> ]
+----
+
 [#logic-statement-examples]
 === Logic statement and expression examples
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -2060,7 +2060,7 @@ During step execution, CircleCI replaces the templates above with runtime values
 
 *Template examples:*
 
-`++myapp-{{ checksum "package-lock.json" }}++`:: CircleCI regenerates the cache every time you change something in the package-lock.json file. Different branches of this project generate the same cache key.
+`++myapp-{{ checksum "package-lock.json" }}++`:: CircleCI regenerates the cache every time you change something in the `package-lock.json` file. Different branches of this project generate the same cache key.
 `myapp-{{ .Branch }}-{{ checksum "package-lock.json" }}`:: Same as the previous one, but each branch generates a separate cache.
 `myapp-{{ epoch }}`:: Every job run generates a separate cache.
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -3111,50 +3111,6 @@ An approval job can have any name. In the example above the approval job is name
 
 '''
 
-[#jobfilters]
-==== *`filters`*
-Filter job execution within a workflow based on the following:
-
-* Branch
-* Tag
-* Expression-based condition
-
-Job filters can have the keys `branches` or `tags`.
-
-NOTE: Workflows will ignore job-level branching. If you use job-level branching and later add workflows, you must remove the branching at the job level and instead declare it in the workflows section of your `config.yml`.
-
-[.table-scroll]
---
-[cols="1,1,1,2", options="header"]
-|===
-| Key | Required | Type | Description
-
-| `filters`
-| N
-| Map
-| A map or string to define rules for job execution. Branch and tag filters require a map. Expression-based filters require a string.
-|===
---
-
-The following is an example of how the CircleCI documentation project uses a regular expression to filter running a job in a workflow only on a specific branch:
-
-[,yaml]
-----
-# ...
-workflows:
-  build-deploy:
-    jobs:
-      - js_build
-      - build_server_pdfs: # << the job to conditionally run based on the filter-by-branch-name.
-          filters:
-            branches:
-              only: /server\/.*/ # the job build_server_pdfs will only run when the branch being built starts with server/
-----
-
-You can read more about using regular expressions in your config in the xref:guides:orchestrate:workflows.adoc#using-regular-expressions-to-filter-tags-and-branches[Using Workflows to Schedule Jobs] page.
-
-'''
-
 ==== Expression-based job filters
 Expression-based job filters allow you to conditionally run jobs based on the following:
 
@@ -3271,8 +3227,57 @@ include::guides:ROOT:partial$using-expressions/operators.adoc[]
 
 '''
 
+[#jobfilters]
+==== *`filters`*
+
+WARNING: job filters are deprecated. Use expression-based job filters instead. See <<expression-based-job-filters>> for more information.
+
+Filter job execution within a workflow based on the following:
+
+* Branch
+* Tag
+* Expression-based condition
+
+Job filters can have the keys `branches` or `tags`.
+
+Workflows ignore job-level branching. If you use job-level branching and later add workflows, you must remove the branching at the job level and instead declare it in the workflows section of your `config.yml`.
+
+[.table-scroll]
+--
+[cols="1,1,1,2", options="header"]
+|===
+| Key | Required | Type | Description
+
+| `filters`
+| N
+| Map
+| A map or string to define rules for job execution. Branch and tag filters require a map. Expression-based filters require a string.
+|===
+--
+
+The following is an example of how the CircleCI documentation project uses a regular expression to filter running a job in a workflow only on a specific branch:
+
+[,yaml]
+----
+# ...
+workflows:
+  build-deploy:
+    jobs:
+      - js_build
+      - build_server_pdfs: # << the job to conditionally run based on the filter-by-branch-name.
+          filters:
+            branches:
+              only: /server\/.*/ # the job build_server_pdfs will only run when the branch being built starts with server/
+----
+
+You can read more about using regular expressions in your config in the xref:guides:orchestrate:workflows.adoc#using-regular-expressions-to-filter-tags-and-branches[Using Workflows to Schedule Jobs] page.
+
+'''
+
 [#branches]
 ==== *`branches`*
+
+WARNING: Job filters are deprecated. Use expression-based job filters instead. See <<expression-based-job-filters>> for more information.
 
 The branches filter can have the keys `only` and `ignore`, which map to a single string naming a branch. You may also use regular expressions to match against branches by enclosing them with slashes, or map to a list of such strings. Regular expressions must match the *entire* string.
 
@@ -3329,6 +3334,8 @@ workflows:
 
 [#tags]
 ==== *`tags`*
+
+WARNING: Job filters are deprecated. Use expression-based job filters instead. See <<expression-based-job-filters>> for more information.
 
 CircleCI does not run workflows for tags unless you explicitly specify tag filters. If a job requires any other jobs (directly or indirectly), you must specify tag filters for those jobs.
 
@@ -3593,93 +3600,6 @@ workflows:
 ----
 
 '''
-
-[#logic-statements]
-== Logic statements
-
-Certain dynamic configuration features accept logic statements as arguments.
-Logic statements are evaluated to boolean values at configuration compilation
-time, that is, before the workflow is run. The group of logic statements
-includes:
-
-[.table-scroll]
---
-[cols="1,1,1,2", options="header"]
-|===
-| Type | Arguments | `true` if | Example
-
-| YAML literal
-| None
-| is truthy
-| `true`/`42`/`"a string"`
-
-| xref:guides:orchestrate:pipeline-variables.adoc#pipeline-values[Pipeline Value]
-| None
-| resolves to a truthy value
-| `<< pipeline.git.branch >>`
-
-| xref:guides:orchestrate:pipeline-variables.adoc#pipeline-parameters-in-configuration[Pipeline Parameter]
-| None
-| resolves to a truthy value
-| `<< pipeline.parameters.my-parameter >>`
-
-| `and`
-| N logic statements
-| all arguments are truthy
-| `and: [ true, true, false ]`
-
-| `or`
-| N logic statements
-| any argument is truthy
-| `or: [ false, true, false ]`
-
-| `not`
-| 1 logic statement
-| the argument is not truthy
-| `not: true`
-
-| `equal`
-| N values
-| all arguments evaluate to equal values
-| `equal: [ 42, << pipeline.number >>]`
-
-| `matches`
-| `pattern` and `value`
-| `value` matches the `pattern`
-| `+matches: { pattern: "^feature-.+$", value: << pipeline.git.branch >> }+`
-|===
---
-
-The following logic values are considered falsy:
-
-* false.
-* null.
-* 0
-* NaN
-* empty strings ("").
-* statements with no arguments.
-
-All other values are truthy. Also note that using logic with an empty list will cause a validation error.
-
-Logic statements always evaluate to a boolean value at the top level, and coerce
-as necessary. They can be nested in an arbitrary fashion, according to their
-argument specifications, and to a maximum depth of 100 levels.
-
-`matches` uses link:https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html[Java regular expressions] for its `pattern`. A full match pattern must be provided, prefix matching is not an option. It is recommended to enclose a pattern in `^` and `$` to avoid accidental partial matches.
-
-NOTE: When using logic statements at the workflow level, do not include the `condition:` key (the `condition` key is only needed for `job` level logic statements).
-
-*Example:*
-
-[,yaml]
-----
-workflows:
-  my-workflow:
-    when:
-      or:
-        - equal: [ main, << pipeline.git.branch >> ]
-        - equal: [ staging, << pipeline.git.branch >> ]
-----
 
 == Using expressions in your configuration
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -3230,7 +3230,7 @@ include::guides:ROOT:partial$using-expressions/operators.adoc[]
 [#jobfilters]
 ==== *`filters`*
 
-WARNING: job filters are deprecated. Use expression-based job filters instead. See <<expression-based-job-filters>> for more information.
+WARNING: Job filters are deprecated. Use expression-based job filters instead. See <<expression-based-job-filters>> for more information.
 
 Filter job execution within a workflow based on the following:
 
@@ -3239,8 +3239,6 @@ Filter job execution within a workflow based on the following:
 * Expression-based condition
 
 Job filters can have the keys `branches` or `tags`.
-
-Workflows ignore job-level branching. If you use job-level branching and later add workflows, you must remove the branching at the job level and instead declare it in the workflows section of your `config.yml`.
 
 [.table-scroll]
 --


### PR DESCRIPTION
# Description

Marks job-level filters as deprecated in the docs and removes the note about job-level branches.

Split out of #10118 so this policy decision (deprecating job filters) can be reviewed independently of the larger "promote expressions as primary syntax" cleanup.

# Reasons

Job filters are being deprecated in favor of expressions/workflow-level `when`. This updates `using-branch-filters.adoc` and `configuration-reference.adoc` to reflect that.

# Content checks

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR.
- [ ] Preview your changes, select the `ci/circleci: build` job and check the `index.html` artifact.