### PR TITLE
Update smarter testing getting started to document the onboarding skill

### DIFF
--- a/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
+++ b/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
@@ -34,6 +34,34 @@ Test suite:: A named configuration in `.circleci/test-suites.yml` that defines h
 
 == 1. Setup
 
+[TIP]
+=====
+If you use an AI coding assistant, CircleCI publishes a link:https://github.com/CircleCI-Public/skills[plugin of agent skills, window=_blank] that can complete this setup for you. Install the plugin, then ask your assistant to set up Smarter Testing for your project.
+
+[tabs]
+====
+Claude Code::
++
+--
+[source,console]
+----
+$ claude plugin marketplace add CircleCI-Public/skills
+$ claude plugin install circleci@circleci-public-skills
+----
+--
+
+Codex::
++
+--
+[source,console]
+----
+$ codex plugin marketplace add CircleCI-Public/skills
+$ codex plugin add circleci@circleci-skills
+----
+--
+====
+=====
+
 Use the `doctor` command to set up and validate your `test-suites.yml`. The CLI runs through a series of checks, executing tests and validating the output. If any results look incorrect, action items are provided to resolve them.
 
 [tabs]


### PR DESCRIPTION
# Description

Update smarter testing getting started to document the onboarding skill

`CircleCI-Public/skills` publishes an onboarding skill for smarter 
testing, document its existence and how to install it via Claude/Codex.

The `circleci-public-skills` and `circleci-skills` difference is due
to the difference between the `.agents` and `.claude-plugin` marketplace
config in `CircleCI-Public/skills`, both commands have been checked and
work in Claude/Codex.

https://github.com/CircleCI-Public/skills/blob/8a228d394f0f613401118bad7d8117064a611561/.agents/plugins/marketplace.json#L2

https://github.com/CircleCI-Public/skills/blob/8a228d394f0f613401118bad7d8117064a611561/.claude-plugin/marketplace.json#L3

# Reasons

Make it easier for users onboarding with agents.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
