### PR TITLE
Add API v3 links to llms.txt files

### DIFF
--- a/extensions/llms-txt-generator-extension.js
+++ b/extensions/llms-txt-generator-extension.js
@@ -197,7 +197,13 @@ function generateLlmsTxt (playbook, contentCatalog) {
 
   // API Documentation
   sections.push('## API Documentation\n')
-  sections.push('CircleCI API v2 documentation is available in LLM-friendly format:\n')
+  sections.push('**RECOMMENDED: Use API v3** - CircleCI API v3 is the latest and recommended API version:\n')
+  sections.push(`- **API v3 Documentation**: ${siteUrl}/api/v3/`)
+  sections.push(`  - Latest API version with improved features and performance`)
+  sections.push(`  - Modern RESTful design`)
+  sections.push(`  - Comprehensive endpoint coverage`)
+  sections.push(`  - Preferred for all new integrations\n`)
+  sections.push('CircleCI API v2 documentation is also available in LLM-friendly format:\n')
   sections.push(`- **API Index for LLMs**: ${siteUrl}/api/v2/llms.txt`)
   sections.push(`  - Structured index of all API endpoints`)
   sections.push(`  - Tag-grouped operations with descriptions`)

--- a/scripts/generate-api-markdown/internal/generator/generator.go
+++ b/scripts/generate-api-markdown/internal/generator/generator.go
@@ -10,7 +10,14 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-const specialInstructions = "## Special Instructions\n\n" +
+const specialInstructions = "## Recommended: Use API v3\n\n" +
+	"**CircleCI API v3 is the latest and recommended API version.** For new integrations and projects, please use API v3 instead:\n\n" +
+	"- **API v3 Documentation**: <https://circleci.com/docs/api/v3/>\n" +
+	"- Modern RESTful design with improved features and performance\n" +
+	"- Comprehensive endpoint coverage\n" +
+	"- Preferred for all new integrations\n\n" +
+	"The information below describes API v2, which is still supported but not recommended for new projects.\n\n" +
+	"## API v2 Special Instructions\n\n" +
 	"- Base URL: `https://circleci.com/api/v2`\n" +
 	"- Authentication: send a personal API token in the `Circle-Token` header. Generate one at <https://app.circleci.com/settings/user/tokens>.\n" +
 	"- `project_id` parameters are UUIDs (not the `gh/org/repo` slug used by older endpoints).\n" +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description
This PR adds prominent links to the CircleCI API v3 documentation in the llms.txt files to guide AI agents and developers toward using the latest API version.

## Changes made:
- Updated the main `llms.txt` generator to recommend API v3 as the preferred version with a prominent section at the top of the API Documentation
- Modified the API v2 `llms.txt` generator to include a clear recommendation to use API v3 at the top of the special instructions
- Kept all existing v2 API documentation accessible but clearly marked v3 as recommended for new projects

# Reasons
This addresses Linear issue DOC-228. The goal is to ensure that AI agents and developers consulting the llms.txt files are directed to use API v3 (https://circleci.com/docs/api/v3/) as the preferred API version for new integrations, while still maintaining access to v2 documentation for existing projects.

The changes affect two files:
1. **`extensions/llms-txt-generator-extension.js`** - Generates the main site-wide llms.txt at `/docs/llms.txt`
2. **`scripts/generate-api-markdown/internal/generator/generator.go`** - Generates the API v2-specific llms.txt at `/docs/api/v2/llms.txt`

# Content checks
**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.

**Notes:**
- The Go code compiles successfully
- These changes will be reflected in the generated llms.txt files on the next build
- No documentation content pages were modified, only the build-time generators
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-228](https://linear.app/circleci/issue/DOC-228/add-links-to-api-v3-docs-for-agents)

<div><a href="https://cursor.com/agents/bc-ee406e7f-2b42-4f4c-9c02-c454d1a9259d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee406e7f-2b42-4f4c-9c02-c454d1a9259d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

