### PR TITLE
Add CircleCI code signing API for iOS and macOS projects

### DIFF
--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -87,7 +87,7 @@
 ** macOS
 *** xref:execution-managed:using-macos.adoc[Using the macOS execution environment]
 *** xref:execution-managed:hello-world-macos.adoc[Configuring a macOS app]
-*** xref:execution-managed:ios-codesigning.adoc[iOS code signing]
+*** xref:execution-managed:ios-codesigning.adoc[iOS and macOS code signing]
 ** Windows
 *** xref:execution-managed:using-windows.adoc[Using the Windows execution environment]
 *** xref:execution-managed:hello-world-windows.adoc[Hello world Windows]

--- a/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
+++ b/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
@@ -1,13 +1,241 @@
-= Set up code signing for iOS projects
+= Set up code signing for iOS and macOS projects
 :page-platform: Cloud
-:page-description: How to set up code signing for an iOS app
+:page-description: How to set up code signing for iOS and macOS apps
 :experimental:
 
-This document describes the guidelines for setting up code signing
-for your iOS project on CircleCI.
+This document describes how to set up code signing for your iOS and
+macOS projects on CircleCI. The recommended method is the *CircleCI code
+signing API*. You upload your Apple signing certificates and provisioning
+profiles to CircleCI, and it installs them onto the macOS executor at
+build time. This method works for both iOS and macOS.
+
+If you would rather store and manage your certificates yourself, or you
+already use it, <<fastlane-match,Fastlane Match>> is available as an
+alternative.
+
+NOTE: CircleCI supports the code signing API (recommended) and Fastlane Match. Other methods may be used, but are not guaranteed to work and are unsupported.
+
+[#code-signing-api]
+== Code signing with the CircleCI API
+
+With the CircleCI code signing API you upload your Apple signing
+certificate (`.p12`) and any required provisioning profiles once, then
+reference the resulting _signing bundle_ by name in your job. At build
+time, CircleCI installs the certificate and profiles into a temporary
+keychain on the macOS executor and removes them when the job finishes.
+The same endpoints and configuration are used for both iOS and macOS.
+
+[#api-prerequisites]
+=== Prerequisites
+
+* *Apple assets*: Your `.p12` certificate file and its password, and your provisioning profiles (if required for your certificate type, see <<supported-certificate-types>>).
+* *CircleCI API token*: A personal API token to authenticate your requests. See xref:guides:toolkit:managing-api-tokens.adoc[Managing API Tokens].
+* *Organization ID*: Your CircleCI organization ID. See xref:guides:toolkit:how-to-find-ids.adoc#find-an-organization-id[How to Find IDs].
+
+[#api-upload-certificate]
+=== 1. Upload a certificate
+
+Send a `POST` request to upload your certificate. The `cert_blob` is the
+Base64-encoded contents of your `.p12` file. On macOS you can generate it
+with `base64 -i <.p12-file> -o -`.
+
+[,shell]
+----
+curl -X POST https://circleci.com/api/v2/certificates \
+  -H "Circle-Token: <your-circleci-api-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "org_id": "<org-id>",
+    "cert_file_name": "<.p12-file>",
+    "cert_blob": "<.p12-base64-encoded-blob>",
+    "cert_password": "<your-cert-password>"
+  }'
+----
+
+The response returns the certificate ID:
+
+[,json]
+----
+{"id":"<cert-id>"}
+----
+
+[#api-create-signing-bundle]
+=== 2. Create a signing bundle
+
+A signing bundle maps a certificate to its provisioning profiles. Send a
+`POST` request, using the `cert-id` returned in the previous step. Each
+profile `blob` is the Base64-encoded contents of the profile file.
+
+NOTE: Signing bundle names must be unique within your organization, be at most 50 characters, and contain only letters, numbers, and hyphens (no underscores or other characters). This matches the naming rules enforced when the bundle is referenced in your configuration. See <<api-constraints>>.
+
+[,shell]
+----
+curl -X POST https://circleci.com/api/v2/signing-configs \
+  -H "Circle-Token: <your-circleci-api-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "<signing-bundle-name>",
+    "org_id": "<org-id>",
+    "cert_id": "<cert-id-from-previous-request>",
+    "provisioning_profiles": [
+      {
+        "file_name": "<provisioning-profile-file>",
+        "blob": "<provisioning-profile-base64-blob>"
+      }
+    ]
+  }'
+----
+
+The response returns the signing bundle ID:
+
+[,json]
+----
+{"id":"<signing-bundle-id>"}
+----
+
+[#api-update-config]
+=== 3. Reference the signing bundle in your configuration
+
+Add a `code_signing` key to your `macos` executor listing the signing
+bundles to install, and add the `install_signing_bundle` step before you
+build. CircleCI installs the referenced bundles onto the executor.
+
+[,yaml]
+----
+version: 2.1
+
+jobs:
+  build-and-sign:
+    macos:
+      xcode: 15.2.0
+      # List the signing bundles to install from your organization
+      code_signing:
+        - <signing-bundle-name>
+        # Add more bundles as needed
+        - <other-signing-bundle-name>
+    steps:
+      # Installs the certificates and profiles from the bundles above
+      - install_signing_bundle
+      - checkout
+      - run:
+          name: Build and archive
+          command: xcodebuild archive -scheme <your-xcode-scheme> -configuration Release
+----
+
+[#api-what-happens]
+=== What happens during the build
+
+When the `install_signing_bundle` step runs, CircleCI:
+
+* Creates a temporary keychain on the executor.
+* Imports the certificate and installs the provisioning profiles into the correct locations.
+* Configures the keychain so Xcode can use the signing key without a password prompt.
+* Removes the keychain and profiles when the job completes.
+
+[#supported-certificate-types]
+=== Supported certificate types
+
+The certificate's Subject Common Name must begin with one of the
+following prefixes, or the upload is rejected. Whether a signing bundle
+requires provisioning profiles depends on the certificate type.
+
+[.table-scroll]
+--
+[cols="2,1,2", options="header"]
+|===
+| Common Name prefix | Platform | Provisioning profiles
+
+| `Apple Distribution:`, `Apple Development:` | iOS and macOS | At least one required
+| `iPhone Distribution:`, `iPhone Developer:` | iOS | At least one required
+| `3rd Party Mac Developer Application:` (Mac App Store) | macOS | At least one required
+| `Mac Developer:` | macOS | At least one required
+| `Developer ID Application:`, `Developer ID Installer:` | macOS | None (profiles are rejected)
+| `3rd Party Mac Developer Installer:` | macOS | None (profiles are rejected)
+|===
+--
+
+[#api-manage-assets]
+=== View and delete certificates and signing bundles
+
+List the certificates stored for your organization:
+
+[,shell]
+----
+curl -H "Circle-Token: <your-circleci-api-token>" \
+  "https://circleci.com/api/v2/certificates?org-id=<org-id>"
+----
+
+List the signing bundles created for your organization:
+
+[,shell]
+----
+curl -H "Circle-Token: <your-circleci-api-token>" \
+  "https://circleci.com/api/v2/signing-configs?org-id=<org-id>"
+----
+
+Delete a certificate. Deletion fails with an HTTP 409 response if any
+signing bundle still references the certificate, so delete or update
+those bundles first.
+
+[,shell]
+----
+curl -X DELETE -H "Circle-Token: <your-circleci-api-token>" \
+  https://circleci.com/api/v2/certificates/<cert-id>
+----
+
+Delete a signing bundle:
+
+[,shell]
+----
+curl -X DELETE -H "Circle-Token: <your-circleci-api-token>" \
+  https://circleci.com/api/v2/signing-configs/<signing-bundle-id>
+----
+
+[#api-placeholders]
+=== Placeholders
+
+Replace these placeholders in the commands and configuration above with your own values.
+
+`<cert-id>`:: The unique identifier for a certificate, returned in the API response after a successful certificate upload.
+`<cert-id-from-previous-request>`:: The specific `cert_id` returned in Step 1, used to associate that certificate with a signing bundle.
+`<org-id>`:: The unique UUID for your CircleCI organization.
+`<other-signing-bundle-name>`:: An optional secondary signing configuration name (for example, `staging-signing`) if your job requires more than one certificate or set of profiles.
+`<.p12-base64-encoded-blob>`:: The raw binary content of your `.p12` certificate file converted into a Base64-encoded string. On macOS, generate it with `base64 -i <.p12-file> -o -`.
+`<.p12-file>`:: The filename of your Apple signing certificate (iOS or macOS), exported from the Keychain Access app on macOS as a `.p12` file.
+`<provisioning-profile-base64-blob>`:: The raw binary content of your provisioning profile file converted into a Base64-encoded string. On macOS, generate it with `base64 -i <provisioning-profile-file> -o -`.
+`<provisioning-profile-file>`:: The filename of the Apple provisioning profile associated with the app's bundle ID. Use a `.mobileprovision` file for iOS, or a `.provisionprofile` file for macOS, usually downloaded from the Apple Developer Portal.
+`<signing-bundle-id>`:: The unique identifier for a signing bundle, returned in the API response after a successful bundle creation.
+`<signing-bundle-name>`:: A descriptive name for this set of credentials (for example, `production-signing`) that you reference in your configuration.
+`<your-cert-password>`:: The password created when the `.p12` file was exported from Keychain Access.
+`<your-circleci-api-token>`:: A personal API token used to authenticate your requests to the CircleCI API.
+`<your-xcode-scheme>`:: The name of the specific build scheme you want to archive (for example, `MyApp` or `Runner`). Found in Xcode under *Product > Scheme*, or by running `xcodebuild -list`.
+
+[#api-constraints]
+=== Constraints
+
+[.table-scroll]
+--
+[cols="2,3", options="header"]
+|===
+| Field | Constraint
+
+| `cert_file_name` | Maximum 40 characters
+| Signing bundle `name` | Unique per organization, maximum 50 characters, letters, numbers, and hyphens only
+| `provisioning_profiles` | Maximum 100 profiles per bundle
+| Provisioning profile `file_name` | Maximum 40 characters
+|===
+--
+
+[#fastlane-match]
+== Alternative: code signing with Fastlane Match
+
+If you prefer to store and manage your own certificates and provisioning
+profiles, you can use Fastlane Match instead of the CircleCI code signing
+API. The following sections describe the Fastlane Match setup for iOS
+projects.
 
 [#basic-configuration-of-ios-projects]
-== Basic configuration of iOS projects
+=== Basic configuration of iOS projects
 
 This document assumes that you already have an iOS project building
 correctly on CircleCI using our recommended best practices. It also assumes that you use Bundler and
@@ -17,10 +245,8 @@ your repository.
 If you have not yet configured your iOS project on CircleCI,
 you can find the configuration instructions in the xref:test:testing-ios.adoc[Testing iOS Applications Document].
 
-NOTE: CircleCI only officially supports Fastlane Match for code signing. Other methods may be used, but are not guaranteed to work and are unsupported.
-
 [#setting-up-fastlane-match]
-== Set up Fastlane Match
+=== Set up Fastlane Match
 
 Code signing must be configured to generate
 ad-hoc distributions of your app and App Store builds.
@@ -42,7 +268,7 @@ To set up Fastlane Match:
 . Then, run `bundle exec fastlane match adhoc` to generate and install the Ad-hoc distribution certificates and profiles.
 
 [#preparing-your-xcode-project-for-use-with-fastlane-match]
-=== Prepare your Xcode project for use with Fastlane Match
+==== Prepare your Xcode project for use with Fastlane Match
 
 Before setting up Match you must ensure that the code signing
 settings in your Xcode project are configured as follows:
@@ -51,7 +277,7 @@ settings in your Xcode project are configured as follows:
 * *Signing & Capabilities \-> Provisioning Profile* choose the appropriate profile created by Fastlane Match (for example, `match adhoc com.circleci.helloworld`).
 
 [#adding-match-to-the-fastlane-lane]
-=== Add Match to the Fastlane lane
+==== Add Match to the Fastlane lane
 
 On CircleCI, Fastlane Match will need to be run every time you build and sign your app. The easiest way to do this is to add the `match` action to the lane which builds your app.
 
@@ -82,7 +308,7 @@ end
 ----
 
 [#adding-a-user-key-to-the-circleci-project]
-=== Add a user key to the CircleCI project
+==== Add a user key to the CircleCI project
 
 To enable Fastlane Match to download the certificates and the keys from GitHub, add a user key to the CircleCI project. This key needs access to both the project repository and the certificates / keys repository.
 
@@ -115,7 +341,7 @@ After you have added a user key, CircleCI will be able to checkout both the
 project repository and the Fastlane Match repository from GitHub.
 
 [#adding-the-match-passphrase-to-the-project]
-=== Add the Match passphrase to the project
+==== Add the Match passphrase to the project
 
 To enable Fastlane Match to decrypt the certificates and profiles stored in the GitHub repository, add the encryption passphrase to the CircleCI project's environment variables. Use the passphrase that you configured in the Match setup step.
 
@@ -123,7 +349,7 @@ In the project settings on CircleCI, click on *Environment Variables* and add th
 encrypted at rest.
 
 [#invoking-the-fastlane-test-lane-on-circleci]
-=== Build and code-sign the app on CircleCI
+==== Build and code-sign the app on CircleCI
 
 After you have configured Match and added its invocation into the appropriate
 lane, you can run that lane on CircleCI. The following `config.yml` will
@@ -159,7 +385,7 @@ workflows:
 ----
 
 [#sample-configuration-files]
-== Sample configuration files
+=== Sample configuration files
 
 The best practice configuration for setting up code signing for iOS projects is as follows:
 
@@ -236,7 +462,7 @@ workflows:
 By setting `FL_OUTPUT_DIR:`, that will tell Fastlane to output the Xcode and Fastlane logs to that directory, so they get uploaded as artifacts for ease in troubleshooting.
 
 [#example-application-on-github]
-== Example application on GitHub
+=== Example application on GitHub
 
 See the link:https://github.com/CircleCI-Public/circleci-demo-ios[`circleci-demo-ios` GitHub repository]
 for an example of how to configure code signing for iOS apps using

--- a/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
+++ b/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
@@ -42,7 +42,7 @@ You will need to provide the following:
 * Your personal API token.
 * `<org-id>`: Your CircleCI organization ID. See xref:guides:toolkit:how-to-find-ids.adoc#find-an-organization-id[How to Find IDs].
 * `<.p12-base64-encoded-blob>`: he the raw binary content of your `.p12` certificate file converted into a Base64-encoded string. On macOS, generate it with `base64 -i <.p12-file> -o -`.
-* `<.p12-file>`: Thsi is the filename of your Apple signing certificate (iOS or macOS), exported from the Keychain Access app on macOS as a `.p12` file. Max 40 characters.
+* `<.p12-file>`: This is the filename of your Apple signing certificate (iOS or macOS), exported from the Keychain Access app on macOS as a `.p12` file. Max 40 characters.
 * `<your-cert-password>`: The password created when the `.p12` file was exported from Keychain Access.
 
 [,shell]
@@ -96,7 +96,7 @@ curl -X POST https://circleci.com/api/v2/signing-configs \
   }'
 ----
 
-The response returns the signing bundle ID. You wiln need the signing bundle ID when managing your assets, for example deleting a signing bundle. See <<api-manage-assets>> for more information:
+The response returns the signing bundle ID. You will need the signing bundle ID when managing your assets, for example deleting a signing bundle. See <<api-manage-assets>> for more information:
 
 [,json]
 ----

--- a/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
+++ b/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
@@ -35,9 +35,15 @@ The same endpoints and configuration are used for both iOS and macOS.
 [#api-upload-certificate]
 === 1. Upload a certificate
 
-Send a `POST` request to upload your certificate. The `cert_blob` is the
-Base64-encoded contents of your `.p12` file. On macOS you can generate it
-with `base64 -i <.p12-file> -o -`.
+Send a `POST` request to upload your certificate.
+
+You will need to provide the following:
+
+* Your personal API token.
+* `<org-id>`: Your CircleCI organization ID. See xref:guides:toolkit:how-to-find-ids.adoc#find-an-organization-id[How to Find IDs].
+* `<.p12-base64-encoded-blob>`: he the raw binary content of your `.p12` certificate file converted into a Base64-encoded string. On macOS, generate it with `base64 -i <.p12-file> -o -`.
+* `<.p12-file>`: Thsi is the filename of your Apple signing certificate (iOS or macOS), exported from the Keychain Access app on macOS as a `.p12` file. Max 40 characters.
+* `<your-cert-password>`: The password created when the `.p12` file was exported from Keychain Access.
 
 [,shell]
 ----
@@ -52,7 +58,7 @@ curl -X POST https://circleci.com/api/v2/certificates \
   }'
 ----
 
-The response returns the certificate ID:
+The response returns the certificate ID. The certificate ID is the unique identifier for a certificate, returned in the API response after a successful certificate upload:
 
 [,json]
 ----
@@ -63,10 +69,14 @@ The response returns the certificate ID:
 === 2. Create a signing bundle
 
 A signing bundle maps a certificate to its provisioning profiles. Send a
-`POST` request, using the `cert-id` returned in the previous step. Each
-profile `blob` is the Base64-encoded contents of the profile file.
+`POST` request, using the following:
 
-NOTE: Signing bundle names must be unique within your organization, be at most 50 characters, and contain only letters, numbers, and hyphens (no underscores or other characters). This matches the naming rules enforced when the bundle is referenced in your configuration. See <<api-constraints>>.
+* Your personal API token.
+* `<signing-bundle-name>`: A descriptive name for this set of credentials (for example, `production-signing`) that you reference in your configuration. Unique per organization, maximum 50 characters, letters, numbers, and hyphens only.
+* `<org-id>`: Your CircleCI organization ID. See xref:guides:toolkit:how-to-find-ids.adoc#find-an-organization-id[How to Find IDs].
+* `cert-id-from-previous-request`: The `cert-id` returned in the previous step.
+* Each provisioning profile's filename and `blob`. The `blob` is the raw binary content of the profile file converted into a Base64-encoded string. On macOS, generate it with `base64 -i <provisioning-profile-file> -o -`. The filename is the filename of the Apple provisioning profile associated with the app's bundle ID. Use a `.mobileprovision` file for iOS, or a `.provisionprofile` file for macOS, usually downloaded from the Apple Developer Portal. Maximum 40 characters.
+* A maximum of 100 profiles per bundle.
 
 [,shell]
 ----
@@ -86,7 +96,7 @@ curl -X POST https://circleci.com/api/v2/signing-configs \
   }'
 ----
 
-The response returns the signing bundle ID:
+The response returns the signing bundle ID. You wiln need the signing bundle ID when managing your assets, for example deleting a signing bundle. See <<api-manage-assets>> for more information:
 
 [,json]
 ----
@@ -99,6 +109,11 @@ The response returns the signing bundle ID:
 Add a `code_signing` key to your `macos` executor listing the signing
 bundles to install, and add the `install_signing_bundle` step before you
 build. CircleCI installs the referenced bundles onto the executor.
+
+* `<signing-bundle-name>`: A descriptive name for this set of credentials (for example, `production-signing`) that you reference in your configuration. Unique per organization, maximum 50 characters, letters, numbers, and hyphens only.
+* `<other-signing-bundle-name>`: An optional secondary signing configuration name (for example, `staging-signing`) if your job requires more than one certificate or set of profiles.
+* `<your-xcode-scheme>`: The name of the specific build scheme you want to archive (for example, `MyApp` or `Runner`). Found in Xcode under *Product > Scheme*, or by running `xcodebuild -list`.
+
 
 [,yaml]
 ----
@@ -157,74 +172,35 @@ requires provisioning profiles depends on the certificate type.
 [#api-manage-assets]
 === View and delete certificates and signing bundles
 
-List the certificates stored for your organization:
+You can list the certificates stored for your organization, and the signing bundles created for your organization. You can also delete a certificate or signing bundle.
 
+.List the certificates stored for your organization
 [,shell]
 ----
 curl -H "Circle-Token: <your-circleci-api-token>" \
   "https://circleci.com/api/v2/certificates?org-id=<org-id>"
 ----
 
-List the signing bundles created for your organization:
-
+.List the signing bundles created for your organization
 [,shell]
 ----
 curl -H "Circle-Token: <your-circleci-api-token>" \
   "https://circleci.com/api/v2/signing-configs?org-id=<org-id>"
 ----
 
-Delete a certificate. Deletion fails with an HTTP 409 response if any
-signing bundle still references the certificate, so delete or update
-those bundles first.
-
+.Delete a certificate. Deletion fails with an HTTP 409 response if any signing bundle still references the certificate, so delete or update those bundles first.
 [,shell]
 ----
 curl -X DELETE -H "Circle-Token: <your-circleci-api-token>" \
   https://circleci.com/api/v2/certificates/<cert-id>
 ----
 
-Delete a signing bundle:
-
+.Delete a signing bundle
 [,shell]
 ----
 curl -X DELETE -H "Circle-Token: <your-circleci-api-token>" \
   https://circleci.com/api/v2/signing-configs/<signing-bundle-id>
 ----
-
-[#api-placeholders]
-=== Placeholders
-
-Replace these placeholders in the commands and configuration above with your own values.
-
-`<cert-id>`:: The unique identifier for a certificate, returned in the API response after a successful certificate upload.
-`<cert-id-from-previous-request>`:: The specific `cert_id` returned in Step 1, used to associate that certificate with a signing bundle.
-`<org-id>`:: The unique UUID for your CircleCI organization.
-`<other-signing-bundle-name>`:: An optional secondary signing configuration name (for example, `staging-signing`) if your job requires more than one certificate or set of profiles.
-`<.p12-base64-encoded-blob>`:: The raw binary content of your `.p12` certificate file converted into a Base64-encoded string. On macOS, generate it with `base64 -i <.p12-file> -o -`.
-`<.p12-file>`:: The filename of your Apple signing certificate (iOS or macOS), exported from the Keychain Access app on macOS as a `.p12` file.
-`<provisioning-profile-base64-blob>`:: The raw binary content of your provisioning profile file converted into a Base64-encoded string. On macOS, generate it with `base64 -i <provisioning-profile-file> -o -`.
-`<provisioning-profile-file>`:: The filename of the Apple provisioning profile associated with the app's bundle ID. Use a `.mobileprovision` file for iOS, or a `.provisionprofile` file for macOS, usually downloaded from the Apple Developer Portal.
-`<signing-bundle-id>`:: The unique identifier for a signing bundle, returned in the API response after a successful bundle creation.
-`<signing-bundle-name>`:: A descriptive name for this set of credentials (for example, `production-signing`) that you reference in your configuration.
-`<your-cert-password>`:: The password created when the `.p12` file was exported from Keychain Access.
-`<your-circleci-api-token>`:: A personal API token used to authenticate your requests to the CircleCI API.
-`<your-xcode-scheme>`:: The name of the specific build scheme you want to archive (for example, `MyApp` or `Runner`). Found in Xcode under *Product > Scheme*, or by running `xcodebuild -list`.
-
-[#api-constraints]
-=== Constraints
-
-[.table-scroll]
---
-[cols="2,3", options="header"]
-|===
-| Field | Constraint
-
-| `cert_file_name` | Maximum 40 characters
-| Signing bundle `name` | Unique per organization, maximum 50 characters, letters, numbers, and hyphens only
-| `provisioning_profiles` | Maximum 100 profiles per bundle
-| Provisioning profile `file_name` | Maximum 40 characters
-|===
---
 
 [#fastlane-match]
 == Alternative: code signing with Fastlane Match

--- a/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
+++ b/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
@@ -41,7 +41,7 @@ You will need to provide the following:
 
 * Your personal API token.
 * `<org-id>`: Your CircleCI organization ID. See xref:guides:toolkit:how-to-find-ids.adoc#find-an-organization-id[How to Find IDs].
-* `<.p12-base64-encoded-blob>`: he the raw binary content of your `.p12` certificate file converted into a Base64-encoded string. On macOS, generate it with `base64 -i <.p12-file> -o -`.
+* `<.p12-base64-encoded-blob>`: The raw binary content of your `.p12` certificate file converted into a Base64-encoded string. On macOS, generate it with `base64 -i <.p12-file> -o -`.
 * `<.p12-file>`: This is the filename of your Apple signing certificate (iOS or macOS), exported from the Keychain Access app on macOS as a `.p12` file. Max 40 characters.
 * `<your-cert-password>`: The password created when the `.p12` file was exported from Keychain Access.
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -1077,6 +1077,11 @@ CircleCI supports running jobs on link:https://developer.apple.com/macos/[macOS]
 | Y
 | String
 | The version of Xcode that is installed on the virtual machine, see the xref:guides:execution-managed:using-macos.adoc#supported-xcode-versions[Supported Xcode Versions Section of the Testing iOS] document for the complete list.
+
+| `code_signing`
+| N
+| List
+| A list of signing bundle names to install onto the macOS virtual machine with the `install_signing_bundle` step. See xref:guides:execution-managed:ios-codesigning.adoc[Set up Code Signing for iOS and macOS Projects].
 |===
 --
 
@@ -2421,6 +2426,30 @@ steps:
 ----
 
 NOTE: Even though CircleCI uses `ssh-agent` to sign all added SSH keys, you *must* use the `add_ssh_keys` key to actually add keys to a container.
+
+'''
+
+[#install-signing-bundle]
+=== *`install_signing_bundle`*
+
+A special step that installs the code signing certificates and provisioning profiles from the signing bundles declared in the `code_signing` key of your `macos` executor. CircleCI installs them into a temporary keychain on the runner at build time and removes them when the job completes. See xref:guides:execution-managed:ios-codesigning.adoc[Set up Code Signing for iOS and macOS Projects].
+
+In the case of `install_signing_bundle`, the step type is just a string with no additional attributes.
+
+*Example:*
+
+[,yaml]
+----
+jobs:
+  build-and-sign:
+    macos:
+      xcode: 15.2.0
+      code_signing:
+        - my-signing-bundle
+    steps:
+      - install_signing_bundle
+      - checkout
+----
 
 '''
 


### PR DESCRIPTION
# Description
What did you change?
Added a CircleCI code signing API section (iOS and macOS) as the primary method and moved the existing Fastlane Match content under an "Alternative" heading.

# Reasons
Why did you make these changes? What problem does this solve?
The API is now the recommended way to manage signing certificates and profiles, so the page should lead with it while keeping Fastlane Match as an option.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
