### PR TITLE
Update testsuite docs to use run and doctor sub commands

### DIFF
--- a/docs/guides/modules/ROOT/partials/tips/testsuite-working-directory.adoc
+++ b/docs/guides/modules/ROOT/partials/tips/testsuite-working-directory.adoc
@@ -1,6 +1,6 @@
 [TIP]
 ====
-Run the `circleci testsuite` CLI tooling from the directory where your tests are located. This is typically your repository root, but for monorepos it can be the root of a subpackage (for example, `cd service-1 && circleci testsuite "ci tests"`).
+Run the `circleci testsuite` CLI tooling from the directory where your tests are located. This is typically your repository root, but for monorepos it can be the root of a subpackage (for example, `cd service-1 && circleci testsuite run "ci tests"`).
 
 The testsuite will look for the `.circleci/test-suites.yml` configuration file in the repository root or the subpackage where the CLI is run. All commands (`discover`, `run`, `analysis`) execute relative to where you run the CLI, so avoid using `cd` or `--directory` flags within your commands.
 ====

--- a/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
+++ b/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
@@ -119,22 +119,22 @@ When `max-auto-rerun` is also set, test atoms rerun until one of the two conditi
 
 == 2. Run locally
 
-Use `--doctor` locally to validate that your `test-suites.yml` is set up correctly. The CLI runs additional checks when auto rerun is enabled. If any results look incorrect, an action item is provided to resolve it.
+Use the `doctor` command to validate that your `test-suites.yml` is set up correctly. The CLI runs additional checks when auto rerun is enabled. If any results look incorrect, an action item is provided to resolve it.
 
 [source,console]
 ----
-$ circleci testsuite "ci tests" --doctor
+$ circleci testsuite doctor "ci tests"
 ----
 
 Follow the steps until all checks pass.
 
 include::ROOT:partial$tips/testsuite-working-directory.adoc[]
 
-To verify auto rerun locally, modify a test to cause it to fail, then run the test suite without the `--doctor` flag:
+To verify auto rerun locally, modify a test to cause it to fail, then run the test suite:
 
 [source,console]
 ----
-$ circleci testsuite "ci tests"
+$ circleci testsuite run "ci tests"
 ----
 
 == 3. Run in CI

--- a/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
+++ b/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
@@ -34,11 +34,11 @@ Test suite:: A named configuration in `.circleci/test-suites.yml` that defines h
 
 == 1. Validate and run locally
 
-Use the `--doctor` flag to set up and validate your `test-suites.yml`. The CLI runs through a series of checks, executing tests and validating the output. If any results look incorrect, action items are provided to resolve them.
+Use the `doctor` command to set up and validate your `test-suites.yml`. The CLI runs through a series of checks, executing tests and validating the output. If any results look incorrect, action items are provided to resolve them.
 
 [source,console]
 ----
-$ circleci testsuite "ci tests" --doctor
+$ circleci testsuite doctor "ci tests"
 ----
 
 Follow the steps until all checks pass.
@@ -47,7 +47,7 @@ include::ROOT:partial$tips/testsuite-working-directory.adoc[]
 
 == 2. Run in CI
 
-In your CircleCI configuration file, replace your existing test command with `circleci testsuite` -- the same command you used locally. Keep all other job steps the same.
+In your CircleCI configuration file, replace your existing test command with `circleci testsuite run "ci tests"` -- the same command you used locally. Keep all other job steps the same.
 
 Verify that `store_test_results` points to the directory that matches `outputs.junit` in your `test-suites.yml` file.
 
@@ -61,7 +61,7 @@ jobs:
     steps:
       - setup
       # Replace previous tests command e.g. vitest run --reporter=junit ...
-      - run: circleci testsuite "ci tests"
+      - run: circleci testsuite run "ci tests"
       - store_test_results:
           # This directory must match the directory of `outputs.junit` in your
           # test-suites.yml

--- a/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
+++ b/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
@@ -141,11 +141,11 @@ options:
 
 == 2. Run locally
 
-Use `--doctor` locally to validate the `test-suites.yml` is set up correctly. The CLI runs additional analysis checks when test impact analysis is enabled. If any results look incorrect, action items are provided to resolve them.
+Use the `doctor` command to validate the `test-suites.yml` is set up correctly. The CLI runs additional analysis checks when test impact analysis is enabled. If any results look incorrect, action items are provided to resolve them.
 
 [source,console]
 ----
-$ circleci testsuite "ci tests" --doctor
+$ circleci testsuite doctor "ci tests"
 ----
 
 Follow the steps until all checks pass.
@@ -294,7 +294,7 @@ jobs:
     steps:
       - setup
       # Disable analysis, run all tests on default branches, impacted tests on feature branches.
-      - run: circleci testsuite "ci tests" --analyze-tests="none"
+      - run: circleci testsuite run "ci tests" --analyze-tests="none"
       - store_test_results:
           path: test-reports
 
@@ -303,7 +303,7 @@ jobs:
     steps:
       - setup
       # Disable running tests, default will analyze impacted tests on main.
-      - run: circleci testsuite "ci tests" --run-tests="none"
+      - run: circleci testsuite run "ci tests" --run-tests="none"
 
   deploy:
     executor: my-executor
@@ -343,7 +343,7 @@ jobs:
       - setup
       # Disable analysis.
       # (Default) Run all tests on default branches, run impacted tests on feature branches.
-      - run: circleci testsuite "ci tests" --analyze-tests="none"
+      - run: circleci testsuite run "ci tests" --analyze-tests="none"
       - store_test_results:
           path: test-reports
 
@@ -353,7 +353,7 @@ jobs:
       - setup
       # Disable running tests.
       # Default will analyze impacted tests on main.
-      - run: circleci testsuite "ci tests" --run-tests="none"
+      - run: circleci testsuite run "ci tests" --run-tests="none"
 
   deploy:
     executor: my-executor
@@ -395,7 +395,7 @@ jobs:
       - setup
       # Analyze impacted tests on "develop" branch, otherwise disable.
       # (Default) Run all tests on default branches, run impacted tests on feature branches.
-      - run: circleci testsuite "ci tests" --analyze-tests=<< pipeline.git.branch == "develop" and "impacted" or "none" >>
+      - run: circleci testsuite run "ci tests" --analyze-tests=<< pipeline.git.branch == "develop" and "impacted" or "none" >>
       - store_test_results:
           path: test-reports
 ----

--- a/docs/guides/modules/test/pages/testsuite-configuration-reference.adoc
+++ b/docs/guides/modules/test/pages/testsuite-configuration-reference.adoc
@@ -33,8 +33,8 @@ The `name` field is used to run a test suite with the local plugin and CI subcom
 
 [source,console]
 ----
-$ circleci testsuite "frontend tests"
-$ circleci testsuite "backend tests"
+$ circleci testsuite run "frontend tests"
+$ circleci testsuite run "backend tests"
 ----
 
 [%linenums,yaml]
@@ -318,7 +318,7 @@ jobs:
     executor: node-with-service
     steps:
       - setup
-      - run: circleci testsuite "ci tests"
+      - run: circleci testsuite run "ci tests"
       - store_test_results:
           path: test-reports
 ----

--- a/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
+++ b/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
@@ -75,11 +75,11 @@ options:
 
 == 2. Run locally
 
-Use `--doctor` locally to validate that your `test-suites.yml` is set up correctly. The CLI runs additional checks when dynamic test splitting is enabled. If any results look incorrect, an action item is provided to resolve it.
+Use the `doctor` command to validate that your `test-suites.yml` is set up correctly. The CLI runs additional checks when dynamic test splitting is enabled. If any results look incorrect, an action item is provided to resolve it.
 
 [source,console]
 ----
-$ circleci testsuite "ci tests" --doctor
+$ circleci testsuite doctor "ci tests"
 ----
 
 Follow the steps until all checks pass.


### PR DESCRIPTION
# Description

The testsuite now supports sub-commands, following the same convention as the new CLI; `circleci <entity> <verb>`.

This change replaces all top-level use with the new sub command equivalent.

- `circleci testsuite "ci tests"` -> `circleci testsuite run "ci tests"` 
- `circleci testsuite "ci tests" --doctor` -> `circleci testsuite doctor "ci tests"`

# Reasons

Whilst the top-level commands remain for backwards compatibility, the sub commands are now the recommended use.
