### PR TITLE
Unpin vale version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,14 +197,6 @@ workflows:
   main:
     jobs:
       - vale/lint:
-          # Pinned: vale v3.17.0+ truncates scope: heading text to its first
-          # sentence-fragment whenever any scope: sentence rule is loaded,
-          # which turns lettered/numbered headings ("a. Create a context")
-          # into errors. Filed upstream with vale-cli/vale. Unpin once fixed
-          # and released.
-          executor:
-            name: vale/default
-            tag: v3.16.0
           reference_branch: main
           base_dir: docs
           filters: pipeline.git.branch != "main"


### PR DESCRIPTION
## Summary
- The vale executor was pinned to `v3.16.0` to work around a v3.17.0+ bug that truncated `scope: heading` text to its first sentence-fragment whenever a `scope: sentence` rule was loaded, turning lettered/numbered headings (e.g. "a. Create a context") into false-positive errors.
- That bug has been fixed and released upstream in vale-cli/vale, so this removes the pin and lets `vale/lint` use the orb's default executor version.

## Test plan
- [ ] Confirm CI's `vale/lint` job runs successfully on this PR with the default (unpinned) executor version
- [ ] Spot-check a page with lettered/numbered headings (e.g. one with "a. Create a context"-style list items) to confirm no false-positive heading errors