### PR TITLE
[DR-762] docs: promote configure deploy markers in navigation

### DIFF
--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -168,8 +168,9 @@
 *** xref:test:testing-macos.adoc[Testing macOS applications]
 
 * Deploy with CircleCI
-** xref:deploy:deployment-overview.adoc[Deployment and deploy management]
-** xref:deploy:configure-deploy-markers.adoc[Configure deploy markers]
+** Deployment management
+*** xref:deploy:deployment-overview.adoc[Overview]
+*** xref:deploy:configure-deploy-markers.adoc[Configure deploy markers]
 ** Smart Deployments
 *** xref:deploy:smart-deployments-overview.adoc[Smart Deployments overview]
 *** xref:deploy:set-up-smart-deployments.adoc[Set up Smart Deployments]

--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -169,6 +169,7 @@
 
 * Deploy with CircleCI
 ** xref:deploy:deployment-overview.adoc[Deployment and deploy management]
+** xref:deploy:configure-deploy-markers.adoc[Configure deploy markers]
 ** Smart Deployments
 *** xref:deploy:smart-deployments-overview.adoc[Smart Deployments overview]
 *** xref:deploy:set-up-smart-deployments.adoc[Set up Smart Deployments]
@@ -179,7 +180,6 @@
 *** xref:deploy:set-up-deploys.adoc[Set up a deploy pipeline]
 *** xref:deploy:deploy-a-component.adoc[Deploy a component]
 *** xref:deploy:rollback-a-deployment.adoc[Rollback a deployment]
-*** xref:deploy:configure-deploy-markers.adoc[Configure deploy markers]
 *** xref:deploy:environment-hierarchy-and-version-promotion.adoc[Environment hierarchy and version promotion]
 ** Release agent setup
 *** xref:deploy:release-agent-overview.adoc[Release agent overview]


### PR DESCRIPTION
# Description

Promote **Configure deploy markers** in the **Deploy with CircleCI** navigation so it appears as a top-level item alongside **Deployment and deploy management**, instead of nested under **Deploys and rollbacks**.

# Reasons

Deploy markers are a foundational setup step for rollbacks, deploy pipelines, and the Deploys UI, but the page was buried deep under **Deploys and rollbacks**. Moving it up one level makes the page easier to discover without changing any page content.

Linear: [DR-762](https://linear.app/circleci/issue/DR-762/make-deploy-markers-easier-to-find-in-docs)

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).