### PR TITLE
Update Xcode versions to reference a top level attribute

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -65,6 +65,7 @@ asciidoc:
     helmversion: 3.9.2
     helmdiffversion: 3.5.0
     kotsversion: 1.65.0
+    xcodeversion: 26.6.0
     page-toclevels: 6
     idprefix: ""
     idseparator: "-"

--- a/docs/guides/modules/about-circleci/pages/concepts.adoc
+++ b/docs/guides/modules/about-circleci/pages/concepts.adoc
@@ -258,7 +258,7 @@ include::ROOT:partial$notes/docker-auth.adoc[]
 Cloud::
 +
 --
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -287,8 +287,8 @@ jobs:
 
 #...
   build3:
-    macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
-      xcode: "12.5.1"
+    macos: # Specifies a macOS virtual machine with Xcode version {xcodeversion}
+      xcode: {xcodeversion}
     steps:
       - checkout
 # ...

--- a/docs/guides/modules/about-circleci/pages/concepts.adoc
+++ b/docs/guides/modules/about-circleci/pages/concepts.adoc
@@ -356,7 +356,7 @@ include::ROOT:partial$notes/docker-auth.adoc[]
 
 The *machine executor* spins up a complete Ubuntu virtual machine image, giving you full access to OS resources and complete control over the job environment. For more information, see the xref:reference:ROOT:configuration-reference.adoc#machine[Using Machine] page.
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -384,8 +384,8 @@ jobs:
 
 #...
   build3:
-    macos: # Specifies a macOS virtual machine with Xcode version 12.5.1
-      xcode: "12.5.1"
+    macos: # Specifies a macOS virtual machine with Xcode version {xcodeversion}
+      xcode: {xcodeversion}
     steps:
       - checkout
 # ...

--- a/docs/guides/modules/deploy/pages/deploy-ios-applications.adoc
+++ b/docs/guides/modules/deploy/pages/deploy-ios-applications.adoc
@@ -43,14 +43,14 @@ All the examples on this page use Fastlane to configure deployment. For each exa
 
 NOTE: The environment variable `FL_OUTPUT_DIR` is the artifact directory where Fastlane logs and a signed `.ipa` file are stored. Use this to set the path in the `store_artifacts` step to automatically save logs and build artifacts from Fastlane.
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 # .circleci/config.yml
 version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 15.4.0
+      xcode: {xcodeversion}
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -67,7 +67,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 15.4.0
+      xcode: {xcodeversion}
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc
@@ -278,13 +278,13 @@ end
 
 To use the Firebase Fastlane plugin, the Firebase CLI must be installed as part of the job via the `+curl -sL https://firebase.tools | bash+` command:
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 jobs:
   adhoc:
     macos:
-      xcode: "12.5.1"
+      xcode: {xcodeversion}
     environment:
       FL_OUTPUT_DIR: output
     steps:

--- a/docs/guides/modules/execution-managed/pages/executor-intro.adoc
+++ b/docs/guides/modules/execution-managed/pages/executor-intro.adoc
@@ -107,16 +107,16 @@ To access the macOS execution environment, use the `macos` executor and specify 
 
 NOTE: If you want to run a macOS build on CircleCI Server, you will need to use xref:execution-runner:runner-overview.adoc[Self-hosted Runner].
 
-[,yml]
+[,yml,subs=attributes+]
 ----
 jobs:
   build: # name of your job
     macos: # executor type
-      xcode: 14.2.0
+      xcode: {xcodeversion}
 
     steps:
       # Commands run in a macOS virtual machine environment
-      # with Xcode 14.2.0 installed
+      # with Xcode {xcodeversion} installed
 ----
 
 Find out more about the macOS execution environment on the xref:using-macos.adoc[Using macOS] page.

--- a/docs/guides/modules/execution-managed/pages/hello-world-macos.adoc
+++ b/docs/guides/modules/execution-managed/pages/hello-world-macos.adoc
@@ -49,14 +49,14 @@ to indicate what is happening at each step.
 
 For a full list of supported Xcode versions, see the xref:using-macos.adoc#supported-xcode-versions[Using macOS] page.
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
 jobs: # a basic unit of work in a run
   test: # your job name
     macos:
-      xcode: 26.4.0 # indicate your selected version of Xcode
+      xcode: {xcodeversion} # indicate your selected version of Xcode
     resource_class: m4pro.medium # specify a resource class (e.g. m4pro.medium or m4pro.large)
     steps: # a series of commands to run
       - checkout  # pull down code from your version control system.
@@ -66,7 +66,7 @@ jobs: # a basic unit of work in a run
 
   build:
     macos:
-      xcode: 26.4.0 # indicate your selected version of Xcode
+      xcode: {xcodeversion} # indicate your selected version of Xcode
     resource_class: m4pro.medium # specify a resource class (e.g. m4pro.medium or m4pro.large)
     steps:
       - checkout

--- a/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
+++ b/docs/guides/modules/execution-managed/pages/ios-codesigning.adoc
@@ -115,14 +115,14 @@ build. CircleCI installs the referenced bundles onto the executor.
 * `<your-xcode-scheme>`: The name of the specific build scheme you want to archive (for example, `MyApp` or `Runner`). Found in Xcode under *Product > Scheme*, or by running `xcodebuild -list`.
 
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
 jobs:
   build-and-sign:
     macos:
-      xcode: 15.2.0
+      xcode: {xcodeversion}
       # List the signing bundles to install from your organization
       code_signing:
         - <signing-bundle-name>
@@ -331,21 +331,21 @@ After you have configured Match and added its invocation into the appropriate
 lane, you can run that lane on CircleCI. The following `config.yml` will
 create an Ad-hoc build every time you push to the `development` branch:
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 # .circleci/config.yml
 version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
       # ...
       - run: bundle exec fastlane test
 
   adhoc:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
       # ...
       - run: bundle exec fastlane adhoc
@@ -388,14 +388,14 @@ platform :ios do
 end
 ----
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 # .circleci/config.yml
 version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -412,7 +412,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc

--- a/docs/guides/modules/execution-managed/pages/using-macos.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-macos.adoc
@@ -7,17 +7,17 @@ The macOS execution environment is used for iOS and macOS development, allowing 
 
 You can use the macOS execution environment to run your xref:orchestrate:jobs-steps.adoc[Jobs] in a macOS environment on a virtual machine (VM). You can access the macOS execution environment by using the `macos` executor and specifying an Xcode version:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 jobs:
   build:
     macos:
-      xcode: 26.4.0
+      xcode: {xcodeversion}
     resource_class: m4pro.medium
 
     steps:
       # Commands will execute in macOS container
-      # with Xcode 26.4.0 installed
+      # with Xcode {xcodeversion} installed
       - run: xcodebuild -version
 ----
 
@@ -34,12 +34,12 @@ include::ROOT:partial$execution-resources/xcode-silicon-vm.adoc[]
 
 include::ROOT:partial$execution-resources/macos-resource-table.adoc[]
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 jobs:
   build:
     macos:
-      xcode: 26.4.0
+      xcode: {xcodeversion}
     resource_class: m4pro.medium
 ----
 
@@ -212,13 +212,13 @@ If build speed, or bugs introduced by new Homebrew updates are a concern, this a
 
 To disable this feature, define the `HOMEBREW_NO_AUTO_UPDATE` environment variable within your job:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 26.4.0
+      xcode: {xcodeversion}
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -251,13 +251,13 @@ React Native projects can be built on CircleCI using `macos` and `docker` execut
 
 It is possible to use multiple xref:executor-intro.adoc[Executor Types] in the same workflow. In the following example each push of an iOS project will be built on macOS, and a deploy image will run in Docker.
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 26.4.0
+      xcode: {xcodeversion}
     environment:
       FL_OUTPUT_DIR: output
 

--- a/docs/guides/modules/getting-started/pages/hello-world.adoc
+++ b/docs/guides/modules/getting-started/pages/hello-world.adoc
@@ -72,14 +72,14 @@ macOS::
 --
 The job `hello-job` spins up a macOS virtual machine running the specified Xcode version. Refer to xref:execution-managed:using-macos.adoc[Using the macOS Execution Environment] page for more information.
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 version: 2.1
 
 jobs:
   hello-job:
     macos:
-      xcode: 26.4.0
+      xcode: {xcodeversion}
     resource_class: m4pro.medium
     steps:
       - checkout # check out the code in the project directory

--- a/docs/guides/modules/getting-started/pages/introduction-to-yaml-configurations.adoc
+++ b/docs/guides/modules/getting-started/pages/introduction-to-yaml-configurations.adoc
@@ -51,15 +51,16 @@ jobs:
 
 Images are used by either a Docker or machine executor. In our example, we are using a Docker **convenience image** that spins up an Ubuntu environment. If we used macOS as an execution environment, we could use a **machine image** instead. This would spin up a dedicated virtual machine with Xcode preinstalled, as in the example below.
 
-```yaml
+[,yaml,subs=attributes+]
+----
 # CircleCI configuration file
 version: 2.1
 
 jobs:
   build:
     macos:
-      xcode: 13.3.0
-```
+      xcode: {xcodeversion}
+----
 
 You will notice that the key-value pairs do not follow the same syntax. Each execution environment will be set up a little differently. You can refer to our execution environment documentation, or visit the CircleCI developer hub to find a list of https://circleci.com/developer/images?imageType=docker[convenience images] and https://circleci.com/developer/images?imageType=machine[machine images], and their syntax.
 

--- a/docs/guides/modules/migrate/pages/migrating-from-aws.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-aws.adoc
@@ -167,7 +167,7 @@ workflows:
           - job3
 ----
 
-2+| Execute jobs on multiple platforms. An AWS CodePipeline project can target a single platform only. If you are targeting multiple platforms, you’re probably using CodePipeline and multiple CodeBuild projects. CircleCI provides executors for Docker, Linux and macOS that can be combined in a single build definition.
+2+| Execute jobs on multiple platforms. An AWS CodePipeline project can target a single platform only. If you are targeting multiple platforms, you are probably using CodePipeline and multiple CodeBuild projects. CircleCI provides executors for Docker, Linux and macOS that can be combined in a single build definition.
 
 a|
 [source,yaml]

--- a/docs/guides/modules/migrate/pages/migrating-from-aws.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-aws.adoc
@@ -191,7 +191,7 @@ a|
 ----
 
 a|
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 jobs:
   ubuntuJob:
@@ -202,7 +202,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/docs/guides/modules/migrate/pages/migrating-from-azuredevops.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-azuredevops.adoc
@@ -192,7 +192,7 @@ jobs:
 ----
 
 a|
-[source, yaml]
+[source, yaml,subs=attributes+]
 ----
 jobs:
   ubuntuJob:
@@ -203,7 +203,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/docs/guides/modules/migrate/pages/migrating-from-azuredevops.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-azuredevops.adoc
@@ -192,7 +192,7 @@ jobs:
 ----
 
 a|
-[source, yaml,subs=attributes+]
+[source, yaml, subs=attributes+]
 ----
 jobs:
   ubuntuJob:

--- a/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-buildkite.adoc
@@ -180,7 +180,7 @@ steps:
 ----
 
 a|
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 jobs:
   ubuntuJob:
@@ -191,7 +191,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osxJob:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/docs/guides/modules/migrate/pages/migrating-from-github.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-github.adoc
@@ -111,7 +111,7 @@ container:
 ----
 
 a|
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 # Docker (container) Executor
 docker:
@@ -123,7 +123,7 @@ machine:
 
 # macOS Executor
 macos:
-  xcode: 14.2.0
+  xcode: {xcodeversion}
 
 # Windows Executor
 machine:

--- a/docs/guides/modules/migrate/pages/migrating-from-gitlab.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-gitlab.adoc
@@ -153,7 +153,7 @@ osx job:
 ----
 
 a|
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 jobs:
   ubuntu-job:
@@ -164,7 +164,7 @@ jobs:
       - run: echo "Hello, $USER!"
   osx-job:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
       - checkout
       - run: echo "Hello, $USER!"

--- a/docs/guides/modules/migrate/pages/migrating-from-teamcity.adoc
+++ b/docs/guides/modules/migrate/pages/migrating-from-teamcity.adoc
@@ -156,14 +156,14 @@ For more information on CircleCI Concepts, visit our https://circleci.com/docs/c
 
 TeamCity requires setting up a build agent with the required OS and tools installed and a corresponding Build Configuration. In CircleCI, all job configurations have an Executor definition, and CircleCI handles spinning up those agents for you. See our list of https://circleci.com/docs/executor-intro/[available executors].
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 version: 2.1
 jobs:
   my-mac-job:
     # Executor definition
     macos:
-      xcode: "12.5.1"
+      xcode: {xcodeversion}
 
     # Steps definition
     steps:

--- a/docs/guides/modules/optimize/pages/optimizations.adoc
+++ b/docs/guides/modules/optimize/pages/optimizations.adoc
@@ -114,12 +114,12 @@ jobs:
 macOS::
 +
 --
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 jobs:
   build:
     macos:
-      xcode: 26.4.0
+      xcode: {xcodeversion}
     resource_class: m4pro.medium
     steps:
     #  ...  other config

--- a/docs/guides/modules/orchestrate/pages/using-matrix-jobs.adoc
+++ b/docs/guides/modules/orchestrate/pages/using-matrix-jobs.adoc
@@ -12,7 +12,7 @@ In the following example, the `test` job runs across a Linux Docker container, L
 
 include::ROOT:partial$notes/docker-auth.adoc[]
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -28,7 +28,7 @@ executors:
       image: ubuntu-2404:current
   macos: # macos executor running Xcode
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
 
 jobs:
   test:

--- a/docs/guides/modules/test/pages/testing-ios.adoc
+++ b/docs/guides/modules/test/pages/testing-ios.adoc
@@ -111,14 +111,14 @@ end
 
 This configuration can be used with the following CircleCI configuration file:
 
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 # .circleci/config.yml
 version: 2.1
 jobs:
   build-and-test:
     macos:
-      xcode: 14.0.1
+      xcode: {xcodeversion}
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
@@ -135,7 +135,7 @@ jobs:
 
   adhoc:
     macos:
-      xcode: 14.0.1
+      xcode: {xcodeversion}
     environment:
       FL_OUTPUT_DIR: output
       FASTLANE_LANE: adhoc

--- a/docs/guides/modules/test/pages/testing-macos.adoc
+++ b/docs/guides/modules/test/pages/testing-macos.adoc
@@ -52,7 +52,7 @@ If additional permissions are required, you can find out how to set these up in 
 
 Sample `config.yml` for testing a macOS app:
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -62,7 +62,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
         - checkout
         - run: echo 'chruby ruby-2.7' >> ~/.bash_profile
@@ -116,7 +116,7 @@ While it can be written to manually with `sqlite3` commands, we encourage the us
 
 To list the currently defined permissions in both the user and system database, call the `list-permissions` command provided by the orb, such as in this example:
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -126,7 +126,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
         - checkout
         - mac-permissions/list-permissions
@@ -152,7 +152,7 @@ This command generates two steps; one lists the contents of the user `TCC.db` an
 
 To grant permissions, the correct type of key for the permission type needs to be passed. These are not clearly documented by Apple, but can be found by running the `list-permission-types` command, as this example shows:
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -162,7 +162,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
         - checkout
         - mac-permissions/list-permission-types
@@ -184,7 +184,7 @@ kTCCServiceSpeechRecognition
 
 For most developers, only a few standard permissions for Terminal and Xcode Helper are required to set up the environment for macOS app UI Testing. These can be set by calling the `add-uitest-permissions` command, such as in this example:
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -194,7 +194,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
         - checkout
         - mac-permissions/add-uitest-permissions
@@ -205,7 +205,7 @@ jobs:
 
 The orb can be used to add custom permissions with the `add-permission` command. The following example grants Screen Capture permissions to Terminal. The Bundle ID and the <<listing-permission-types,permission>> type are both required parameters:
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -215,7 +215,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
         - checkout
         - mac-permissions/add-permission:
@@ -228,7 +228,7 @@ jobs:
 
 In the unlikely event that a permission needs to be removed during a job, use the `delete-permission` command. In the following example, we are removing Screen Capture permissions from Terminal. The Bundle ID and the <<listing-permission-types,permission>> type are both required parameters:
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -238,7 +238,7 @@ orbs:
 jobs:
   build-test:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
         - checkout
         - mac-permissions/delete-permission:

--- a/docs/guides/modules/toolkit/pages/sample-config.adoc
+++ b/docs/guides/modules/toolkit/pages/sample-config.adoc
@@ -682,7 +682,7 @@ jobs:
       - run:
           name: Compute version number
           command: |
-            echo 'export IPERF3_BUILD_VERSION="<< pipeline.parameters.branch-name>>-${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:7}"' | tee -a "$BASH_ENV"
+            echo 'export IPERF3_BUILD_VERSION="<< pipeline.parameters.branch-name>>-$\{CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:7}"' | tee -a "$BASH_ENV"
       - github-release/release:
           tag: v$IPERF3_BUILD_VERSION
           title: $IPERF3_BUILD_VERSION

--- a/docs/guides/modules/toolkit/pages/sample-config.adoc
+++ b/docs/guides/modules/toolkit/pages/sample-config.adoc
@@ -451,7 +451,7 @@ In Example 2 each push of an iOS project will be built on macOS, and additional 
 Example 1::
 +
 --
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
@@ -550,7 +550,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     parameters:
       label:
         type: string
@@ -649,7 +649,7 @@ jobs:
 
   test-macos:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     parameters:
       label:
         type: string
@@ -715,14 +715,14 @@ workflows:
 Example 2::
 +
 --
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 version: 2.1
 
 jobs:
   build-and-test:
     macos:
-      xcode: 14.2.0
+      xcode: {xcodeversion}
     steps:
       - checkout
       - run:

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -1085,14 +1085,14 @@ CircleCI supports running jobs on link:https://developer.apple.com/macos/[macOS]
 |===
 --
 
-*Example:* Use a macOS virtual machine with Xcode version 26.4.0:
+*Example:* Use a macOS virtual machine with Xcode version {xcodeversion}:
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 jobs:
   build:
     macos:
-      xcode: 26.4.0
+      xcode: {xcodeversion}
 ----
 
 '''
@@ -1271,12 +1271,12 @@ include::guides:ROOT:partial$execution-resources/macos-resource-table.adoc[]
 
 *Example:*
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 jobs:
   build:
     macos:
-      xcode: 26.4.0
+      xcode: {xcodeversion}
     resource_class: m4pro.medium
     steps:
       ... // other config
@@ -2438,12 +2438,12 @@ In the case of `install_signing_bundle`, the step type is just a string with no 
 
 *Example:*
 
-[,yaml]
+[,yaml,subs=attributes+]
 ----
 jobs:
   build-and-sign:
     macos:
-      xcode: 15.2.0
+      xcode: {xcodeversion}
       code_signing:
         - my-signing-bundle
     steps:


### PR DESCRIPTION
# Description
This PR creates a top level `xcodeversion` attribute which stores the latest stable version of Xcode, and updates all pages that use a hardcoded Xcode version to reference this attribute.

# Reasons
Storing the latest version of Xcode in an attribute make it easy to update all references at once whenever we add a new version to our [list of supported Xcode versions](https://circleci.com/docs/guides/execution-managed/using-macos/#supported-xcode-versions-silicon).

**Note:** There were some _really_ old code examples that referenced _very_ old versions of Xcode. I went and updated all of these (since some of them aren't even supported anymore), but if any of these examples don't make sense with this current latest version (26.6), please mark them and I can revert the change!

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.