### PR TITLE
Add API v3 link to API reference homepage

### DIFF
--- a/docs/reference/modules/ROOT/pages/api-homepage.adoc
+++ b/docs/reference/modules/ROOT/pages/api-homepage.adoc
@@ -3,7 +3,7 @@
 
 Find reference docs for the CircleCI APIs:
 
-* link:../../api/v3/[API v3 docs]
+* link:https://circleci.com/docs/api/v3/[API v3 docs]
 * link:../../api/v2/[API v2 docs]
 * link:../../api/v1/[API v1 docs]
 

--- a/docs/reference/modules/ROOT/pages/api-homepage.adoc
+++ b/docs/reference/modules/ROOT/pages/api-homepage.adoc
@@ -3,6 +3,7 @@
 
 Find reference docs for the CircleCI APIs:
 
+* link:../../api/v3/[API v3 docs]
 * link:../../api/v2/[API v2 docs]
 * link:../../api/v1/[API v1 docs]
 


### PR DESCRIPTION
## Summary

- Adds a link to the API v3 docs on the API reference homepage, alongside the existing v1 and v2 links.