### PR TITLE
Track attempted_url on dd_docs_404-page event

### DIFF
--- a/ui/src/layouts/404.hbs
+++ b/ui/src/layouts/404.hbs
@@ -12,6 +12,7 @@
     var pathName = window.location.pathname.replace("docs/", "");
     analytics.track("dd_docs_404-page", {
       fullPath: pathName,
+      attempted_url: window.location.href,
       action: "viewed",
       orgId: (typeof Cookies !== "undefined") ? Cookies.get("cci-org-analytics-id") || null : null,
       page: pathName,


### PR DESCRIPTION
## Summary
- Adds `attempted_url` (full URL, including query string) as an explicit property on the `dd_docs_404-page` Segment/Amplitude event
- Makes it possible to group 404 events in Amplitude by `attempted_url` to find the most common broken links

## Test plan
- [ ] Deploy and confirm `dd_docs_404-page` events in Amplitude include `attempted_url`