### PR TITLE
TEST-252 Update smarter testing docs to document local and CI use

### DIFF
--- a/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
+++ b/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
@@ -117,7 +117,7 @@ When `max-auto-rerun` is also set, test atoms rerun until one of the two conditi
 |===
 --
 
-== 2. Run locally
+== 2. Run
 
 Use the `doctor` command to validate that your `test-suites.yml` is set up correctly. The CLI runs additional checks when auto rerun is enabled. If any results look incorrect, an action item is provided to resolve it.
 
@@ -136,8 +136,6 @@ To verify auto rerun locally, modify a test to cause it to fail, then run the te
 ----
 $ circleci testsuite run "ci tests"
 ----
-
-== 3. Run in CI
 
 Commit `.circleci/test-suites.yml` to your feature branch and push to your VCS.
 

--- a/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
+++ b/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
@@ -4,6 +4,7 @@
 :page-platform: Cloud
 :experimental:
 :page-show-readtime: true
+:tabs-sync-option:
 
 include::ROOT:partial$notes/smarter-testing-beta.adoc[]
 
@@ -20,10 +21,9 @@ This guide walks you through the foundational setup that all three features buil
 
 == Before you begin
 
-* You need to install the link:https://cli.circleci.com/[latest CircleCI CLI, window=_blank]. If you have the previous stable version installed you will need to link:https://github.com/CircleCI-Public/circleci-cli#preview-installation[uninstall it first, window=_blank].
-* You need a repository with an existing test suite. The following setup process guides you through configuring JUnit XML output and installing the CLI `testsuite` plugin.
+You need a repository with an existing test suite. The following setup process guides you through configuring JUnit XML output and running tests.
 
-NOTE: You can complete step 1 (configure and validate locally) without a CircleCI account. A CircleCI account with a project connected to your VCS is only required for step 2, when you run tests in CI.
+NOTE: You can complete local steps (setup and run locally) without a CircleCI account. A CircleCI account with a project connected to your VCS is only required when you run tests in CI.
 
 === Terminology
 
@@ -32,26 +32,75 @@ The following terms are used throughout the Smarter Testing documentation:
 Test atom:: The smallest unit of work your test runner can execute independently - typically a test file (for example, `tests/auth_test.py`), but can also be a test package or module.
 Test suite:: A named configuration in `.circleci/test-suites.yml` that defines how to discover and run your test atoms.
 
-== 1. Validate and run locally
+== 1. Setup
 
 Use the `doctor` command to set up and validate your `test-suites.yml`. The CLI runs through a series of checks, executing tests and validating the output. If any results look incorrect, action items are provided to resolve them.
+
+[tabs]
+====
+Local::
++
+--
+
+Ensure the link:https://cli.circleci.com/[latest CircleCI CLI, window=_blank] is installed to validate locally.
+
+Run the doctor command in your terminal where you usually run tests.
 
 [source,console]
 ----
 $ circleci testsuite doctor "ci tests"
 ----
+--
+
+CI::
++
+--
+
+The CLI is already available in CI, no install is needed.
+
+Run the doctor command in your job with your usual test setup.
+
+[source,yaml]
+----
+version: 2.1
+jobs:
+  doctor:
+    executor: docker
+    steps:
+      - setup
+      - run: circleci testsuite doctor "ci tests"
+----
+--
+====
 
 Follow the steps until all checks pass.
 
 include::ROOT:partial$tips/testsuite-working-directory.adoc[]
 
-== 2. Run in CI
+== 2. Run
 
-In your CircleCI configuration file, replace your existing test command with `circleci testsuite run "ci tests"` -- the same command you used locally. Keep all other job steps the same.
+[tabs]
+====
+Local::
++
+--
+
+Run the test command in your terminal where you usually run tests.
+
+[source,console]
+----
+$ circleci testsuite run "ci tests"
+----
+--
+
+CI::
++
+--
+
+In your CircleCI configuration file, replace your existing test command with `circleci testsuite run "ci tests"` -- the same command you used to setup. Keep all other job steps the same.
 
 Verify that `store_test_results` points to the directory that matches `outputs.junit` in your `test-suites.yml` file.
 
-.Example CircleCI test job configuration with the testsuite command
 [source,yaml]
 ----
 version: 2.1
@@ -69,8 +118,10 @@ jobs:
 ----
 
 Commit both `.circleci/test-suites.yml` and `.circleci/config.yml` to your feature branch and push to your VCS.
+--
+====
 
-=== Verify in CI
+== 3. Verify in CI
 
 After your pipeline runs, verify the test job behaves as expected before merging:
 

--- a/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
+++ b/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
@@ -139,7 +139,7 @@ options:
   test-impact-analysis: true
 ----
 
-== 2. Run locally
+== 2. Run
 
 Use the `doctor` command to validate the `test-suites.yml` is set up correctly. The CLI runs additional analysis checks when test impact analysis is enabled. If any results look incorrect, action items are provided to resolve them.
 
@@ -155,8 +155,6 @@ include::ROOT:partial$tips/testsuite-working-directory.adoc[]
 Once all checks pass, follow the "Next steps" from the doctor output to generate initial impact data locally and send it to CircleCI.
 
 NOTE: Depending on the test runner, the first run of analysis can take a long time because every test atom needs to run analysis.
-
-== 3. Run in CI
 
 Commit the `.circleci/test-suites.yml` changes to your feature branch and push to your VCS. Follow your usual process to merge to your default branch.
 

--- a/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
+++ b/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
@@ -73,7 +73,7 @@ options:
   dynamic-test-splitting: true
 ----
 
-== 2. Run locally
+== 2. Run
 
 Use the `doctor` command to validate that your `test-suites.yml` is set up correctly. The CLI runs additional checks when dynamic test splitting is enabled. If any results look incorrect, an action item is provided to resolve it.
 
@@ -85,8 +85,6 @@ $ circleci testsuite doctor "ci tests"
 Follow the steps until all checks pass.
 
 include::ROOT:partial$tips/testsuite-working-directory.adoc[]
-
-== 3. Run in CI
 
 Commit `.circleci/test-suites.yml` to your feature branch and push to your VCS.
 


### PR DESCRIPTION
# Description
What did you change?

The doctor command is now available locally and in CI. This change documents onboarding can be complete in either environment.

- Update getting started to include a local/CI tab.
- Combine local/CI steps in feature docs.

# Reasons
Why did you make these changes? What problem does this solve?

Not all local environments can run tests.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
