### PR TITLE
runner: promote Runner Provisioner to beta

### DIFF
--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -117,7 +117,7 @@
 ** xref:execution-runner:runner-concepts.adoc[Self-hosted runner concepts]
 ** xref:execution-runner:runner-feature-comparison-matrix.adoc[Runner feature comparison matrix]
 ** Runner provisioner
-*** xref:execution-runner:runner-provisioner.adoc[Runner provisioner overview - Preview]
+*** xref:execution-runner:runner-provisioner.adoc[Runner provisioner overview - Beta]
 
 ** Container runner
 *** xref:execution-runner:container-runner-installation.adoc[Container runner installation]

--- a/docs/guides/modules/execution-runner/pages/runner-overview.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-overview.adoc
@@ -13,7 +13,7 @@ Self-hosted runner installation options are as follows:
 
 * Install in a Kubernetes cluster, using a **container runner**.
 * Install in a machine execution environment using a **machine runner**.
-* Automatically scale runner VMs in a Kubernetes cluster using **runner provisioner** (preview).
+* Automatically scale runner VMs in a Kubernetes cluster using **runner provisioner** (beta).
 
 The diagrams below illustrate how CircleCI's container and machine runners extend our existing systems.
 
@@ -89,13 +89,13 @@ If you do not use Kubernetes but still want to run your CI job in a container on
 Machine runner is not compatible with CircleCI's Convenience Images or custom Docker images.
 
 [#runner-provisioner-use-case]
-=== Runner provisioner (preview)
+=== Runner provisioner (beta)
 
 Runner Provisioner is a Kubernetes controller that automatically scales CircleCI runner VMs using KubeVirt. Rather than running jobs in containers, each job runs inside a full virtual machine that is provisioned on demand and shut down after the job completes. This approach provides stronger isolation than container runner. It is suited for workloads that require a full OS environment, hardware-level isolation, or privileged access that is impractical inside a container.
 
 Runner Provisioner polls the CircleCI API for pending and running tasks, then adjusts a `VirtualMachinePool` replica count to match demand. A configurable `minReplicas` setting keeps a pre-warmed pool of VMs ready to claim jobs immediately.
 
-CAUTION: Runner Provisioner is currently in preview and not recommended for production workloads. Its image and Helm chart are publicly available. Refer to the xref:runner-provisioner.adoc[Runner Provisioner] page for installation and configuration details.
+NOTE: Runner Provisioner is currently in beta and not recommended for critical workloads. Its image and Helm chart are publicly available. Refer to the xref:runner-provisioner.adoc[Runner Provisioner] page for installation and configuration details.
 
 [#getting-started]
 == Getting started

--- a/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
+++ b/docs/guides/modules/execution-runner/pages/runner-provisioner.adoc
@@ -1,37 +1,34 @@
 = Runner provisioner
 :page-platform: Cloud, Server v4+
-:page-badge: Preview
+:page-badge: Beta
 :page-description: Learn how to install and configure Runner Provisioner to automatically scale CircleCI runner VMs using KubeVirt on Kubernetes.
 :experimental:
 
-[CAUTION]
+[NOTE]
 ====
-Runner Provisioner is currently in preview. The product, its configuration schema, and its APIs are subject to change before general availability. It is not recommended for production workloads. If you encounter issues or have feedback, see <<feedback-and-support,Feedback and Support>>.
+*Runner Provisioner* is available in beta. This means the product is in early stages. You may encounter bugs, unexpected behavior, or incomplete features. The product, its configuration schema, and its APIs are subject to change before general availability. It is not recommended for critical workloads. If you encounter issues or have feedback, see <<feedback-and-support,Feedback and Support>>.
 ====
 
 Runner Provisioner is a Kubernetes controller that automatically scales CircleCI runner VMs using link:https://github.com/kubevirt/kubevirt[KubeVirt]. Runner Provisioner polls the CircleCI API for pending and running tasks, then adjusts a `VirtualMachinePool` replica count to match demand.
 
-The current preview version is `0.1.2`.
+The current beta version is `0.1.2`.
 
 == Getting access
 
 The Runner Provisioner image and Helm chart are publicly available. No registry credentials or invitation are required to install and use Runner Provisioner.
 
-Preview participants get access to a dedicated Slack channel for support and feedback during the preview. To request access to the Slack channel, fill out the link:https://forms.gle/7W8z12EBdjuiTQJWA[Runner Provisioner preview access request form].
-
+[#feedback-and-support]
 == Feedback and support
 
-Runner Provisioner is preview software. Expect bugs and missing features. Runner Provisioner is early-stage software and sharp edges are normal.
+Runner Provisioner is beta software. Expect bugs and missing features. Runner Provisioner is early-stage software and sharp edges are normal.
 
-Preview participants get direct access to the CircleCI product and engineering team via the preview Slack channel throughout the preview. In exchange, detailed feedback is expected. Your input directly shapes what gets built before general availability.
+Detailed feedback during the beta is welcome. Your input directly shapes what gets built before general availability.
 
-Escalate directly via the `#runner-provisioner-preview` Slack channel for:
+Open a link:https://support.circleci.com/hc/en-us/requests/new[support ticket] for:
 
 * *Troubleshooting issues*
 * *Bugs and feature requests*
 * *General questions*
-
-Do not open a support ticket for issues with Runner Provisioner. Issues are routed directly to the product team with a 24-hour internal response target.
 
 == Prerequisites
 
@@ -44,6 +41,7 @@ Do not open a support ticket for issues with Runner Provisioner. Issues are rout
 
 The following sections cover the cluster requirements for running Runner Provisioner on a Kubernetes cluster.
 
+[#nested-virtualization]
 ==== Nested virtualization
 
 KubeVirt runs VMs inside Kubernetes pods. Each node that will host runner VMs must expose `/dev/kvm` — the node itself must support hardware-accelerated virtualization (either bare metal, or a cloud VM with nested virtualization enabled).
@@ -1046,6 +1044,7 @@ If `desired_vms` is not changing in response to queued jobs, check the following
 
 Scaler errors appear as log entries with messages like `failed to get unclaimed tasks` or `failed to get running tasks`, indicating the provisioner cannot reach the CircleCI API.
 
+[#upgrading]
 == Upgrading
 
 Update your `my-values.yaml` and run:
@@ -1225,15 +1224,15 @@ $ kubectl label nodes --all node-role.kubernetes.io/control-plane=
 * VM OS must be Debian/Ubuntu or RHEL/CentOS based.
 * The provisioner requires KubeVirt's `VirtualMachinePool` API (`pool.kubevirt.io`).
 
-[#preview-stage-gaps]
-=== Preview-stage gaps
+[#beta-stage-gaps]
+=== Beta-stage gaps
 
 The following capabilities are not yet available and are planned before general availability:
 
 * Metrics endpoint (Prometheus-compatible).
 * Windows guest OS support for runner VMs (the cloud-init startup script is Linux-only).
 
-If any of these are blocking your use case, post in the `#runner-provisioner-preview` Slack channel.
+If any of these are blocking your use case, open a link:https://support.circleci.com/hc/en-us/requests/new[support ticket].
 
 [#vm-startup-latency]
 === VM startup latency


### PR DESCRIPTION
# Description

This promotes Runner Provisioner from "Preview" to "Beta".

# Reasons

The product is already accessible to all customers, and while all the ergonomics aren't stable, it is stable for non-critical workloads.

# Content checks

Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
