### PR TITLE
add some redirects based on new data showing where people got a 404

### DIFF
--- a/scripts/redirects_v2.yml
+++ b/scripts/redirects_v2.yml
@@ -1,6 +1,6 @@
 # Generated redirects from Jekyll to Antora
 # Format: old (Jekyll) -> new (Antora)
-# Total redirects: 502
+# Total redirects: 513
 
 - old: /2.0/testing-ios/
   new: /guides/test/testing-ios/

--- a/scripts/redirects_v2.yml
+++ b/scripts/redirects_v2.yml
@@ -2,6 +2,45 @@
 # Format: old (Jekyll) -> new (Antora)
 # Total redirects: 502
 
+- old: /2.0/testing-ios/
+  new: /guides/test/testing-ios/
+
+- old: /2.0/getting-started/
+  new: /guides/getting-started/getting-started/
+
+- old: /release/manage-releases/
+  new: /guides/deploy/manage-releases/
+
+- old: /api/
+  new: /reference/api-homepage/
+
+- old: /2.0/orb-intro/
+  new: /orbs/use/orb-intro/
+
+- old: /orb-author-intro/
+  new: /orbs/author/orb-author/
+
+- old: /2.0/oss/
+  new: /guides/integration/oss/
+
+- old: /server-3-whats-new/
+  new: /server-admin/latest/overview/release-notes/
+
+- old: /2.0/
+  new: /
+
+- old: /release/releases-overview/
+  new: /guides/deploy/deployment-overview/
+
+- old: /2.0/workflows/
+  new: /guides/orchestrate/workflows/
+
+- old: /projects/
+  new: /guides/getting-started/create-project/
+
+- old: /2.0/env-vars/
+  new: /guides/security/env-vars/
+
 - old: /2.0/configuration-reference/
   new: /reference/configuration-reference/
 


### PR DESCRIPTION
We now track URLs that people use and then get a 404

This PR adds redirects for some of the top URLs which match URLs from the old docs site and so could well be coming from other internal services/messaging or just bookmarks runbooks with links.