### PR TITLE
Adding Android gen2 support

### DIFF
--- a/docs/guides/modules/execution-managed/pages/android-images-support-policy.adoc
+++ b/docs/guides/modules/execution-managed/pages/android-images-support-policy.adoc
@@ -11,43 +11,54 @@ This document outlines the CircleCI Android image release, update, and deprecati
 [#release-policy]
 == Release policy
 
-Android images are released once a quarter, with patch releases potentially made for security issues. These images are generally built on top of the latest version of our most recent stable base Ubuntu image with added packages for Android.
+We release Android images once a quarter, and we ship patch releases for security issues as needed. We generally build these images on top of the latest stable base Ubuntu image, with added packages for Android.
 
 - We install the most up-to-date versions of each tool/package in newly built images.
 - We aim to package 6 levels of the Android API within each image release.
 - As this image is not specifically designed for the Android Gradle Plugin (AGP), some updates may come later than desired. We aim to follow compatibility matrices for link:https://docs.gradle.org/current/userguide/compatibility.html[AGP] and link:https://developer.android.com/build/releases/gradle-plugin#updating-gradle[Gradle].
 
-Releases may be skipped if there are no material updates to core Android functionality, such as `sdkmanager`, `ndk` or platform versions.
+We may skip a release if core Android functionality (such as `sdkmanager`, `ndk`, or platform versions) has no material updates.
+
+[#gen2-support]
+== Gen2 support
+
+Gen2 resource classes are available for the Android machine image on CircleCI Cloud. Every Android gen1 resource class has a gen2 equivalent:
+
+- `medium`
+- `large`
+- `xlarge`
+- `2xlarge`
+- `2xlarge+`
+
+Gen2 resource classes are not available on CircleCI Server.
 
 [#tagging]
 == Tagging
 
-Tags we support for this image (tag is what is specified in config when requesting an image):
+The following tags specify which image version to request in your configuration:
 
-For the latest major version of Docker:
+- `default`: CircleCI updates this tag every three months. This image is the current stable version.
 
-- `default`: This image is the current stable version of the image and will receive updates approximately every 3 months.
-
-- `edge`: These tags are reserved for previews of new releases, which will initially point to this tag. The `edge` tags may include incremental updates to the `current` image release, which may change without notice, and are not recommended to be used for production CI workloads. `current` will be updated with these changes after a period of stability (generally an average of a week).
+- `edge`: Use `edge` for previews of new releases that point to this tag initially. Edge tags may include incremental updates to the `default` image release, which may change without notice. Do not use `edge` for production CI workloads. CircleCI updates `default` with these changes after a period of stability, generally about a week.
 
 [#critical-cve-patches]
 == Critical CVE patches
 
-When critical CVEs are disclosed around the operating system or software stack of this image, we will investigate the impact this has on the image within the CircleCI execution environment. If customers are impacted by these CVEs we will push a patch fix to the released image(s), and this image will supersede the original image.
+When vendors disclose critical CVEs around the operating system or software stack of this image, we investigate the impact on the image within the CircleCI execution environment. If these CVEs affect customers, we push a patch fix to the released image(s). This new image supersedes the original.
 
 [#bug-reports-issues-and-prs]
 == Bug reports, issues, and PRs
 
-File a link:https://support.circleci.com/hc/en-us/requests/new[Support Ticket with CircleCI Support] for any issues or bugs found with the Android VM (machine) images. Our Support Team will be able to escalate issues internally to the correct engineering team and provide updates on the issue.
+You can file a link:https://support.circleci.com/hc/en-us/requests/new[support ticket] with CircleCI Support for any issues or bugs found with the Android VM (machine) images. Our support team can escalate issues internally to the correct engineering team and provide updates on the issue.
 
 [#image-lifespan-eol]
 == Image lifespan / EOL
 
-When a new API Level for Android is released we will release it to edge. We will give a 3-month warning before the default image will have oldest version no longer supported. We will create an announcement on our Discuss forum, along with additional outreach where possible.
+When a new Android API level ships, we release it to `edge`. We give a 3-month warning before we drop support for the oldest version in `default`. We post an announcement on our Discuss forum, along with additional outreach where possible.
 
-Generally we will aim to start EOL process within 3 months of a new version release.
+We aim to start the EOL process within 3 months of a new version release.
 
 [#exceptions]
 == Exceptions
 
-​​At any time, we reserve the right to work outside of the information in this document if the circumstances require. In the event that we are required to make an exception to the policy, we will aim to provide as much notice and clarity as possible. In these cases, an announcement will be posted on our Discuss Forum, along with additional outreach, such as an email notice, where possible.
+At any time, we reserve the right to work outside of the information in this document if the circumstances require. If we need to make an exception to the policy, we aim to provide as much notice and clarity as possible. In these cases, we post an announcement on our Discuss Forum. We also provide additional outreach such as an email notice where possible.

--- a/docs/guides/modules/execution-managed/pages/android-images-support-policy.adoc
+++ b/docs/guides/modules/execution-managed/pages/android-images-support-policy.adoc
@@ -30,16 +30,18 @@ Gen2 resource classes are available for the Android machine image on CircleCI Cl
 - `2xlarge`
 - `2xlarge+`
 
-Gen2 resource classes are not available on CircleCI Server.
+Gen2 images use the `current` tag instead of the `default` tag used by gen1 images. See <<tagging>> for details. Gen2 resource classes are not available on CircleCI Server.
 
 [#tagging]
 == Tagging
 
-The following tags specify which image version to request in your configuration:
+The following tags specify which image version to request in your configuration. Gen1 and gen2 images use different stable tags: gen1 uses `default` for legacy reasons, and gen2 uses `current` to stay consistent with the Linux VM tagging convention.
 
-- `default`: CircleCI updates this tag every three months. This image is the current stable version.
+- `default`: The stable tag for gen1 images. CircleCI updates this tag every three months.
 
-- `edge`: Use `edge` for previews of new releases that point to this tag initially. Edge tags may include incremental updates to the `default` image release, which may change without notice. Do not use `edge` for production CI workloads. CircleCI updates `default` with these changes after a period of stability, generally about a week.
+- `current`: The stable tag for gen2 images. CircleCI updates this tag every three months.
+
+- `edge`: Use `edge` for previews of new releases that point to this tag initially. Edge tags may include incremental updates to the stable image release, which may change without notice. Do not use `edge` for production CI workloads. CircleCI updates the stable tag with these changes after a period of stability, generally about a week.
 
 [#critical-cve-patches]
 == Critical CVE patches
@@ -54,7 +56,7 @@ You can file a link:https://support.circleci.com/hc/en-us/requests/new[support t
 [#image-lifespan-eol]
 == Image lifespan / EOL
 
-When a new Android API level ships, we release it to `edge`. We give a 3-month warning before we drop support for the oldest version in `default`. We post an announcement on our Discuss forum, along with additional outreach where possible.
+When a new Android API level ships, we release it to `edge`. We give a 3-month warning before we drop support for the oldest version in the stable tag (`default` for gen1, `current` for gen2). We post an announcement on our Discuss forum, along with additional outreach where possible.
 
 We aim to start the EOL process within 3 months of a new version release.
 

--- a/docs/guides/modules/execution-managed/pages/android-machine-image.adoc
+++ b/docs/guides/modules/execution-managed/pages/android-machine-image.adoc
@@ -47,7 +47,7 @@ On a per-resource-class basis, gen2 pricing can be higher or lower than its gen1
 [#using-android-gen2]
 ==== Using gen2
 
-All Android gen1 resource classes are also available as gen2. To use a gen2 resource class, specify a `large.gen2` or equivalent class in your job configuration:
+All Android gen1 resource classes are also available as gen2. Gen2 images use the `current` tag instead of the `default` tag used by gen1, to stay consistent with the Linux VM tagging convention. To use a gen2 resource class, specify the `current` tag along with a `large.gen2` or equivalent resource class in your job configuration:
 
 [,yaml]
 ----
@@ -55,7 +55,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: android:default
+      image: android:current
     resource_class: large.gen2
     steps:
       # ... steps for your job

--- a/docs/guides/modules/execution-managed/pages/android-machine-image.adoc
+++ b/docs/guides/modules/execution-managed/pages/android-machine-image.adoc
@@ -6,22 +6,72 @@
 [#overview]
 == Overview
 
-The Android machine image is accessed through the xref:reference:ROOT:configuration-reference.adoc#available-linux-machine-images-cloud[Linux Machine Executor], like other Linux machine images on CircleCI. The Android machine image supports nested virtualization and x86 Android emulators, so it can be used for Android UI testing. It also comes with the Android SDK pre-installed.
+You access the Android machine image through the xref:reference:ROOT:configuration-reference.adoc#available-linux-machine-images-cloud[Linux Machine Executor], like other Linux machine images on CircleCI. The Android machine image supports nested virtualization and x86 Android emulators, so you can use it for Android UI testing. It also comes with the Android SDK pre-installed.
 
 [#using-the-android-machine-image]
 == Using the Android machine image
 
-It is possible to configure the use of the Android image in your configuration with xref:orbs:use:orb-intro.adoc[Orbs], as well as manually. The Android orb will simplify your configuration. More complex and custom configurations may benefit from manually configuring your usage instead of using the orb. This document will cover both use cases. Refer to the <<examples>> section below for more details.
+You can configure the Android image in your configuration using xref:orbs:use:orb-intro.adoc[Orbs], or manually. The Android orb simplifies your configuration. More complex and custom configurations may work better with manual configuration instead of the orb. This document covers both use cases. Refer to the <<examples>> section below for more details.
+
+[#available-android-resource-classes]
+== Available resource classes
+
+=== Gen1
+
+include::ROOT:partial$execution-resources/machine-resource-table.adoc[]
+
+=== Gen2
+
+include::ROOT:partial$execution-resources/machine-gen2-resource-table.adoc[]
+
+[#view-resource-usage]
+=== View resource usage
+
+include::ROOT:partial$execution-resources/resource-class-view.adoc[]
+
+[#android-generations]
+== Android machine image generations
+
+[#android-gen2-benefits]
+=== Gen2
+
+Resource classes running on gen2 infrastructure offer significant performance and cost improvements over their gen1 equivalents.
+
+[#android-gen2-performance-improvements]
+==== Performance improvements
+
+Using more modern compute, gen2 instances deliver up to 47% faster performance compared to gen1 equivalents.
+
+On a per-resource-class basis, gen2 pricing can be higher or lower than its gen1 equivalent. See our link:https://circleci.com/pricing/price-list/[Pricing Page] for details.
+
+[#using-android-gen2]
+==== Using gen2
+
+All Android gen1 resource classes are also available as gen2. To use a gen2 resource class, specify a `large.gen2` or equivalent class in your job configuration:
+
+[,yaml]
+----
+version: 2.1
+jobs:
+  build:
+    machine:
+      image: android:default
+    resource_class: large.gen2
+    steps:
+      # ... steps for your job
+----
+
+NOTE: Gen2 resource classes for the Android machine image are available on CircleCI Cloud only.
 
 [#pre-installed-software]
 == Pre-installed software
 
-View the quarterly update announcement on our link:https://discuss.circleci.com/c/ecosystem/circleci-images/[Discuss] page for a list of current pre-installed software.
+View the latest update announcement on our link:https://discuss.circleci.com/c/ecosystem/circleci-images/[Discuss] page for a list of current pre-installed software.
 
 [#examples]
 == Examples
 
-Below you will find several examples demonstrating the use of the Android machine image both with and without orbs.
+The following examples show how to use the Android machine image, both with and without orbs.
 
 [#simple-orb-usage]
 === Simple orb usage
@@ -100,7 +150,7 @@ workflows:
 [#no-orb-example]
 === No-orb example
 
-The following is an example of using the Android machine image, _without_ using the `circleci/android` link:https://circleci.com/developer/orbs/orb/circleci/android[orb]. These steps are similar to what is run when you use the link:https://circleci.com/developer/orbs/orb/circleci/android#jobs-run-ui-tests[`run-ui-tests` job] of the orb.
+The following example uses the Android machine image _without_ the `circleci/android` link:https://circleci.com/developer/orbs/orb/circleci/android[orb]. These steps match what runs when you use the link:https://circleci.com/developer/orbs/orb/circleci/android#jobs-run-ui-tests[`run-ui-tests` job] of the orb.
 
 ```yaml
 # .circleci/config.yml
@@ -180,9 +230,9 @@ workflows:
 [#using-the-android-image-on-server-v3x]
 === Using the Android image on server
 
-NOTE: Android machine images are only available on server installations on Google Cloud Platform (GCP) at this time.
+NOTE: Android machine images are only available on server installations on Google Cloud Platform (GCP).
 
-From CircleCI Server 3.4+, Android machine images are supported for installations on GCP. To use the Android image in your projects set the `image` key to `android-default` in your jobs.
+CircleCI Server 3.4+ supports Android machine images for installations on GCP. To use the Android image in your projects, set the `image` key to `android-default` in your jobs.
 
 ```yaml
 version: 2.1
@@ -195,7 +245,7 @@ jobs:
     # job steps here
 ```
 
-It is also possible to use the Android orb, as shown above, for cloud. Your server administrator will need to import the orb first. Also, you will need to define the `android-default` image for the machine executor, as shown in the example below, rather than using the default executor built into the orb. View the xref:server-admin:operator:managing-orbs.adoc[CircleCI Server Orbs] page for instructions on importing orbs.
+You can also use the Android orb, as shown above, for cloud. Your server administrator needs to import the orb first. You also need to define the `android-default` image for the machine executor, as shown in the example below, rather than using the default executor built into the orb. View the xref:server-admin:operator:managing-orbs.adoc[CircleCI Server Orbs] page for instructions on importing orbs.
 
 This example shows how you can use granular orb commands to achieve what the link:https://circleci.com/developer/orbs/orb/circleci/android#commands-start-emulator-and-run-tests[start-emulator-and-run-tests] command does.
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -1098,10 +1098,12 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: android:2024.11.1
+      image: android:default
 ----
 
 The Android image can also be accessed using the link:https://circleci.com/developer/orbs/orb/circleci/android[Android orb].
+
+Gen2 resource classes (for example, `large.gen2`) are also available for the Android machine image on CircleCI Cloud. See the xref:guides:execution-managed:android-machine-image.adoc#android-generations[Android Machine Image Generations] section for details.
 
 For examples, refer to the xref:guides:execution-managed:android-machine-image.adoc#[Using Android Images With the Machine Executor] page.
 


### PR DESCRIPTION
# Description
Adding Android gen2 to the docs.

# Reasons
With its pending release, we want to add documentation on its functionality, support, etc.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [x] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [x] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.
