### PR TITLE
Make config template expressions easier to find in search.

### DIFF
--- a/.cursor/rules/circleci-docs.mdc
+++ b/.cursor/rules/circleci-docs.mdc
@@ -8,6 +8,7 @@ alwaysApply: true
 When working on CircleCI documentation, read and follow all guidelines in @AGENTS.md at the root of this repository.
 
 The @AGENTS.md file contains the complete style guide including:
+- Git worktree workflow
 - Voice and style requirements
 - AsciiDoc formatting rules
 - CircleCI-specific terminology

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,22 @@ For a comprehensive overview of the CircleCI documentation structure, see the au
 
 This guide focuses on **how to write documentation**. The llms.txt file tells you **what documentation exists and where**.
 
+## Git worktrees
+
+Always create a git worktree for your work in:
+
+```
+../circleci-docs-worktrees/<issue-id>-<short-description>
+```
+
+For example:
+
+```
+git worktree add ../circleci-docs-worktrees/LIN-123-fix-nav -b LIN-123-fix-nav
+```
+
+Do all work in that directory, not in the main circleci-docs checkout. If there is no issue ID, use a short description only.
+
 ## Creating New Documentation Pages
 
 **IMPORTANT**: When creating new documentation pages, always start with the appropriate page template from `docs/contributors/modules/templates/pages/`:

--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -40,6 +40,7 @@
 *** xref:orchestrate:jobs-steps.adoc[Jobs and steps overview]
 *** xref:orchestrate:workflows.adoc[Workflow orchestration]
 *** xref:orchestrate:pipeline-variables.adoc[Pipeline values and parameters]
+*** xref:orchestrate:config-templating.adoc[Config templating]
 ** Trigger and schedule pipelines
 *** xref:orchestrate:triggers-overview.adoc[Trigger options]
 *** xref:orchestrate:set-up-triggers.adoc[Set up triggers]

--- a/docs/guides/modules/orchestrate/pages/config-templating.adoc
+++ b/docs/guides/modules/orchestrate/pages/config-templating.adoc
@@ -36,7 +36,26 @@ Expressions add comparison and logic operators to this templating syntax. Use th
 
 Some fields accept an expression directly, including job `filters` and workflow `when` or `unless` clauses. For other fields, wrap the expression in `<<` and `>>`.
 
-For operators and examples, see xref:reference:ROOT:configuration-reference.adoc#using-expressions-in-your-configuration[Using Expressions in Your Configuration].
+.Direct expression in a job filter
+[source,yaml]
+----
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+
+workflows:
+  my-workflow:
+    jobs:
+      - build:
+          filters: pipeline.git.branch == "main" or pipeline.git.branch starts-with "release/"
+----
+
+For operators and more examples, see xref:reference:ROOT:configuration-reference.adoc#using-expressions-in-your-configuration[Using Expressions in Your Configuration].
 
 [#include-or-omit-a-block]
 == Include or omit a YAML block
@@ -63,8 +82,6 @@ jobs:
       - run: npm run e2e
       <</ pipeline.parameters.run_e2e >>
 ----
-
-Prefer a workflow `when` clause, job `filters`, or a `when` step when you can. Those options keep the source file valid YAML before compilation. Use a templated block when you need a key or list item to be absent from the compiled config.
 
 [#config-templating-vs-dynamic-configuration]
 == How this differs from dynamic configuration

--- a/docs/guides/modules/orchestrate/pages/config-templating.adoc
+++ b/docs/guides/modules/orchestrate/pages/config-templating.adoc
@@ -1,0 +1,80 @@
+= Config templating
+:page-platform: Cloud, Server v4+
+:page-description: Use compile-time config templating to insert pipeline values and parameters into your CircleCI configuration.
+:experimental:
+
+CircleCI can update your `.circleci/config.yml` at compile time using pipeline values and parameters. This config templating lets you insert values, check conditions, and optionally include or omit blocks of YAML.
+
+Config templating is not the same as xref:dynamic-config.adoc[Dynamic Configuration]. Dynamic configuration generates or continues a pipeline with a different config at runtime.
+
+[#insert-a-pipeline-value]
+== Insert a pipeline value
+
+Wrap a pipeline value or pipeline parameter in `<<` and `>>` to insert it into a string or field:
+
+.Insert a pipeline value into a job step
+[source,yaml]
+----
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - run: echo "This pipeline is on << pipeline.git.branch >>"
+----
+
+For the full list of values you can insert, see the xref:pipeline-variables.adoc[Pipeline Values and Parameters] page.
+
+The YAML merge key `<<:` is a different feature. See xref:getting-started:introduction-to-yaml-configurations.adoc#merging-maps[Merging Maps] in the YAML introduction.
+
+[#add-logic-with-expressions]
+== Add logic with expressions
+
+Expressions add comparison and logic operators to this templating syntax. Use them to set a field from a condition, or to decide whether a job or workflow runs.
+
+Some fields accept an expression directly, including job `filters` and workflow `when` or `unless` clauses. For other fields, wrap the expression in `<<` and `>>`.
+
+For operators and examples, see xref:reference:ROOT:configuration-reference.adoc#using-expressions-in-your-configuration[Using Expressions in Your Configuration].
+
+[#include-or-omit-a-block]
+== Include or omit a YAML block
+
+You can include or omit a block of YAML when a pipeline value or parameter is truthy:
+
+.Include a step only when a pipeline parameter is true
+[source,yaml]
+----
+version: 2.1
+
+parameters:
+  run_e2e:
+    type: boolean
+    default: false
+
+jobs:
+  test:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      <<# pipeline.parameters.run_e2e >>
+      - run: npm run e2e
+      <</ pipeline.parameters.run_e2e >>
+----
+
+Prefer a workflow `when` clause, job `filters`, or a `when` step when you can. Those options keep the source file valid YAML before compilation. Use a templated block when you need a key or list item to be absent from the compiled config.
+
+[#config-templating-vs-dynamic-configuration]
+== How this differs from dynamic configuration
+
+Config templating edits the config you already have, before CircleCI assembles the pipeline. xref:dynamic-config.adoc[Dynamic Configuration] uses a setup workflow to generate or continue with a different config at runtime.
+
+[#next-steps]
+== Next steps
+
+* xref:pipeline-variables.adoc[Pipeline Values and Parameters]
+* xref:reference:ROOT:configuration-reference.adoc#using-expressions-in-your-configuration[Using Expressions in Your Configuration]
+* xref:using-branch-filters.adoc[Branch and Tag Filtering]
+* xref:dynamic-config.adoc[Dynamic Configuration Overview]

--- a/docs/guides/modules/orchestrate/pages/config-templating.adoc
+++ b/docs/guides/modules/orchestrate/pages/config-templating.adoc
@@ -5,13 +5,15 @@
 
 CircleCI can update your `.circleci/config.yml` at compile time using pipeline values and parameters. This config templating lets you insert values and check conditions.
 
-Config templating is not the same as xref:dynamic-config.adoc[Dynamic Configuration]. Dynamic configuration generates or continues a pipeline with a different config at runtime.
-
-[#insert-a-pipeline-value]
 == Insert a pipeline value
 
 Wrap a pipeline value or pipeline parameter in `<<` and `>>` to insert it into a string or field:
 
+[tabs]
+====
+Pipeline value::
++
+--
 .Insert a pipeline value into a job step
 [source,yaml]
 ----
@@ -24,18 +26,45 @@ jobs:
     steps:
       - run: echo "This pipeline is on << pipeline.git.branch >>"
 ----
+--
+Pipeline parameter::
++
+--
+.Insert a pipeline parameter into a job image
+[source,yaml]
+----
+version: 2.1
+
+parameters:
+  image-tag:
+    type: string
+    default: "current"
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:<< pipeline.parameters.image-tag >>
+    steps:
+      - checkout
+----
+--
+====
 
 For the full list of values you can insert, see the xref:pipeline-variables.adoc[Pipeline Values and Parameters] page.
 
-The YAML merge key `<<:` is a different feature. See xref:getting-started:introduction-to-yaml-configurations.adoc#merging-maps[Merging Maps] in the YAML introduction.
+NOTE: The YAML merge key `<<:` is a different feature. See xref:getting-started:introduction-to-yaml-configurations.adoc#merging-maps[Merging Maps] in the YAML introduction.
 
-[#add-logic-with-expressions]
 == Add logic with expressions
 
 Expressions add comparison and logic operators to this templating syntax. Use them to set a field from a condition, or to decide whether a job or workflow runs.
 
 The job `filters`, and workflow `when` and `unless` fields accept expressions directly. For other fields wrap the expression in `<<` and `>>`.
 
+[tabs]
+====
+Job filters::
++
+--
 .Direct expression in a job filter
 [source,yaml]
 ----
@@ -54,16 +83,77 @@ workflows:
       - build:
           filters: pipeline.git.branch == "main" or pipeline.git.branch starts-with "release/"
 ----
+--
+Workflow when::
++
+--
+.Direct expression in a workflow `when` clause
+[source,yaml]
+----
+version: 2.1
+
+jobs:
+  deploy:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+
+workflows:
+  deploy-workflow:
+    when: pipeline.git.tag starts-with "v" and pipeline.trigger_source == "webhook"
+    jobs:
+      - deploy
+----
+--
+Workflow unless::
++
+--
+.Direct expression in a workflow `unless` clause
+[source,yaml]
+----
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+
+workflows:
+  feature-workflow:
+    unless: pipeline.git.branch == "main"
+    jobs:
+      - build
+----
+--
+Other fields::
++
+--
+.Expression wrapped in `<<` and `>>`
+[source,yaml]
+----
+version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: cimg/base:current
+    parallelism: << pipeline.git.branch == "main" and 10 or 1 >>
+    steps:
+      - checkout
+----
+--
+====
 
 For operators and more examples, see xref:reference:ROOT:configuration-reference.adoc#using-expressions-in-your-configuration[Using Expressions in Your Configuration].
-
 
 [#config-templating-vs-dynamic-configuration]
 == How this differs from dynamic configuration
 
 Config templating edits the config you already have, before CircleCI assembles the pipeline. xref:dynamic-config.adoc[Dynamic Configuration] uses a setup workflow to generate or continue with a different config at runtime.
 
-[#next-steps]
 == Next steps
 
 * xref:pipeline-variables.adoc[Pipeline Values and Parameters]

--- a/docs/guides/modules/orchestrate/pages/config-templating.adoc
+++ b/docs/guides/modules/orchestrate/pages/config-templating.adoc
@@ -9,11 +9,6 @@ CircleCI can update your `.circleci/config.yml` at compile time using pipeline v
 
 Wrap a pipeline value or pipeline parameter in `<<` and `>>` to insert it into a string or field:
 
-[tabs]
-====
-Pipeline value::
-+
---
 .Insert a pipeline value into a job step
 [source,yaml]
 ----
@@ -26,10 +21,7 @@ jobs:
     steps:
       - run: echo "This pipeline is on << pipeline.git.branch >>"
 ----
---
-Pipeline parameter::
-+
---
+
 .Insert a pipeline parameter into a job image
 [source,yaml]
 ----
@@ -47,8 +39,6 @@ jobs:
     steps:
       - checkout
 ----
---
-====
 
 For the full list of values you can insert, see the xref:pipeline-variables.adoc[Pipeline Values and Parameters] page.
 
@@ -60,11 +50,6 @@ Expressions add comparison and logic operators to this templating syntax. Use th
 
 The job `filters`, and workflow `when` and `unless` fields accept expressions directly. For other fields wrap the expression in `<<` and `>>`.
 
-[tabs]
-====
-Job filters::
-+
---
 .Direct expression in a job filter
 [source,yaml]
 ----
@@ -83,10 +68,7 @@ workflows:
       - build:
           filters: pipeline.git.branch == "main" or pipeline.git.branch starts-with "release/"
 ----
---
-Workflow when::
-+
---
+
 .Direct expression in a workflow `when` clause
 [source,yaml]
 ----
@@ -105,10 +87,7 @@ workflows:
     jobs:
       - deploy
 ----
---
-Workflow unless::
-+
---
+
 .Direct expression in a workflow `unless` clause
 [source,yaml]
 ----
@@ -127,10 +106,7 @@ workflows:
     jobs:
       - build
 ----
---
-Other fields::
-+
---
+
 .Expression wrapped in `<<` and `>>`
 [source,yaml]
 ----
@@ -144,8 +120,6 @@ jobs:
     steps:
       - checkout
 ----
---
-====
 
 For operators and more examples, see xref:reference:ROOT:configuration-reference.adoc#using-expressions-in-your-configuration[Using Expressions in Your Configuration].
 

--- a/docs/guides/modules/orchestrate/pages/config-templating.adoc
+++ b/docs/guides/modules/orchestrate/pages/config-templating.adoc
@@ -34,7 +34,7 @@ The YAML merge key `<<:` is a different feature. See xref:getting-started:introd
 
 Expressions add comparison and logic operators to this templating syntax. Use them to set a field from a condition, or to decide whether a job or workflow runs.
 
-Some fields accept an expression directly, including job `filters` and workflow `when` or `unless` clauses. For other fields, wrap the expression in `<<` and `>>`.
+The job `filters`, and workflow `when` and `unless` fields accept expressions directly. For other fields wrap the expression in `<<` and `>>`.
 
 .Direct expression in a job filter
 [source,yaml]
@@ -57,31 +57,6 @@ workflows:
 
 For operators and more examples, see xref:reference:ROOT:configuration-reference.adoc#using-expressions-in-your-configuration[Using Expressions in Your Configuration].
 
-[#include-or-omit-a-block]
-== Include or omit a YAML block
-
-You can include or omit a block of YAML when a pipeline value or parameter is truthy:
-
-.Include a step only when a pipeline parameter is true
-[source,yaml]
-----
-version: 2.1
-
-parameters:
-  run_e2e:
-    type: boolean
-    default: false
-
-jobs:
-  test:
-    docker:
-      - image: cimg/base:current
-    steps:
-      - checkout
-      <<# pipeline.parameters.run_e2e >>
-      - run: npm run e2e
-      <</ pipeline.parameters.run_e2e >>
-----
 
 [#config-templating-vs-dynamic-configuration]
 == How this differs from dynamic configuration

--- a/docs/guides/modules/orchestrate/pages/config-templating.adoc
+++ b/docs/guides/modules/orchestrate/pages/config-templating.adoc
@@ -3,7 +3,7 @@
 :page-description: Use compile-time config templating to insert pipeline values and parameters into your CircleCI configuration.
 :experimental:
 
-CircleCI can update your `.circleci/config.yml` at compile time using pipeline values and parameters. This config templating lets you insert values, check conditions, and optionally include or omit blocks of YAML.
+CircleCI can update your `.circleci/config.yml` at compile time using pipeline values and parameters. This config templating lets you insert values and check conditions.
 
 Config templating is not the same as xref:dynamic-config.adoc[Dynamic Configuration]. Dynamic configuration generates or continues a pipeline with a different config at runtime.
 

--- a/docs/guides/modules/orchestrate/pages/config-templating.adoc
+++ b/docs/guides/modules/orchestrate/pages/config-templating.adoc
@@ -51,41 +51,15 @@ Expressions add comparison and logic operators to this templating syntax. Use th
 The job `filters`, and workflow `when` and `unless` fields accept expressions directly. For other fields wrap the expression in `<<` and `>>`.
 
 .Direct expression in a job filter
-[source,yaml]
+[,yaml]
 ----
-version: 2.1
-
-jobs:
-  build:
-    docker:
-      - image: cimg/base:current
-    steps:
-      - checkout
-
-workflows:
-  my-workflow:
-    jobs:
-      - build:
-          filters: pipeline.git.branch == "main" or pipeline.git.branch starts-with "release/"
+include::ROOT:example$expression-examples/job-filters/multiple-or.yml[]
 ----
 
 .Direct expression in a workflow `when` clause
-[source,yaml]
+[,yaml]
 ----
-version: 2.1
-
-jobs:
-  deploy:
-    docker:
-      - image: cimg/base:current
-    steps:
-      - checkout
-
-workflows:
-  deploy-workflow:
-    when: pipeline.git.tag starts-with "v" and pipeline.trigger_source == "webhook"
-    jobs:
-      - deploy
+include::ROOT:example$expression-examples/workflow-when/or-equal-dynamic.yml[]
 ----
 
 .Direct expression in a workflow `unless` clause

--- a/docs/guides/modules/orchestrate/pages/dynamic-config.adoc
+++ b/docs/guides/modules/orchestrate/pages/dynamic-config.adoc
@@ -57,7 +57,7 @@ Some constraints on continuing pipelines from a `setup: true` configuration are 
 ** Use logic conditions to ensure only one workflow is run for each pipeline.
 - A pipeline can only be continued once. A pipeline cannot be continued with another setup configuration. Workflow reruns will fail as part of this restriction. Rather than rerun a setup workflow you can trigger a new pipeline.
 - A pipeline can only be continued within six hours of its creation.
-- If you declare a pipeline parameter with the same name and type in both the setup and continuation configuration files, but with different default values, the default values apply respectively to each configuration.
+- You can declare a pipeline parameter with the same name and type in both the setup and continuation configuration files. If the default values differ, each configuration uses its own default.
 - You can set the value of a pipeline parameter declared in the continuation configuration to a value other than the default. To do so, specify the parameter's name and value when calling the `continue` job or command from the link:https://circleci.com/developer/orbs/orb/circleci/continuation[continuation orb] using the `parameters` parameter.
 - The `continue` job/command will fail with the error {"message":"Conflicting pipeline parameters."} when all three of these conditions occur:
 
@@ -70,7 +70,7 @@ Some constraints on continuing pipelines from a `setup: true` configuration are 
 
 CircleCI's dynamic configuration is made up of the following resources, which can be used together to fit a variety of use cases:
 
-* The xref:reference:ROOT:configuration-reference.adoc#setup[`setup` config field] allows you to designate a configuration file as _dynamic_, allowing the use of dynamic configuration features. When a configuration is dynamic (`setup: true`) the `CIRCLE_CONTINUATION_KEY` environment variable is available, which is a secret, unique-per-pipeline key that is automatically injected into the build environment for jobs that run in a _setup_ configuration.
+* The xref:reference:ROOT:configuration-reference.adoc#setup[`setup` config field] allows you to designate a configuration file as _dynamic_, allowing the use of dynamic configuration features. When a configuration is dynamic (`setup: true`) the `CIRCLE_CONTINUATION_KEY` environment variable is available. `CIRCLE_CONTINUATION_KEY` is a secret, unique-per-pipeline key. CircleCI injects it into the build environment for jobs that run in a _setup_ configuration.
 +
 The `CIRCLE_CONTINUATION_KEY` environment variable is required to authorize the continuation of one configuration to another via the link:https://circleci.com/docs/api/v2/index.html#operation/continuePipeline[continue a pipeline] API v2 endpoint. The API also accepts a configuration string, as well as a set of pipeline parameters.
 +
@@ -82,7 +82,7 @@ A _setup_ configuration:
 
 * Use the API v2 link:https://circleci.com/docs/api/v2/index.html#operation/continuePipeline[continue a pipeline] endpoint to continue a pipeline from one configuration to another. This endpoint can be used directly or via one of the dynamic configuration orbs described next.
 
-* Use the link:https://circleci.com/developer/orbs/orb/circleci/path-filtering[path filtering orb] to map file paths, pipelines parameters, and configuration files to determine the work that is done when a change happens in a specific location in a repository.
+* Use the link:https://circleci.com/developer/orbs/orb/circleci/path-filtering[path filtering orb] to map file paths, pipeline parameters, and configuration files. This determines the work that runs when a change happens in a specific location in a repository.
 
 * Use the link:https://circleci.com/developer/orbs/orb/circleci/continuation[continuation orb] to continue one configuration to another and set up any required pipeline parameters.
 

--- a/docs/guides/modules/orchestrate/pages/dynamic-config.adoc
+++ b/docs/guides/modules/orchestrate/pages/dynamic-config.adoc
@@ -5,6 +5,8 @@
 
 Dynamic configuration in CircleCI is the process of describing a pipeline in which the work done is dynamically determined. Dynamic configuration is flexible. The features described in this guide allow you to create a configuration to match the requirements of your specific project.
 
+To insert pipeline values into a single `config.yml` at compile time, see the xref:config-templating.adoc[Config Templating] page. This page covers generating or assembling configuration at runtime.
+
 Dynamic configuration can mean:
 
 * The work is determined by values passed in at runtime as _pipeline parameters_.
@@ -167,6 +169,7 @@ include::ROOT:partial$faq/dynamic-configuration-faq-snip.adoc[]
 [#what-to-read-next]
 == Next steps
 
+- xref:config-templating.adoc[Config Templating] for compile-time value insertion
 - A how-to guide for xref:using-dynamic-configuration.adoc[Using Dynamic Configuration]
 - The link:https://circleci.com/developer/orbs/orb/circleci/continuation[continuation orb]
 - The link:https://circleci.com/docs/api/v2/#operation/continuePipeline[Continue a pipeline API endpoint]

--- a/docs/guides/modules/orchestrate/pages/pipeline-variables.adoc
+++ b/docs/guides/modules/orchestrate/pages/pipeline-variables.adoc
@@ -7,7 +7,7 @@
 [#introduction]
 == Introduction
 
-Pipeline values and parameters can be used to create reusable pipeline configurations.
+Pipeline values and parameters can be used to create reusable pipeline configurations. To insert them into `config.yml` at compile time, see the xref:config-templating.adoc[Config Templating] page.
 
 - *Pipeline values* represent pipeline metadata that can be used throughout the configuration.
 - *Pipeline parameters* are typed pipeline variables that are declared in the `parameters` key at the top level of a configuration. Users can pass `parameters` into their pipelines when triggering a new run of a pipeline through the API or web app.

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -3711,13 +3711,9 @@ workflows:
 
 == Using expressions in your configuration
 
-CircleCI supports limited dynamic expressions in its configuration through a custom templating framework. These config template expressions appear between `<<` and `>>`.
+CircleCI supports limited dynamic expressions in its configuration through a custom templating framework. Expressions can include pipeline values, pipeline parameters, and literals. They also support operators such as `and`, `or`, and comparison operators.
 
-Use this templating syntax to:
-
-* Insert pipeline values, pipeline parameters, and literals.
-* Apply operators such as `and`, `or`, and comparison operators.
-* Set dynamic configuration fields.
+Some fields accept a config template expression directly, including job filters and workflow `when` or `unless` clauses. For other fields, wrap the expression in `<<` and `>>`.
 
 [#expressions-in-config-fields]
 === Expressions in configuration fields

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -3715,6 +3715,8 @@ CircleCI supports limited dynamic expressions in its configuration through a cus
 
 Some fields accept a config template expression directly, including job filters and workflow `when` or `unless` clauses. For other fields, wrap the expression in `<<` and `>>`.
 
+For value insertion and an overview of compile-time templating, see the xref:guides:orchestrate:config-templating.adoc[Config Templating] page.
+
 [#expressions-in-config-fields]
 === Expressions in configuration fields
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -3713,7 +3713,7 @@ workflows:
 
 CircleCI configuration supports expressions for dynamic value evaluation. Expressions can include pipeline values, pipeline parameters, and literals. They also support operators such as `and`, `or`, and comparison operators.
 
-Some fields accept an expression directly, including job filters and workflow `when` or `unless` clauses. For other fields, wrap the expression in `<<` and `>>`.
+The job `filters`, and workflow `when` and `unless` fields accept expressions directly. For other fields wrap the expression in `<<` and `>>`.
 
 To insert a pipeline value without logic, or for an overview of compile-time config templating, see the xref:guides:orchestrate:config-templating.adoc[Config Templating] page.
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -3711,11 +3711,11 @@ workflows:
 
 == Using expressions in your configuration
 
-CircleCI supports limited dynamic expressions in its configuration through a custom templating framework. Expressions can include pipeline values, pipeline parameters, and literals. They also support operators such as `and`, `or`, and comparison operators.
+CircleCI configuration supports expressions for dynamic value evaluation. Expressions can include pipeline values, pipeline parameters, and literals. They also support operators such as `and`, `or`, and comparison operators.
 
-Some fields accept a config template expression directly, including job filters and workflow `when` or `unless` clauses. For other fields, wrap the expression in `<<` and `>>`.
+Some fields accept an expression directly, including job filters and workflow `when` or `unless` clauses. For other fields, wrap the expression in `<<` and `>>`.
 
-For value insertion and an overview of compile-time templating, see the xref:guides:orchestrate:config-templating.adoc[Config Templating] page.
+To insert a pipeline value without logic, or for an overview of compile-time config templating, see the xref:guides:orchestrate:config-templating.adoc[Config Templating] page.
 
 [#expressions-in-config-fields]
 === Expressions in configuration fields

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -3711,7 +3711,13 @@ workflows:
 
 == Using expressions in your configuration
 
-CircleCI configuration supports expressions for dynamic value evaluation. Expressions can include pipeline values, pipeline parameters, literals, and operators such as `and`, `or`, and comparison operators.
+CircleCI supports limited dynamic expressions in its configuration through a custom templating framework. These config template expressions appear between `<<` and `>>`.
+
+Use this templating syntax to:
+
+* Insert pipeline values, pipeline parameters, and literals.
+* Apply operators such as `and`, `or`, and comparison operators.
+* Set dynamic configuration fields.
 
 [#expressions-in-config-fields]
 === Expressions in configuration fields


### PR DESCRIPTION
* Templating key words added to expressions section of config reference to help people find it.
* Adds new page covering various config templating methods. Also adds sections to disambiguate with dynamic config.

Not relevant to the intent PR but included
* Fixes a bunch of pre-existing linter errors
* Adds cursor rule for using worktrees for local agents