### PR TITLE
Clarify concurrency limits for Scale plan

### DIFF
--- a/docs/guides/modules/ROOT/partials/troubleshoot/pipelines-troubleshoot-snip.adoc
+++ b/docs/guides/modules/ROOT/partials/troubleshoot/pipelines-troubleshoot-snip.adoc
@@ -39,7 +39,7 @@ A job might end up being queued because you have reached your organization's con
 [#why-are-my-jobs-queuing-performance-plan]
 === Why are my jobs queuing even though I'm on the Performance Plan?
 
-Concurrency limits are set per xref:reference:ROOT:configuration-reference.adoc#resourceclass[resource class] and vary between Free, Performance, and Custom plans. For example, macOS resource classes have a lower concurrency limit than other resource classes on the same plan. If you are experiencing queuing on your jobs, it is possible you have reached the limit for that specific resource class, even if you have not reached your overall plan limit. link:https://support.circleci.com/hc/en-us/requests/new[Contact CircleCI Support] to request an increase to your limit.
+Concurrency limits are set per xref:reference:ROOT:configuration-reference.adoc#resourceclass[Resource Class] and vary between Free, Performance, and Custom plans. For example, macOS resource classes have a lower concurrency limit than other resource classes on the same plan. If you are experiencing queuing, you may have reached the limit for that specific resource class. This can happen even if you have not reached your overall plan limit. link:https://support.circleci.com/hc/en-us/requests/new[Contact CircleCI Support] to request an increase to your limit.
 
 [#find-project-projects-dashboard]
 === Why can I not find my project on the Projects dashboard?

--- a/docs/guides/modules/ROOT/partials/troubleshoot/pipelines-troubleshoot-snip.adoc
+++ b/docs/guides/modules/ROOT/partials/troubleshoot/pipelines-troubleshoot-snip.adoc
@@ -34,12 +34,12 @@ After checking your `.circleci/config.yml` for formatting errors, search for you
 [#why-is-my-job-queued]
 === Why is my job queued?
 
-A job might end up being queued because of a concurrency limit being imposed due to your organization's plan. If your jobs are queuing often, you can consider link:https://circleci.com/pricing/[upgrading your plan].
+A job might end up being queued because you have reached your organization's concurrency limit. Free, Performance, and Custom plans each have a maximum number of jobs that can run concurrently, based on your plan tier. Scale plan organizations have no concurrency limit, except for macOS resource classes, which retain a custom concurrency limit. If your jobs are queuing often, you can consider link:https://circleci.com/pricing/[upgrading your plan].
 
 [#why-are-my-jobs-queuing-performance-plan]
 === Why are my jobs queuing even though I'm on the Performance Plan?
 
-In order to keep the system stable for all CircleCI customers, we implement different soft concurrency limits on each of the xref:reference:ROOT:configuration-reference.adoc#resourceclass[Resource Classes]. If you are experiencing queuing on your jobs, it is possible you are hitting these limits. link:https://support.circleci.com/hc/en-us/requests/new[Contact CircleCI Support] to request raises on these limits.
+Concurrency limits are set per xref:reference:ROOT:configuration-reference.adoc#resourceclass[resource class] and vary between Free, Performance, and Custom plans. For example, macOS resource classes have a lower concurrency limit than other resource classes on the same plan. If you are experiencing queuing on your jobs, it is possible you have reached the limit for that specific resource class, even if you have not reached your overall plan limit. link:https://support.circleci.com/hc/en-us/requests/new[Contact CircleCI Support] to request an increase to your limit.
 
 [#find-project-projects-dashboard]
 === Why can I not find my project on the Projects dashboard?

--- a/docs/guides/modules/about-circleci/pages/concepts.adoc
+++ b/docs/guides/modules/about-circleci/pages/concepts.adoc
@@ -11,7 +11,9 @@ This guide introduces some basic concepts to help you understand how CircleCI ma
 [#concurrency]
 == Concurrency
 
-In CircleCI, _concurrency_ refers to utilizing multiple containers to run multiple jobs at the same time. Concurrency is different from CircleCI _parallelism_, which splits the tests of a single job across multiple containers. To keep the system stable for all CircleCI customers, we use different soft concurrency limits on each of the xref:reference:ROOT:configuration-reference.adoc#resourceclass[Resource Classes] for different executors. If you experience queueing on your jobs, you may be hitting these limits. Customers on annual plans can request an increase to those limits at no extra charge.
+In CircleCI, _concurrency_ refers to utilizing multiple containers to run multiple jobs at the same time. Concurrency is different from CircleCI _parallelism_, which splits the tests of a single job across multiple containers. Free, Performance, and Custom plans each have a set concurrency limit based on your plan tier. Scale plan organizations have no concurrency limit, except for macOS xref:reference:ROOT:configuration-reference.adoc#resourceclass[Resource Classes], which retain a custom concurrency limit.
+
+If you experience queueing on your jobs and are on a Free, Performance, or Custom plan, you may be hitting your plan's concurrency limit. Customers on annual plans can request an increase to their limit at no extra charge. For more information about plan tiers, see the xref:guides:plans-pricing:plan-overview.adoc[Plans Overview] page.
 
 See the xref:optimize:concurrency.adoc[Concurrency] page for more information.
 

--- a/docs/guides/modules/plans-pricing/pages/plan-overview.adoc
+++ b/docs/guides/modules/plans-pricing/pages/plan-overview.adoc
@@ -62,7 +62,7 @@ The Scale plan is designed for large organizations with advanced compliance, cus
 In addition to everything in the Performance plan, the Scale plan includes:
 
 * *All resource classes*: Access to every available machine size across all execution environments, including GPUs.
-* *Custom concurrency*: Configure exactly how many jobs run concurrently across all build configurations and execution environments.
+* *No concurrency limits*: Run an unlimited number of jobs concurrently across all build configurations and execution environments. macOS resource classes are the exception and retain a custom concurrency limit.
 * *Custom user seat count*: Set user limits based on your organization's needs.
 * *Unlimited self-hosted runners*: No cap on the number of jobs running on your own infrastructure.
 * *Custom storage retention*: Full customization of retention periods for artifacts, workspaces, and caches.

--- a/docs/reference/modules/ROOT/pages/glossary.adoc
+++ b/docs/reference/modules/ROOT/pages/glossary.adoc
@@ -55,7 +55,7 @@ In the context of <<deployment,deployments>>, a collection of code and configura
 
 == Concurrency
 
-Running multiple jobs at the same time, either multiple jobs within a single <<workflow>> or multiple workflows running across an organization. Concurrency is limited by soft limits on each <<resource-class>>. Concurrency is _not_ the same as <<parallelism>>, which splits the tests of a single job across multiple containers. See the xref:guides:optimize:concurrency.adoc[Concurrency] page.
+Running multiple jobs at the same time, either multiple jobs within a single <<workflow>> or multiple workflows running across an organization. Free, Performance, and Custom plans each have a concurrency limit that varies by <<resource-class>> and plan tier. Scale plan organizations have no concurrency limit, except for macOS resource classes, which retain a custom concurrency limit. Concurrency is _not_ the same as <<parallelism>>, which splits the tests of a single job across multiple containers. See the xref:guides:optimize:concurrency.adoc[Concurrency] page.
 
 == Config policies
 


### PR DESCRIPTION
## Summary
- Scale plan no longer has a concurrency limit, except for macOS resource classes, which retain a custom concurrency limit.
- Updates `plan-overview.adoc` to reflect this for the Scale plan.
- Clarifies `concepts.adoc`, `glossary.adoc`, and the pipelines troubleshooting partial to distinguish Free/Performance/Custom (each with a plan-based concurrency limit) from Scale (no limit except macOS).

## Files changed
- `docs/guides/modules/plans-pricing/pages/plan-overview.adoc`
- `docs/guides/modules/about-circleci/pages/concepts.adoc`
- `docs/reference/modules/ROOT/pages/glossary.adoc`
- `docs/guides/modules/ROOT/partials/troubleshoot/pipelines-troubleshoot-snip.adoc`

## Follow-ups (not in this PR)
Other pages/properties still reference the old concurrency-limit language and need review by their respective owners:
- Docs repo: `migrating-from-travis.adoc`, `configuration-reference.adoc`, `optimize/concurrency.adoc`
- Public website: circleci.com/pricing/ comparison table and Scale plan card
- Support Center: "Why are my jobs queueing?" and "Jobs Queuing or Stuck..." articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)