### PR TITLE
DOC-246: Add CircleCI agent skills page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,15 +162,14 @@ xref:guides:integration:github-integration.adoc#user-keys-and-deploy-keys[User K
   - **Good**: `xref:guides:orchestrate:schedule-triggers.adoc[Schedule Triggers]`
   - **Bad**: `xref:guides:orchestrate:schedule-triggers.adoc[schedule triggers]`
 - Always verify xrefs before using them. Check that the page you are referencing exists in the location you are using to create the resource ID
-- **Never guess heading hashes.** AsciiDoc auto-IDs (for example `<<_install_circleci_agent_skills>>`) often do not match the IDs the docs site emits. `validate-html` fails when a hash does not exist on the built page.
-- For same-page or in-page links, set an explicit ID on the target heading first, then link to that ID:
+- **Heading hashes are lowercase kebab-case of the heading text.** The playbook sets `idprefix: ""` and `idseparator: "-"`, so `== Install CircleCI agent skills` becomes `#install-circleci-agent-skills`. Do not use AsciiDoc's default underscore IDs (`#_install_circleci_agent_skills`). `validate-html` fails when a hash does not exist on the built page.
+- Add an explicit `[#custom-id]` only when the hash must differ from that kebab-case heading. Otherwise link to the generated ID:
 ```adoc
-[#install-circleci-agent-skills]
 == Install CircleCI agent skills
 
 See the Codex and Copilot tabs in <<install-circleci-agent-skills>>.
 ```
-- For cross-page section links, use the same explicit ID: `xref:guides:toolkit:circleci-agent-skills.adoc#install-circleci-agent-skills[Install CircleCI Agent Skills]`
+- For cross-page section links: `xref:guides:toolkit:circleci-agent-skills.adoc#install-circleci-agent-skills[Install CircleCI Agent Skills]`
 
 Before adding any xref to a document, you must verify the target file exists and the path is correct:
 
@@ -466,7 +465,7 @@ Content for Tab B
 14. Not using appropriate page templates for new content
 15. Using xrefs without verifying the target file exists and path is correct
 16. **Committing without running Vale and fixing linting errors**
-17. Guessing in-page heading hashes (`<<_auto_generated_id>>`) instead of setting an explicit `[#section-id]`
+17. Using AsciiDoc underscore heading IDs (`<<_install_circleci_agent_skills>>`) instead of the site kebab-case ID (`<<install-circleci-agent-skills>>`)
 
 ## AsciiDoc Validation Rules
 - Close all attribute blocks properly
@@ -608,7 +607,7 @@ Before committing documentation changes:
 
 1. ✅ **REQUIRED**: Run Vale locally and fix all error-level violations (recommended for all agents)
 2. ✅ Preview locally to check formatting and links
-3. ✅ Verify all xrefs point to existing files, and that any in-page hash uses an explicit `[#id]` (never a guessed `<<_auto_id>>`)
+3. ✅ Verify all xrefs point to existing files, and that heading hashes use kebab-case of the heading (not `_underscore_ids`)
 4. ✅ Check `:page-description:` is 70-160 characters
 5. ✅ Ensure link text uses title case
 6. ✅ Confirm page is added to `nav.adoc` if new

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,15 @@ xref:guides:integration:github-integration.adoc#user-keys-and-deploy-keys[User K
   - **Good**: `xref:guides:orchestrate:schedule-triggers.adoc[Schedule Triggers]`
   - **Bad**: `xref:guides:orchestrate:schedule-triggers.adoc[schedule triggers]`
 - Always verify xrefs before using them. Check that the page you are referencing exists in the location you are using to create the resource ID
+- **Never guess heading hashes.** AsciiDoc auto-IDs (for example `<<_install_circleci_agent_skills>>`) often do not match the IDs the docs site emits. `validate-html` fails when a hash does not exist on the built page.
+- For same-page or in-page links, set an explicit ID on the target heading first, then link to that ID:
+```adoc
+[#install-circleci-agent-skills]
+== Install CircleCI agent skills
+
+See the Codex and Copilot tabs in <<install-circleci-agent-skills>>.
+```
+- For cross-page section links, use the same explicit ID: `xref:guides:toolkit:circleci-agent-skills.adoc#install-circleci-agent-skills[Install CircleCI Agent Skills]`
 
 Before adding any xref to a document, you must verify the target file exists and the path is correct:
 
@@ -457,6 +466,7 @@ Content for Tab B
 14. Not using appropriate page templates for new content
 15. Using xrefs without verifying the target file exists and path is correct
 16. **Committing without running Vale and fixing linting errors**
+17. Guessing in-page heading hashes (`<<_auto_generated_id>>`) instead of setting an explicit `[#section-id]`
 
 ## AsciiDoc Validation Rules
 - Close all attribute blocks properly
@@ -598,7 +608,7 @@ Before committing documentation changes:
 
 1. ✅ **REQUIRED**: Run Vale locally and fix all error-level violations (recommended for all agents)
 2. ✅ Preview locally to check formatting and links
-3. ✅ Verify all xrefs point to existing files
+3. ✅ Verify all xrefs point to existing files, and that any in-page hash uses an explicit `[#id]` (never a guessed `<<_auto_id>>`)
 4. ✅ Check `:page-description:` is 70-160 characters
 5. ✅ Ensure link text uses title case
 6. ✅ Confirm page is added to `nav.adoc` if new

--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -321,28 +321,29 @@
 ** Project management
 *** xref:integration:jira-plugin.adoc[Connect With Jira]
 
+* Working with agents
+** xref:toolkit:circleci-agent-skills.adoc[CircleCI Agent Skills]
+** MCP
+*** xref:toolkit:circleci-mcp-overview.adoc[CircleCI MCP overview]
+*** xref:toolkit:connecting-to-the-circleci-mcp-server.adoc[Connecting to the CircleCI MCP server]
+*** xref:toolkit:connecting-to-the-circleci-cli-mcp.adoc[Connecting to the CircleCI CLI MCP]
+*** xref:toolkit:connecting-to-a-docs-mcp-server.adoc[Connecting to the CircleCI Docs MCP Server]
+** Chunk
+*** xref:guides:toolkit:chunk-setup-and-overview.adoc[Chunk Setup and Overview]
+*** xref:toolkit:install-and-configure-the-chunk-cli.adoc[Install and configure the Chunk CLI]
+*** xref:toolkit:how-to-use-chunk-cli.adoc[How to use the Chunk CLI]
+
 * Developer toolkit
 ** xref:toolkit:how-to-find-ids.adoc[How to find IDs]
 ** CircleCI CLI
 *** xref:toolkit:circleci-cli.adoc[The CircleCI CLI]
 *** xref:toolkit:cli-migration-guide.adoc[CLI migration guide]
 
-** Chunk CLI
-*** xref:toolkit:install-and-configure-the-chunk-cli.adoc[Install and configure the Chunk CLI]
-*** xref:toolkit:how-to-use-chunk-cli.adoc[How to use the Chunk CLI]
-
 ** Environment CLI
 *** xref:toolkit:environment-cli-usage-guide.adoc[CircleCI environment CLI usage guide]
 
-** MCP
-*** xref:toolkit:circleci-mcp-overview.adoc[CircleCI MCP overview]
-*** xref:toolkit:connecting-to-the-circleci-mcp-server.adoc[Connecting to the CircleCI MCP server]
-*** xref:toolkit:connecting-to-the-circleci-cli-mcp.adoc[Connecting to the CircleCI CLI MCP]
-*** xref:toolkit:connecting-to-a-docs-mcp-server.adoc[Connecting to the CircleCI Docs MCP Server]
-
-** AI-powered features
+** In-app AI features
 *** xref:guides:toolkit:enable-ai-powered-features.adoc[Enable AI-powered features]
-*** xref:guides:toolkit:chunk-setup-and-overview.adoc[Chunk Setup and Overview]
 *** xref:toolkit:intelligent-summaries.adoc[Intelligent summaries]
 
 ** APIs

--- a/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
+++ b/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
@@ -82,6 +82,7 @@ Before enabling auto rerun failed tests, ensure you have completed the xref:gett
 * Verified your tests run successfully with the `testsuite` command.
 * Correctly configured JUnit XML output in `.circleci/test-suites.yml`.
 
+TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI agent skills] get Smarter Testing set up. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
 
 == 1. Enable auto rerun failed tests in your `.circleci/test-suites.yml` file
 

--- a/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
+++ b/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
@@ -82,7 +82,7 @@ Before enabling auto rerun failed tests, ensure you have completed the xref:gett
 * Verified your tests run successfully with the `testsuite` command.
 * Correctly configured JUnit XML output in `.circleci/test-suites.yml`.
 
-TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI agent skills] get Smarter Testing set up. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
+TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI Agent Skills] get Smarter Testing set up. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
 
 == 1. Enable auto rerun failed tests in your `.circleci/test-suites.yml` file
 

--- a/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
+++ b/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
@@ -23,7 +23,9 @@ This guide walks you through the foundational setup that all three features buil
 
 You need a repository with an existing test suite. The following setup process guides you through configuring JUnit XML output and running tests.
 
-NOTE: You can complete local steps (setup and run locally) without a CircleCI account. A CircleCI account with a project connected to your VCS is only required when you run tests in CI.
+You can complete local steps (setup and run locally) without a CircleCI account. A CircleCI account with a project connected to your VCS is only required when you run tests in CI.
+
+TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI agent skills] to get set up for Smarter Testing. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
 
 === Terminology
 

--- a/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
+++ b/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
@@ -25,7 +25,7 @@ You need a repository with an existing test suite. The following setup process g
 
 You can complete local steps (setup and run locally) without a CircleCI account. A CircleCI account with a project connected to your VCS is only required when you run tests in CI.
 
-TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI agent skills] to get set up for Smarter Testing. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
+TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI Agent Skills] to get set up for Smarter Testing. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
 
 === Terminology
 

--- a/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
+++ b/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
@@ -126,7 +126,7 @@ Before enabling test impact analysis, ensure you have completed the xref:getting
 * Configured your `.circleci/test-suites.yml` with `discover` and `run` commands.
 * Verified your tests run successfully with the `testsuite` command.
 
-TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI agent skills] get Smarter Testing set up. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
+TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI Agent Skills] get Smarter Testing set up. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
 
 == 1. Enable test impact analysis in your test-suites.yml file
 

--- a/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
+++ b/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
@@ -126,6 +126,8 @@ Before enabling test impact analysis, ensure you have completed the xref:getting
 * Configured your `.circleci/test-suites.yml` with `discover` and `run` commands.
 * Verified your tests run successfully with the `testsuite` command.
 
+TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI agent skills] get Smarter Testing set up. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
+
 == 1. Enable test impact analysis in your test-suites.yml file
 
 Add the `test-impact-analysis` option to your `test-suites.yml` configuration.

--- a/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
+++ b/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
@@ -59,6 +59,7 @@ Before enabling dynamic test splitting, ensure you have completed the xref:getti
 * Verified your tests run successfully with the `testsuite` command.
 * Set parallelism greater than 1 for the test jobs that you want to split. See the xref:reference:ROOT:configuration-reference.adoc#parallelism[Configuration Reference] for more information.
 
+TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI agent skills] get Smarter Testing set up. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
 
 == 1. Enable dynamic test splitting in your test-suites.yml file
 

--- a/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
+++ b/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
@@ -59,7 +59,7 @@ Before enabling dynamic test splitting, ensure you have completed the xref:getti
 * Verified your tests run successfully with the `testsuite` command.
 * Set parallelism greater than 1 for the test jobs that you want to split. See the xref:reference:ROOT:configuration-reference.adoc#parallelism[Configuration Reference] for more information.
 
-TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI agent skills] get Smarter Testing set up. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
+TIP: You can use the xref:guides:toolkit:circleci-agent-skills.adoc[CircleCI Agent Skills] get Smarter Testing set up. Install the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] plugin to your AI coding agent and ask your agent to get set up for Smarter Testing.
 
 == 1. Enable dynamic test splitting in your test-suites.yml file
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -71,6 +71,7 @@ The CircleCI plugin currently includes the following seven skills. Your agent pi
 --
 
 
+[#install-circleci-agent-skills]
 == Install CircleCI agent skills
 
 CircleCI distributes the skills as the `circleci` plugin in the `CircleCI-Public/skills` marketplace. Add the marketplace, then install the plugin.
@@ -178,7 +179,7 @@ Use GitHub Copilot's plugin update workflow. For current commands, see the link:
 
 After install, ask your agent for the outcome you want. Name the branch, project, or file when you can. The agent selects the matching skill.
 
-You can also invoke a skill by name. In Claude Code and Cursor, type `/circleci-builds`. In Codex and GitHub Copilot, use each product's skill invocation flow. See the Codex and Copilot tabs in <<_install_circleci_agent_skills>>.
+You can also invoke a skill by name. In Claude Code and Cursor, type `/circleci-builds`. In Codex and GitHub Copilot, use each product's skill invocation flow. See the Codex and Copilot tabs in <<install-circleci-agent-skills>>.
 
 Example requests:
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -10,7 +10,7 @@ CircleCI agent skills give your AI coding agent reusable workflows for common Ci
 
 Skills are instruction files that your AI agent follows. They tell the agent which CircleCI commands to run, which files to inspect, and how to report results.
 
-CircleCI publishes these skills as a plugin in the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] repository. The plugin works with Claude Code, Cursor, Codex, and GitHub Copilot.
+CircleCI publishes these skills as a plugin in the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] repository.
 
 Skills are not the same as CircleCI MCP servers. MCP servers give your agent live tools for CircleCI. Skills give your agent a workflow to follow. You can use either, or both. See the xref:circleci-mcp-overview.adoc[CircleCI MCP Overview] page.
 
@@ -20,9 +20,9 @@ The `chunk` skill in this plugin helps you set up Chunk. Chunk is CircleCI valid
 
 Before you install CircleCI agent skills, set up the following:
 
-* An AI coding agent: Claude Code, Cursor, Codex, or GitHub Copilot.
-* A CircleCI account with access to the projects you want to work on.
-* The CircleCI CLI, installed and authenticated, for skills that run CircleCI commands. See xref:circleci-cli.adoc[The CircleCI CLI].
+* An AI coding agent, for example, Claude Code, Cursor, Codex, or GitHub Copilot.
+* A CircleCI account with access to the projects you want to work on. You can sign up for a free account at link:https://circleci.com/signup[CircleCI].
+* It is a good idea to install the CircleCI CLI, and authenticate for your CircleCI account. See xref:circleci-cli.adoc[The CircleCI CLI]. This is optional but most skills do make use of the CLI.
 
 == Available CircleCI agent skills
 
@@ -47,15 +47,15 @@ The CircleCI plugin currently includes the following seven skills. Your agent pi
 | Review the CircleCI configuration for this project and suggest improvements.
 
 | `onboarding`
-| Walks through first-time CircleCI setup for a new repo, including the GitHub App and pipeline.
+| Walks through first-time CircleCI setup for a new repository.
 | Onboard my project to CircleCI.
 
 | `chunk`
-| Sets up Chunk sidecars and tasks so your agent can validate changes before you push.
+| Sets up either/or/both Chunk for the CircleCI web app (cloud based CI/CD assistant) or the Chunk CLI (local CI/CD development tooling). For more information on Chunk, see the xref:chunk-setup-and-overview.adoc[Chunk Overview and Setup] page and the xref:install-and-configure-the-chunk-cli.adoc[Install and Configure the Chunk CLI] page.
 | Set up Chunk sidecars for this project.
 
 | `circleci-testsuite`
-| Adds `.circleci/test-suites.yml` and switches tests to `circleci testsuite run`. This skill gets your project set up to use Smarter Testing features. The manual setup is described on the xref:guides:test:getting-started-with-smarter-testing.adoc[Getting Started With Smarter Testing] page.
+| Get set up for Smarter Testing by using `.circleci/test-suites.yml` and switch tests to `circleci testsuite run`. The manual setup is described on the xref:guides:test:getting-started-with-smarter-testing.adoc[Getting Started With Smarter Testing] page.
 | Set up a testsuite for this project.
 
 | `circleci-smarter-testing`
@@ -63,7 +63,6 @@ The CircleCI plugin currently includes the following seven skills. Your agent pi
 | Set up CircleCI Smarter Testing for running tests in this project.
 |===
 --
-
 
 == Install CircleCI agent skills
 
@@ -201,12 +200,10 @@ CircleCI agent skills, MCP servers, and Chunk work together in an agentic CI/CD 
 | xref:circleci-mcp-overview.adoc[CircleCI MCP Overview]
 
 | Chunk
-| Validation that keeps up with your agents. Sidecars run lightweight checks in a clean cloud environment while your agent works. Chunk Tasks monitors and repairs CI in the outer loop.
-| xref:chunk-setup-and-overview.adoc[Chunk Overview and Setup]
+| Validation that keeps up with your agents. Sidecars run lightweight checks in a clean cloud environment while your agent works. Chunk Tasks monitors and repairs CI.
+| xref:chunk-setup-and-overview.adoc[Chunk Overview and Setup] and xref:install-and-configure-the-chunk-cli.adoc[Install and Configure the Chunk CLI]
 |===
 --
-
-The `chunk` skill in this plugin walks your agent through Chunk setup. After setup, `chunk skill install` adds sidecar and review skills such as `chunk-sidecar` and `chunk-review`. Those skills keep your agent on the rails with hooks and deterministic feedback. See the xref:install-and-configure-the-chunk-cli.adoc#install-skills[Install and Configure the Chunk CLI] page.
 
 == Next steps
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -22,7 +22,7 @@ Before you install CircleCI agent skills, set up the following:
 
 * An AI coding agent, for example, Claude Code, Cursor, Codex, or GitHub Copilot.
 * A CircleCI account with access to the projects you want to work on. You can sign up for a free account at link:https://circleci.com/signup[CircleCI].
-* It is a good idea to install the CircleCI CLI, and authenticate for your CircleCI account. See xref:circleci-cli.adoc[The CircleCI CLI]. This is optional but most skills do make use of the CLI.
+* It is a good idea to install the CircleCI CLI, and authenticate for your CircleCI account. See xref:circleci-cli.adoc[The CircleCI CLI]. Installing the CLI is optional, but most skills make use of it.
 
 == Available CircleCI agent skills
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -169,7 +169,7 @@ Use GitHub Copilot's plugin update workflow. For current commands, see the link:
 
 After install, ask your agent for the outcome you want. Name the branch, project, or file when you can. The agent selects the matching skill.
 
-You can also invoke a skill by name. In Claude Code and Cursor, type `/circleci-builds`. In Codex and GitHub Copilot, use each product's skill invocation flow. See the Codex and Copilot tabs in <<install-circleci-agent-skills>>.
+You can also invoke a skill by name. In Claude Code and Cursor, type `circleci-builds`. In Codex and GitHub Copilot, use each product's skill invocation flow. See the Codex and Copilot tabs in <<install-circleci-agent-skills>>.
 
 Example requests:
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -135,6 +135,45 @@ Install that plugin with GitHub Copilot's marketplace and plugin workflow. For s
 --
 ====
 
+== Keep CircleCI agent skills up to date
+
+CircleCI publishes skill updates in the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] repository. How you pick up those updates depends on how you installed the skills.
+
+[tabs]
+====
+Claude Code::
++
+--
+Claude Code caches the marketplace catalog. Refresh it, then load the new plugin version:
+
+[source]
+----
+/plugin marketplace update circleci-public-skills
+----
+
+Third-party marketplaces do not auto-update by default. To have Claude Code refresh this marketplace and its installed plugins in the background, run `/plugin`, open *Marketplaces*, select the CircleCI marketplace, and enable auto-update.
+
+Reload plugins when Claude Code prompts you, or start a new session. For more information, see the link:https://code.claude.com/docs/en/discover-plugins#configure-auto-updates[Claude Code auto-update documentation].
+--
+Cursor::
++
+--
+Copied Cursor skills are a snapshot of the repository at install time. Cursor does not update them for you.
+
+To refresh them, copy the skill folders again from `CircleCI-Public/skills`, then restart Cursor or run *Developer: Reload Window*.
+--
+Codex::
++
+--
+Use Codex's marketplace and plugin update workflow. For current commands, see the link:https://developers.openai.com/codex/plugins[Codex plugin documentation].
+--
+GitHub Copilot::
++
+--
+Use GitHub Copilot's plugin update workflow. For current commands, see the link:https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing[GitHub Copilot CLI plugin documentation].
+--
+====
+
 == Use CircleCI agent skills
 
 After install, ask your agent for the outcome you want. Name the branch, project, or file when you can. The agent selects the matching skill.

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -4,7 +4,6 @@
 :experimental:
 :page-show-readtime: true
 
-#TODO: check if this is supported for Server#
 #TODO: check preview, beta, or paid-plan status for the plugin and each skill#
 
 CircleCI agent skills give your AI coding agent reusable workflows for common CircleCI tasks. Install the CircleCI plugin once, then ask your agent to debug a failed build, optimize config, or onboard a project.
@@ -28,7 +27,6 @@ Before you install CircleCI agent skills, set up the following:
 * The CircleCI CLI, installed and authenticated, for skills that run CircleCI commands. See xref:circleci-cli.adoc[The CircleCI CLI].
 
 #TODO: check which skills work without the CircleCI CLI#
-#TODO: check if Server customers can use these skills#
 
 == Available CircleCI agent skills
 
@@ -49,7 +47,7 @@ The CircleCI plugin currently includes the following seven skills. Your agent pi
 | Watch the CircleCI run for my current branch and report the results.
 
 | `circleci-config`
-| Optimizes your CircleCI config YAML for speed, reliability, and maintainability. Config files must be `.yml`. For some integrations they can have any name and live anywhere in the repo.
+| Optimizes your CircleCI config YAML for speed, reliability, and maintainability.
 | Review the CircleCI configuration for this project and suggest improvements.
 
 | `onboarding`
@@ -100,8 +98,6 @@ Cursor::
 +
 --
 The CircleCI listing on the link:https://cursor.com/marketplace/circleci[Cursor Marketplace] is a different plugin. That plugin, from the link:https://github.com/CircleCI-Public/cursor-plugin[CircleCI Public Cursor Plugin] repository, connects Cursor to the hosted CircleCI MCP server. It does not install the agent skills from the CircleCI Public Skills repository.
-
-You can use the marketplace MCP plugin alongside these skills. For MCP setup, see xref:connecting-to-the-circleci-mcp-server.adoc[Connecting to the CircleCI MCP Server].
 
 To install CircleCI agent skills in Cursor, copy the skill folders into your Cursor skills directory:
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -99,28 +99,25 @@ For more information on plugin marketplaces, see the link:https://code.claude.co
 Cursor::
 +
 --
-#TODO: confirm whether CircleCI is listed on the Cursor Marketplace#
-#TODO: confirm whether Import from Repo works without a Cursor plugin marketplace manifest#
+The CircleCI listing on the link:https://cursor.com/marketplace/circleci[Cursor Marketplace] is a different plugin. That plugin, from the link:https://github.com/CircleCI-Public/cursor-plugin[CircleCI Public Cursor Plugin] repository, connects Cursor to the hosted CircleCI MCP server. It does not install the agent skills from the CircleCI Public Skills repository.
 
-Cursor supports agent plugins and skills. CircleCI does not yet publish a Cursor-specific marketplace manifest.
+You can use the marketplace MCP plugin alongside these skills. For MCP setup, see xref:connecting-to-the-circleci-mcp-server.adoc[Connecting to the CircleCI MCP Server].
 
-Use one of these options:
+To install CircleCI agent skills in Cursor, copy the skill folders into your Cursor skills directory:
 
-. *Cursor Marketplace.* Open *Customize* in the sidebar and search for CircleCI. Install the plugin if it appears.
-. *Team marketplace.* On a Cursor Teams or Enterprise plan, import `https://github.com/CircleCI-Public/skills` from *Dashboard > Plugins*. Then install the CircleCI plugin from *Customize*.
-. *Copy the skill folders.* Use this option when the plugin is not listed, or when a team marketplace is not available:
-+
 [source,console]
 ----
 $ git clone https://github.com/CircleCI-Public/skills.git
 $ mkdir -p ~/.cursor/skills
 $ cp -R skills/plugins/circleci/skills/* ~/.cursor/skills/
 ----
-+
-To limit the skills to one project, copy the folders into `.cursor/skills/` in that repository instead.
-. Restart Cursor, or run *Developer: Reload Window*. Open *Customize* and confirm the CircleCI skills appear.
 
-For more information, see the link:https://cursor.com/docs/plugins[Cursor plugin documentation].
+To limit the skills to one project, copy the folders into `.cursor/skills/` in that repository instead.
+
+. Restart Cursor, or run *Developer: Reload Window*.
+. Open *Customize* and confirm the CircleCI skills appear.
+
+For more information on Cursor skills, see the link:https://cursor.com/docs/plugins[Cursor plugin documentation].
 --
 Codex::
 +

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -71,7 +71,6 @@ The CircleCI plugin currently includes the following seven skills. Your agent pi
 --
 
 
-[#install-circleci-agent-skills]
 == Install CircleCI agent skills
 
 CircleCI distributes the skills as the `circleci` plugin in the `CircleCI-Public/skills` marketplace. Add the marketplace, then install the plugin.

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -4,8 +4,8 @@
 :experimental:
 :page-show-readtime: true
 
-// #TODO check if this is supported for Server
-// #TODO check preview, beta, or paid-plan status for the plugin and each skill
+#TODO: check if this is supported for Server#
+#TODO: check preview, beta, or paid-plan status for the plugin and each skill#
 
 CircleCI agent skills give your AI coding agent reusable workflows for common CircleCI tasks. Install the CircleCI plugin once, then ask your agent to debug a failed build, optimize config, or onboard a project.
 
@@ -27,8 +27,8 @@ Before you install CircleCI agent skills, set up the following:
 * A CircleCI account with access to the projects you want to work on.
 * The CircleCI CLI, installed and authenticated, for skills that run CircleCI commands. See xref:circleci-cli.adoc[The CircleCI CLI].
 
-// #TODO check which skills work without the CircleCI CLI
-// #TODO check if Server customers can use these skills
+#TODO: check which skills work without the CircleCI CLI#
+#TODO: check if Server customers can use these skills#
 
 == Available CircleCI agent skills
 
@@ -49,11 +49,11 @@ The CircleCI plugin currently includes the following seven skills. Your agent pi
 | Watch the CircleCI run for my current branch and report the results.
 
 | `circleci-config`
-| Optimizes `.circleci/config.yml` for speed, reliability, and maintainability.
+| Optimizes your CircleCI config YAML for speed, reliability, and maintainability. Config files must be `.yml`. For some integrations they can have any name and live anywhere in the repo.
 | Review the CircleCI configuration for this project and suggest improvements.
 
 | `onboarding`
-| Walks through account, org, GitHub App, project, and pipeline setup for a new repo.
+| Walks through first-time CircleCI setup for a new repo, including the GitHub App and pipeline.
 | Onboard my project to CircleCI.
 
 | `chunk`
@@ -65,14 +65,14 @@ The CircleCI plugin currently includes the following seven skills. Your agent pi
 | Set up a testsuite for this project.
 
 | `circleci-smarter-testing`
-| Enables test impact analysis, dynamic test splitting, and auto-rerun of failed tests.
+| Enables test impact analysis, dynamic test splitting, and auto-rerun of failed tests. Smarter Testing is in beta.
 | Set up CircleCI Smarter Testing for running tests in this project.
 |===
 --
 
-// #TODO check preview, beta, or paid-plan status for circleci-testsuite and circleci-smarter-testing
+include::ROOT:partial$notes/smarter-testing-beta.adoc[]
 
-`circleci-smarter-testing` requires a doctor-clean testsuite. Use `circleci-testsuite` first if `.circleci/test-suites.yml` does not exist.
+`circleci-smarter-testing` requires a testsuite that already passes `circleci testsuite doctor`. Use `circleci-testsuite` first if `.circleci/test-suites.yml` does not exist, or if doctor still reports failed checks.
 
 For Smarter Testing product docs, see the xref:guides:test:getting-started-with-smarter-testing.adoc[Getting Started With Smarter Testing] page.
 
@@ -104,8 +104,8 @@ For more information on plugin marketplaces, see the link:https://code.claude.co
 Cursor::
 +
 --
-// #TODO confirm whether CircleCI is listed on the Cursor Marketplace
-// #TODO confirm whether Import from Repo works without .cursor-plugin/marketplace.json
+#TODO: confirm whether CircleCI is listed on the Cursor Marketplace#
+#TODO: confirm whether Import from Repo works without a Cursor plugin marketplace manifest#
 
 Cursor supports agent plugins and skills. CircleCI does not yet publish a Cursor-specific marketplace manifest.
 
@@ -130,7 +130,7 @@ For more information, see the link:https://cursor.com/docs/plugins[Cursor plugin
 Codex::
 +
 --
-// #TODO confirm the marketplace name Codex assigns after add (expected: circleci-skills)
+#TODO: confirm the marketplace name Codex assigns after add (expected: CircleCI skills)#
 
 . Add the CircleCI marketplace:
 +
@@ -151,8 +151,8 @@ The CircleCI repository includes a Codex marketplace at `.agents/plugins/marketp
 GitHub Copilot::
 +
 --
-// #TODO confirm Copilot CLI reads .claude-plugin/marketplace.json
-// #TODO confirm install steps for GitHub Copilot in VS Code, not only Copilot CLI
+#TODO: confirm Copilot CLI reads the Claude plugin marketplace manifest#
+#TODO: confirm install steps for GitHub Copilot in VS Code, not only Copilot CLI#
 
 . Add the CircleCI marketplace to Copilot CLI:
 +

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -14,7 +14,7 @@ CircleCI publishes these skills as a plugin in the link:https://github.com/Circl
 
 Skills are not the same as CircleCI MCP servers. MCP servers give your agent live tools for CircleCI. Skills give your agent a workflow to follow. You can use either, or both. See the xref:circleci-mcp-overview.adoc[CircleCI MCP Overview] page.
 
-The `chunk` skill in this plugin helps you set up Chunk. Chunk is CircleCI validation for agentic development. Sidecars run lightweight checks in a clean cloud environment while your agent is still working, so you catch failures before the push. See <<compare-skills-with-other-circleci-ai-tools>>.
+The `chunk` skill in this plugin helps you set up Chunk. Chunk is CircleCI validation for agentic development. Sidecars run lightweight checks in a clean cloud environment while your agent is still working, so you catch failures before the push. See <<compare-skills-with-other-ai-tools>>.
 
 == Prerequisites
 
@@ -75,13 +75,13 @@ Claude Code::
 --
 . In Claude Code, add the CircleCI marketplace:
 +
-[source]
+[source,shell]
 ----
 /plugin marketplace add CircleCI-Public/skills
 ----
 . Install the CircleCI plugin:
 +
-[source]
+[source,shell]
 ----
 /plugin install circleci@circleci-public-skills
 ----
@@ -136,7 +136,7 @@ Claude Code::
 --
 Claude Code caches the marketplace catalog. Refresh it, then load the new plugin version:
 
-[source]
+[source,shell]
 ----
 /plugin marketplace update circleci-public-skills
 ----
@@ -168,7 +168,7 @@ Use GitHub Copilot's plugin update workflow. For current commands, see the link:
 
 After install, ask your agent for the outcome you want. Name the branch, project, or file when you can. The agent selects the matching skill.
 
-You can also invoke a skill by name. In Claude Code and Cursor, type `circleci-builds`. In Codex and GitHub Copilot, use each product's skill invocation flow. See the Codex and Copilot tabs in <<install-circleci-agent-skills>>.
+You can also invoke a skill by name. In Claude Code and Cursor, type `circleci-builds`. In Codex and GitHub Copilot, use each product's skill invocation flow.
 
 Example requests:
 
@@ -180,7 +180,7 @@ Example requests:
 * Set up a testsuite for this project.
 * Set up CircleCI Smarter Testing for running tests in this project.
 
-[#compare-skills-with-other-circleci-ai-tools]
+[#compare-skills-with-other-ai-tools]
 == Compare skills with other CircleCI AI tools
 
 CircleCI agent skills, MCP servers, and Chunk work together in an agentic CI/CD loop. Use this page to install the plugin skills. Use the pages below for live CircleCI tools and for Chunk validation.

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -1,0 +1,229 @@
+= CircleCI agent skills
+:page-platform: Cloud
+:page-description: Install CircleCI agent skills in Claude Code, Cursor, Codex, or Copilot to debug builds, optimize config, and onboard projects.
+:experimental:
+:page-show-readtime: true
+
+// #TODO check if this is supported for Server
+// #TODO check preview, beta, or paid-plan status for the plugin and each skill
+
+CircleCI agent skills give your AI coding agent reusable workflows for common CircleCI tasks. Install the CircleCI plugin once, then ask your agent to debug a failed build, optimize config, or onboard a project.
+
+== Introduction
+
+Skills are instruction files that your AI agent follows. They tell the agent which CircleCI commands to run, which files to inspect, and how to report results.
+
+CircleCI publishes these skills as a plugin in the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] repository. The plugin works with Claude Code, Cursor, Codex, and GitHub Copilot.
+
+Skills are not the same as CircleCI MCP servers. MCP servers give your agent live tools for CircleCI. Skills give your agent a workflow to follow. You can use either, or both. See the xref:circleci-mcp-overview.adoc[CircleCI MCP Overview] page.
+
+The `chunk` skill in this plugin helps you set up Chunk. Chunk is CircleCI validation for agentic development. Sidecars run lightweight checks in a clean cloud environment while your agent is still working, so you catch failures before the push. See <<compare-skills-with-other-circleci-ai-tools>>.
+
+== Prerequisites
+
+Before you install CircleCI agent skills, set up the following:
+
+* An AI coding agent: Claude Code, Cursor, Codex, or GitHub Copilot.
+* A CircleCI account with access to the projects you want to work on.
+* The CircleCI CLI, installed and authenticated, for skills that run CircleCI commands. See xref:circleci-cli.adoc[The CircleCI CLI].
+
+// #TODO check which skills work without the CircleCI CLI
+// #TODO check if Server customers can use these skills
+
+== Available CircleCI agent skills
+
+The CircleCI plugin currently includes the following seven skills. Your agent picks a skill from your request, or you can invoke a skill by name.
+
+[.table-scroll]
+--
+[cols="1,2,2", options="header"]
+|===
+| Skill | What it does | Example prompt
+
+| `circleci-builds`
+| Diagnoses failing CircleCI jobs, classifies the failure, and applies a minimal fix.
+| Diagnose and fix build failures for the current branch.
+
+| `circleci-cli`
+| Runs the day-to-day CLI loop: validate config, watch a run, read logs, and rerun jobs.
+| Watch the CircleCI run for my current branch and report the results.
+
+| `circleci-config`
+| Optimizes `.circleci/config.yml` for speed, reliability, and maintainability.
+| Review the CircleCI configuration for this project and suggest improvements.
+
+| `onboarding`
+| Walks through account, org, GitHub App, project, and pipeline setup for a new repo.
+| Onboard my project to CircleCI.
+
+| `chunk`
+| Sets up Chunk sidecars and tasks so your agent can validate changes before you push.
+| Set up Chunk sidecars for this project.
+
+| `circleci-testsuite`
+| Adds `.circleci/test-suites.yml` and switches tests to `circleci testsuite run`.
+| Set up a testsuite for this project.
+
+| `circleci-smarter-testing`
+| Enables test impact analysis, dynamic test splitting, and auto-rerun of failed tests.
+| Set up CircleCI Smarter Testing for running tests in this project.
+|===
+--
+
+// #TODO check preview, beta, or paid-plan status for circleci-testsuite and circleci-smarter-testing
+
+`circleci-smarter-testing` requires a doctor-clean testsuite. Use `circleci-testsuite` first if `.circleci/test-suites.yml` does not exist.
+
+For Smarter Testing product docs, see the xref:guides:test:getting-started-with-smarter-testing.adoc[Getting Started With Smarter Testing] page.
+
+== Install CircleCI agent skills
+
+CircleCI distributes the skills as the `circleci` plugin in the `CircleCI-Public/skills` marketplace. Add the marketplace, then install the plugin.
+
+[tabs]
+====
+Claude Code::
++
+--
+. In Claude Code, add the CircleCI marketplace:
++
+[source]
+----
+/plugin marketplace add CircleCI-Public/skills
+----
+. Install the CircleCI plugin:
++
+[source]
+----
+/plugin install circleci@circleci-public-skills
+----
+. Reload plugins if Claude Code prompts you to, then start a new session.
+
+For more information on plugin marketplaces, see the link:https://code.claude.com/docs/en/discover-plugins[Claude Code plugin documentation].
+--
+Cursor::
++
+--
+// #TODO confirm whether CircleCI is listed on the Cursor Marketplace
+// #TODO confirm whether Import from Repo works without .cursor-plugin/marketplace.json
+
+Cursor supports agent plugins and skills. CircleCI does not yet publish a Cursor-specific marketplace manifest.
+
+Use one of these options:
+
+. *Cursor Marketplace.* Open *Customize* in the sidebar and search for CircleCI. Install the plugin if it appears.
+. *Team marketplace.* On a Cursor Teams or Enterprise plan, import `https://github.com/CircleCI-Public/skills` from *Dashboard > Plugins*. Then install the CircleCI plugin from *Customize*.
+. *Copy the skill folders.* Use this option when the plugin is not listed, or when a team marketplace is not available:
++
+[source,console]
+----
+$ git clone https://github.com/CircleCI-Public/skills.git
+$ mkdir -p ~/.cursor/skills
+$ cp -R skills/plugins/circleci/skills/* ~/.cursor/skills/
+----
++
+To limit the skills to one project, copy the folders into `.cursor/skills/` in that repository instead.
+. Restart Cursor, or run *Developer: Reload Window*. Open *Customize* and confirm the CircleCI skills appear.
+
+For more information, see the link:https://cursor.com/docs/plugins[Cursor plugin documentation].
+--
+Codex::
++
+--
+// #TODO confirm the marketplace name Codex assigns after add (expected: circleci-skills)
+
+. Add the CircleCI marketplace:
++
+[source,console]
+----
+$ codex plugin marketplace add CircleCI-Public/skills
+----
+. Install the CircleCI plugin:
++
+[source,console]
+----
+$ codex plugin add circleci@circleci-skills
+----
+. Restart Codex, or open `/plugins` and confirm the CircleCI plugin appears.
+
+The CircleCI repository includes a Codex marketplace at `.agents/plugins/marketplace.json`.
+--
+GitHub Copilot::
++
+--
+// #TODO confirm Copilot CLI reads .claude-plugin/marketplace.json
+// #TODO confirm install steps for GitHub Copilot in VS Code, not only Copilot CLI
+
+. Add the CircleCI marketplace to Copilot CLI:
++
+[source,console]
+----
+$ copilot plugin marketplace add CircleCI-Public/skills
+----
+. Install the CircleCI plugin:
++
+[source,console]
+----
+$ copilot plugin install circleci@circleci-public-skills
+----
+. Start a new Copilot CLI session and confirm the skills are available.
+
+For more information, see the link:https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing[GitHub Copilot CLI plugin documentation].
+--
+====
+
+== Use CircleCI agent skills
+
+After install, ask your agent for the outcome you want. Name the branch, project, or file when you can. The agent selects the matching skill.
+
+You can also invoke a skill by name:
+
+* Claude Code and Cursor: `/circleci-builds`
+* Codex: `$circleci-builds`
+* Copilot CLI: use `/skills` to list installed skills, then invoke by name.
+
+Example requests:
+
+* Diagnose and fix build failures for the current branch.
+* Watch the CircleCI run for my current branch and report the results.
+* Review the CircleCI configuration for this project and suggest improvements.
+* Onboard my project to CircleCI.
+* Set up Chunk sidecars for this project.
+* Set up a testsuite for this project.
+* Set up CircleCI Smarter Testing for running tests in this project.
+
+[#compare-skills-with-other-circleci-ai-tools]
+== Compare skills with other CircleCI AI tools
+
+CircleCI agent skills, MCP servers, and Chunk work together in an agentic CI/CD loop. Use this page to install the plugin skills. Use the pages below for live CircleCI tools and for Chunk validation.
+
+[.table-scroll]
+--
+[cols="1,2,2", options="header"]
+|===
+| Tool | What it is | Where to start
+
+| CircleCI agent skills
+| Workflows your coding agent follows for CircleCI tasks.
+| This page.
+
+| CircleCI MCP servers
+| Live tools your agent can call to inspect and act on CircleCI runs.
+| xref:circleci-mcp-overview.adoc[CircleCI MCP Overview]
+
+| Chunk
+| Validation that keeps up with your agents. Sidecars run lightweight checks in a clean cloud environment while your agent works. Chunk Tasks monitors and repairs CI in the outer loop.
+| xref:chunk-setup-and-overview.adoc[Chunk Overview and Setup]
+|===
+--
+
+The `chunk` skill in this plugin walks your agent through Chunk setup. After setup, `chunk skill install` adds sidecar and review skills such as `chunk-sidecar` and `chunk-review`. Those skills keep your agent on the rails with hooks and deterministic feedback. See the xref:install-and-configure-the-chunk-cli.adoc#install-skills[Install and Configure the Chunk CLI] page.
+
+== Next steps
+
+* xref:circleci-mcp-overview.adoc[CircleCI MCP Overview]
+* xref:connecting-to-the-circleci-mcp-server.adoc[Connecting to the CircleCI MCP Server]
+* xref:chunk-setup-and-overview.adoc[Chunk Overview and Setup]
+* xref:install-and-configure-the-chunk-cli.adoc[Install and Configure the Chunk CLI]
+* xref:guides:test:getting-started-with-smarter-testing.adoc[Getting Started With Smarter Testing]
+* link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills repository]

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -26,8 +26,6 @@ Before you install CircleCI agent skills, set up the following:
 * A CircleCI account with access to the projects you want to work on.
 * The CircleCI CLI, installed and authenticated, for skills that run CircleCI commands. See xref:circleci-cli.adoc[The CircleCI CLI].
 
-#TODO: check which skills work without the CircleCI CLI#
-
 == Available CircleCI agent skills
 
 The CircleCI plugin currently includes the following seven skills. Your agent picks a skill from your request, or you can invoke a skill by name.

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -70,7 +70,6 @@ The CircleCI plugin currently includes the following seven skills. Your agent pi
 |===
 --
 
-include::ROOT:partial$notes/smarter-testing-beta.adoc[]
 
 == Install CircleCI agent skills
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -122,45 +122,16 @@ For more information on Cursor skills, see the link:https://cursor.com/docs/plug
 Codex::
 +
 --
-#TODO: confirm the marketplace name Codex assigns after add (expected: CircleCI skills)#
+CircleCI publishes the skills as a plugin in the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] repository.
 
-. Add the CircleCI marketplace:
-+
-[source,console]
-----
-$ codex plugin marketplace add CircleCI-Public/skills
-----
-. Install the CircleCI plugin:
-+
-[source,console]
-----
-$ codex plugin add circleci@circleci-skills
-----
-. Restart Codex, or open `/plugins` and confirm the CircleCI plugin appears.
-
-The CircleCI repository includes a Codex marketplace at `.agents/plugins/marketplace.json`.
+Install that plugin with Codex's marketplace and plugin workflow. For setup steps, see the link:https://developers.openai.com/codex/plugins[Codex plugin documentation] and the link:https://developers.openai.com/codex/skills[Codex skills documentation].
 --
 GitHub Copilot::
 +
 --
-#TODO: confirm Copilot CLI reads the Claude plugin marketplace manifest#
-#TODO: confirm install steps for GitHub Copilot in VS Code, not only Copilot CLI#
+CircleCI publishes the skills as a plugin in the link:https://github.com/CircleCI-Public/skills[CircleCI Public Skills] repository.
 
-. Add the CircleCI marketplace to Copilot CLI:
-+
-[source,console]
-----
-$ copilot plugin marketplace add CircleCI-Public/skills
-----
-. Install the CircleCI plugin:
-+
-[source,console]
-----
-$ copilot plugin install circleci@circleci-public-skills
-----
-. Start a new Copilot CLI session and confirm the skills are available.
-
-For more information, see the link:https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing[GitHub Copilot CLI plugin documentation].
+Install that plugin with GitHub Copilot's marketplace and plugin workflow. For setup steps, see the link:https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing[GitHub Copilot CLI plugin documentation].
 --
 ====
 
@@ -168,11 +139,7 @@ For more information, see the link:https://docs.github.com/en/copilot/how-tos/co
 
 After install, ask your agent for the outcome you want. Name the branch, project, or file when you can. The agent selects the matching skill.
 
-You can also invoke a skill by name:
-
-* Claude Code and Cursor: `/circleci-builds`
-* Codex: `$circleci-builds`
-* Copilot CLI: use `/skills` to list installed skills, then invoke by name.
+You can also invoke a skill by name. In Claude Code and Cursor, type `/circleci-builds`. In Codex and GitHub Copilot, use each product's skill invocation flow. See the Codex and Copilot tabs in <<_install_circleci_agent_skills>>.
 
 Example requests:
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -97,7 +97,6 @@ For more information on plugin marketplaces, see the link:https://code.claude.co
 Cursor::
 +
 --
-The CircleCI listing on the link:https://cursor.com/marketplace/circleci[Cursor Marketplace] is a different plugin. That plugin, from the link:https://github.com/CircleCI-Public/cursor-plugin[CircleCI Public Cursor Plugin] repository, connects Cursor to the hosted CircleCI MCP server. It does not install the agent skills from the CircleCI Public Skills repository.
 
 To install CircleCI agent skills in Cursor, copy the skill folders into your Cursor skills directory:
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -61,20 +61,16 @@ The CircleCI plugin currently includes the following seven skills. Your agent pi
 | Set up Chunk sidecars for this project.
 
 | `circleci-testsuite`
-| Adds `.circleci/test-suites.yml` and switches tests to `circleci testsuite run`.
+| Adds `.circleci/test-suites.yml` and switches tests to `circleci testsuite run`. This skill gets your project set up to use Smarter Testing features. The manual setup is described on the xref:guides:test:getting-started-with-smarter-testing.adoc[Getting Started With Smarter Testing] page.
 | Set up a testsuite for this project.
 
 | `circleci-smarter-testing`
-| Enables test impact analysis, dynamic test splitting, and auto-rerun of failed tests. Smarter Testing is in beta.
+| Enables Smarter Testing features: test impact analysis, dynamic test splitting, and auto-rerun of failed tests. Smarter Testing is in beta. Using this skill, your agent asks you to confirm which of the Smarter Testing features you want to set up.
 | Set up CircleCI Smarter Testing for running tests in this project.
 |===
 --
 
 include::ROOT:partial$notes/smarter-testing-beta.adoc[]
-
-`circleci-smarter-testing` requires a testsuite that already passes `circleci testsuite doctor`. Use `circleci-testsuite` first if `.circleci/test-suites.yml` does not exist, or if doctor still reports failed checks.
-
-For Smarter Testing product docs, see the xref:guides:test:getting-started-with-smarter-testing.adoc[Getting Started With Smarter Testing] page.
 
 == Install CircleCI agent skills
 

--- a/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
+++ b/docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc
@@ -4,8 +4,6 @@
 :experimental:
 :page-show-readtime: true
 
-#TODO: check preview, beta, or paid-plan status for the plugin and each skill#
-
 CircleCI agent skills give your AI coding agent reusable workflows for common CircleCI tasks. Install the CircleCI plugin once, then ask your agent to debug a failed build, optimize config, or onboard a project.
 
 == Introduction

--- a/skills/vale-linter/SKILL.md
+++ b/skills/vale-linter/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: vale-linter
-description: Run the Vale prose linter on CircleCI documentation files to identify and fix style errors, then create pull requests for review. Use this skill when the user explicitly asks to "run vale", "fix vale errors", "lint docs with vale", or mentions vale linting. This skill processes documentation files, fixes error-level Vale issues, and creates individual PRs per file for easier review.
+description: Run the Vale prose linter on CircleCI documentation files to identify and fix style errors. Use this skill when the user explicitly asks to "run vale", "fix vale errors", "lint docs with vale", or mentions vale linting. Always clarifies scope and delivery method with the user before making changes — it does not assume per-file PRs.
 ---
 
 # Vale Linter Skill
 
-This skill automates the process of running Vale prose linter on CircleCI documentation, fixing errors, and creating pull requests for review.
+This skill runs Vale prose linter on CircleCI documentation, fixes error-level issues, and delivers the fixes the way the user actually wants.
 
 ## When to Use This Skill
 
@@ -18,24 +18,32 @@ Use this skill when the user:
 
 Do NOT trigger this skill automatically just because .adoc files are being edited.
 
+## Step 1: Clarify the Task First
+
+Never assume scope or delivery method. Before running Vale, ask the user (a single combined question is fine if the intent is already partly clear from their request):
+
+1. **Which files?**
+   - Files changed on the current branch (`git diff --name-only main...HEAD` or against whatever the base branch is) — this is the common case when clearing a CI lint check before merge
+   - A specific file or list of files
+   - A directory or glob pattern
+   - The whole docs tree
+
+2. **What should happen with the fixes?**
+   - **Push straight to the current branch** — fix in place, commit, and push to the branch that's already open (e.g., to clear a failing CI/lint job on an existing PR). No new branch.
+   - **Create a new branch + PR** — for one file, for all files together, or one PR per file (ask which grouping if this option is picked)
+   - **Just show me the fixes / don't commit anything** — dry run, edits left in the working tree uncommitted
+
+Do not default to "one PR per file" — that's only one of several valid outcomes. If the user's request already answers both questions (e.g., "fix vale errors on my current branch and push"), skip the question and confirm briefly instead of re-asking.
+
 ## Prerequisites
 
 Verify these requirements before proceeding:
 1. Vale is installed (`vale --version`)
 2. A `.vale.ini` configuration file exists in the repo root
-3. The current branch is clean or user confirms it's okay to create new branches
-4. User has specified which files to process
+3. For the "push to current branch" path: the branch is a real feature branch (not `main`), and any pre-existing local changes are the user's own in-progress work — check `git status` and don't clobber it
+4. For any path that creates branches/PRs: confirm with the user before creating new branches, per the git safety rules — don't create branches or push without saying so first
 
-## Workflow
-
-### Step 1: Identify Files to Process
-
-Ask the user which files to check if not already specified:
-- Specific files: `docs/guides/modules/toolkit/pages/install-cli.adoc`
-- Directory: `docs/guides/modules/toolkit/pages/`
-- Pattern: `docs/**/*.adoc`
-
-### Step 2: Run Vale to Identify Errors
+## Step 2: Run Vale to Identify Errors
 
 Run Vale with JSON output to get structured error information:
 
@@ -55,106 +63,112 @@ vale --output=JSON file.adoc | jq 'to_entries | map(select(.value[] | .Severity 
 
 If no errors are found, inform the user and exit.
 
-### Step 3: Process Each File (One PR Per File)
+## Step 3: Fix Errors
 
-For each file with errors, process it independently:
+For each file with errors:
 
-1. **Create a new branch** using this naming convention:
-   ```bash
-   git checkout -b vale-fix-{filename-without-extension}-{short-hash}
-   ```
-   Example: `vale-fix-install-cli-a7f3b2`
-
-2. **Read the file** and understand its structure
-
-3. **Analyze each error** from Vale output:
+1. **Read the file** and understand its structure
+2. **Analyze each error** from Vale output:
    - Error location (line number)
    - Rule violated (e.g., `circleci-docs.OxfordComma`)
    - Error message explaining what's wrong
    - Suggested fix if available
-
-4. **Apply fixes** to address each error:
-   - Use the Edit tool to make precise changes
+3. **Apply fixes** using the Edit tool:
    - Preserve AsciiDoc formatting and structure
    - Maintain existing line breaks and whitespace where possible
    - Fix only the specific issues Vale reported
-
-5. **Re-run Vale** on the fixed file to verify errors are resolved:
+   - Apply all fixes on a line in a single edit when multiple errors occur on the same line
+4. **Re-run Vale** on the fixed file to verify errors are resolved:
    ```bash
    vale --output=JSON fixed-file.adoc
    ```
    - If errors remain, attempt additional fixes
-   - If errors cannot be fixed automatically, note them in the PR description
+   - If errors cannot be fixed automatically, note them clearly in the summary — do not force a fix that would harm accuracy or meaning
 
-6. **Commit changes**:
+## Step 4: Deliver the Fixes
+
+Follow whichever path the user chose in Step 1.
+
+### Path A: Push to the current branch
+
+Use this for the "clear the pipeline for merge" case — fixing lint errors on a branch that already has an open PR.
+
+1. Confirm the current branch isn't `main`/the default branch.
+2. Stage only the files that were fixed:
    ```bash
-   git add <file>
-   git commit -m "Fix Vale errors in <filename>
+   git add <file1> <file2> ...
+   ```
+3. Commit with a plain, factual message (say what the commit does, not the diagnosis that led to it):
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   Fix Vale errors in <file1>, <file2>, ...
 
-   Resolved the following Vale errors:
-   - [List specific errors fixed]
-
-   Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+   Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+4. Confirm with the user before pushing, then:
+   ```bash
+   git push
    ```
 
-7. **Create PR**:
+### Path B: New branch + PR
+
+Only take this path if the user asked for it.
+
+1. Create a branch:
    ```bash
-   gh pr create --title "Fix Vale errors in <filename>" --body "$(cat <<'EOF'
+   git checkout -b vale-fix-{scope}-{short-hash}
+   ```
+2. Commit and push as above.
+3. Create the PR:
+   ```bash
+   gh pr create --title "Fix Vale errors in <scope>" --body "$(cat <<'EOF'
    ## Summary
-   This PR fixes Vale error-level issues in `<filename>`.
+   Fixes Vale error-level issues in <scope>.
 
-   ## Errors Fixed
+   ## Errors fixed
    - **Line X**: [Rule name] - [Description]
-   - **Line Y**: [Rule name] - [Description]
-
-   ## Verification
-   Ran Vale after fixes:
-   ```
-   vale <filename>
-   ```
-
-   [Result: No errors remaining / X errors could not be auto-fixed]
 
    ## Notes
-   - Only error-level issues were addressed
-   - Warnings and suggestions were left for human review
-   - Changes preserve existing AsciiDoc structure
+   - Only error-level issues were addressed; warnings and suggestions were left for human review
 
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    EOF
    )"
    ```
+4. If the user asked for one PR per file, repeat per file with its own branch. If they asked for a single PR covering all files, use one branch/commit/PR for the whole batch.
 
-### Step 4: Summary Report
+### Path C: Dry run
 
-After processing all files, provide a summary:
+Apply the edits to the working tree and stop. Do not stage, commit, or push. Tell the user what changed and let them review with `git diff`.
+
+## Step 5: Summary Report
+
+Regardless of path, report clearly:
 
 ```
 Vale Error Fixing Summary
 ========================
 
 Files processed: 3
-PRs created: 2
+Files with errors fixed: 2
 Files with no errors: 1
 
-Pull Requests:
-1. PR #123: Fix Vale errors in install-cli.adoc
-   - Branch: vale-fix-install-cli-a7f3b2
-   - Errors fixed: 5
-   - URL: https://github.com/org/repo/pull/123
+Fixed:
+- docs/guides/modules/toolkit/pages/install-cli.adoc (5 errors fixed)
+- docs/guides/modules/toolkit/pages/config-reference.adoc (3 errors fixed)
 
-2. PR #124: Fix Vale errors in config-reference.adoc
-   - Branch: vale-fix-config-reference-d9e1f4
-   - Errors fixed: 3
-   - URL: https://github.com/org/repo/pull/124
-
-Files with no errors:
+No errors found:
 - docs/guides/modules/toolkit/pages/troubleshooting.adoc
+
+Delivery: <pushed to branch X / PR #123 created / left uncommitted for review>
+
+Unresolved (needs human review):
+- <file>:<line> — <rule> — <why it wasn't auto-fixed>
 ```
 
 ## Error Fixing Guidelines
-
-When fixing Vale errors, follow these principles:
 
 ### Common Vale Errors and How to Fix Them
 
@@ -195,11 +209,8 @@ When fixing Vale errors, follow these principles:
 Some errors require judgment:
 
 1. **Sentence restructuring**: If fixing an error requires rewriting the sentence, preserve the original meaning while improving clarity
-
-2. **Technical accuracy**: Never sacrifice technical accuracy for style. If a fix would make documentation incorrect, note it in the PR for human review
-
-3. **Context-dependent fixes**: Some rules have exceptions. If you're unsure, include a note in the PR description explaining the decision
-
+2. **Technical accuracy**: Never sacrifice technical accuracy for style. If a fix would make documentation incorrect, note it for human review instead of forcing it
+3. **Context-dependent fixes**: Some rules have exceptions. If unsure, flag it in the summary rather than guessing
 4. **Multiple fixes per line**: Apply all fixes in a single edit when multiple errors occur on the same line
 
 ## Edge Cases and Error Handling
@@ -209,36 +220,19 @@ Some errors require judgment:
 - Verify `.vale.ini` exists and is valid
 - Report the error to the user
 
-**If a file cannot be fixed**:
-- Create PR anyway with available fixes
-- Document unfixable errors in PR description
+**If a file cannot be fully fixed**:
+- Apply the fixes that are safe to make
+- Document unfixable errors in the summary
 - Suggest human review
 
 **If git operations fail**:
 - Check that the working directory is clean
 - Ensure user has write permissions
-- Verify `gh` CLI is authenticated
-
-**If multiple files have identical names** (in different directories):
-- Use partial path in branch name: `vale-fix-toolkit-install-cli-a7f3b2`
-
-## Best Practices
-
-1. **Batch efficiently**: Process multiple files, but keep PRs separate for easier review
-
-2. **Verify fixes**: Always re-run Vale after making changes
-
-3. **Preserve formatting**: Maintain AsciiDoc structure, indentation, and line breaks
-
-4. **Be specific**: List exact errors fixed in commit messages and PR descriptions
-
-5. **Stay focused**: Only fix Vale errors; don't make unrelated improvements
-
-6. **Handle errors gracefully**: If automatic fixing fails, document why and suggest manual review
+- Verify `gh` CLI is authenticated (only needed for Path B)
 
 ## Notes
 
 - This skill only fixes error-level issues. Warnings and suggestions are left for humans.
-- Each file gets its own PR to make review easier and allow independent merging.
 - Vale rules are defined in `styles/circleci-docs/` and configured in `.vale.ini`.
 - All fixes should align with the CircleCI documentation style guide in `AGENTS.md`.
+- Stay focused: only fix Vale errors reported by the tool; don't make unrelated improvements.

--- a/styles/circleci-docs/EditorNotes.yml
+++ b/styles/circleci-docs/EditorNotes.yml
@@ -8,9 +8,11 @@ script: |
   text := import("text")
   matches := []
 
-  // Match notes like #TBC#, #TODO something#, or #Do we need this?# but not [.class]#text#
-  // Two patterns: 1) specific keywords alone 2) any text with spaces
-  note_pattern := "#(?:TBC|TODO|FIXME|NOTE|REVIEW|CHECKME|VERIFY|HACK|XXX|TEMP)#|#\\w+\\s+[^#]+#"
+  // Match notes like #TBC#, #TODO something#, #TODO: something#, or #Do we need this?#
+  // but not AsciiDoc highlight spans like [.class]#text#.
+  // 1) keyword with optional ": text" or " text"
+  // 2) any #word rest# editor note
+  note_pattern := "#(?:TBC|TODO|FIXME|NOTE|REVIEW|CHECKME|VERIFY|HACK|XXX|TEMP)(?::)?(?:\\s+[^#]+)?#|#\\w+\\s+[^#]+#"
 
   for line in text.split(scope, "\n") {
     if text.re_match(note_pattern, line) {


### PR DESCRIPTION
## Summary
- Adds a new CircleCI agent skills page covering the seven skills in [CircleCI-Public/skills](https://github.com/CircleCI-Public/skills) and setup for Claude Code, Cursor, Codex, and Copilot.
- Introduces a top-level **Working with agents** nav section for developers using agents in their CI/CD loop (skills, MCP, Chunk).
- Renames leftover toolkit items to **In-app AI features** (enable AI-powered features, intelligent summaries).

Linear: https://linear.app/circleci/issue/DOC-246/create-new-page-covering-the-skills-provided-by-circleci

# Description
New docs page for CircleCI agent skills, plus a nav regroup so skills, MCP, and Chunk live together under Working with agents.

# Reasons
Developers using coding agents need a single place to find CircleCI skills, how to install them, and how they fit with MCP and Chunk. The old AI-powered features grouping mixed in-app helpers with agent workflows.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [x] Break up walls of text by adding paragraph breaks.
- [x] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [x] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [x] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [x] Keep the title between 20 and 70 characters.
- [x] Check all headings h1-h6 are in sentence case (only first letter is capitalized).

## Test plan
- [ ] Confirm the page renders at `/docs/guides/toolkit/circleci-agent-skills/`
- [ ] Confirm **Working with agents** appears in the left nav with skills, MCP, and Chunk
- [ ] Confirm toolkit still lists **In-app AI features** (enable AI-powered features, intelligent summaries)
- [ ] Review `#TODO` comments in the page source for Server, preview/beta/paid-plan, and install-path follow-ups
- [ ] Run Vale on `docs/guides/modules/toolkit/pages/circleci-agent-skills.adoc`


Made with [Cursor](https://cursor.com)