### PR TITLE
update docs for xcode 27 beta 6

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/xcode-silicon-vm.adoc
@@ -10,12 +10,12 @@
 | Release Notes
 
 | `27.0`
-| Xcode 27.0 (27A5228h)
+| Xcode 27.0 (27A5252f)
 | 26.5.1
 a| `m4pro.medium` +
    `m4pro.large`
-| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v19120/manifest.txt[Installed software]
-| link:https://circleci.com/changelog/xcode-27-0-beta-4-available/[Release Notes]
+| link:https://circle-macos-docs.s3.amazonaws.com/image-manifest/v19268/manifest.txt[Installed software]
+| link:https://circleci.com/changelog/xcode-27-0-beta-6-available/[Release Notes]
 
 | `26.6`
 | Xcode 26.6 (17F113)


### PR DESCRIPTION
# Description
What did you change?

New Xcode Image Released: Xcode 27 beta 6: https://developer.apple.com/documentation/xcode-release-notes/xcode-27-release-notes

# Reasons
Why did you make these changes? What problem does this solve?

New Xcode Image Released: Xcode 27 beta 6: https://developer.apple.com/documentation/xcode-release-notes/xcode-27-release-notes

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
