### PR TITLE
Update machine gen3 caveats to the current state

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/machine-gen3-resource-table.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/machine-gen3-resource-table.adoc
@@ -6,9 +6,6 @@
 
 * This feature is under active development and behavior may change without notice.
 * We are still validating performance and reliability. We measure SLOs, but do not guarantee them yet.
-* Some jobs may see longer-than-expected queue times as we tune capacity.
-* We recommend testing on non-critical workloads first while we refine the Beta based on customer feedback.
-* **Known issue (temporary):** Enabling Docker Layer Caching (`docker_layer_caching: true`) on gen3 resource classes can currently cause infrastructure failures. We are actively working on a fix. See xref:guides:optimize:docker-layer-caching.adoc#gen3-infrastructure-failures[Known Issues] for details.
 ====
 
 [.table-scroll]

--- a/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
+++ b/docs/guides/modules/execution-managed/pages/building-docker-images.adoc
@@ -225,8 +225,6 @@ To use Docker 29, use the following tag:
 
 * `docker29`
 
-WARNING: Avoid `docker29` if you use DLC. See xref:optimize:docker-layer-caching.adoc#docker29-incompatibility[Known Issues] for details.
-
 To use Docker 27, use the following tag:
 
 * `docker27`

--- a/docs/guides/modules/execution-managed/pages/using-docker.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-docker.adoc
@@ -114,7 +114,7 @@ Resource classes running on gen2 infrastructure offer significant performance an
 [#docker-gen2-performance-improvements]
 === Performance improvements
 
-Using more modern compute, gen2 instances are nearly 1.4x faster than their gen1 equivalents.
+Using more modern compute, gen2 instances deliver up to 71% faster performance compared to gen1 equivalents.
 
 x86 gen2 resources have a higher cost in credits per minute than their gen1 equivalents. See our link:https://circleci.com/pricing/price-list/[Pricing Page] for details.
 

--- a/docs/guides/modules/execution-managed/pages/using-linuxvm.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-linuxvm.adoc
@@ -79,7 +79,7 @@ Resource classes running on gen2 infrastructure offer significant performance an
 [#performance-improvements]
 ==== Performance improvements
 
-Using more modern compute, gen2 instances deliver up to 25% faster performance compared to gen1 equivalents. This figure comes from real-world benchmarks across open source projects.
+Using more modern compute, gen2 instances deliver up to 24% faster performance compared to gen1 equivalents. This figure comes from real-world benchmarks across open source projects.
 
 On a per-resource-class basis, gen2 pricing can be higher or lower than its gen1 equivalent. See our link:https://circleci.com/pricing/price-list/[Pricing Page] for details.
 
@@ -109,7 +109,7 @@ NOTE: Gen3 is an Open Beta feature. See the <<gen3-beta-notice,Gen3 Beta Release
 [#gen3-performance-improvements]
 ==== Performance improvements
 
-Gen3 instances deliver up to 67% faster performance compared to gen1 equivalents, based on benchmarks collected during Beta across open source projects.
+Gen3 instances deliver up to 85% faster performance compared to gen1 equivalents, based on benchmarks collected during Beta across open source projects.
 
 Gen3 costs less than both its gen1 and gen2 equivalents. See our link:https://circleci.com/pricing/price-list/[Pricing Page] for details.
 

--- a/docs/guides/modules/execution-managed/pages/using-linuxvm.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-linuxvm.adoc
@@ -109,7 +109,7 @@ NOTE: Gen3 is an Open Beta feature. See the <<gen3-beta-notice,Gen3 Beta Release
 [#gen3-performance-improvements]
 ==== Performance improvements
 
-Gen3 instances deliver up to 67% faster performance compared to gen1 equivalents, based on benchmarks collected during Beta across open source projects. These figures are promising, but we have not yet validated them at production scale, and queue times may be longer than expected while we continue tuning Gen3 capacity during Beta.
+Gen3 instances deliver up to 67% faster performance compared to gen1 equivalents, based on benchmarks collected during Beta across open source projects.
 
 Gen3 costs less than both its gen1 and gen2 equivalents. See our link:https://circleci.com/pricing/price-list/[Pricing Page] for details.
 

--- a/docs/guides/modules/optimize/pages/docker-layer-caching.adoc
+++ b/docs/guides/modules/optimize/pages/docker-layer-caching.adoc
@@ -16,7 +16,7 @@ You can use DLC with both the `machine` executor and in a xref:execution-managed
 
 DLC costs 200 credits per job run. For more information about DLC charges, see the xref:plans-pricing:credits.adoc#charge-for-docker-layer-caching[FAQ].
 
-NOTE: DLC has a couple of temporary, known issues. See <<known-issues,Known Issues>> before enabling it on gen3 resource classes or newer Docker versions.
+NOTE: DLC has a known issue with QEMU/binfmt multi-arch `buildx` builds. See <<known-issues,Known Issues>> before enabling it.
 
 [#quickstart]
 == Quickstart
@@ -63,20 +63,22 @@ jobs:
 [#known-issues]
 == Known issues
 
-[#gen3-infrastructure-failures]
-=== Gen3 resource classes causing infrastructure failures
+[#qemu-binfmt-corruption]
+=== DLC corruption with QEMU/binfmt multi-arch builds
 
 [WARNING]
 ====
-We are investigating reports that enabling DLC (`docker_layer_caching: true`) on gen3 resource classes (`*.gen3`) can cause infrastructure failures. This incompatibility is a temporary, known issue, not a permanent limitation of DLC or gen3. Avoid enabling DLC on gen3 resource classes for now, whether you are using the `machine` executor or a xref:execution-managed:building-docker-images.adoc[Remote Docker Environment].
-====
+Registering QEMU `binfmt` handlers (for example, with `tonistiigi/binfmt --install all`) for multi-architecture `buildx` builds can corrupt the DLC cache. When this happens, CircleCI automatically resets the Docker filesystem, so the job usually still succeeds. However, DLC discards the cached layers instead of reusing them, and the same corruption tends to recur on the next run that registers `binfmt` handlers.
 
-[#docker29-incompatibility]
-=== Docker 29 compatibility
+**Workaround:** Uninstall the QEMU `binfmt` handlers as the last step of your job (using `when: always`), then <<purge-dlc,purge the existing DLC cache>>:
 
-[WARNING]
-====
-DLC is not currently compatible with Docker 29 or later. This incompatibility is a temporary, known issue, and we are working on a fix. Avoid `docker29` if you use DLC. See xref:execution-managed:building-docker-images.adoc#docker-version[Specify a Docker Version for Remote Docker] for how to pin a version.
+[,yaml]
+----
+- run:
+    name: Uninstall QEMU binfmt handlers
+    when: always
+    command: docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*
+----
 ====
 
 [#limitations]


### PR DESCRIPTION
# Description
Updating machine gen3's caveats.

# Reasons
As gen3 begins to stabilize, we need to update our docs to reflect the current state. This also includes a specific DLC bug that we've discovered, but unrelated to gen3 or Docker 29 for that matter.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.