### PR TITLE
[PIPE-9704] Add Rego v0 vs v1 syntax note to config policy docs

### DIFF
--- a/docs/guides/modules/config-policies/pages/config-policy-management-overview.adoc
+++ b/docs/guides/modules/config-policies/pages/config-policy-management-overview.adoc
@@ -134,6 +134,32 @@ Policy names must be unique. Two policies cannot have the same name within an or
 
 The `policy_name` must be declared using a partial rule and declare the name as a `rego key`: `policy_name["NAME"]`.
 
+[#rego-v0-vs-v1-syntax]
+=== Rego v0 vs v1 syntax
+
+CircleCI config policies support two Rego language syntax versions: **v0** (the legacy syntax) and **v1** (the syntax introduced with link:https://www.openpolicyagent.org/docs/v0-upgrade[OPA 1.0]). CircleCI parses policy files as v0 by default. This is why the examples on this page, such as `policy_name["unique_policy_name"]`, use the legacy bracket syntax.
+
+To opt in to v1 syntax, add `import rego.v1` to the top of your policy file. You can mix v0-style and v1-style files within the same policy bundle. The most common difference you will encounter is how partial rules like `policy_name` and `enable_hard`/`enable_soft` are declared:
+
+[.table-scroll]
+--
+[cols="1,1", options="header"]
+|===
+| v0 (default) | v1 (with `import rego.v1`)
+
+| `policy_name["unique_policy_name"]`
+| `policy_name contains "unique_policy_name"`
+
+| `enable_hard["check_version"]`
+| `enable_hard contains "check_version"`
+
+| `check_version = reason { ... }`
+| `check_version := reason if { ... }`
+|===
+--
+
+NOTE: If you use `if`, `contains`, or other v1 keywords without adding `import rego.v1` to your file, the policy will fail to parse. The error will look similar to "contains keyword is required for partial set rules".
+
 [#rules]
 === Rules
 


### PR DESCRIPTION
# Description
Adds a new "Rego v0 vs v1 syntax" subsection to the config policy management overview page. It explains that config policies are parsed as Rego v0 by default, and how to opt in to v1 syntax per-file via `import rego.v1`, with a before/after comparison table (`policy_name[...]` vs `policy_name contains ...`, etc.) and a note about the parse error users hit if they use v1 keywords without the import.

I've tested that v1 works on a personal project - http://app.circleci.com/pipelines/github/SashaLsnko/test-repo-again/380; related slack convo -> [link](https://circleci.slack.com/archives/C06GW7D0K0F/p1787863175871059?thread_ts=1787153464.059019&cid=C06GW7D0K0F)

# Reasons
Customers who want to use modern Rego syntax (`if`/`contains`) often don't realize it's already supported per-policy via `import rego.v1` — they either write invalid policies and hit a confusing `contains` keyword is required for partial set rules error, or never discover the option. This behavior was previously undocumented.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).