### PR TITLE
fix: correct broken server-terraform release tag links in upgrade guides (4.8, 4.9, 4.10)

### DIFF
--- a/docs/server-admin-4.10/modules/installation/pages/upgrade-server.adoc
+++ b/docs/server-admin-4.10/modules/installation/pages/upgrade-server.adoc
@@ -46,7 +46,7 @@ Customers that do not perform this step may have issues restoring Vault from bac
 [source,shell,subs=attributes+]
 helm diff upgrade circleci-server oci://cciserver.azurecr.io/circleci-server -n $namespace --version {serverversion410} -f <path-to-values.yaml> --username $USERNAME --password $PASSWORD
 
-. Upgrade your Nomad clients and servers (if externalized) Terraform modules to the link:https://github.com/CircleCI-Public/server-terraform/releases/tag/{serverversion410}[4.10 release]. Follow the documentation to plan and apply the Terraform changes for your xref:phase-3-aws-execution-environments.adoc#create-your-cluster-with-terraform[AWS] or xref:phase-3-gcp-execution-environments.adoc#create-your-cluster-with-terraform[GCP] environment.
+. Upgrade your Nomad clients and servers (if externalized) Terraform modules to the link:https://github.com/CircleCI-Public/server-terraform/releases/tag/server-{serverversion410}[4.10 release]. Follow the documentation to plan and apply the Terraform changes for your xref:phase-3-aws-execution-environments.adoc#create-your-cluster-with-terraform[AWS] or xref:phase-3-gcp-execution-environments.adoc#create-your-cluster-with-terraform[GCP] environment.
 
 . Perform the upgrade:
 +

--- a/docs/server-admin-4.8/modules/installation/pages/upgrade-server.adoc
+++ b/docs/server-admin-4.8/modules/installation/pages/upgrade-server.adoc
@@ -45,7 +45,7 @@ Customers that do not perform this step may have issues restoring Vault from bac
 [source,shell,subs=attributes+]
 helm diff upgrade circleci-server oci://cciserver.azurecr.io/circleci-server -n $namespace --version {serverversion48} -f <path-to-values.yaml> --username $USERNAME --password $PASSWORD
 
-. Upgrade your Nomad clients and servers (if externalized) Terraform modules to the link:https://github.com/CircleCI-Public/server-terraform/releases/tag/{serverversion48}[4.8 release]. Follow the documentation to plan and apply the Terraform changes for your xref:phase-3-aws-execution-environments.adoc#create-your-cluster-with-terraform[AWS] or xref:phase-3-gcp-execution-environments.adoc#create-your-cluster-with-terraform[GCP] environment.
+. Upgrade your Nomad clients and servers (if externalized) Terraform modules to the link:https://github.com/CircleCI-Public/server-terraform/releases/tag/server-{serverversion48}[4.8 release]. Follow the documentation to plan and apply the Terraform changes for your xref:phase-3-aws-execution-environments.adoc#create-your-cluster-with-terraform[AWS] or xref:phase-3-gcp-execution-environments.adoc#create-your-cluster-with-terraform[GCP] environment.
 
 . Perform the upgrade:
 +

--- a/docs/server-admin-4.9/modules/installation/pages/upgrade-server.adoc
+++ b/docs/server-admin-4.9/modules/installation/pages/upgrade-server.adoc
@@ -44,7 +44,7 @@ Customers that do not perform this step may have issues restoring Vault from bac
 [source,shell,subs=attributes+]
 helm diff upgrade circleci-server oci://cciserver.azurecr.io/circleci-server -n $namespace --version {serverversion49} -f <path-to-values.yaml> --username $USERNAME --password $PASSWORD
 
-. Upgrade your Nomad clients and servers (if externalized) Terraform modules to the link:https://github.com/CircleCI-Public/server-terraform/releases/tag/{serverversion49}[4.9 release]. Follow the documentation to plan and apply the Terraform changes for your xref:phase-3-aws-execution-environments.adoc#create-your-cluster-with-terraform[AWS] or xref:phase-3-gcp-execution-environments.adoc#create-your-cluster-with-terraform[GCP] environment.
+. Upgrade your Nomad clients and servers (if externalized) Terraform modules to the link:https://github.com/CircleCI-Public/server-terraform/releases/tag/server-{serverversion49}[4.9 release]. Follow the documentation to plan and apply the Terraform changes for your xref:phase-3-aws-execution-environments.adoc#create-your-cluster-with-terraform[AWS] or xref:phase-3-gcp-execution-environments.adoc#create-your-cluster-with-terraform[GCP] environment.
 
 . Perform the upgrade:
 +


### PR DESCRIPTION
## Summary

The server-terraform GitHub release tag naming convention changed starting from version 4.8.
Tags no longer use bare version numbers (e.g. `4.9.4`) but now include a `server-` prefix
(e.g. `server-4.9.4`). As a result, the Terraform module upgrade links in the upgrade
guides for Server 4.8, 4.9, and 4.10 were pointing to 404 URLs.

## Changes

Updated the `server-terraform` release URLs in the following pages to include the `server-`
prefix in the tag path:

- `docs/server-admin-4.8/modules/installation/pages/upgrade-server.adoc`
- `docs/server-admin-4.9/modules/installation/pages/upgrade-server.adoc`
- `docs/server-admin-4.10/modules/installation/pages/upgrade-server.adoc`

**Before:**
```
https://github.com/CircleCI-Public/server-terraform/releases/tag/4.9.4  (404)
```

**After:**
```
https://github.com/CircleCI-Public/server-terraform/releases/tag/server-4.9.4  (✓)
```

Note: The `{serverversion*}` attributes in `antora-playbook.yml` intentionally retain bare
version numbers (e.g. `4.9.4`) as they are also used in Helm commands where the prefix is
not required. The fix was applied at the URL template level instead.

## Testing

Verified the following URLs resolve correctly:
- https://github.com/CircleCI-Public/server-terraform/releases/tag/server-4.8.11
- https://github.com/CircleCI-Public/server-terraform/releases/tag/server-4.9.4
- https://github.com/CircleCI-Public/server-terraform/releases/tag/server-4.10.0

Made with [Cursor](https://cursor.com)