### PR TITLE
Update Xcode 27.0 image to beta 4

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
@@ -10,12 +10,12 @@
 | Release Notes
 
 | `27.0`
-| Xcode 27.0 (27A5209h)
+| Xcode 27.0 (27A5228h)
 | 26.5.1
 a| `m4pro.medium` +
    `m4pro.large`
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v18905/manifest.txt[Installed software]
-| link:https://circleci.com/changelog/xcode-27-0-beta-2-available/[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v19120/manifest.txt[Installed software]
+| link:https://circleci.com/changelog/xcode-27-0-beta-4-available/[Release Notes]
 
 | `26.6`
 | Xcode 26.6 (17F113)


### PR DESCRIPTION
Updates the Xcode 27.0 row on the macOS supported-versions table to reflect the newly released beta 4 image (`v19120`).

- Build: `27A5209h` (beta 2) → `27A5228h` (beta 4)
- Manifest link: `v18905` → `v19120`
- Release Notes link: `xcode-27-0-beta-2-available` → `xcode-27-0-beta-4-available`

macOS version (26.5.1) and resource classes are unchanged.