### PR TITLE
Correct guided setup availability in Smart Deployments docs

### DIFF
--- a/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
+++ b/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
@@ -30,7 +30,7 @@ Deploy markers also enable you to use the rollback and deploy features:
 
 == Choose your setup method
 
-TIP: *Consider using Smart Deployments instead of this guide.* The Smart Deployments guided setup configures deploy markers along with rollback and deploy pipelines, release validation, and automatic rollback, then opens a single pull request for you to merge. See the xref:set-up-smart-deployments.adoc[Set up Smart Deployments] guide. Use this page when you want deploy markers on their own, when your code is not in a GitHub repository, or when your organization does not have AI features enabled.
+TIP: *Consider using Smart Deployments instead of this guide.* The Smart Deployments guided setup configures deploy markers along with rollback and deploy pipelines, release validation, and automatic rollback. See the xref:set-up-smart-deployments.adoc[Set up Smart Deployments] guide and its xref:set-up-smart-deployments.adoc#setup-routes[Setup routes] section. Use this page when you want deploy markers on their own, or when you prefer to edit YAML directly.
 
 You can set up deploy markers in two ways:
 

--- a/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
+++ b/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
@@ -30,7 +30,7 @@ Deploy markers also enable you to use the rollback and deploy features:
 
 == Choose your setup method
 
-TIP: *Consider using Smart Deployments instead of this guide.* The Smart Deployments guided setup configures deploy markers along with rollback and deploy pipelines, release validation, and automatic rollback, then opens a single pull request for you to merge when AI features are enabled and the CircleCI GitHub App is installed. See the xref:set-up-smart-deployments.adoc[Set up Smart Deployments] guide and its xref:set-up-smart-deployments.adoc#setup-routes[Setup routes] section. Use this page when you want deploy markers on their own, when your code is not in a GitHub repository, when your organization does not have AI features enabled, or when you prefer to edit YAML directly.
+TIP: *Consider using Smart Deployments instead of this guide.* The Smart Deployments guided setup configures deploy markers, rollback and deploy pipelines, release validation, and automatic rollback. When AI features are enabled and the CircleCI GitHub App is installed, CircleCI opens a single pull request for you to merge. See the xref:set-up-smart-deployments.adoc[Set up Smart Deployments] guide and its xref:set-up-smart-deployments.adoc#setup-routes[Setup routes] section. Use this page when you want deploy markers on their own. Also use it when your code is not in a GitHub repository, when your organization does not have AI features enabled, or when you prefer to edit YAML directly.
 
 You can set up deploy markers in two ways:
 

--- a/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
+++ b/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
@@ -30,7 +30,7 @@ Deploy markers also enable you to use the rollback and deploy features:
 
 == Choose your setup method
 
-TIP: *Consider using Smart Deployments instead of this guide.* The Smart Deployments guided setup configures deploy markers along with rollback and deploy pipelines, release validation, and automatic rollback. See the xref:set-up-smart-deployments.adoc[Set up Smart Deployments] guide and its xref:set-up-smart-deployments.adoc#setup-routes[Setup routes] section. Use this page when you want deploy markers on their own, or when you prefer to edit YAML directly.
+TIP: *Consider using Smart Deployments instead of this guide.* The Smart Deployments guided setup configures deploy markers along with rollback and deploy pipelines, release validation, and automatic rollback, then opens a single pull request for you to merge when AI features are enabled and the CircleCI GitHub App is installed. See the xref:set-up-smart-deployments.adoc[Set up Smart Deployments] guide and its xref:set-up-smart-deployments.adoc#setup-routes[Setup routes] section. Use this page when you want deploy markers on their own, when your code is not in a GitHub repository, when your organization does not have AI features enabled, or when you prefer to edit YAML directly.
 
 You can set up deploy markers in two ways:
 

--- a/docs/guides/modules/deploy/pages/deployment-overview.adoc
+++ b/docs/guides/modules/deploy/pages/deployment-overview.adoc
@@ -139,8 +139,8 @@ image::guides:ROOT:deploy/rollback-guided-setup.png[Rollback guided setup]
 
 Smart Deployments configures deploy markers, rollback and deploy pipelines, release validation, and automatic rollback together. Start with the xref:smart-deployments-overview.adoc[Smart Deployments Overview] page, then choose a setup route:
 
-* xref:set-up-smart-deployments.adoc[Set up Smart Deployments]: The guided setup in the web app generates your configuration with AI and opens a pull request. Requires a GitHub repository and AI features enabled for your organization.
-* xref:set-up-release-validation-manually.adoc[Set up Release Validation Manually]: Write the configuration yourself and connect your monitoring tool. Use this route if your code is not in a GitHub repository, or if your organization does not have AI features enabled.
+* xref:set-up-smart-deployments.adoc[Set up Smart Deployments]: Use the guided setup in the web app. See the xref:set-up-smart-deployments.adoc#setup-routes[Setup routes] section for what the wizard generates with and without the GitHub App and AI features.
+* xref:set-up-release-validation-manually.adoc[Set up Release Validation Manually]: Write the configuration yourself and connect your monitoring tool. Use this route when you prefer to edit YAML directly.
 
 ==== Get set up feature by feature
 

--- a/docs/guides/modules/deploy/pages/release-validation-reference.adoc
+++ b/docs/guides/modules/deploy/pages/release-validation-reference.adoc
@@ -29,6 +29,7 @@ With `enabled: true` and nothing else, CircleCI creates a system catch-all check
 
 You need to write this configuration by hand in the following cases:
 
+* Your code is not in a GitHub repository, or your organization does not have AI features enabled. The guided setup can provide starting templates, but you must copy them into your repository and adapt them to match your pipeline.
 * You prefer to edit YAML directly rather than use the guided setup.
 * You want more than one named check per release.
 * Your monitoring tool sends payloads in a shape the provider defaults do not understand.

--- a/docs/guides/modules/deploy/pages/release-validation-reference.adoc
+++ b/docs/guides/modules/deploy/pages/release-validation-reference.adoc
@@ -29,8 +29,7 @@ With `enabled: true` and nothing else, CircleCI creates a system catch-all check
 
 You need to write this configuration by hand in the following cases:
 
-* You use a version control system other than GitHub, so the guided setup is unavailable.
-* Your organization does not have AI features enabled.
+* You prefer to edit YAML directly rather than use the guided setup.
 * You want more than one named check per release.
 * Your monitoring tool sends payloads in a shape the provider defaults do not understand.
 

--- a/docs/guides/modules/deploy/pages/set-up-release-validation-manually.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-release-validation-manually.adoc
@@ -1,29 +1,26 @@
 = Set up release validation manually
 :page-platform: Cloud
-:page-description: Configure release validation by editing your CircleCI configuration file, for organizations that cannot use the Smart Deployments guided setup.
+:page-description: Configure release validation by editing your CircleCI configuration file, or when you prefer to write the validation policy yourself.
 :experimental:
 
-Release validation evaluates webhook signals from your monitoring tool during an evaluation window after each deploy. This guide shows how to configure it by editing your CircleCI configuration file, rather than through the Smart Deployments guided setup.
+Release validation evaluates webhook signals from your monitoring tool during an evaluation window after each deploy. This guide shows how to configure it by editing your CircleCI configuration file directly.
 
 == Introduction
 
-The xref:set-up-smart-deployments.adoc[Set up Smart Deployments] guided setup generates this configuration for you, but it is unavailable in two cases:
+The xref:set-up-smart-deployments.adoc[Set up Smart Deployments] guided setup can generate this configuration for you in the web app. Use this guide when you prefer to edit YAML directly, or when you need field-level detail beyond what the wizard provides.
 
-* Your code is not stored in a GitHub repository.
-* Your organization does not have AI features enabled.
-
-Follow this guide in either case. The result is the same release validation feature. The difference is that you write the configuration and connect your monitoring tool yourself.
+Follow this guide to write the configuration and connect your monitoring tool yourself. The result is the same release validation feature.
 
 === What you can set up manually
 
-Release validation and deploy markers are configuration, so they work on any version control system. Rollback and deploy pipelines are a web app feature that currently requires GitHub.
+Release validation and deploy markers are configuration, so they work on any version control system. Rollback and deploy pipelines require the CircleCI GitHub App.
 
 [.table-scroll]
 --
 [cols="2,1,2", options="header"]
 |===
 |Capability
-|Needs GitHub
+|Needs GitHub App
 |Notes
 
 |Deploy markers

--- a/docs/guides/modules/deploy/pages/set-up-smart-deployments.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-smart-deployments.adoc
@@ -25,10 +25,10 @@ The guided setup is available for every project. What it generates depends on yo
 |CircleCI generates your configuration, opens a pull request for you to merge, and registers rollback and deploy pipelines. Automatic rollback is available.
 
 |GitHub App installed and AI features not enabled
-|The guided setup runs in the web app and shows configuration examples for you to copy into your repository. Rollback and deploy pipelines can still be registered when the GitHub App is installed.
+|The guided setup runs in the web app and shows configuration examples for you to copy into your repository. Edit each example to match your pipeline before you continue. Rollback and deploy pipelines can still be registered when the GitHub App is installed.
 
 |GitHub App not installed (skip the GitHub App step)
-|Deploy markers and release validation only. The wizard shows configuration to copy. Rollback and deploy pipelines and automatic rollback are not available until you install the CircleCI GitHub App.
+|Deploy markers and release validation only. The wizard shows configuration to copy. Edit each example to match your pipeline before you continue. Rollback and deploy pipelines and automatic rollback are not available until you install the CircleCI GitHub App.
 
 |Prefer to edit YAML directly
 |Follow the xref:set-up-release-validation-manually.adoc[Set up Release Validation Manually] guide instead.
@@ -111,7 +111,7 @@ Select btn:[Generate configuration] to continue.
 
 In this step CircleCI writes the generated configuration to a branch in your repository, and you review and merge it. See <<setup-routes,Setup routes>> for other paths.
 
-NOTE: When AI features are not enabled, or when you skipped GitHub App installation, the wizard shows configuration examples instead of opening a pull request. Copy each example into your repository, then select btn:[I've updated my config] to continue.
+NOTE: When AI features are not enabled, or when you skipped GitHub App installation, the wizard shows configuration examples instead of opening a pull request. Copy each example into your repository, edit it to match your pipeline, then select btn:[I've updated my config] to continue.
 
 === 2.1. Select the config branch
 

--- a/docs/guides/modules/deploy/pages/set-up-smart-deployments.adoc
+++ b/docs/guides/modules/deploy/pages/set-up-smart-deployments.adoc
@@ -3,13 +3,37 @@
 :page-description: Use the guided setup in the CircleCI web app to configure Smart Deployments, including release validation and automatic rollback, from one flow.
 :experimental:
 
-This guide shows how to configure Smart Deployments using the guided setup in the CircleCI web app. You answer a few questions, and CircleCI generates the configuration and opens a pull request for you to merge.
+This guide shows how to configure Smart Deployments using the guided setup in the CircleCI web app. You answer a few questions, and CircleCI prepares configuration for your repository. When AI features are enabled and the CircleCI GitHub App is installed, CircleCI opens a pull request for you to merge.
 
 Smart Deployments is the CircleCI continuous validation feature. For more information, see the xref:smart-deployments-overview.adoc[Smart Deployments Overview] page.
 
 The guided setup configures deploy markers, release validation, rollback and deploy pipelines, and automatic rollback in one flow. It replaces working through the deploy marker, rollback pipeline, and deploy pipeline guides separately.
 
-TIP: If your code is not in a GitHub repository, or your organization does not have AI features enabled, the guided setup is unavailable. Follow the xref:set-up-release-validation-manually.adoc[Set up Release Validation Manually] guide instead.
+[#setup-routes]
+== Setup routes
+
+The guided setup is available for every project. What it generates depends on your GitHub App and AI settings:
+
+[.table-scroll]
+--
+[cols="1,2", options="header"]
+|===
+|Your setup
+|What the guided setup does
+
+|GitHub App installed and AI features enabled
+|CircleCI generates your configuration, opens a pull request for you to merge, and registers rollback and deploy pipelines. Automatic rollback is available.
+
+|GitHub App installed and AI features not enabled
+|The guided setup runs in the web app and shows configuration examples for you to copy into your repository. Rollback and deploy pipelines can still be registered when the GitHub App is installed.
+
+|GitHub App not installed (skip the GitHub App step)
+|Deploy markers and release validation only. The wizard shows configuration to copy. Rollback and deploy pipelines and automatic rollback are not available until you install the CircleCI GitHub App.
+
+|Prefer to edit YAML directly
+|Follow the xref:set-up-release-validation-manually.adoc[Set up Release Validation Manually] guide instead.
+|===
+--
 
 == Prerequisites
 
@@ -17,10 +41,10 @@ Before you start, confirm the following:
 
 * A CircleCI account connected to your code. You can link:https://circleci.com/signup/[sign up for free].
 * A CircleCI project with a workflow configured to deploy your code.
-* Your code must be stored in a *GitHub* repository. CircleCI installs the GitHub App in your organization during setup if it is not installed already. For more information, see the xref:permissions-authentication:users-organizations-and-integrations-guide.adoc[Users, Organizations, and Integrations Guide].
+* For pull request generation and rollback or deploy pipelines, the CircleCI GitHub App installed in your organization. The guided setup prompts you to install it if it is not installed already. You can skip this step to configure deploy markers and release validation without pipelines. For more information, see the xref:permissions-authentication:users-organizations-and-integrations-guide.adoc[Users, Organizations, and Integrations Guide].
 +
 NOTE: Only organization administrators can install the GitHub App.
-* AI features enabled for your organization, because the guided setup generates your configuration with AI. See the xref:toolkit:enable-ai-powered-features.adoc[Enable AI-Powered Features] page for steps.
+* When AI features are enabled, CircleCI generates configuration and opens a pull request. When AI features are not enabled, the guided setup shows configuration examples for you to copy. See the xref:toolkit:enable-ai-powered-features.adoc[Enable AI-Powered Features] page for steps.
 * For continuous validation, a monitoring tool that can send outbound webhooks. Datadog and Prometheus-compatible tools are supported directly, and you can connect any other tool as a custom provider.
 
 == Start the guided setup
@@ -46,13 +70,17 @@ The first step of the guided setup asks how much protection you want, and which 
 
 Select *Continuous validation*, marked *Suggested*, to validate every release against your monitoring tool. Select *Deploy tracking* to log your deploys and set up the pipelines without validating anything.
 
-Both levels generate deploy markers, a rollback pipeline, and a deploy pipeline. The difference is that continuous validation also adds a validation policy, so the release validation engine decides whether each release is healthy.
+Both levels generate deploy markers, a rollback pipeline, and a deploy pipeline when the CircleCI GitHub App is installed. The difference is that continuous validation also adds a validation policy, so the release validation engine decides whether each release is healthy.
+
+If you skip GitHub App installation, the wizard configures deploy markers only for deploy tracking, or deploy markers and release validation for continuous validation.
 
 If you select deploy tracking, the guided setup skips monitoring provider selection and the Connect monitoring step. You can return later and add a validation policy to your configuration.
 
 === 1.2. Configure automatic rollback
 
 Leave *Auto rollback on failure* enabled unless you want failure detection without an automatic revert. When the toggle is enabled, CircleCI attempts a rollback to the last healthy version if validation fails during the evaluation window.
+
+When the CircleCI GitHub App is not installed, the auto rollback toggle is not shown. Validation failures still mark the release failed, but CircleCI cannot trigger an automatic rollback without a rollback pipeline.
 
 You can also change this setting later in your configuration file. See the xref:release-validation-reference.adoc#optional-validation-fields[Optional Validation Fields] section.
 
@@ -81,7 +109,9 @@ Select btn:[Generate configuration] to continue.
 
 == 2. Generate configuration and merge the pull request
 
-In this step CircleCI writes the generated configuration to a branch in your repository, and you review and merge it.
+In this step CircleCI writes the generated configuration to a branch in your repository, and you review and merge it. See <<setup-routes,Setup routes>> for other paths.
+
+NOTE: When AI features are not enabled, or when you skipped GitHub App installation, the wizard shows configuration examples instead of opening a pull request. Copy each example into your repository, then select btn:[I've updated my config] to continue.
 
 === 2.1. Select the config branch
 

--- a/docs/guides/modules/deploy/pages/smart-deployments-overview.adoc
+++ b/docs/guides/modules/deploy/pages/smart-deployments-overview.adoc
@@ -18,10 +18,10 @@ To get set up right away, choose your route:
 |Your situation
 |Start here
 
-|Your code is in a GitHub repository, and your organization has AI features enabled
-|xref:set-up-smart-deployments.adoc[Set up Smart Deployments]. The guided setup generates your configuration and opens a pull request for you to merge.
+|You want the guided setup in the web app
+|xref:set-up-smart-deployments.adoc[Set up Smart Deployments]. See the xref:set-up-smart-deployments.adoc#setup-routes[Setup routes] section for what the wizard generates with and without the GitHub App and AI features.
 
-|Anything else
+|You prefer to edit YAML directly
 |xref:set-up-release-validation-manually.adoc[Set up Release Validation Manually]. You write the validation policy and connect your monitoring tool yourself.
 |===
 --
@@ -181,6 +181,6 @@ CAUTION: Do not use both Smart Deployments and the CircleCI release agent in the
 
 == Get started
 
-* xref:set-up-smart-deployments.adoc[Set up Smart Deployments]: Use the guided setup in the web app to generate your configuration and open a pull request. Use this route for projects in a GitHub repository.
-* xref:set-up-release-validation-manually.adoc[Set up Release Validation Manually]: Write the configuration yourself and connect your monitoring tool. Use this route if your code is not in a GitHub repository, or if your organization does not have AI features enabled.
+* xref:set-up-smart-deployments.adoc[Set up Smart Deployments]: Use the guided setup in the web app. See the xref:set-up-smart-deployments.adoc#setup-routes[Setup routes] section for what the wizard generates with and without the GitHub App and AI features.
+* xref:set-up-release-validation-manually.adoc[Set up Release Validation Manually]: Write the configuration yourself and connect your monitoring tool. Use this route when you prefer to edit YAML directly.
 * xref:release-validation-reference.adoc[Release Validation Configuration Reference]: Every field you can set on the `validation` block.


### PR DESCRIPTION
# Description

Corrects inaccurate claims in the Smart Deployments docs on PR #10631 that the guided setup is unavailable without a GitHub repository or AI features. The wizard remains available; GitHub App and AI settings change what it generates.

Changes across six deploy pages:

- `set-up-smart-deployments.adoc`: adds a Setup routes table with an anchor, softens prerequisites, and documents manual-config and no-pipelines paths.
- `smart-deployments-overview.adoc`, `deployment-overview.adoc`, `configure-deploy-markers.adoc`: update routing text to point at Setup routes instead of sending readers to the manual guide as a fallback.
- `set-up-release-validation-manually.adoc`: reframes the page as the hand-written YAML route; renames the capability table column to Needs GitHub App.
- `release-validation-reference.adoc`: removes false "guided setup unavailable" bullets from the hand-written config list.

Stacked on `DOC-225-smart-deployments` for #10631.

# Reasons

Engineering shipped DR-719: users can skip GitHub App installation and still configure deploy markers and release validation from the wizard. When AI is off, the wizard shows copy-paste config instead of opening a pull request. The docs currently tell readers to leave the guided setup entirely in both cases.

# Content checks

Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your branch.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).

Checked locally before pushing:

- Vale passes with 0 errors on all six changed files.
- Antora build not run locally (worktree checkout; CI build job validates xrefs).