### PR TITLE
[DR-770] docs: live version restoration on failed deploy markers

### DIFF
--- a/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
+++ b/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
@@ -266,7 +266,7 @@ When a deploy marker reports `RUNNING`, CircleCI marks the target version as liv
 
 If CircleCI cannot find a prior successful version, the target version stays live. A component is never left with zero live versions.
 
-NOTE: This live-version restoration applies only to deploy markers (`circleci run release update`). If you use the CircleCI xref:release-agent-overview.adoc[release agent] for Kubernetes deployments, the release agent handles status and live-version updates for you.
+NOTE: This live-version restoration applies only to deploy markers (`circleci run release update`). If you use the CircleCI xref:release-agent-overview.adoc[release agent] for Kubernetes deployments, the release agent handles status and live-version updates for you. If you use xref:set-up-release-validation-manually.adoc[release validation], a failed validation leaves the target version marked live so automatic rollback can run correctly.
 
 If your deployment failed in CircleCI but the new version is still serving traffic (for example, a partial rollout that you mark as failed), pass `--keep-target-version-live` on the `FAILED` or `CANCELED` update to keep the target version marked live:
 

--- a/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
+++ b/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
@@ -266,9 +266,9 @@ When a deploy marker reports `RUNNING`, CircleCI marks the target version as liv
 
 If CircleCI cannot find a prior successful version, the target version stays live. A component is never left with zero live versions.
 
-NOTE: This live-version restoration applies only to deploy markers (`circleci run release update`). If you use the CircleCI xref:release-agent-overview.adoc[release agent] for Kubernetes deployments, the release agent handles status and live-version updates for you. If you use xref:set-up-release-validation-manually.adoc[release validation], a failed validation leaves the target version marked live so automatic rollback can run correctly.
+NOTE: This live-version restoration applies only to deploy markers (`circleci run release update`). If you use the CircleCI xref:release-agent-overview.adoc[Release Agent Overview] for Kubernetes deployments, the release agent handles status and live-version updates for you. If you use xref:set-up-release-validation-manually.adoc[Set Up Release Validation Manually], a failed validation leaves the target version marked live so automatic rollback can run correctly.
 
-If your deployment failed in CircleCI but the new version is still serving traffic (for example, a partial rollout that you mark as failed), pass `--keep-target-version-live` on the `FAILED` or `CANCELED` update to keep the target version marked live:
+If your deployment failed in CircleCI but the new version is still serving traffic, pass `--keep-target-version-live` on the `FAILED` or `CANCELED` update to keep the target version marked live. For example, you might mark a partial Rollout as failed even though the new version is still serving traffic:
 
 .Keep the target version live after a failed deploy marker
 [,yml]

--- a/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
+++ b/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
@@ -256,6 +256,32 @@ jobs:
 
 In this example, the status of the deploy is updated to `SUCCESS` or `FAILED` depending on the outcome of your job.
 
+[#live-version-on-failed-or-canceled-deploys]
+===== Live version on failed or canceled deploys
+
+When a deploy marker reports `RUNNING`, CircleCI marks the target version as live in the Deploys UI. If the deploy later reports `FAILED` or `CANCELED`, CircleCI restores the previous live version by default:
+
+* The failed or canceled target version is no longer marked live.
+* The last successful version for that component in the environment is marked live again.
+
+This keeps rollback pipelines, version promotion, and the live version shown in the Deploys UI aligned with the version that was serving traffic before the failed deploy.
+
+If CircleCI cannot find a prior successful version, the target version stays live. A component is never left with zero live versions.
+
+Progressive releases keep their existing behavior: the previous version was already live when the release started, so only the failed target is demoted.
+
+NOTE: This live-version restoration applies only to deploy markers (`circleci run release update`). If you use the CircleCI xref:release-agent-overview.adoc[release agent] for Kubernetes deployments, the release agent handles status and live-version updates for you.
+
+If your deployment failed in CircleCI but the new version is still serving traffic (for example, a partial rollout that you mark as failed), pass `--keep-target-version-live` on the `FAILED` or `CANCELED` update to keep the target version marked live:
+
+.Keep the target version live after a failed deploy marker
+[,yml]
+----
+circleci run release update <deploy-name> \
+  --status=FAILED \
+  --keep-target-version-live
+----
+
 The `failure_reason.env` file can be created by a previous step in the job. This can be done, for example, in a step in which we are validating the status of the deployment. One way to do this is as follows:
 
 .Create a file to store the failure reason
@@ -303,7 +329,7 @@ workflows:
               - canceled
 ----
 
-In this example, the `cancel-deploy` job will be run only when the `deploy` job is canceled, thus updating the deployment to the `canceled` status.
+In this example, the `cancel-deploy` job will be run only when the `deploy` job is canceled, thus updating the deployment to the `canceled` status. Unless you pass `--keep-target-version-live`, CircleCI also restores the last successful version as live. See <<live-version-on-failed-or-canceled-deploys,Live version on failed or canceled deploys>>.
 
 ==== 5. Full config example
 

--- a/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
+++ b/docs/guides/modules/deploy/pages/configure-deploy-markers.adoc
@@ -264,11 +264,7 @@ When a deploy marker reports `RUNNING`, CircleCI marks the target version as liv
 * The failed or canceled target version is no longer marked live.
 * The last successful version for that component in the environment is marked live again.
 
-This keeps rollback pipelines, version promotion, and the live version shown in the Deploys UI aligned with the version that was serving traffic before the failed deploy.
-
 If CircleCI cannot find a prior successful version, the target version stays live. A component is never left with zero live versions.
-
-Progressive releases keep their existing behavior: the previous version was already live when the release started, so only the failed target is demoted.
 
 NOTE: This live-version restoration applies only to deploy markers (`circleci run release update`). If you use the CircleCI xref:release-agent-overview.adoc[release agent] for Kubernetes deployments, the release agent handles status and live-version updates for you.
 

--- a/docs/guides/modules/toolkit/pages/environment-cli-usage-guide.adoc
+++ b/docs/guides/modules/toolkit/pages/environment-cli-usage-guide.adoc
@@ -15,7 +15,7 @@ This reference guide covers some basic information about the CircleCI task-agent
 
 == CLI differentiation
 
-The environment CLI is different from the xref:local-cli.adoc[CircleCI local CLI] tool that you may already know. Understanding the difference between these two CLI interfaces is essential for effective usage during your build processes.
+The environment CLI is different from the xref:local-cli.adoc[CircleCI Local CLI] tool that you may already know. Understanding the difference between these two CLI interfaces is essential for effective usage during your build processes.
 
 The CircleCI environment CLI:: A specialized command-line interface. The environment CLI retrieves and configures a task before managing the execution of the job within a chosen compute environment. The environment CLI is available for use in your CI/CD pipelines.
 
@@ -92,7 +92,7 @@ Output:
 }
 ----
 
-For more information on using the `env` command, see the xref:security:env-vars.adoc#environment-variable-substitution[Introduction to environment variables] page.
+For more information on using the `env` command, see the xref:security:env-vars.adoc#environment-variable-substitution[Introduction to Environment Variables] page.
 
 === Run
 
@@ -102,7 +102,7 @@ Invokes a task-agent subcommand by name.
 
 A subcommand of `run`. The `circleci run oidc` command runs authentication using OIDC.
 
-For more information, including an example, see the xref:permissions-authentication:oidc-tokens-with-custom-claims.adoc[OpenID Connect tokens with custom claims] page.
+For more information, including an example, see the xref:permissions-authentication:oidc-tokens-with-custom-claims.adoc[OpenID Connect Tokens With Custom Claims] page.
 
 ==== Release
 
@@ -123,7 +123,7 @@ A _planned_ deployment is displayed in the Deploys UI with `pending` status.
 | Flag | Description
 
 | `deploy-name`
-| An arbitrary positional argument that is used to identify the deployment. This should be unique within the workflow.
+| An arbitrary positional argument that is used to identify the deployment. Keep this unique within the workflow.
 
 | `environment-name`
 | Sets the target environment. If the specified environment does not exist, it will be created. If you do not specify an environment, CircleCI will create one named default.
@@ -132,7 +132,7 @@ A _planned_ deployment is displayed in the Deploys UI with `pending` status.
 | Sets the name that will be displayed in the UI. If you do not already have a component in your project a new one will be created with the name of the project. This will be set as the component that is being deployed.
 
 | `target-version`
-| Should match the version being deployed.
+| Must match the version being deployed.
 
 | `namespace`
 | Optional flag to use a namespace value other than default.
@@ -154,11 +154,11 @@ jobs:
             circleci run release plan <deploy-name> --environment-name=<some-environment-name> --component-name=<some-component-name> --target-version=<some-version-name> --namespace=<some-namespace>
 ----
 
-For more information on using the `circleci run release plan` command, see the xref:deploy:configure-deploy-markers.adoc[Configure deploy markers] page.
+For more information on using the `circleci run release plan` command, see the xref:deploy:configure-deploy-markers.adoc[Configure Deploy Markers] page.
 
 ==== Update
 
-WARNING: The `circleci run release update` command is only for use with deploy markers. If you are using the CircleCI xref:deploy:release-agent-overview.adoc[release agent] for Kubernetes deployments, do NOT use the `update` commands. The release agent automatically handles status updates for you.
+WARNING: The `circleci run release update` command is only for use with deploy markers. If you are using the CircleCI xref:deploy:release-agent-overview.adoc[Release Agent Overview] for Kubernetes deployments, do NOT use the `update` commands. The release agent automatically handles status updates for you.
 
 A subcommand of `release`. Use the `circleci run release update` command to update the status of the deployment.
 
@@ -196,7 +196,7 @@ jobs:
             circleci run release update <deploy-name> --status=running
 ----
 
-For more information on using the `circleci run release update` command, see the xref:deploy:configure-deploy-markers.adoc[Configure deploy markers] page.
+For more information on using the `circleci run release update` command, see the xref:deploy:configure-deploy-markers.adoc[Configure Deploy Markers] page.
 
 ==== Log
 
@@ -217,7 +217,7 @@ A subcommand of `release`. The `circleci run release log` command allows you to 
 | Sets the name to display in the UI. If you do not already have a component in your project a new one will be created with the name of the project. This will be set as the component that is being deployed.
 
 | `target-version`
-| Should match the version you are deploying.
+| Must match the version you are deploying.
 
 | `namespace`
 | Optional flag to use a namespace value other than default.
@@ -239,7 +239,7 @@ jobs:
             circleci run release log --environment-name=<some-environment-name> --component-name=<some-component-name> --target-version=<some-version-name>
 ----
 
-For more information on using the `circleci run release log` command, see the xref:deploy:configure-deploy-markers.adoc[Configure deploy markers] page.
+For more information on using the `circleci run release log` command, see the xref:deploy:configure-deploy-markers.adoc[Configure Deploy Markers] page.
 
 === Task
 
@@ -261,7 +261,7 @@ circleci step halt
 
 === Tests
 
-Collect and split tests so they can run in parallel. For full details of splitting and running tests using the environment CLI, see the xref:optimize:use-the-circleci-cli-to-split-tests.adoc[Use the CircleCI environment CLI to split tests] page.
+Collect and split tests so they can run in parallel. For full details of splitting and running tests using the environment CLI, see the xref:optimize:use-the-circleci-cli-to-split-tests.adoc[Use the CircleCI Environment CLI to Split Tests] page.
 
 ==== Split
 
@@ -415,8 +415,8 @@ jobs:
 
 *More information on using the `tests` command*:
 
-* xref:optimize:parallelism-faster-jobs.adoc#how-test-splitting-works[Guide to Test splitting and parallelism]
-* xref:optimize:use-the-circleci-cli-to-split-tests.adoc[Use the CircleCI CLI to split tests]
+* xref:optimize:parallelism-faster-jobs.adoc#how-test-splitting-works[Guide to Test Splitting and Parallelism]
+* xref:optimize:use-the-circleci-cli-to-split-tests.adoc[Use the CircleCI CLI to Split Tests]
 
 === Version
 

--- a/docs/guides/modules/toolkit/pages/environment-cli-usage-guide.adoc
+++ b/docs/guides/modules/toolkit/pages/environment-cli-usage-guide.adoc
@@ -171,7 +171,13 @@ A subcommand of `release`. Use the `circleci run release update` command to upda
 | Flag | Description
 
 | `status`
-| Update the deploy status (values can be `RUNNING`, `SUCCESS`, or `FAILED`).
+| Update the deploy status (values can be `RUNNING`, `SUCCESS`, `FAILED`, or `CANCELED`).
+
+| `failure-reason`
+| Optional text describing why the deploy failed. Use with `--status=FAILED`.
+
+| `keep-target-version-live`
+| Keep the target version marked live when the deploy reports `FAILED` or `CANCELED`. By default, CircleCI restores the last successful version as live. See xref:deploy:configure-deploy-markers.adoc#live-version-on-failed-or-canceled-deploys[Live version on failed or canceled deploys].
 |===
 --
 

--- a/docs/guides/modules/toolkit/pages/environment-cli-usage-guide.adoc
+++ b/docs/guides/modules/toolkit/pages/environment-cli-usage-guide.adoc
@@ -177,7 +177,7 @@ A subcommand of `release`. Use the `circleci run release update` command to upda
 | Optional text describing why the deploy failed. Use with `--status=FAILED`.
 
 | `keep-target-version-live`
-| Keep the target version marked live when the deploy reports `FAILED` or `CANCELED`. By default, CircleCI restores the last successful version as live. See xref:deploy:configure-deploy-markers.adoc#live-version-on-failed-or-canceled-deploys[Live version on failed or canceled deploys].
+| Keep the target version marked live when the deploy reports `FAILED` or `CANCELED`. By default, CircleCI restores the last successful version as live. See xref:deploy:configure-deploy-markers.adoc#live-version-on-failed-or-canceled-deploys[Live Version on Failed or Canceled Deploys].
 |===
 --
 


### PR DESCRIPTION
# Description
Document live-version behavior for deploy markers when a release reports `FAILED` or `CANCELED`, and the `--keep-target-version-live` opt-out flag on `circleci run release update`.

Updates:
- `configure-deploy-markers.adoc`: new section on live version restoration, cross-reference from the canceled-status section.
- `environment-cli-usage-guide.adoc`: `CANCELED` status, `failure-reason`, and `keep-target-version-live` flags.

# Reasons
[DR-765](https://linear.app/circleci/issue/DR-765) and [DR-766](https://linear.app/circleci/issue/DR-766) shipped to production. Deploy markers now restore the last successful version as live by default when a deploy fails or is canceled. Public docs should describe this behavior and when to use `--keep-target-version-live`.

Follow-up to [DR-770](https://linear.app/circleci/issue/DR-770).

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).