### PR TITLE
Increase docs information density (left nav, article, page TOC)

### DIFF
--- a/ui/src/css/base.css
+++ b/ui/src/css/base.css
@@ -313,17 +313,30 @@ html[data-theme="dark"] [data-page-navigation] .nav-link:hover {
   color: var(--dark-link-color);
 }
 
-/* Current page navigation item text color and weight in dark mode */
-html[data-theme="dark"] [data-page-navigation] [data-current] span,
-html[data-theme="dark"] [data-page-navigation] .bg-fog span {
-  color: var(--dark-text-primary);
-  font-weight: 400;
+/* Current page in the left nav (dark mode): blue text, matching light mode.
+   --color-link-on-light remaps to the dark link colour under data-theme="dark". */
+html[data-theme="dark"] [data-page-navigation] [data-current] .nav-link-text {
+  color: var(--color-link-on-light);
+  font-weight: 500;
 }
 
 /* Active parent navigation item (parent of current page) color and weight in dark mode */
 html[data-theme="dark"] [data-page-navigation] [data-active-parent] a,
 html[data-theme="dark"] [data-page-navigation] [data-active-parent] span {
   color: var(--dark-text-muted);
+  font-weight: 600;
+}
+
+/* Current page in the left nav: blue text, no background pill (matches design).
+   Dark mode keeps its own treatment via the higher-specificity rule above. */
+[data-page-navigation] [data-current] .nav-link-text {
+  color: var(--color-link-on-light);
+  font-weight: 500;
+}
+
+/* Active parent (ancestor of the current page) in the left nav: bold, to match
+   the design. Dark mode keeps its own treatment via the rule above. */
+[data-page-navigation] [data-active-parent] .nav-link-text {
   font-weight: 600;
 }
 

--- a/ui/src/css/body.css
+++ b/ui/src/css/body.css
@@ -17,7 +17,7 @@
   [data-page-navigation] aside {
     height: 100%;
     overflow-y: auto;
-    padding-top: 2.5rem; /* Space for component nav area */
+    padding-top: 2rem; /* 32px gap below the header, aligned with the article breadcrumbs */
     padding-bottom: 3rem; /* Extra space at bottom for last nav item */
   }
 }

--- a/ui/src/css/doc.css
+++ b/ui/src/css/doc.css
@@ -109,40 +109,41 @@
     font-size: 24px;
   }
 
-  /* Gives the breadcrumbs→title gap on mobile, matching the tablet/desktop rule.
-     Uses the same --rem-base calc as the ≥768 rule; with the 16px root and
-     --rem-base:16 this resolves to a true 40px. */
+  /* On mobile, the breadcrumbs→title gap and section-heading top margin are 32px
+     (desktop/tablet uses 24px — see the ≥768 rule below). */
   .doc h1.page {
-    margin-top: calc(40 / var(--rem-base) * 1rem);
+    margin-top: calc(32 / var(--rem-base) * 1rem); /* 32px */
   }
 
   .doc h2 {
     font-size: 20px;
+    margin-top: calc(32 / var(--rem-base) * 1rem); /* 32px */
     margin-bottom: 24px;
   }
 
   .doc h3 {
     font-size: 18px;
-    margin-top: 20px;
+    margin-top: calc(32 / var(--rem-base) * 1rem); /* 32px */
   }
 
   .doc h4 {
     font-size: 16px;
+    margin-top: calc(32 / var(--rem-base) * 1rem); /* 32px */
   }
 }
 
 /* Special case: Page title gets extra top margin on larger screens */
 @media screen and (min-width: 768px) {
   .doc h1.page {
-    margin-top: calc(40 / var(--rem-base) * 1rem); /* 40px */
+    margin-top: calc(24 / var(--rem-base) * 1rem); /* 24px */
     margin-bottom: calc(32 / var(--rem-base) * 1rem); /* 32px */
   }
 
-  /* Section headings should have 40px top margin */
+  /* Section headings should have 24px top margin */
   .doc h2,
   .doc h3,
   .doc h4 {
-    margin-top: calc(40 / var(--rem-base) * 1rem); /* 40px */
+    margin-top: calc(24 / var(--rem-base) * 1rem); /* 24px */
   }
 }
 

--- a/ui/src/css/main.css
+++ b/ui/src/css/main.css
@@ -7,11 +7,6 @@ body.-toc aside.toc.sidebar {
     display: none;
   }
 
-  aside.toc.embedded {
-    margin-top: 2.5rem;
-    margin-bottom: 2.5rem;
-  }
-
   /* Overflow guard for the content wrapper only. Excludes the breadcrumb
      toolbar: this unlayered max-width would otherwise override the toolbar's
      max-w-[888px] utility (unlayered beats @layer) and break its centring,
@@ -33,25 +28,15 @@ body.-toc aside.toc.sidebar {
   }
 }
 
-/* Tablet view (1024px - 1199px): Show embedded TOC, hide sidebar TOC */
+/* Tablet view (1024px - 1199px): hide sidebar TOC (page TOC lives in the floating dropdown) */
 @media screen and (min-width: 1024px) and (max-width: 1199.5px) {
   aside.toc.sidebar {
     display: none;
   }
-
-  aside.toc.embedded {
-    display: block;
-    margin-top: 2.5rem;
-    margin-bottom: 2.5rem;
-  }
 }
 
-/* Desktop view (1200px+): Show sidebar TOC, hide embedded TOC */
+/* Desktop view (1200px+): show sidebar TOC */
 @media screen and (min-width: 1200px) {
-  aside.toc.embedded {
-    display: none;
-  }
-
   aside.toc.sidebar {
     flex: 0 0 var(--toc-width);
     order: 1;

--- a/ui/src/css/toc.css
+++ b/ui/src/css/toc.css
@@ -31,15 +31,6 @@
   margin-bottom: 1.2rem;
 }
 
-/* The embedded TOC is shown the whole way up to the 1200px sidebar reflow, so
-   its heading spacing must cover that range too — previously this stopped at
-   1024px, leaving the heading cramped against the links in the 1024–1199 band. */
-@media screen and (max-width: 1199.5px) {
-  .toc.embedded .toc-menu h3 {
-    margin-bottom: 1.25rem;
-  }
-}
-
 .toc .toc-menu ul {
   font-size: calc(15 / var(--rem-base) * 1rem);
   line-height: var(--toc-line-height);
@@ -98,9 +89,9 @@
   transition: border-left-color 0.3s ease, border-left-width 0.3s ease;
 }
 
-/* The embedded TOC (shown below the 1200px sidebar reflow) uses link-blue for its
-   items on both mobile and tablet — previously this stopped at 768px, leaving the
-   tablet links grey. The sidebar TOC at 1200px+ keeps its own grey styling. */
+/* Below the 1200px sidebar reflow the page TOC appears only in the floating
+   dropdown panel; colour its links link-blue. The sidebar TOC at 1200px+ keeps
+   its own grey styling. */
 @media screen and (max-width: 1199.5px) {
   .toc .toc-menu a {
     color: var(--link-font-color);
@@ -112,7 +103,7 @@
   outline: none;
 }
 
-.toc.embedded .toc-menu a {
+.toc-float-panel .toc-menu a {
   display: block;
 }
 
@@ -188,4 +179,85 @@
 /* Hide subsection badges in TOC */
 .toc .subsection-badge {
   display: none;
+}
+
+/* === Floating "On this page" button + dropdown ===
+   Shown below the 1200px sidebar reflow (replaces the old embedded link list at
+   the top of the article). The sidebar TOC owns >= 1200px. Built in
+   js/02-on-this-page.js and appended to <body> so it floats over the content. */
+.toc-float {
+  display: none;
+}
+
+@media screen and (max-width: 1199.5px) {
+  .toc-float {
+    display: block;
+    position: fixed;
+    top: calc(var(--header-height) + 1.5rem); /* 24px below the header */
+    right: 1.5rem;
+    z-index: 40;
+  }
+}
+
+/* The mobile header has no component-nav row, so it is shorter than
+   --header-height; sit the button closer to the top. */
+@media screen and (max-width: 767.5px) {
+  .toc-float {
+    top: 8rem; /* ~24px below the shorter mobile header */
+    right: 1rem;
+  }
+}
+
+.toc-float-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  color: var(--toc-heading-font-color);
+  background: var(--body-background); /* opaque page bg: reads as "no fill" but no content bleeds through */
+  border: 1px solid var(--toc-border-color); /* vapor #D4D4D4 */
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+/* Active (panel open) and hover: filled with fog-60 (#EDEDED; dark #2E3C52). */
+.toc-float-btn:hover,
+.toc-float-btn[aria-expanded="true"] {
+  background: var(--color-fog);
+}
+
+.toc-float-btn:focus-visible {
+  outline: 2px solid var(--link-font-color);
+  outline-offset: 2px;
+}
+
+.toc-float-panel {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  width: max-content;
+  min-width: 220px;
+  max-width: min(320px, calc(100vw - 2rem));
+  max-height: calc(100vh - var(--header-height) - 3rem);
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+  background: var(--body-background);
+  border: 1px solid var(--toc-border-color);
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 30px rgb(0 0 0 / 16%);
+}
+
+.toc-float-panel[hidden] {
+  display: none;
+}
+
+.toc-float-panel .toc-menu {
+  margin: 0;
+}
+
+.toc-float-panel .toc-menu h3 {
+  margin-bottom: 0.5rem;
 }

--- a/ui/src/css/toc.css
+++ b/ui/src/css/toc.css
@@ -92,7 +92,8 @@
   color: inherit;
   border-left: 1px solid var(--toc-border-color);
   display: inline-block;
-  padding: 0.6rem 0 0.6rem 0.8rem;
+  /* Inter-item spacing is 2x this vertical padding (li margin is 0); 0.45rem -> 12px gap. */
+  padding: 0.45rem 0 0.45rem 0.8rem;
   text-decoration: none;
   transition: border-left-color 0.3s ease, border-left-width 0.3s ease;
 }

--- a/ui/src/css/vars.css
+++ b/ui/src/css/vars.css
@@ -215,7 +215,6 @@
   --heading-font-weight: 500;
   --alt-heading-font-weight: 500;
   --toc-line-height: 1.2;
-  --nav-line-height: 1.35;
   --footer-line-height: var(--doc-line-height);
   --caption-font-style: italic;
   --caption-font-weight: 300;
@@ -234,7 +233,6 @@
   --nav-height--desktop: var(--body-min-height);
   --nav-panel-menu-height: calc(100% - var(--drawer-height));
   --nav-panel-explore-height: calc(50% + var(--drawer-height));
-  --nav-width: calc(270 / var(--rem-base) * 1rem);
   --spacing: 0.25rem; /* Base spacing unit */
   --toc-top: calc(var(--header-height) + var(--spacing) * 2); /* Sticky TOC sits below the header with an 8px gap (≈10rem/160px). */
   --toc-height: calc(100vh - var(--toc-top) - 6.2rem);

--- a/ui/src/js/02-on-this-page.js
+++ b/ui/src/js/02-on-this-page.js
@@ -58,21 +58,62 @@
   menu.appendChild(title)
   menu.appendChild(list)
 
-  var pageTitle = article.querySelector('h1.page')
-  if (pageTitle) {
-    var embeddedToc = document.createElement('aside')
-    embeddedToc.className = 'toc embedded'
-    embeddedToc.appendChild(menu.cloneNode(true))
-    // Find the info bar (next sibling after the title, or the element after the title)
-    var infoBar = pageTitle.nextElementSibling
-    if (infoBar && infoBar.classList && infoBar.classList.contains('mt-5')) {
-      // Insert after the info bar
-      infoBar.parentNode.insertBefore(embeddedToc, infoBar.nextSibling)
-    } else {
-      // Fallback: insert after the title if no info bar found
-      pageTitle.parentNode.insertBefore(embeddedToc, pageTitle.nextSibling)
-    }
+  // Below the 1200px sidebar reflow, surface the TOC through a floating
+  // book button that toggles a dropdown panel (CSS shows this only < 1200px;
+  // the sidebar above owns >= 1200px). Cloning happens before 12-toc-collapse
+  // runs, so the panel copy has no collapse button.
+  var tocTitle = sidebar.dataset.title || 'On This Page'
+  var float = document.createElement('div')
+  float.className = 'toc-float'
+
+  var btn = document.createElement('button')
+  btn.className = 'toc-float-btn'
+  btn.setAttribute('type', 'button')
+  btn.setAttribute('aria-haspopup', 'true')
+  btn.setAttribute('aria-expanded', 'false')
+  btn.setAttribute('aria-controls', 'toc-float-panel')
+  btn.setAttribute('aria-label', tocTitle)
+  btn.innerHTML = '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/><path d="M6 8h2"/><path d="M6 12h2"/><path d="M16 8h2"/><path d="M16 12h2"/></svg>'
+
+  var panel = document.createElement('div')
+  panel.className = 'toc toc-float-panel'
+  panel.id = 'toc-float-panel'
+  panel.setAttribute('hidden', '')
+  panel.appendChild(menu.cloneNode(true))
+
+  float.appendChild(btn)
+  float.appendChild(panel)
+  document.body.appendChild(float)
+
+  function openPanel () {
+    panel.removeAttribute('hidden')
+    btn.setAttribute('aria-expanded', 'true')
+    float.classList.add('open')
   }
+  function closePanel () {
+    panel.setAttribute('hidden', '')
+    btn.setAttribute('aria-expanded', 'false')
+    float.classList.remove('open')
+  }
+
+  btn.addEventListener('click', function (e) {
+    e.stopPropagation()
+    if (panel.hasAttribute('hidden')) openPanel(); else closePanel()
+  })
+  // Close after choosing a destination.
+  panel.addEventListener('click', function (e) {
+    if (e.target.closest('a')) closePanel()
+  })
+  // Close on outside click and on Escape.
+  document.addEventListener('click', function (e) {
+    if (!panel.hasAttribute('hidden') && !float.contains(e.target)) closePanel()
+  })
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !panel.hasAttribute('hidden')) {
+      closePanel()
+      btn.focus()
+    }
+  })
 
   window.addEventListener('load', function () {
     onScroll()

--- a/ui/src/partials/article-info-bar.hbs
+++ b/ui/src/partials/article-info-bar.hbs
@@ -1,4 +1,4 @@
-<div class="mt-5 mb-10 lg:mt-0 w-full md:w-fit max-w-full md:px-4 flex flex-col md:flex-row border border-vapor rounded-xl items-stretch justify-between {{#if class}}{{class}}{{/if}}">
+<div class="mt-5 mb-6 lg:mt-0 w-full md:w-fit max-w-full md:px-4 flex flex-col md:flex-row border border-vapor rounded-xl items-stretch justify-between {{#if class}}{{class}}{{/if}}">
   {{#with (get-page-meta page)}}
 
     <div class="flex items-center pl-3 md:pl-0 pr-3 py-2">

--- a/ui/src/partials/article-toolbar.hbs
+++ b/ui/src/partials/article-toolbar.hbs
@@ -1,3 +1,3 @@
-<div role="navigation" aria-label="Article Toolbar" class="article-toolbar flex flex-col max-w-[var(--doc-max-width--desktop)] md:items-center ml-auto mr-auto px-[var(--doc-padding-x)] lg:ml-12 lg:mr-0 lg:px-0 mt-6 md:mt-12 md:flex-row text-base font-normal" >
+<div role="navigation" aria-label="Article Toolbar" class="article-toolbar flex flex-col max-w-[var(--doc-max-width--desktop)] md:items-center ml-auto mr-auto px-[var(--doc-padding-x)] lg:ml-12 lg:mr-0 lg:px-0 mt-6 md:mt-8 md:flex-row text-base font-normal" >
   {{> breadcrumbs}}
 </div>

--- a/ui/src/partials/mobile-component-dropdown.hbs
+++ b/ui/src/partials/mobile-component-dropdown.hbs
@@ -1,4 +1,6 @@
 <!-- Component Dropdown for Mobile -->
-<div class="md:hidden flex justify-center px-[32px] mt-6 mb-4">
+<!-- pr is widened to clear the floating page-TOC book button (fixed top-right below 768px).
+     Temporary: the book button is slated for rework in a separate change. -->
+<div class="md:hidden flex justify-center pl-[32px] pr-[84px] mt-6 mb-4">
   {{> dropdown options=(components-to-nav-list) class="w-full" }}
 </div>

--- a/ui/src/partials/navigation-tree.hbs
+++ b/ui/src/partials/navigation-tree.hbs
@@ -3,9 +3,9 @@
   {{#each navigation}}
   <li data-navigation-tree-content class="my-0" data-depth="{{or ../level 0}}" {{#if (eq ./url @root.page.url)}} data-current{{/if}}>
     {{#if ./content}}
-      <div data-navigation-tree-toggle class="flex items-start py-[4px] px-[12px] space-x-2 max-w-fit"{{#if (has-active-child ./items)}} data-active-parent{{/if}}>
+      <div data-navigation-tree-toggle class="flex items-start py-[4px] pl-[8px] pr-[12px] space-x-2 max-w-fit"{{#if (has-active-child ./items)}} data-active-parent{{/if}}>
         {{#if ./items.length }}
-          <button class="flex items-center h-[26px] -ml-[1.3rem] p-1 flex-shrink-0" aria-label="Toggle {{./content}}" aria-expanded="{{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url)))}}false{{else}}true{{/if}}">
+          <button class="flex items-center h-[26px] p-1 flex-shrink-0" aria-label="Toggle {{./content}}" aria-expanded="{{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url)))}}false{{else}}true{{/if}}">
             <svg width="6" height="4" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-[6px] h-[6px] transform {{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url))) }}-rotate-90{{/if}}" aria-hidden="true">
               <path fill-rule="evenodd" clip-rule="evenodd" d="M3.35355 3.85355C3.15829 4.04882 2.84171 4.04882 2.64645 3.85355L0.146447 1.35355C-0.0488155 1.15829 -0.0488155 0.841708 0.146447 0.646446C0.341709 0.451184 0.658292 0.451184 0.853554 0.646446L3 2.79289L5.14645 0.646447C5.34171 0.451184 5.65829 0.451184 5.85355 0.646447C6.04882 0.841709 6.04882 1.15829 5.85355 1.35355L3.35355 3.85355Z" fill="currentColor"/>
             </svg>
@@ -42,7 +42,14 @@
     {{/if}}
   </li>
   <li data-navigation-tree-children class="{{#if (and ./content ./items.length (not (has-active-child ./items)) (not (eq ./url @root.page.url)) ) }}hidden{{/if}}">
-    {{> navigation-tree class="pr-2 pl-8" navigation=./items level=(increment ../level)}}
+    {{!-- Indent 32px per real nesting level. The component nav has an empty root
+          wrapper node, so its children are the visible top-level items and must
+          stay flush; only indent when the parent item itself has content. --}}
+    {{#if ./content}}
+      {{> navigation-tree class="pr-2 pl-8" navigation=./items level=(increment ../level)}}
+    {{else}}
+      {{> navigation-tree class="pr-2" navigation=./items level=(increment ../level)}}
+    {{/if}}
   </li>
   {{/each}}
 </ul>

--- a/ui/src/partials/navigation-tree.hbs
+++ b/ui/src/partials/navigation-tree.hbs
@@ -1,11 +1,11 @@
 {{#if navigation.length}}
 <ul class="{{#if (and class (not (eq class "")))}}{{class}} {{/if}}text-terminal-black font-normal">
   {{#each navigation}}
-  <li data-navigation-tree-content class="my-1" data-depth="{{or ../level 0}}" {{#if (eq ./url @root.page.url)}} data-current{{/if}}>
+  <li data-navigation-tree-content class="my-0" data-depth="{{or ../level 0}}" {{#if (eq ./url @root.page.url)}} data-current{{/if}}>
     {{#if ./content}}
-      <div data-navigation-tree-toggle class="flex items-center py-[8px] px-[12px] space-x-2 max-w-fit {{#if (eq ./url @root.page.url)}} rounded-lg bg-fog{{/if}} {{#if (has-active-child ./items)}} border-none{{/if}}"{{#if (has-active-child ./items)}} data-active-parent{{/if}}>
+      <div data-navigation-tree-toggle class="flex items-start py-[4px] px-[12px] space-x-2 max-w-fit {{#if (has-active-child ./items)}} border-none{{/if}}"{{#if (has-active-child ./items)}} data-active-parent{{/if}}>
         {{#if ./items.length }}
-          <button class="block -ml-[1.3rem] p-1 h-full flex-shrink-0" aria-label="Toggle {{./content}}" aria-expanded="{{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url)))}}false{{else}}true{{/if}}">
+          <button class="flex items-center h-[26px] -ml-[1.3rem] p-1 flex-shrink-0" aria-label="Toggle {{./content}}" aria-expanded="{{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url)))}}false{{else}}true{{/if}}">
             <svg width="6" height="4" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-[6px] h-[6px] transform {{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url))) }}-rotate-90{{/if}}" aria-hidden="true">
               <path fill-rule="evenodd" clip-rule="evenodd" d="M3.35355 3.85355C3.15829 4.04882 2.84171 4.04882 2.64645 3.85355L0.146447 1.35355C-0.0488155 1.15829 -0.0488155 0.841708 0.146447 0.646446C0.341709 0.451184 0.658292 0.451184 0.853554 0.646446L3 2.79289L5.14645 0.646447C5.34171 0.451184 5.65829 0.451184 5.85355 0.646447C6.04882 0.841709 6.04882 1.15829 5.85355 1.35355L3.35355 3.85355Z" fill="currentColor"/>
             </svg>
@@ -42,7 +42,7 @@
     {{/if}}
   </li>
   <li data-navigation-tree-children class="{{#if (and ./content ./items.length (not (has-active-child ./items)) (not (eq ./url @root.page.url)) ) }}hidden{{/if}}">
-    {{> navigation-tree class="pr-2 pl-6" navigation=./items level=(increment ../level)}}
+    {{> navigation-tree class="pr-2 pl-8" navigation=./items level=(increment ../level)}}
   </li>
   {{/each}}
 </ul>

--- a/ui/src/partials/navigation-tree.hbs
+++ b/ui/src/partials/navigation-tree.hbs
@@ -3,7 +3,7 @@
   {{#each navigation}}
   <li data-navigation-tree-content class="my-0" data-depth="{{or ../level 0}}" {{#if (eq ./url @root.page.url)}} data-current{{/if}}>
     {{#if ./content}}
-      <div data-navigation-tree-toggle class="flex items-start py-[4px] px-[12px] space-x-2 max-w-fit {{#if (has-active-child ./items)}} border-none{{/if}}"{{#if (has-active-child ./items)}} data-active-parent{{/if}}>
+      <div data-navigation-tree-toggle class="flex items-start py-[4px] px-[12px] space-x-2 max-w-fit"{{#if (has-active-child ./items)}} data-active-parent{{/if}}>
         {{#if ./items.length }}
           <button class="flex items-center h-[26px] -ml-[1.3rem] p-1 flex-shrink-0" aria-label="Toggle {{./content}}" aria-expanded="{{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url)))}}false{{else}}true{{/if}}">
             <svg width="6" height="4" viewBox="0 0 6 4" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-[6px] h-[6px] transform {{#if (and (not (has-active-child ./items)) (not (eq ./url @root.page.url))) }}-rotate-90{{/if}}" aria-hidden="true">

--- a/ui/src/partials/navigation.hbs
+++ b/ui/src/partials/navigation.hbs
@@ -1,5 +1,5 @@
 <div data-page-navigation class="{{#if class}}{{class}}{{/if}} h-full border-r border-vapor fixed lg:sticky inset-0 lg:top-0 lg:h-screen transform -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 lg:z-auto bg-body-bg" {{#if page.component}} data-tcomponent="{{page.component.name}}" data-tversion="{{page.version}}"{{/if}}>
-  <aside class="relative h-full py-6 px-9 lg:pl-16 overflow-y-scroll scrollbar-thin scrollbar-thumb-rounded-xl scrollbar-thumb-fog scrollbar-track-vapor scrollbar-track-border">
+  <aside class="relative h-full py-6 px-6 overflow-y-scroll scrollbar-thin scrollbar-thumb-rounded-xl scrollbar-thumb-fog scrollbar-track-vapor scrollbar-track-border">
     <div class="flex items-center justify-between lg:hidden text-terminal-black mb-10">
       <img data-page-navigation-back-button src="{{{uiRootPath}}}/img/arrow-back.svg" alt="Arrow Back" class="invisible lg:hidden h-4 w-4">
       <h3 class="font-medium"> {{page.component.title}}</h3>


### PR DESCRIPTION
Redesign pass to increase information density across the docs UI, matching the Figma "Docs redesign" spec. Desktop-first, with tablet/mobile handled per area.

## Changes

**Desktop left-hand nav** (`fa659e394`)
- Denser rows (~34px): dropped inter-item margin and halved row padding; chevron aligned to the first line so wrapping titles hang correctly.
- Nesting indent 24px → 32px.
- Active state: current page is blue text (no grey pill) in both light and dark mode; active parent is bold.
- Sidebar padding 24px on all sides (chevrons hang in the gutter left of the logo, per design).
- Header→content gap set to 32px for both the nav and the article breadcrumbs.

**Page TOC spacing** (`ec31a68a2`)
- Right-hand page TOC item spacing 16px → 12px (sidebar + embedded, all breakpoints).

**Article body spacing** (`e64590e28`)
- Breadcrumbs→title and section-heading top margins 40px → 24px (tablet/desktop), 32px (mobile).
- Article info bar bottom margin 40px → 24px.

<details>
  <summary>Before and after screenshots for content density</summary>

Before:
<img width="1585" height="855" alt="Screenshot 2026-07-27 at 00 22 36" src="https://github.com/user-attachments/assets/f24fbb2d-db1b-4673-8f4f-f546f0980d62" />

After:
<img width="1588" height="858" alt="Screenshot 2026-07-27 at 00 22 53" src="https://github.com/user-attachments/assets/d8e5688b-8070-425e-9069-6724dd3c0d45" />

</details>


**Floating page-TOC button below 1200px** (`87ccb88e8`)
- Replaced the embedded top-of-article TOC link list with a floating open-book button (fixed top-right, 24px below the header) that toggles the TOC in a dropdown panel.
- Closes on outside click, Escape (restores focus), and link select; ≥1200px sidebar + scroll-spy unchanged.
- Widened the mobile component-switcher pill's right padding so it clears the button (temporary until the button is reworked).
- Removed the now-dead `.toc.embedded` rules.

<details>
  <summary>Before and after screenshots for On this page button</summary>

Before:
<img width="606" height="750" alt="Screenshot 2026-07-27 at 00 24 51" src="https://github.com/user-attachments/assets/13965fa7-813e-4f36-9028-ffa653ef8219" />

After:
<img width="599" height="795" alt="Screenshot 2026-07-27 at 00 24 36" src="https://github.com/user-attachments/assets/26b11714-3d01-4775-8f02-52fe3f89c509" />

</details>

## Testing
Previewed locally via `npm run start:dev` across desktop, tablet (~1000px), and mobile (~500px), in light and dark mode.

## Follow-ups
- Verify the mobile floating-button `top` offset (mobile header height is currently estimated).
- Mobile page-TOC button rework is planned as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)