### PR TITLE
Remove paid plan restrictions for Docker gen2

### DIFF
--- a/docs/guides/modules/ROOT/partials/execution-resources/docker-gen2-resource-table.adoc
+++ b/docs/guides/modules/ROOT/partials/execution-resources/docker-gen2-resource-table.adoc
@@ -1,4 +1,4 @@
-NOTE: Docker gen2 resource classes are available on paid plans only. For credit and access information, see the link:https://circleci.com/product/features/resource-classes/[Resource classes page].
+NOTE: For credit and access information, see the link:https://circleci.com/product/features/resource-classes/[Resource classes page]. Resource class access is dependent on your xref:guides:plans-pricing:plan-overview.adoc[Plan].
 
 [.table-scroll]
 --

--- a/docs/guides/modules/execution-managed/pages/using-docker.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-docker.adoc
@@ -107,8 +107,6 @@ include::ROOT:partial$execution-resources/resource-class-view.adoc[]
 [#docker-gen2-benefits]
 == Docker gen2
 
-NOTE: Docker gen2 resource classes are available on paid plans only. See the xref:plans-pricing:plan-overview.adoc[Plans Overview] for details.
-
 Resource classes running on gen2 infrastructure offer significant performance and cost improvements over their gen1 equivalents.
 
 [#docker-gen2-performance-improvements]


### PR DESCRIPTION
# Description
Docker gen2 is now available on the free plan! This PR updates the language to reflect that.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.