### PR TITLE
Add og:title, og:description, and JSON-LD to page head

### DIFF
--- a/extensions/markdown-export-extension.js
+++ b/extensions/markdown-export-extension.js
@@ -501,7 +501,9 @@ module.exports.register = function () {
        * layout appends it to the heading, so we preserve it here too.
        */
       const doctitle = page.asciidoc && page.asciidoc.doctitle
+      let plainTitle = ''
       if (doctitle) {
+        plainTitle = turndownService.turndown(doctitle).trim()
         const badge = page.asciidoc.attributes && page.asciidoc.attributes['page-badge']
         const titleHtml = badge ? `${doctitle} ${badge}` : doctitle
         const titleMd = turndownService.turndown(`<h1>${titleHtml}</h1>`).trim()
@@ -542,6 +544,44 @@ module.exports.register = function () {
        */
       const llmsTxtDirective = `> For the complete documentation index, see [llms.txt](${siteUrl}/llms.txt)\n\n`
       markdown = llmsTxtDirective + markdown
+
+      /**
+       * ADD YAML FRONTMATTER
+       *
+       * Metadata an agent can read without parsing the body: title,
+       * description, the doc version this page belongs to (or "unversioned"
+       * for the version-less components: guides, reference, orbs, services,
+       * contributors), and the source file's last-updated date. lastUpdate
+       * comes from page-metadata-extension.js, which runs earlier in the
+       * same 'documentsConverted' event and stashes it on this same
+       * attributes object, so it's already there by the time we get here.
+       *
+       * doc_version: page-version is '' for version-less components, so only
+       * trust page-component-display-version (the human-readable version,
+       * e.g. "Server 4.10") when a real version is set. Antora itself
+       * defaults displayVersion to the literal string 'default' when a
+       * component has no version and no display_version configured
+       * (content-catalog.js), which would be a misleading value to publish.
+       */
+      const yamlString = (value) => JSON.stringify(value || '')
+      const description = page.asciidoc.attributes && page.asciidoc.attributes['page-description']
+      const rawVersion = page.asciidoc.attributes && page.asciidoc.attributes['page-version']
+      const docVersion = rawVersion
+        ? (page.asciidoc.attributes['page-component-display-version'] || rawVersion)
+        : 'unversioned'
+      const lastUpdate = page.asciidoc.attributes && page.asciidoc.attributes.meta && page.asciidoc.attributes.meta.lastUpdate
+      const lastUpdatedISO = lastUpdate ? new Date(lastUpdate).toISOString().split('T')[0] : ''
+
+      const frontmatter = [
+        '---',
+        `title: ${yamlString(plainTitle)}`,
+        `description: ${yamlString(description)}`,
+        `doc_version: ${yamlString(docVersion)}`,
+        `last_updated: ${yamlString(lastUpdatedISO)}`,
+        '---',
+        ''
+      ].join('\n')
+      markdown = frontmatter + '\n' + markdown
 
       /**
        * CONSTRUCT OUTPUT PATH

--- a/ui/src/helpers/get-json-ld.js
+++ b/ui/src/helpers/get-json-ld.js
@@ -1,17 +1,21 @@
 'use strict'
 
-const detag = require('./detag')
+const TAG_ALL_RX = /<[^>]+>/g
+const detag = (html) => html && html.replace(TAG_ALL_RX, '')
 
 module.exports = (page, site, defaultPageTitle, { data }) => {
-  const { contentCatalog } = data.root
-  const pageFromCatalog = contentCatalog.findBy({
-    family: 'page',
-    version: page.componentVersion.version,
-    component: page.component.name,
-    module: page.module,
-    relative: page.relativeSrcPath,
-  })
-  const meta = pageFromCatalog[0]?.asciidoc?.attributes?.meta
+  let meta
+  if (page.componentVersion && page.component) {
+    const { contentCatalog } = data.root
+    const pageFromCatalog = contentCatalog.findBy({
+      family: 'page',
+      version: page.componentVersion.version,
+      component: page.component.name,
+      module: page.module,
+      relative: page.relativeSrcPath,
+    })
+    meta = pageFromCatalog[0]?.asciidoc?.attributes?.meta
+  }
 
   const jsonLd = {
     '@context': 'https://schema.org',

--- a/ui/src/helpers/get-json-ld.js
+++ b/ui/src/helpers/get-json-ld.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const detag = require('./detag')
+
+module.exports = (page, site, defaultPageTitle, { data }) => {
+  const { contentCatalog } = data.root
+  const pageFromCatalog = contentCatalog.findBy({
+    family: 'page',
+    version: page.componentVersion.version,
+    component: page.component.name,
+    module: page.module,
+    relative: page.relativeSrcPath,
+  })
+  const meta = pageFromCatalog[0]?.asciidoc?.attributes?.meta
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: detag(page.title || defaultPageTitle),
+    url: page.canonicalUrl,
+  }
+
+  const description = page.description || page.attributes?.description
+  if (description) jsonLd.description = detag(description)
+  if (meta?.lastUpdate) jsonLd.dateModified = new Date(meta.lastUpdate).toISOString().split('T')[0]
+  if (site?.title) jsonLd.publisher = { '@type': 'Organization', name: site.title }
+
+  return jsonLd
+}

--- a/ui/src/helpers/stringify.js
+++ b/ui/src/helpers/stringify.js
@@ -1,5 +1,5 @@
 'use strict'
 
 module.exports = (data) => {
-  return JSON.stringify(data, null, 2)
+  return JSON.stringify(data, null, 2).replace(/</g, '\\u003c')
 }

--- a/ui/src/partials/head-json-ld.hbs
+++ b/ui/src/partials/head-json-ld.hbs
@@ -1,0 +1,3 @@
+<script type="application/ld+json">
+{{{stringify (get-json-ld page site defaultPageTitle)}}}
+</script>

--- a/ui/src/partials/head-meta.hbs
+++ b/ui/src/partials/head-meta.hbs
@@ -1,4 +1,8 @@
 {{#if page.attributes.noindex}}
     <meta name="robots" content="noindex">
 {{/if}}
+<meta property="og:title" content="{{{detag (or page.title defaultPageTitle)}}}{{#with site.title}} - {{this}}{{/with}}">
+{{#with (or page.description page.attributes.description)}}
+<meta property="og:description" content="{{{detag this}}}">
+{{/with}}
 {{!-- Add additional meta tags here --}}

--- a/ui/src/partials/head.hbs
+++ b/ui/src/partials/head.hbs
@@ -3,5 +3,6 @@
 {{> head-info}}
 {{> head-styles}}
 {{> head-meta}}
+{{> head-json-ld}}
 {{> head-scripts}}
 {{> head-icons}}


### PR DESCRIPTION
## Summary
- Adds `og:title` and `og:description` meta tags to the Antora UI head partials, mirroring the existing `<title>`/`<meta name="description">` logic.
- Adds a JSON-LD `TechArticle` structured-data block (`headline`, `url`, `description`, `dateModified`, `publisher`) to every page.
- Hardens the `stringify` helper to escape `<` so embedded JSON can't break out of its `<script>` tag.
- Fixes a bug in the JSON-LD helper that crashed the full Antora build: a sibling `require('./detag')` doesn't resolve under Antora's UI-bundle loading (helpers are loaded via `require-from-string` with a synthetic path), and `page.componentVersion`/`page.component` are undefined on the 404 page.

Addresses the [html.og-title](https://a14y.dev/scorecards/0.2.0/checks/html.og-title/) and [html.json-ld](https://a14y.dev/scorecards/0.2.0/checks/html.json-ld/) a14y.dev accessibility checks — previously there was no Open Graph or structured-data coverage anywhere in the site.

## Test plan
- [x] `npm run build:ui` builds cleanly
- [x] Full `npm run build:docs` (all components: root, guides, reference, orbs, 4 server-admin versions, services, contributors) builds without error, including the 404 page
- [x] Verified `application/ld+json` output on real built pages is syntactically valid JSON
- [x] Smoke-tested the JSON-LD helper with a mock page containing quotes/HTML/ampersands in the title to confirm proper JSON escaping
- [ ] Visual check via `npm run start:dev` (optional, no visual change expected — head-only additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)