### PR TITLE
Remove Docker gen2 disclaimer for IP Ranges

### DIFF
--- a/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
+++ b/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
@@ -50,11 +50,7 @@ A remote Docker environment uses a **Linux VM machine** resource class that corr
 
 Gen2/Gen3 resource classes are also available for remote Docker (for example, `medium.gen2`/`medium.gen3`). The `small.gen2`/`small.gen3` resource classes are not supported for remote Docker; the smallest available size is `medium.gen2`/`medium.gen3`.
 
-[NOTE]
-====
-* **Gen3 resource classes for remote Docker are part of an Open Beta.** See the xref:using-linuxvm.adoc#gen3-beta-notice[Gen3 Beta Release Notes] for full details.
-* Gen2/Gen3 does not currently support the xref:security:ip-ranges.adoc[IP Ranges].
-====
+NOTE: **Gen3 resource classes for remote Docker are part of an Open Beta.** See the xref:using-linuxvm.adoc#gen3-beta-notice[Gen3 Beta Release Notes] for full details.
 
 === Arm architecture
 

--- a/docs/guides/modules/execution-managed/pages/using-docker.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-docker.adoc
@@ -118,8 +118,6 @@ Using more modern compute, gen2 instances are nearly 1.4x faster than their gen1
 
 x86 gen2 resources have a higher cost in credits per minute than their gen1 equivalents. See our link:https://circleci.com/pricing/price-list/[Pricing Page] for details.
 
-NOTE: Gen2 does not currently support the use of xref:security:ip-ranges.adoc[IP Ranges].
-
 [#using-docker-gen2]
 === Using gen2
 


### PR DESCRIPTION
# Description
Remove Docker gen2 disclaimer for IP Ranges.

# Reasons
We just added support for it and want to set the record straight.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.
