### PR TITLE
Update Chunk CLI docs for sidecar UX and new commands

### DIFF
--- a/docs/guides/modules/toolkit/pages/how-to-use-chunk-cli.adoc
+++ b/docs/guides/modules/toolkit/pages/how-to-use-chunk-cli.adoc
@@ -1,22 +1,44 @@
 = How to use the Chunk CLI
 :page-platform: Cloud
-:page-description: How to use the `chunk` CLI to generate AI review prompts, run validations, manage Chunk sidecars, and install AI agent skills.
+:page-description: How to use the `chunk` CLI to initialize projects, generate AI review prompts, run validations, manage Chunk sidecars, and install AI agent skills.
 :experimental:
 
-This page describes how to use the main features of the `chunk` CLI.
+This page describes how to use the main features of the `chunk` CLI. For installation, authentication, and first-time setup, see xref:install-and-configure-the-chunk-cli.adoc[Install and Configure the Chunk CLI].
 
 [#prerequisites]
 == Prerequisites
 
-* An installed and configured `chunk` CLI. See the xref:install-and-configure-the-chunk-cli.adoc[Install and Configure the Chunk CLI] page.
-* A project initialized with `chunk init`, or a `.chunk/config.json` file with commands configured.
+* An installed and configured `chunk` CLI with skills installed. See xref:install-and-configure-the-chunk-cli.adoc[Install and Configure the Chunk CLI].
+* A team review prompt generated with `chunk build-prompt`. See xref:#generate-a-review-prompt[Generate a team review prompt].
+
+[#concepts]
+== Concepts
+
+* **`.chunk/` directory** — holds `config.json` (your validation commands) and `context/review-prompt.md` (your team's review standards). Commit both so everyone on your team gets the same setup.
+* **Sidecars** — ephemeral Linux environments on CircleCI where you run checks remotely, catching failures that only reproduce outside your machine.
+* **Skills** — instructions installed into your AI coding agent that add commands like `/chunk-review` and `/chunk-sidecar`, triggered by slash commands or natural language.
+
+[#typical-workflow]
+== Typical workflow
+
+Once set up, your day-to-day workflow looks like this:
+
+. Make your changes.
+. Ask your agent to review: type `/chunk-review`, or say "review my changes" or "review PR #123".
+. Ask your agent to validate remotely: type `/chunk-sidecar`, or say "validate on the sidecar".
+. Push when checks pass.
 
 [#generate-a-review-prompt]
 == Generate a team review prompt
 
 The `chunk build-prompt` command mines your GitHub pull request review history and uses Claude to generate a team-specific review prompt. The prompt captures your reviewers' patterns and preferences so that AI coding agents apply your team's standards when reviewing code.
 
-The command saves the generated prompt to `.chunk/context/review-prompt.md`, which the `chunk-review` skill uses automatically.
+The command saves the generated prompt to `.chunk/context/review-prompt.md`, which the `chunk-review` skill uses automatically. Once this file exists, ask your agent to "review my changes" or "review PR #123" to start a review.
+
+[NOTE]
+====
+`chunk build-prompt` requires GitHub and Anthropic credentials. If you have not set these up, see xref:install-and-configure-the-chunk-cli.adoc#authentication[Authentication] in the install guide.
+====
 
 From your project directory:
 
@@ -58,6 +80,26 @@ You can customize this behavior with the following flags:
 |`--output`
 |`--output .chunk/context/review-prompt.md`
 |Path where the command saves the generated prompt.
+
+|`--max-comments`
+|`--max-comments 100`
+|Maximum number of comments to analyze per reviewer. No limit by default.
+
+|`--include-attribution`
+|`--include-attribution`
+|Include reviewer names in the generated prompt.
+
+|`--analyze-model`
+|`--analyze-model claude-opus-4-5`
+|Claude model to use for the analysis step.
+
+|`--prompt-model`
+|`--prompt-model claude-sonnet-5`
+|Claude model to use for the prompt generation step.
+
+|`--debug`
+|`--debug`
+|Write intermediate files alongside the prompt (details JSON, analysis, PR rankings CSV) for troubleshooting.
 |===
 --
 
@@ -82,6 +124,20 @@ $ chunk validate <name>
 
 Replace `<name>` with the name of the command as defined in `.chunk/config.json`.
 
+To run an inline command without adding it to your config:
+
+[source,console]
+----
+$ chunk validate --cmd "go test ./..."
+----
+
+Add `--save` to write the inline command to `.chunk/config.json` for future runs:
+
+[source,console]
+----
+$ chunk validate --cmd "go test ./..." --save
+----
+
 The following flags are available:
 
 [.table-scroll]
@@ -96,11 +152,26 @@ The following flags are available:
 |`--dry-run`
 |Show the commands that would run, without executing them.
 
-|`--force-run`
-|Ignore the cache and run all commands regardless of file changes.
+|`--cmd <command>`
+|Run an inline command instead of configured commands.
+
+|`--save`
+|Save the `--cmd` value to `.chunk/config.json`.
+
+|`--remote`
+|Run on the active sidecar. Creates a new sidecar if none is set.
 
 |`--sidecar-id <id>`
-|Validate commands remotely in the specified Chunk sidecar. Get a Chunk sidecar ID from `chunk sidecar create` output or `chunk sidecar list`.
+|Run commands in a specific Chunk sidecar. Get a sidecar ID from `chunk sidecar list`.
+
+|`-e <KEY=VALUE>`
+|Set an environment variable in the remote sidecar session. Repeatable.
+
+|`--env-file <path>`
+|Load environment variables from a file. Defaults to `.env.local`.
+
+|`--json`
+|Output results as JSON. Only applies with `--list`.
 |===
 --
 
@@ -112,11 +183,46 @@ CAUTION: Chunk sidecars are available in preview on all CircleCI plans. The prod
 
 Chunk sidecars let you validate your changes in a CircleCI Cloud environment instead of locally. This ensures your code runs against the same environment your CI pipeline uses.
 
-Follow these steps to validate in a Chunk sidecar:
+The easiest way to get started is to ask your AI agent — type `/chunk-sidecar` or say "validate on the sidecar". The skill handles auth checks, sidecar creation, file sync, and validation automatically. If you prefer to run the steps yourself, continue below.
 
-=== 1. Authenticate with CircleCI
+TIP: Use `chunk watch` (or `chunk watch --all` for all projects) for a live dashboard of sidecar status and activity while validation runs.
 
-Before creating a Chunk sidecar, authenticate with CircleCI:
+You can set up sidecar validation in two ways: the `chunk sidecar setup` command handles everything in one step, or you can run each step manually for more control.
+
+[#fast-path-setup]
+=== Fast path: set up with one command
+
+The `chunk sidecar setup` command detects your tech stack, syncs your files, runs setup commands in a sidecar, and creates a snapshot — all in one step:
+
+[source,console]
+----
+$ chunk sidecar setup --name <name> --org-id <org-id>
+----
+
+Replace `<name>` with a descriptive name for the sidecar and `<org-id>` with your CircleCI organization ID.
+
+After the first run, the detected environment is saved to `.chunk/config.json`. Subsequent runs reuse the saved environment and skip detection. Pass `--force` to re-detect:
+
+[source,console]
+----
+$ chunk sidecar setup --force
+----
+
+[#manual-sidecar-setup]
+=== Manual setup: step by step
+
+Follow these steps to set up and use a Chunk sidecar manually:
+
+==== 1. Authenticate with CircleCI
+
+Before creating a Chunk sidecar, authenticate with CircleCI. The recommended method uses browser-based OAuth:
+
+[source,console]
+----
+$ chunk auth login
+----
+
+This opens your browser for a secure login flow. If you prefer to use a personal API token instead:
 
 [source,console]
 ----
@@ -125,7 +231,7 @@ $ chunk auth set circleci
 
 Enter your CircleCI personal API token when prompted. Generate a token from your link:https://app.circleci.com/settings/user/tokens[User Settings, window=_blank] in the CircleCI web app.
 
-=== 2. Create a Chunk sidecar
+==== 2. Create a Chunk sidecar
 
 Create a new Chunk sidecar environment:
 
@@ -134,31 +240,57 @@ Create a new Chunk sidecar environment:
 $ chunk sidecar create --name <name>
 ----
 
-Replace `<name>` with a descriptive name for your sidecar. The command auto-detects your tech stack, generates a Dockerfile, and provisions a cloud environment. When ready, it prints the Chunk sidecar ID. Copy this ID for use in the validation step.
+Replace `<name>` with a descriptive name for your sidecar. The `--name` flag is optional — a name is auto-generated if you omit it. The command auto-detects your tech stack, generates a Dockerfile, and provisions a cloud environment. When ready, it prints the Chunk sidecar ID. Copy this ID for use in the validation step.
 
-=== 3. Sync your local files to the sidecar
+To launch a sidecar from an existing snapshot, pass the snapshot ID with `--image`:
 
-Sync your local project files to the Chunk sidecar:
+[source,console]
+----
+$ chunk sidecar create --name <name> --image <snapshot-id>
+----
+
+==== 3. Sync your local files to the sidecar
+
+Sync your current working directory to the Chunk sidecar:
 
 [source,console]
 ----
 $ chunk sidecar sync
 ----
 
-This copies your current working directory to the remote environment.
+==== 4. Set the active sidecar
 
-=== 4. Run validation in the sidecar
+Set the sidecar you just created as the active sidecar for this project, so you can omit `--sidecar-id` from future commands:
 
-Run your validation commands in the Chunk sidecar:
+[source,console]
+----
+$ chunk sidecar use <sidecar-id>
+----
+
+Replace `<sidecar-id>` with the ID printed by `chunk sidecar create`. To check which sidecar is currently active:
+
+[source,console]
+----
+$ chunk sidecar current
+----
+
+==== 5. Run validation in the sidecar
+
+Run your validation commands in the active Chunk sidecar:
+
+[source,console]
+----
+$ chunk validate --remote
+----
+
+To target a specific sidecar by ID instead of using the active one:
 
 [source,console]
 ----
 $ chunk validate --sidecar-id <sidecar-id>
 ----
 
-Replace `<sidecar-id>` with the ID from step 2. The command executes all configured validation commands from your `.chunk/config.json` in the remote environment.
-
-=== 5. (Optional) SSH into the sidecar for debugging
+==== 6. (Optional) SSH into the sidecar for debugging
 
 If validation fails and you need to investigate, SSH into the Chunk sidecar:
 
@@ -169,7 +301,7 @@ $ chunk sidecar ssh
 
 This opens an interactive shell in the remote environment.
 
-=== 6. (Optional) Snapshot the sidecar for reuse
+==== 7. (Optional) Snapshot the sidecar for reuse
 
 After configuring a Chunk sidecar successfully, capture its state as a snapshot for faster future sessions:
 
@@ -178,7 +310,9 @@ After configuring a Chunk sidecar successfully, capture its state as a snapshot 
 $ chunk sidecar snapshot create --name <snapshot-name>
 ----
 
-The command prints a snapshot ID. Use this ID to create new sidecars with `chunk sidecar create --name <name> --image <snapshot-id>`.
+The command captures the configured state of the active Chunk sidecar and prints the snapshot ID. Use this ID with `chunk sidecar create --image <snapshot-id>` to boot new sidecars from the snapshot.
+
+CAUTION: `chunk sidecar snapshot create` deletes the source Chunk sidecar after capturing the snapshot to avoid leaving the build instance running. If the deleted sidecar was the active one, local active-sidecar state is cleared. Launch a new Chunk sidecar from the snapshot with `chunk sidecar create --name <name> --image <snapshot-id>` to resume work.
 
 For more details on managing Chunk sidecars, see the <<manage-sidecars>> section.
 
@@ -186,78 +320,54 @@ For more details on managing Chunk sidecars, see the <<manage-sidecars>> section
 [badge="Preview"]
 == Manage Chunk sidecars
 
-CAUTION: Chunk sidecars are available in preview on all CircleCI plans. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
+[.table-scroll]
+--
+[cols=2*, options="header"]
+|===
+|Task |Command
 
-Chunk sidecars are CircleCI Cloud environments where the `chunk` CLI validates your changes remotely. This lets you validate changes against the same environment your CI pipeline uses, without running them locally.
+|Create a sidecar
+|`chunk sidecar create --name <name>`
 
-[#create-a-sidecar]
-=== Create a Chunk sidecar
+|Create from a snapshot
+|`chunk sidecar create --name <name> --image <snapshot-id>`
 
-[source,console]
-----
-$ chunk sidecar create --name <name>
-----
+|Set the active sidecar
+|`chunk sidecar use <sidecar-id>`
 
-The `chunk` CLI auto-detects your tech stack, generates a Dockerfile, and provisions a cloud environment on CircleCI. The command prints the Chunk sidecar ID when the environment is ready. Use this ID with `chunk validate --sidecar-id` to run validations in that environment.
+|View the active sidecar
+|`chunk sidecar current`
 
-To launch a Chunk sidecar from an existing snapshot, pass the snapshot ID with `--image`:
+|Clear the active sidecar (without deleting)
+|`chunk sidecar forget`
 
-[source,console]
-----
-$ chunk sidecar create --name <name> --image <snapshot-id>
-----
+|List all sidecars
+|`chunk sidecar list`
 
-This skips environment detection and boots from the captured state. See <<snapshot-a-sidecar>> for how to produce a snapshot ID.
+|Sync local files to the active sidecar
+|`chunk sidecar sync`
 
-[#list-sidecars]
-=== List Chunk sidecars
+|SSH into the active sidecar
+|`chunk sidecar ssh`
 
-[source,console]
-----
-$ chunk sidecar list
-----
+|Execute a command in the active sidecar
+|`chunk sidecar exec <command>`
 
-Lists all your Chunk sidecars and their IDs. Use this to retrieve a Chunk sidecar ID if you need it after creation.
+|Create a snapshot
+|`chunk sidecar snapshot create --name <snapshot-name>`
 
-[#snapshot-a-sidecar]
-=== Snapshot a Chunk sidecar
+|List snapshots
+|`chunk sidecar snapshot list`
 
-After you have configured a Chunk sidecar and confirmed it works with `chunk validate`, capture its state as a snapshot so future sessions boot fast:
+|Delete the active sidecar
+|`chunk sidecar delete`
 
-[source,console]
-----
-$ chunk sidecar snapshot create --name <snapshot-name>
-----
+|Delete a specific sidecar
+|`chunk sidecar delete --sidecar-id <id>`
+|===
+--
 
-The command captures the configured state of the active Chunk sidecar and prints the snapshot ID. Pass `--sidecar-id <id>` to snapshot a specific Chunk sidecar instead of the active one. Snapshot names are limited to 255 characters.
-
-CAUTION: `chunk sidecar snapshot create` deletes the source Chunk sidecar after the snapshot is captured to avoid leaving the build instance running. If the deleted sidecar was the active one, local active-sidecar state is cleared. Launch a new Chunk sidecar from the snapshot with `chunk sidecar create --name <name> --image <snapshot-id>` to resume work.
-
-If the post-snapshot deletion fails, the command prints a warning but the snapshot itself still succeeds. Delete the source Chunk sidecar manually, or wait for it to expire.
-
-[#ssh-into-sidecar]
-=== SSH into a Chunk sidecar
-
-[source,console]
-----
-$ chunk sidecar ssh
-----
-
-[#sync-files-to-sidecar]
-=== Sync local files to a Chunk sidecar
-
-[source,console]
-----
-$ chunk sidecar sync
-----
-
-[#exec-in-chunk-sidecar]
-=== Execute a command in a sidecar
-
-[source,console]
-----
-$ chunk sidecar exec <command>
-----
+CAUTION: `chunk sidecar snapshot create` deletes the source sidecar after capturing to avoid leaving the build instance running. If the deleted sidecar was the active one, local active-sidecar state is cleared. Launch a new sidecar from the snapshot with `chunk sidecar create --name <name> --image <snapshot-id>` to resume work.
 
 [#trigger-chunk-tasks]
 == Trigger Chunk tasks
@@ -320,94 +430,15 @@ The following flags are available:
 |===
 --
 
-[#install-skills]
-== Install AI agent skills
-
-The `chunk skill install` command installs `chunk` CLI skills into your AI coding agent (Claude Code, Cursor, or VS Code Copilot).
-
-[source,console]
-----
-$ chunk skill install
-----
-
-To see available skills and their current installation status, run the following:
-
-[source,console]
-----
-$ chunk skill list
-----
-
-The following skills are available:
-
-[.table-scroll]
---
-[cols=2*, options="header"]
-|===
-|Skill |Description
-
-|`chunk-review`
-|Reviews pull requests and diffs using your team's review standards from `.chunk/context/review-prompt.md`.
-
-|`chunk-sidecar`
-|Creates and manages Chunk sidecar environments.
-
-|`chunk-testing-gaps`
-|Identifies test coverage gaps through mutation testing.
-
-|`debug-ci-failures`
-|Debugs CircleCI pipeline failures and identifies flaky tests.
-|===
---
-
-After installation, you can invoke these skills directly in your AI coding agent. For example, in Claude Code, type `/chunk-review` to start a code review.
-
 [#configure-hooks]
-== Configure validation hooks
+== Validation hooks
 
-Running `chunk init` adds hooks to `.claude/settings.json` that trigger `chunk validate` automatically at key points:
+`chunk init` automatically adds two hooks to `.claude/settings.json`:
 
-* **PreToolUse hook**: Blocks `git commit` if validation fails, preventing bad code from entering the repository.
-* **Stop hook**: Validates your changes when your Claude Code session ends, catching uncommitted changes.
+* **PreToolUse hook** — runs before every `git commit` and blocks it if validation fails, preventing broken code from entering the repository.
+* **Stop hook** — runs when your Claude Code session ends. If your working tree has changes, it validates them automatically.
 
-To add or update hooks without re-running the full initialization, run the following:
-
-[source,console]
-----
-$ chunk init --skip-validate
-----
-
-[#view-config]
-== View and set configuration
-
-To display the fully resolved `chunk` CLI configuration for your project, run the following:
-
-[source,console]
-----
-$ chunk config show
-----
-
-To set a configuration value, run the following:
-
-[source,console]
-----
-$ chunk config set <key> <value>
-----
-
-Supported keys:
-
-[.table-scroll]
---
-[cols=2*, options="header"]
-|===
-|Key |Description
-
-|`model`
-|The default Claude model to use for `chunk build-prompt`.
-
-|`apiKey`
-|Your Anthropic API key. You can also set this with `chunk auth set anthropic`.
-|===
---
+To reinstall hooks without re-running full initialization, run `chunk init --skip-validate`.
 
 [#next-steps]
 == Next steps

--- a/docs/guides/modules/toolkit/pages/how-to-use-chunk-cli.adoc
+++ b/docs/guides/modules/toolkit/pages/how-to-use-chunk-cli.adoc
@@ -9,14 +9,14 @@ This page describes how to use the main features of the `chunk` CLI. For install
 == Prerequisites
 
 * An installed and configured `chunk` CLI with skills installed. See xref:install-and-configure-the-chunk-cli.adoc[Install and Configure the Chunk CLI].
-* A team review prompt generated with `chunk build-prompt`. See xref:#generate-a-review-prompt[Generate a team review prompt].
+* A team review prompt generated with `chunk build-prompt`. See xref:#generate-a-review-prompt[Generate a Team Review Prompt].
 
 [#concepts]
 == Concepts
 
-* **`.chunk/` directory** — holds `config.json` (your validation commands) and `context/review-prompt.md` (your team's review standards). Commit both so everyone on your team gets the same setup.
-* **Sidecars** — ephemeral Linux environments on CircleCI where you run checks remotely, catching failures that only reproduce outside your machine.
-* **Skills** — instructions installed into your AI coding agent that add commands like `/chunk-review` and `/chunk-sidecar`, triggered by slash commands or natural language.
+* **`.chunk/` directory**: holds `config.json` (your validation commands) and `context/review-prompt.md` (your team's review standards). Commit both so everyone on your team gets the same setup.
+* **Sidecars**: ephemeral Linux environments on CircleCI where you run checks remotely, catching failures that only reproduce outside your machine.
+* **Skills**: instructions installed into your AI coding agent that add commands like `/chunk-review` and `/chunk-sidecar`, triggered by slash commands or natural language.
 
 [#typical-workflow]
 == Typical workflow
@@ -159,7 +159,7 @@ The following flags are available:
 |Save the `--cmd` value to `.chunk/config.json`.
 
 |`--remote`
-|Run on the active sidecar. Creates a new sidecar if none is set.
+|Run on the active sidecar. Creates a new sidecar if none exists.
 
 |`--sidecar-id <id>`
 |Run commands in a specific Chunk sidecar. Get a sidecar ID from `chunk sidecar list`.
@@ -179,7 +179,7 @@ The following flags are available:
 [badge="Preview"]
 == Validate in a Chunk sidecar
 
-CAUTION: Chunk sidecars are available in preview on all CircleCI plans. The product is in its early stages and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature is made generally available, there will be a cost associated with access and usage.
+CAUTION: Chunk sidecars are available in preview on all CircleCI plans. The product is in active development and you may encounter bugs, unexpected behavior, or incomplete features. If you have feedback, you can share it on our link:https://discord.com/invite/circleci[Discord]. When the feature becomes generally available, there will be a cost associated with access and usage.
 
 Chunk sidecars let you validate your changes in a CircleCI Cloud environment instead of locally. This ensures your code runs against the same environment your CI pipeline uses.
 
@@ -201,7 +201,7 @@ $ chunk sidecar setup --name <name> --org-id <org-id>
 
 Replace `<name>` with a descriptive name for the sidecar and `<org-id>` with your CircleCI organization ID.
 
-After the first run, the detected environment is saved to `.chunk/config.json`. Subsequent runs reuse the saved environment and skip detection. Pass `--force` to re-detect:
+After the first run, the CLI saves the detected environment to `.chunk/config.json`. Subsequent runs reuse the saved environment and skip detection. Pass `--force` to re-detect:
 
 [source,console]
 ----
@@ -312,7 +312,7 @@ $ chunk sidecar snapshot create --name <snapshot-name>
 
 The command captures the configured state of the active Chunk sidecar and prints the snapshot ID. Use this ID with `chunk sidecar create --image <snapshot-id>` to boot new sidecars from the snapshot.
 
-CAUTION: `chunk sidecar snapshot create` deletes the source Chunk sidecar after capturing the snapshot to avoid leaving the build instance running. If the deleted sidecar was the active one, local active-sidecar state is cleared. Launch a new Chunk sidecar from the snapshot with `chunk sidecar create --name <name> --image <snapshot-id>` to resume work.
+CAUTION: `chunk sidecar snapshot create` deletes the source Chunk sidecar after capturing the snapshot to avoid leaving the build instance running. If the deleted sidecar was the active one, the CLI clears local active-sidecar state. Launch a new Chunk sidecar from the snapshot with `chunk sidecar create --name <name> --image <snapshot-id>` to resume work.
 
 For more details on managing Chunk sidecars, see the <<manage-sidecars>> section.
 
@@ -367,7 +367,7 @@ For more details on managing Chunk sidecars, see the <<manage-sidecars>> section
 |===
 --
 
-CAUTION: `chunk sidecar snapshot create` deletes the source sidecar after capturing to avoid leaving the build instance running. If the deleted sidecar was the active one, local active-sidecar state is cleared. Launch a new sidecar from the snapshot with `chunk sidecar create --name <name> --image <snapshot-id>` to resume work.
+CAUTION: `chunk sidecar snapshot create` deletes the source sidecar after capturing to avoid leaving the build instance running. If the deleted sidecar was the active one, the CLI clears local active-sidecar state. Launch a new sidecar from the snapshot with `chunk sidecar create --name <name> --image <snapshot-id>` to resume work.
 
 [#trigger-chunk-tasks]
 == Trigger Chunk tasks
@@ -398,9 +398,9 @@ After you have configured the repository, trigger a task run with `chunk task ru
 $ chunk task run --definition <name-or-uuid> --prompt "<prompt text>"
 ----
 
-Replace `<name-or-uuid>` with the name or UUID of the Chunk task definition you want to run, and `<prompt text>` with the instructions to send to the task. Both flags are required.
+Replace `<name-or-uuid>` with the name or UUID of the Chunk task definition you want to run, and `<prompt text>` with the instructions to send to the task. You must provide both flags.
 
-The command prints the run ID and pipeline ID when the task is triggered.
+The command prints the run ID and pipeline ID after triggering the task.
 
 The following flags are available:
 
@@ -435,8 +435,8 @@ The following flags are available:
 
 `chunk init` automatically adds two hooks to `.claude/settings.json`:
 
-* **PreToolUse hook** — runs before every `git commit` and blocks it if validation fails, preventing broken code from entering the repository.
-* **Stop hook** — runs when your Claude Code session ends. If your working tree has changes, it validates them automatically.
+* **PreToolUse hook**: runs before every `git commit` and blocks it if validation fails, preventing broken code from entering the repository.
+* **Stop hook**: runs when your Claude Code session ends. If your working tree has changes, it validates them automatically.
 
 To reinstall hooks without re-running full initialization, run `chunk init --skip-validate`.
 

--- a/docs/guides/modules/toolkit/pages/install-and-configure-the-chunk-cli.adoc
+++ b/docs/guides/modules/toolkit/pages/install-and-configure-the-chunk-cli.adoc
@@ -3,40 +3,28 @@
 :page-description: How to install and configure the Chunk CLI, a tool for integrating AI code review standards and remote validation into your development workflow.
 :experimental:
 
-The link:https://github.com/CircleCI-Public/chunk-cli[`chunk` CLI] is a developer tool that brings AI-powered code review and remote validation to your local workflow. The `chunk` CLI works with AI coding agents such as Claude Code, Cursor, and VS Code Copilot.
+The link:https://github.com/CircleCI-Public/chunk-cli[`chunk` CLI] is a developer tool for AI-assisted development workflows. It works with AI coding agents such as Claude Code, Cursor, and VS Code Copilot, and does two things:
 
-Some of the things you can do with the `chunk` CLI include:
+. *Generates team review context* — mines your GitHub PR review history, analyzes it with Claude, and produces a `.chunk/context/review-prompt.md` file that encodes how your team actually reviews code. AI coding agents pick this file up automatically and apply your team's standards.
+. *Validates changes remotely* — runs your quality checks (tests, lint, format) in a clean CircleCI Cloud environment before you push, so you catch failures that only reproduce outside your machine.
 
-* Mine your team's GitHub pull request history to generate a team-specific review prompt for AI agents using `chunk build-prompt`.
-* Validate commands locally or in CircleCI Cloud environments using `chunk validate`.
-* Trigger Chunk tasks in CircleCI Cloud from your terminal using `chunk task`.
-* Install AI agent skills for code review, mutation testing, and CI failure debugging using `chunk skill install`.
-* Set up pre-commit and session-end hooks that automatically validate in Claude Code using `chunk init`.
+After following these steps, you'll be able to say "review my changes" in Claude Code to get a review against your team's standards, and "validate on the sidecar" to run checks in a CircleCI Cloud environment that matches your CI pipeline.
 
 NOTE: **Chunk CLI vs Chunk by CircleCI.** The `chunk` CLI is a local developer tool. It is separate from link:https://circleci.com/docs/chunk-setup-and-overview/[Chunk by CircleCI], the AI-powered CI/CD assistant in the CircleCI web app.
-
-[#supported-platforms]
-== Supported platforms
-
-The `chunk` CLI supports macOS and Linux on both arm64 and x86_64 architectures. Windows is not supported.
 
 [#installation]
 == 1. Installation
 
-[#macos-install-with-homebrew]
-=== 1.1 macOS and Linux install with Homebrew
+NOTE: The `chunk` CLI supports macOS and Linux (arm64 and x86_64). Windows is not supported.
 
-The recommended installation method for both macOS and Linux is Homebrew:
+Install with Homebrew:
 
 [source,console]
 ----
 $ brew install CircleCI-Public/circleci/chunk
 ----
 
-[#verify-installation]
-=== 1.2 Verify the installation
-
-Confirm the `chunk` CLI is working and check the version:
+Verify the installation:
 
 [source,console]
 ----
@@ -51,14 +39,30 @@ After installing the `chunk` CLI, set credentials for each service you plan to u
 [#auth-circleci]
 === 2.1 CircleCI
 
-Required for `chunk sidecar` and `chunk task` commands. The `chunk` CLI uses your CircleCI token to create and manage cloud sidecar environments for running remote validations.
+Required for `chunk sidecar` and `chunk task` commands. The `chunk` CLI uses your CircleCI credentials to create and manage cloud sidecar environments for running remote validations.
+
+The recommended method uses browser-based OAuth. If you already have a CircleCI account:
+
+[source,console]
+----
+$ chunk auth login
+----
+
+If you are new to CircleCI:
+
+[source,console]
+----
+$ chunk auth signup
+----
+
+Both commands open your browser for a secure login flow. If you prefer to use a personal API token instead:
 
 [source,console]
 ----
 $ chunk auth set circleci
 ----
 
-Enter your CircleCI personal API token when prompted. Generate a personal API token from your link:https://app.circleci.com/settings/user/tokens[User Settings, window=_blank] in the CircleCI web app.
+Enter your CircleCI personal API token when prompted. Generate a token from your link:https://app.circleci.com/settings/user/tokens[User Settings, window=_blank] in the CircleCI web app.
 
 [#auth-anthropic]
 === 2.2 Anthropic
@@ -100,7 +104,9 @@ $ chunk init
 
 * Detects your build, test, lint, and format commands.
 * Creates a `.chunk/config.json` file with the detected commands.
+* Installs shell completions.
 * Generates hook configuration in `.claude/settings.json` for Claude Code.
+* Installs AI agent skills into your coding agent.
 
 The following flags are available for `chunk init`:
 
@@ -116,8 +122,17 @@ The following flags are available for `chunk init`:
 |`--skip-hooks`
 |Skip generating hook configuration in `.claude/settings.json`.
 
+|`--skip-git-hook`
+|Skip installing the git pre-commit hook.
+
+|`--skip-skills`
+|Skip installing AI agent skills.
+
+|`--skip-completions`
+|Skip installing shell completions.
+
 |`--skip-validate`
-|Skip command detection. Creates the config file without running command auto-detection.
+|Skip command detection. Creates the config file without auto-detecting commands.
 
 |`--project-dir <path>`
 |Set the project directory. Defaults to the current directory.
@@ -128,52 +143,75 @@ The following flags are available for `chunk init`:
 
 After initialization, run `chunk validate` to run the detected commands. You can also run `chunk build-prompt` to mine your GitHub PR history for a team-specific review prompt.
 
-For detailed information on using the `chunk` CLI, including generating review prompts, running validations, and installing skills, refer to xref:how-to-use-chunk-cli.adoc[How to Use the `chunk` CLI].
+For detailed information on using the `chunk` CLI, including generating review prompts and running validations, refer to xref:how-to-use-chunk-cli.adoc[How to Use the `chunk` CLI].
 
-[#updating-the-cli]
-== Update the Chunk CLI
+[#install-skills]
+== 4. Install AI agent skills
 
-Run the following command to update the `chunk` CLI:
-
-[source,console]
-----
-$ brew upgrade chunk
-----
-
-[#uninstall]
-== Uninstall the Chunk CLI
-
-To uninstall the `chunk` CLI, run the following command:
+`chunk init` installs skills automatically, but you can also run `chunk skill install` directly at any time to install or reinstall skills into your AI coding agent (Claude Code, Cursor, or VS Code Copilot):
 
 [source,console]
 ----
-$ brew uninstall chunk
+$ chunk skill install
 ----
 
-[#manage-credentials]
-== Manage credentials
-
-[#check-auth-status]
-=== Check authentication status
-
-To see which credentials you have configured:
+To see available skills and their current installation status:
 
 [source,console]
 ----
-$ chunk auth status
+$ chunk skill list
 ----
 
-[#remove-credentials]
-=== Remove credentials
+The following skills are available:
 
-To remove stored credentials for a provider:
+[.table-scroll]
+--
+[cols=3*, options="header"]
+|===
+|Skill |Trigger phrases |Description
 
-[source,console]
-----
-$ chunk auth remove <provider>
-----
+|`chunk-review`
+|"review my changes", "review PR #123"
+|Reviews pull requests and diffs using your team's review standards from `.chunk/context/review-prompt.md`.
 
-Replace `<provider>` with `circleci`, `anthropic`, or `github`.
+|`chunk-sidecar`
+|"validate on the sidecar", "sidecar dev loop"
+|Creates and manages Chunk sidecar environments for cloud validation.
+
+|`chunk-testing-gaps`
+|"find testing gaps", "mutation test"
+|Identifies test coverage gaps through mutation testing.
+
+|`debug-ci-failures`
+|"debug CI", "why is CI failing"
+|Debugs CircleCI pipeline failures and identifies flaky tests.
+|===
+--
+
+Once installed, invoke skills directly in your AI coding agent. In Claude Code, type `/chunk-review` to review a diff or `/chunk-sidecar` to validate changes in a CircleCI Cloud environment.
+
+[#maintenance]
+== Maintenance
+
+[.table-scroll]
+--
+[cols=2*, options="header"]
+|===
+|Task |Command
+
+|Update the CLI
+|`brew upgrade chunk`
+
+|Uninstall the CLI
+|`brew uninstall chunk`
+
+|Check authentication status
+|`chunk auth status`
+
+|Remove credentials for a provider
+|`chunk auth remove <provider>` (`circleci`, `anthropic`, or `github`)
+|===
+--
 
 [#next-steps]
 == Next steps
@@ -181,4 +219,3 @@ Replace `<provider>` with `circleci`, `anthropic`, or `github`.
 * xref:how-to-use-chunk-cli.adoc#generate-a-review-prompt[Generate a Team Review Prompt From Your GitHub PR History]
 * xref:how-to-use-chunk-cli.adoc#run-validation[Validate Your Changes]
 * xref:how-to-use-chunk-cli.adoc#trigger-chunk-tasks[Trigger Chunk Tasks]
-* xref:how-to-use-chunk-cli.adoc#install-skills[Install AI Agent Skills]

--- a/docs/guides/modules/toolkit/pages/install-and-configure-the-chunk-cli.adoc
+++ b/docs/guides/modules/toolkit/pages/install-and-configure-the-chunk-cli.adoc
@@ -5,10 +5,10 @@
 
 The link:https://github.com/CircleCI-Public/chunk-cli[`chunk` CLI] is a developer tool for AI-assisted development workflows. It works with AI coding agents such as Claude Code, Cursor, and VS Code Copilot, and does two things:
 
-. *Generates team review context* — mines your GitHub PR review history, analyzes it with Claude, and produces a `.chunk/context/review-prompt.md` file that encodes how your team actually reviews code. AI coding agents pick this file up automatically and apply your team's standards.
-. *Validates changes remotely* — runs your quality checks (tests, lint, format) in a clean CircleCI Cloud environment before you push, so you catch failures that only reproduce outside your machine.
+. *Generates team review context*: mines your GitHub PR review history, analyzes it with Claude, and produces a `.chunk/context/review-prompt.md` file that encodes how your team actually reviews code. AI coding agents pick this file up automatically and apply your team's standards.
+. *Validates changes remotely*: runs your quality checks (tests, lint, format) in a clean CircleCI Cloud environment before you push, so you catch failures that only reproduce outside your machine.
 
-After following these steps, you'll be able to say "review my changes" in Claude Code to get a review against your team's standards, and "validate on the sidecar" to run checks in a CircleCI Cloud environment that matches your CI pipeline.
+After following these steps, say "review my changes" in Claude Code to get a review against your team's standards. Say "validate on the sidecar" to run checks in a CircleCI Cloud environment.
 
 NOTE: **Chunk CLI vs Chunk by CircleCI.** The `chunk` CLI is a local developer tool. It is separate from link:https://circleci.com/docs/chunk-setup-and-overview/[Chunk by CircleCI], the AI-powered CI/CD assistant in the CircleCI web app.
 
@@ -34,7 +34,7 @@ $ chunk --version
 [#authentication]
 == 2. Authentication
 
-After installing the `chunk` CLI, set credentials for each service you plan to use. Authentication is required for some commands, such as `chunk sidecar` and `chunk task`.
+After installing the `chunk` CLI, set credentials for each service you plan to use. Some commands require authentication, such as `chunk sidecar` and `chunk task`.
 
 [#auth-circleci]
 === 2.1 CircleCI


### PR DESCRIPTION
# Description

Updated both chunk cli docs pages to reflect new commands a reorganized setup flow. 

Install and configure the chunk-cli
- Rewrote the intro to lead with what the tool does rather than listing subcommands. 
- Added chunk auth login and chunk auth signup OAuth commands as the recommended auth path
- Install ai agent skills to it's own step with a trigger phrases columns in the skills table
- Added some flags to the chunk init table
- Collapsed update, uninstall, and credential management into a maintenance reference table. 

How to use chunk-cli
- Added concepts and typical workflow sections to orient new users before getting into commands. 
- Documented new chunk validate flags: --cmd, --save, --remote etc
- Added chunk sidecar setup as a fast-path alternative to the existing manual sidecar steps
- Condensed validation hooks sections

# Reasons
docs were out of sync with the current cli. 

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
