### PR TITLE
Update the skip ci docs

### DIFF
--- a/docs/guides/modules/orchestrate/pages/skip-build.adoc
+++ b/docs/guides/modules/orchestrate/pages/skip-build.adoc
@@ -16,7 +16,7 @@ All methods are described below.
 [#skip-jobs]
 == Skip CI for a specific push
 
-If you have a trigger configured to run a pipeline on push events, you can skip it. Add one of the following tags within the first 250 characters of the body or title of the **latest commit** you push:
+If you have a trigger configured to run a pipeline on push events, you can skip it. Add one of the following tags anywhere in the title or body of the **latest commit** you push:
 
 * `[ci skip]`
 * `[skip ci]`
@@ -25,7 +25,7 @@ Adding one of these tags skips pipeline execution for all the commits included i
 
 === The skip CI process
 
-When you include `[ci skip]` or `[skip ci]` in the first 250 characters of the body or title of a commit, CircleCI uses this information to decide not to build your project.
+When you include `[ci skip]` or `[skip ci]` anywhere in the title or body of a commit, CircleCI uses this information to decide not to build your project.
 
 A skipped pipeline will not show on the pipelines page, and no pipeline will be returned for a skipped commit using the API.
 
@@ -35,6 +35,7 @@ A skipped pipeline will not show on the pipelines page, and no pipeline will be 
 A few points to note regarding the scope of the `ci skip` feature:
 
 * If you push multiple commits at once, and the latest commit includes a `[ci skip]` or `[skip ci]` tag, it will skip the pipeline execution for all commits in that push.
+* The entire commit message is checked, including the title and body. If you squash commits when merging, your VCS provider may concatenate all individual commit messages into the body of the squashed commit. If any of the original commit messages contain a skip tag, the resulting pipeline will be skipped. Review your squashed commit message before merging.
 * This feature is not supported for fork PRs. Scheduled workflows will run even if you push a commit with `[ci skip]` message. Changing the config file is the way to upgrade the current schedule.
 * For GitHub OAuth and Bitbucket Cloud pipelines, this functionality applies also when the pipeline is triggered via API, manually via the web app, or via schedule.
 * GitHub App pipelines triggered via Custom webhook, schedule or API are never skipped.


### PR DESCRIPTION
# Description

- Replaced "within the first 250 characters of the body or title" with "anywhere in the title or body" in both the intro and process description sections
- Added a scope bullet explaining that squash merges can concatenate commit messages, so a stale `[ci skip]` tag from an earlier commit can unexpectedly skip the pipeline

# Reasons

The skip CI docs claimed that `[ci skip]` / `[skip ci]` tags were only detected within the first 250 characters of a commit message. This was never true, the code has always checked the entire commit message. The docs were likely encoding an old data storage limitation that has since been removed.

A customer ran into this when they squash-merged a PR where one of the intermediate commits contained `[ci skip]`. Their VCS concatenated all commit messages into the squashed body, putting the tag past 250 chars, but the pipeline was still skipped. After discussion with product, the decision was to keep current behavior and fix the docs.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
