### PR TITLE
Move default machine image to Ubuntu 2404

### DIFF
--- a/docs/guides/modules/ROOT/partials/faq/architecture-faq-snip.adoc
+++ b/docs/guides/modules/ROOT/partials/faq/architecture-faq-snip.adoc
@@ -26,10 +26,7 @@ You can also configure Docker to assign IPv6 address to containers, to test serv
 jobs:
   ipv6_tests:
     machine:
-      # The image uses the current tag, which always points to the most recent
-      # supported release. If stability and determinism are crucial for your CI
-      # pipeline, use a release date tag with your image, e.g. ubuntu-2004:202201-02
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     steps:
       - checkout
       - run:

--- a/docs/guides/modules/about-circleci/pages/concepts.adoc
+++ b/docs/guides/modules/about-circleci/pages/concepts.adoc
@@ -120,7 +120,7 @@ jobs:
 
   build2:
     machine:
-      image: ubuntu-2204:2024.01.2
+      image: ubuntu-2404:current
     steps:
       - attach_workspace:
         # Must be absolute path or relative path from working_directory
@@ -207,7 +207,7 @@ See the xref:orchestrate:workspaces.adoc[Using Workspaces] page for more informa
 
 Docker layer caching (DLC) caches the individual layers of Docker images built during your CircleCI jobs. CircleCI uses any unchanged layers on subsequent runs, rather than rebuilding the image each time.
 
-In the `.circleci/config.yml` snippet below, the `build_elixir` job builds an image using the `ubuntu-2004:202104-01` Dockerfile. Adding `docker_layer_caching: true` below the `machine` executor key ensures CircleCI saves each Docker image layer as the Elixir image is built.
+In the `.circleci/config.yml` snippet below, the `build_elixir` job builds an image using the `ubuntu-2404:current` Dockerfile. Adding `docker_layer_caching: true` below the `machine` executor key ensures CircleCI saves each Docker image layer as the Elixir image is built.
 
 [,yaml]
 ----
@@ -216,7 +216,7 @@ version: 2.1
 jobs:
   build_elixir:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2404:current
       docker_layer_caching: true
     steps:
       - checkout
@@ -279,10 +279,9 @@ jobs:
 #...
   build2:
     machine: # Specifies a machine image that uses
-      # an Ubuntu version 20.04 image with Docker 20.10.12
-      # and docker compose 1.29.2, follow CircleCI Discuss Announcements
+      # an Ubuntu version 24.04 image, follow CircleCI Discuss Announcements
       # for new image releases.
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     steps:
       - checkout
 
@@ -378,8 +377,8 @@ jobs:
 #...
   build2:
     machine: # Specifies a machine image that uses
-      # an Ubuntu version 22.04 image
-      image: ubuntu-2204:2024.01.2
+      # an Ubuntu version 24.04 image
+      image: ubuntu-2404:current
     steps:
       - checkout
 

--- a/docs/guides/modules/deploy/pages/deploy-over-ssh.adoc
+++ b/docs/guides/modules/deploy/pages/deploy-over-ssh.adoc
@@ -46,7 +46,7 @@ jobs:
   #...
   deploy:
     machine:
-      image: ubuntu-2204:2023.07.2
+      image: ubuntu-2404:current
     steps:
       - run:
           name: Deploy Over SSH

--- a/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
+++ b/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
@@ -227,7 +227,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2404:current
     steps:
       - checkout
       # start proprietary DB using private Docker image

--- a/docs/guides/modules/execution-managed/pages/executor-intro.adoc
+++ b/docs/guides/modules/execution-managed/pages/executor-intro.adoc
@@ -78,7 +78,7 @@ Cloud::
 jobs:
   build: # name of your job
     machine: # executor type
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
 
     steps:
         # Commands run in a Linux virtual machine environment
@@ -278,7 +278,7 @@ version: 2.1
 jobs:
   build-medium:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: arm.medium
     steps:
       - run: uname -a
@@ -286,7 +286,7 @@ jobs:
 
   build-large:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     resource_class: arm.large
     steps:
       - run: uname -a

--- a/docs/guides/modules/execution-managed/pages/machine-convenience-image-lifecycle.adoc
+++ b/docs/guides/modules/execution-managed/pages/machine-convenience-image-lifecycle.adoc
@@ -42,7 +42,7 @@ image: ubuntu-2004:202201-01  # Deprecated image
 
 # To this:
 machine:
-  image: ubuntu-2004:current    # or "default" for the latest supported version
+  image: ubuntu-2404:current    # or "default" for the latest supported version
 ----
 
 **For Remote Docker**: Update the version parameter:

--- a/docs/guides/modules/execution-managed/pages/private-images.adoc
+++ b/docs/guides/modules/execution-managed/pages/private-images.adoc
@@ -82,7 +82,7 @@ workflows:
 jobs:
   machine-job:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     resource_class: large
     steps:
       - docker/check:
@@ -103,7 +103,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     resource_class: large
     working_directory: ~/my_app
     steps:

--- a/docs/guides/modules/execution-managed/pages/resource-class-lifecycle.adoc
+++ b/docs/guides/modules/execution-managed/pages/resource-class-lifecycle.adoc
@@ -54,12 +54,12 @@ docker:
 ----
 # Change this:
 machine:
-  image: ubuntu-2204:current
+  image: ubuntu-2404:current
   resource_class: old.medium        # Deprecated resource class
 
 # To this:
 machine:
-  image: ubuntu-2204:current
+  image: ubuntu-2404:current
   resource_class: new.medium         # Supported resource class
 ----
 

--- a/docs/guides/modules/execution-managed/pages/resource-class-overview.adoc
+++ b/docs/guides/modules/execution-managed/pages/resource-class-overview.adoc
@@ -50,7 +50,7 @@ Another use of the `resource_class` key is to specify an execution environment. 
 jobs:
   my-job:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2404:current
     resource_class: arm.medium # arm.medium or arm.large selects the Arm execution environment
     steps:
       - run: uname -a

--- a/docs/guides/modules/execution-managed/pages/using-arm.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-arm.adoc
@@ -16,7 +16,7 @@ Cloud::
 jobs:
   my-job:
     machine:
-      image: ubuntu-2204:2023.07.1
+      image: ubuntu-2404:current
     resource_class: arm.medium
     steps:
       - run: uname -a

--- a/docs/guides/modules/getting-started/pages/hello-world.adoc
+++ b/docs/guides/modules/getting-started/pages/hello-world.adoc
@@ -56,7 +56,7 @@ version: 2.1
 jobs:
   hello-job:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2404:current
     steps:
       - checkout # check out the code in the project directory
       - run: echo "hello world" # run the `echo` command
@@ -158,7 +158,7 @@ version: 2.1
 jobs:
   hello-job:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2404:current
     resource_class: arm.medium
     steps:
       - checkout # check out the code in the project directory

--- a/docs/guides/modules/migrate/pages/migrating-from-aws.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-aws.adoc
@@ -196,10 +196,7 @@ a|
 jobs:
   ubuntuJob:
     machine:
-      # The image uses the current tag, which always points to the most recent
-      # supported release. If stability and determinism are crucial for your CI
-      # pipeline, use a release date tag with your image, e.g. ubuntu-2004:202201-02
-      ubuntu-2004:current
+      ubuntu-2404:current
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/docs/guides/modules/migrate/pages/migrating-from-azuredevops.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-azuredevops.adoc
@@ -197,10 +197,7 @@ a|
 jobs:
   ubuntuJob:
     machine:
-      # The image uses the current tag, which always points to the most recent
-      # supported release. If stability and determinism are crucial for your CI
-      # pipeline, use a release date tag with your image, e.g. ubuntu-2004:202201-02
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
@@ -185,10 +185,7 @@ a|
 jobs:
   ubuntuJob:
     machine:
-      # The image uses the current tag, which always points to the most recent
-      # supported release. If stability and determinism are crucial for your CI
-      # pipeline, use a release date tag with your image, e.g. ubuntu-2004:202201-02
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/docs/guides/modules/migrate/pages/migrating-from-github.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-github.adoc
@@ -119,7 +119,7 @@ docker:
 
 # Linux Ubuntu Executor
 machine:
-  image: ubuntu-2004:202010-01
+  image: ubuntu-2404:current
 
 # macOS Executor
 macos:

--- a/docs/guides/modules/migrate/pages/migrating-from-gitlab.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-gitlab.adoc
@@ -158,10 +158,7 @@ a|
 jobs:
   ubuntu-job:
     machine:
-      # The image uses the current tag, which always points to the most recent
-      # supported release. If stability and determinism are crucial for your CI
-      # pipeline, use a release date tag with your image, e.g. ubuntu-2004:202201-02
-      ubuntu-2004:current
+      ubuntu-2404:current
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/docs/guides/modules/optimize/pages/docker-layer-caching.adoc
+++ b/docs/guides/modules/optimize/pages/docker-layer-caching.adoc
@@ -51,7 +51,7 @@ version: 2.1
 jobs:
  build:
     machine:
-      image: ubuntu-2004:202104-01  # any available image
+      image: ubuntu-2404:current  # any available image
       docker_layer_caching: true    # default - false
 
     steps:

--- a/docs/guides/modules/optimize/pages/optimizations.adoc
+++ b/docs/guides/modules/optimize/pages/optimizations.adoc
@@ -105,7 +105,7 @@ Linux VM::
 jobs:
   my-job:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     resource_class: large
     steps:
     #  ...  other config
@@ -147,7 +147,7 @@ Arm::
 jobs:
   my-job:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2404:current
     resource_class: arm.medium
     steps:
     #  ...  other config

--- a/docs/guides/modules/orchestrate/pages/pipeline-variables.adoc
+++ b/docs/guides/modules/orchestrate/pages/pipeline-variables.adoc
@@ -161,7 +161,7 @@ commands:
 jobs:
   daily-message:
     machine:
-      image: ubuntu-2004:current
+      image: ubuntu-2404:current
     resource_class: large
     parameters:
       message:

--- a/docs/guides/modules/orchestrate/pages/using-matrix-jobs.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-matrix-jobs.adoc
@@ -23,9 +23,9 @@ executors:
   docker: # Docker using the Base Convenience Image
     docker:
       - image: cimg/base:stable
-  linux: # a Linux VM running Ubuntu 20.04
+  linux: # a Linux VM running Ubuntu 24.04
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2404:current
   macos: # macos executor running Xcode
     macos:
       xcode: 14.2.0

--- a/docs/guides/modules/toolkit/pages/chunk-setup-and-overview.adoc
+++ b/docs/guides/modules/toolkit/pages/chunk-setup-and-overview.adoc
@@ -437,7 +437,7 @@ workflows:
 jobs:
   cci-agent-setup:
     machine:
-      image: ubuntu-2204:2024.01.2
+      image: ubuntu-2404:current
     resource_class: large
     steps:
       - checkout

--- a/docs/guides/modules/toolkit/pages/sample-config.adoc
+++ b/docs/guides/modules/toolkit/pages/sample-config.adoc
@@ -356,10 +356,7 @@ jobs:
 
     build-docker-image:
         machine:
-            # The image uses the current tag, which always points to the most recent
-            # supported release. If stability and determinism are crucial for your CI
-            # pipeline, use a release date tag with your image, e.g. ubuntu-2004:202201-02
-            image: ubuntu-2004:current
+            image: ubuntu-2404:current
         steps:
             - attach_workspace:
                   at: .
@@ -396,7 +393,7 @@ jobs:
 
     deploy-docker-image:
         machine:
-            image: ubuntu-2004:current
+            image: ubuntu-2404:current
         steps:
             - attach_workspace:
                   at: .

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -942,7 +942,7 @@ Cloud::
 jobs:
   build: # name of your job
     machine: # executor type
-      image: ubuntu-2004:current # recommended linux image
+      image: ubuntu-2404:current # recommended linux image
 
     steps:
       # Commands run in a Linux virtual machine environment
@@ -1221,7 +1221,7 @@ Cloud::
 jobs:
   build:
     machine:
-      image: ubuntu-2004:2024.01.2 # recommended linux image
+      image: ubuntu-2404:current # recommended linux image
     resource_class: large
     steps:
       ... // other config
@@ -1408,7 +1408,7 @@ Cloud::
 jobs:
   my-job:
     machine:
-      image: ubuntu-2004:2024.01.2
+      image: ubuntu-2404:current
     resource_class: arm.medium
     steps:
       - run: uname -a
@@ -1825,7 +1825,7 @@ jobs: # conditional steps may also be defined in `commands:`
         type: string
         default: ""
     machine:
-      image: ubuntu-2004:2024.11.1
+      image: ubuntu-2404:current
     steps:
       - when:
           condition: <<parameters.custom_checkout>>
@@ -3604,7 +3604,7 @@ version: 2.1
 jobs:
   bar:
     machine:
-      image: ubuntu-2004:2024.05.1
+      image: ubuntu-2404:current
     steps:
       - checkout
       - run:


### PR DESCRIPTION
# Description
Move default Linux VM / machine image to Ubuntu 2404.

# Reasons
In preparation for next year's Ubuntu 2204 deprecation, we are moving all references to 2404 in case they copy/paste our configs. 

In addition, date-stamped images are no longer advised. We recommend tagged images as that reduces idle time by 65-70% per our testing.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.
