### PR TITLE
DOC-130: Add a skill for discovering and inserting docs partials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,7 @@ link:https://circleci.com[CircleCI]
 - Links must have descriptive link text (not "click here", "here", or "this")
 
 ### Code Samples
+- **Reuse shared snippets** from `docs/guides/modules/ROOT/examples/` when the same config already exists. Include them with `example$` inside a source block. Follow `skills/partials/SKILL.md` to discover, insert, or extract examples.
 - **Provide working examples**: Code should be tested and valid
 - Readers should copy-paste with minimal changes
 - **Specify language** for syntax highlighting:
@@ -282,7 +283,7 @@ some code
 
 ### Reusable Partials
 
-When discovering, inserting, or creating partials, follow the partials skill at `skills/partials/SKILL.md`. That skill is the workflow for browsing categories, searching, suggesting from page context, proposing extractions, and writing the correct `include::` syntax. Other docs-authoring skills should reference it instead of copying reusable content.
+When discovering, inserting, or creating partials or shared code examples, follow the partials skill at `skills/partials/SKILL.md`. That skill covers both `partials/` (AsciiDoc prose) and `examples/` (shared config snippets). It is the workflow for browsing categories, searching, suggesting from page context, proposing extractions, and writing the correct `include::` syntax. Other docs-authoring skills should reference it instead of copying reusable content.
 
 CircleCI docs use reusable partials to maintain consistency and reduce duplication. Partials are AsciiDoc snippets that can be included in multiple pages.
 
@@ -397,6 +398,20 @@ When creating a new partial:
 - Document partials that accept custom text parameters
 - Update all pages when modifying a partial (partials affect multiple pages)
 - Use meaningful filenames that describe the content
+
+### Reusable Examples
+
+Shared code snippets live in `docs/guides/modules/ROOT/examples/`, next to `partials/`. Include them with `example$` **inside** a source block. Do not paste the snippet into the page.
+
+```adoc
+.Optional title for the snippet
+[source,yaml]
+----
+include::ROOT:example$orchestration-examples/job-group.yml[]
+----
+```
+
+From another component, use `include::guides:ROOT:example$path.yml[]`. Current categories: `expression-examples/` (current expression syntax), `logic-statement-examples/` (legacy logic statements), `orchestration-examples/` (job groups, serial groups, `override-with`). Follow `skills/partials/SKILL.md` to browse, search, insert, or extract examples.
 
 ### Images
 - **Always include descriptive alt text**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,8 @@ some code
 
 ### Reusable Partials
 
+When discovering, inserting, or creating partials, follow the partials skill at `skills/partials/SKILL.md`. That skill is the workflow for browsing categories, searching, suggesting from page context, and writing the correct `include::` syntax. Other docs-authoring skills should reference it instead of copying reusable content.
+
 CircleCI docs use reusable partials to maintain consistency and reduce duplication. Partials are AsciiDoc snippets that can be included in multiple pages.
 
 **When to use partials:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,7 +282,7 @@ some code
 
 ### Reusable Partials
 
-When discovering, inserting, or creating partials, follow the partials skill at `skills/partials/SKILL.md`. That skill is the workflow for browsing categories, searching, suggesting from page context, and writing the correct `include::` syntax. Other docs-authoring skills should reference it instead of copying reusable content.
+When discovering, inserting, or creating partials, follow the partials skill at `skills/partials/SKILL.md`. That skill is the workflow for browsing categories, searching, suggesting from page context, proposing extractions, and writing the correct `include::` syntax. Other docs-authoring skills should reference it instead of copying reusable content.
 
 CircleCI docs use reusable partials to maintain consistency and reduce duplication. Partials are AsciiDoc snippets that can be included in multiple pages.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -27,7 +27,7 @@ Runs the Vale prose linter on CircleCI documentation files to identify and fix s
 A skill the CircleCI docs team use to create a newsletter each month to showcase notable additions and improvements.
 
 ### partials
-Discovers, previews, and inserts reusable AsciiDoc partials with the correct `include::` syntax. Also proposes when new or existing content should become a shared partial, then creates it and replaces duplicates after confirmation. Use when writing or editing docs that need shared navigation steps, notes, FAQs, resource tables, or other repeated content. Other docs-authoring skills should follow this skill instead of copying reusable content.
+Discovers, previews, and inserts reusable AsciiDoc partials and shared code examples with the correct `include::` syntax. Also proposes when new or existing content should become a shared partial or example, then creates it and replaces duplicates after confirmation. Use when writing or editing docs that need shared navigation steps, notes, FAQs, resource tables, config snippets, or other repeated content. Other docs-authoring skills should follow this skill instead of copying reusable content.
 
 ## Installation (Claude Code)
 
@@ -90,21 +90,25 @@ The skill will:
 - "Is there a partial for project settings?"
 - "Use a partial for the Docker auth note"
 - "Should this be a shared partial?"
-- Writing or editing a page that needs shared nav steps, notes, FAQs, or resource tables
+- "Is there a shared example for serial groups?"
+- Writing or editing a page that needs shared nav steps, notes, FAQs, resource tables, or config snippets
 
 **Explicit invocation:**
 ```
 /partials
 /partials navigation
 /partials search project settings
+/examples
+/examples orchestration
+/examples search job-group
 ```
 
 The skill will:
-1. Scan `docs/guides/modules/ROOT/partials/` (not a memorized list)
-2. Preview matching partials
-3. Insert the correct `include::ROOT:partial$...` or `include::guides:ROOT:partial$...` line
-4. Call out page attributes or `leveloffset` when the partial needs them
-5. Propose extracting duplicated or reusable content into a partial, then replace the copies after you confirm
+1. Scan `docs/guides/modules/ROOT/partials/` or `docs/guides/modules/ROOT/examples/` (not a memorized list)
+2. Preview matching files
+3. Insert the correct `include::ROOT:partial$...` or `include::ROOT:example$...` line (examples go inside a source block)
+4. Call out page attributes or `leveloffset` when a partial needs them
+5. Propose extracting duplicated or reusable content, then replace the copies after you confirm
 
 ## Using Skills with Other AI Agents
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,6 +17,7 @@ Reviews CircleCI documentation pages for quality, clarity, and adherence to styl
 - Consistency (internal and with related docs)
 - Repetition and flow
 - Value proposition
+- Partial and example reuse (hand-written content that should use, or become, a shared partial or example)
 
 **Output:** Saves a markdown report to the repository root as `content-review-[page-name].md`
 
@@ -68,10 +69,11 @@ Once installed, Claude Code will automatically trigger skills when relevant, or 
 ```
 
 The skill will:
-1. Analyze the page across 10 quality dimensions
+1. Analyze the page across 11 quality dimensions
 2. Check 3-5 related pages for consistency
-3. Generate a prioritized report
-4. Save the report as `content-review-[page-name].md` in the repo root
+3. Flag hand-written content that should use, or become, a shared partial or example (see the partials skill below)
+4. Generate a prioritized report
+5. Save the report as `content-review-[page-name].md` in the repo root
 
 ### vale-linter
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -26,6 +26,9 @@ Runs the Vale prose linter on CircleCI documentation files to identify and fix s
 ### monthly-docs-report
 A skill the CircleCI docs team use to create a newsletter each month to showcase notable additions and improvements.
 
+### partials
+Discovers, previews, and inserts reusable AsciiDoc partials with the correct `include::` syntax. Use when writing or editing docs that need shared navigation steps, notes, FAQs, resource tables, or other repeated content. Other docs-authoring skills should follow this skill instead of copying reusable content.
+
 ## Installation (Claude Code)
 
 Skills need to be installed in Claude Code's skills directory to be recognized.
@@ -45,6 +48,7 @@ If you're actively developing skills, symlink them so changes sync automatically
 # From the repository root
 ln -s "$(pwd)/skills/content-review" ~/.claude/skills/content-review
 ln -s "$(pwd)/skills/vale-linter" ~/.claude/skills/vale-linter
+ln -s "$(pwd)/skills/partials" ~/.claude/skills/partials
 ```
 
 ## Usage
@@ -79,6 +83,26 @@ The skill will:
 ```
 /vale-linter docs/path/to/file.adoc
 ```
+
+### partials
+
+**Automatic triggering:**
+- "Is there a partial for project settings?"
+- "Use a partial for the Docker auth note"
+- Writing or editing a page that needs shared nav steps, notes, FAQs, or resource tables
+
+**Explicit invocation:**
+```
+/partials
+/partials navigation
+/partials search project settings
+```
+
+The skill will:
+1. Scan `docs/guides/modules/ROOT/partials/` (not a memorized list)
+2. Preview matching partials
+3. Insert the correct `include::ROOT:partial$...` or `include::guides:ROOT:partial$...` line
+4. Call out page attributes or `leveloffset` when the partial needs them
 
 ## Using Skills with Other AI Agents
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -27,7 +27,7 @@ Runs the Vale prose linter on CircleCI documentation files to identify and fix s
 A skill the CircleCI docs team use to create a newsletter each month to showcase notable additions and improvements.
 
 ### partials
-Discovers, previews, and inserts reusable AsciiDoc partials with the correct `include::` syntax. Use when writing or editing docs that need shared navigation steps, notes, FAQs, resource tables, or other repeated content. Other docs-authoring skills should follow this skill instead of copying reusable content.
+Discovers, previews, and inserts reusable AsciiDoc partials with the correct `include::` syntax. Also proposes when new or existing content should become a shared partial, then creates it and replaces duplicates after confirmation. Use when writing or editing docs that need shared navigation steps, notes, FAQs, resource tables, or other repeated content. Other docs-authoring skills should follow this skill instead of copying reusable content.
 
 ## Installation (Claude Code)
 
@@ -89,6 +89,7 @@ The skill will:
 **Automatic triggering:**
 - "Is there a partial for project settings?"
 - "Use a partial for the Docker auth note"
+- "Should this be a shared partial?"
 - Writing or editing a page that needs shared nav steps, notes, FAQs, or resource tables
 
 **Explicit invocation:**
@@ -103,6 +104,7 @@ The skill will:
 2. Preview matching partials
 3. Insert the correct `include::ROOT:partial$...` or `include::guides:ROOT:partial$...` line
 4. Call out page attributes or `leveloffset` when the partial needs them
+5. Propose extracting duplicated or reusable content into a partial, then replace the copies after you confirm
 
 ## Using Skills with Other AI Agents
 

--- a/skills/content-review/SKILL.md
+++ b/skills/content-review/SKILL.md
@@ -46,7 +46,7 @@ Read these related pages to understand:
 
 ### Step 3: Conduct the Review
 
-Evaluate the page across these 10 dimensions:
+Evaluate the page across these 11 dimensions:
 
 #### 1. **Tone & Audience**
 - **General pages**: Should have a friendly, authoritative tone suitable for a junior engineer
@@ -108,6 +108,12 @@ Evaluate the page across these 10 dimensions:
 - Reader (human or agent) should know immediately if this page is relevant
 - Flag if the opening is vague, overly technical, or doesn't answer "why read this"
 
+#### 11. **Partial and Example Reuse**
+- Check hand-written prose (nav steps, notes, tips, FAQs, resource tables) against `docs/guides/modules/ROOT/partials/`. Flag it if an existing partial already covers the same content and should replace it.
+- Check hand-written YAML or config blocks against `docs/guides/modules/ROOT/examples/`. Flag it if an existing example already covers the same snippet and should replace it.
+- Flag hand-written prose or code that looks generic or reusable (not page-specific) as a candidate for a **new** partial or example, especially if you find the same or near-identical content on another page during Step 2.
+- Do not perform the search, extraction, or replacement yourself. Follow `skills/partials/SKILL.md` for that workflow; this review only surfaces the opportunity.
+
 ### Step 4: Generate and Save the Report
 
 Generate a narrative-style report with this structure:
@@ -129,7 +135,7 @@ Generate a narrative-style report with this structure:
 
 ### [Priority level]: [Issue title]
 
-**Category:** [Which of the 10 categories this relates to]
+**Category:** [Which of the 11 categories this relates to]
 
 **Issue:** [Clear description of the problem]
 
@@ -143,7 +149,7 @@ Generate a narrative-style report with this structure:
 
 ## Detailed Findings
 
-[Go through each of the 10 categories. For each category, either:]
+[Go through each of the 11 categories. For each category, either:]
 - ✅ **[Category Name]**: [Brief note on why this passes]
 - ⚠️ **[Category Name]**: [Detailed findings of issues]
 
@@ -183,7 +189,8 @@ Generate a narrative-style report with this structure:
 **Priority Levels:**
 - **Critical**: Issues that break comprehension or accessibility (missing "why", code without context, buried essential info)
 - **High**: Issues that significantly impact usability (poor headings, confusing flow, major inconsistencies)
-- **Medium**: Issues that reduce quality (minor inconsistencies, unnecessary repetition, weak value proposition)
+- **Medium**: Issues that reduce quality (minor inconsistencies, unnecessary repetition, weak value proposition, a partial/example that should replace hand-written content)
+- **Low**: Nice-to-have improvements (hand-written content that is a good candidate for a *new* partial or example, but nothing is broken today)
 
 **Specificity:**
 - Reference specific headings, paragraphs, or line numbers where possible
@@ -217,7 +224,7 @@ You:
 3. Check :page-platform: to determine audience
 4. Find 3-5 related getting-started pages using Grep/Glob
 5. Read those related pages
-6. Analyze all 10 dimensions
+6. Analyze all 11 dimensions
 7. Generate the narrative report with prioritized recommendations
 8. Save the report as `content-review-hello-world.md` in the repository root
 9. Inform the user where the report has been saved
@@ -228,11 +235,13 @@ You:
 - Consider both human and AI agent readability
 - Remember that agents often retrieve just one section or code block, so each should be self-contained
 - Use the full context from AGENTS.md - it contains detailed style rules beyond what's summarized here
-- If you can't find related pages, note that in the consistency section but still complete the other 9 categories
+- If you can't find related pages, note that in the consistency section but still complete the other 10 categories (Partial and Example Reuse does not depend on finding related pages)
 - Always read the actual related pages - don't guess at consistency without evidence
+- For the Partial and Example Reuse check, actually search `docs/guides/modules/ROOT/partials/` and `docs/guides/modules/ROOT/examples/` (Glob/Grep) rather than guessing whether something already exists
 
 ## What This Skill Is NOT
 
 - This is not a Vale linter replacement - focus on content quality, not grammar/style nitpicks
 - This is not a full copyedit - identify patterns and priorities, not every minor issue
 - This is not a rewrite - provide recommendations, not rewritten content
+- This is not the partials skill - it flags reuse and extraction opportunities but does not search categories, create partials/examples, or edit other pages. Hand that off to `skills/partials/SKILL.md`

--- a/skills/partials/SKILL.md
+++ b/skills/partials/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: partials
+description: >
+  Discover, preview, and insert CircleCI docs AsciiDoc partials with the correct
+  include syntax. Use this skill whenever the user mentions partials, includes,
+  reusable snippets, or /partials, and whenever you are writing or editing .adoc
+  pages that need shared navigation steps, notes, tips, FAQs, troubleshooting,
+  resource tables, runner setup, or other repeated content. Other docs-authoring
+  skills must follow this skill instead of copying reusable content by hand.
+---
+
+# CircleCI Docs Partials
+
+Use existing AsciiDoc partials instead of rewriting shared steps, notes, tables, or FAQs. Always scan the repo. Do not invent filenames or rely on a memorized catalog.
+
+## How other skills should use this
+
+If another skill is writing or editing docs content:
+
+1. Read this file before drafting reusable steps, notes, FAQs, tables, or troubleshooting.
+2. Follow **Suggest from context** for the page you are writing.
+3. Insert an `include::` line. Never paste the body of a partial into a page.
+4. If no partial fits, write the content inline unless it will be reused on two or more pages. Then follow **Create a partial**.
+
+## Source of truth
+
+Scan these trees. Do not treat the category map below as a file list.
+
+| Content | Path | Ignore |
+|---|---|---|
+| Shared docs partials | `docs/guides/modules/ROOT/partials/` | `ui/src/partials/` (Handlebars UI templates) |
+| Server Admin partials | `docs/server-admin-<version>/modules/ROOT/partials/` | Versioned copies. Edit the version you are working on. |
+
+List files with Glob (`**/partials/**/*.adoc` under `docs/`) or:
+
+```bash
+find docs/guides/modules/ROOT/partials -name '*.adoc' | sort
+```
+
+## Include syntax
+
+**Same component** (a guides page including a guides partial):
+
+```adoc
+include::ROOT:partial$category/filename.adoc[]
+```
+
+**Cross-component** (orbs, reference, or another component including a guides partial):
+
+```adoc
+include::guides:ROOT:partial$category/filename.adoc[]
+```
+
+Prefer the short `ROOT:partial$` form inside guides. Use the full `guides:ROOT:partial$` coordinate from every other component.
+
+**Optional author comment** (does not change rendered content; common on well-known notes and nav steps):
+
+```adoc
+include::ROOT:partial$notes/standalone-unsupported.adoc[This feature is not supported for GitLab, GitHub App or Bitbucket Data Center]
+```
+
+**AsciiDoc include attributes** (do change rendering). Use `leveloffset` when the partial starts with section headings that must nest under the current heading:
+
+```adoc
+include::guides:ROOT:partial$deploy/configure-validation-providers.adoc[leveloffset=+2]
+```
+
+Do not put a comment and `leveloffset` in the same brackets unless you are sure both are valid attributes.
+
+## Category map
+
+Use the directory name to browse. Confirm the file still exists before inserting.
+
+| Directory | Use when the page needs |
+|---|---|
+| `app-navigation/` | Steps to project, org, user, or job settings, or to find IDs |
+| `create-project/` | Shared Create Project / choose-a-repo / GitLab cleanup steps |
+| `notes/` | Reusable notes and warnings (Docker auth, feature support, org ID) |
+| `tips/` | How to check org type, GitHub type, project slug, env vars vs contexts |
+| `faq/` | FAQ answers (`*-snip.adoc`). Usually included from FAQ pages |
+| `troubleshoot/` | Troubleshooting snippets (`*-snip.adoc`) |
+| `runner/` | Self-hosted runner terms, install steps, package install, examples |
+| `orbs/` | Orb type definitions and comparison table |
+| `pipelines-and-triggers/` | Schedule triggers, custom webhooks, pipeline values |
+| `execution-resources/` | Executor resource class tables and related notices |
+| `using-expressions/` | Expression operators and env-var caveats |
+| `deploy/` | Deploy/release shared sections (supported versions, validation providers) |
+| `prerequisites/` | Shared prerequisite bullets (for example org admin) |
+| `shared-sections/` | Longer shared sections (API token, secrets masking, product features) |
+| `installation/` | Server Admin install-phase partials only |
+
+## Workflows
+
+Decide which workflow the user asked for. A write-docs skill usually wants **Suggest from context**, then **Insert**.
+
+### Browse (`/partials`, `/partials navigation`)
+
+1. Resolve the category from the request (`navigation` → `app-navigation/`, `faq` → `faq/`, and so on). If the request is just `/partials`, list the category directories first and ask which to open.
+2. Glob that directory. For each file, give **path**, a **one-line summary** from the actual content, and the **exact `include::` line**. Do not dump every file body.
+3. Preview only the best match (or the one the user picks) by quoting the partial.
+4. Ask whether to insert it, unless the user already named the file and said to insert it.
+5. Follow **Insert**.
+
+### Search (`/partials search project settings`)
+
+1. Search filenames and file bodies:
+
+```bash
+find docs/guides/modules/ROOT/partials -iname '*<term>*'
+rg -l -i '<term>' docs/guides/modules/ROOT/partials
+```
+
+2. Read the matches. Rank in this order:
+   1. Filename matches the request
+   2. The partial's primary purpose is the request (`app-navigation/` for "how do I get there", `tips/` for "how do I check X")
+   3. Body-only mentions in `faq/`, `troubleshoot/`, or other pages that just happen to say the words
+3. Show 2–4 candidates with path, one-line summary, and the exact `include::` line.
+4. Preview the chosen file, then follow **Insert**.
+
+### Suggest from context
+
+Use this when writing or editing a page, even if the user did not say "partial".
+
+1. Grep the page for existing `include::` lines. Do not re-suggest partials that are already there.
+2. Read the page (or the draft outline) and list repeated or standard chunks: nav steps, support caveats, resource tables, FAQs, runner install, org-type checks.
+3. For each chunk, search `docs/guides/modules/ROOT/partials/` by filename and content.
+4. Read every candidate. Prefer the **most specific** partial:
+   - Finding a project slug → `tips/find-project-slug.adoc`, not the generic project-settings steps
+   - Finding a project or org ID → `app-navigation/steps-to-project-id.adoc` or `steps-to-org-id.adoc` (these already include the settings steps)
+   - Checking GitHub App vs OAuth → `tips/check-github-type.adoc`
+5. Suggest a partial only when the wording and scope match.
+6. If a page has a **shortened** version of a standard nav partial, offer the full partial for that shared prefix and keep the page-specific steps that follow. Do not auto-insert if the reader is clearly already mid-flow (for example, already on the Projects page).
+7. If one candidate is a clear match, insert it and tell the user which partial you used.
+8. If several could work, show the options and ask.
+9. If none fit, write the content inline. Offer a new partial only when a second page will need the same text.
+
+Common starting points (still verify by reading the file):
+
+| Need | First file to open |
+|---|---|
+| Steps to project settings | `app-navigation/steps-to-project-settings.adoc` |
+| Steps to org settings | `app-navigation/steps-to-org-settings.adoc` |
+| Create Project through pipeline setup | `create-project/steps-up-to-pipeline.adoc` |
+| Docker authenticated pulls note | `notes/docker-auth.adoc` |
+| Feature unsupported for some VCS / pipeline types | `notes/standalone-unsupported.adoc` |
+| Check organization type | `tips/check-org-type.adoc` |
+| Check GitHub App vs OAuth | `tips/check-github-type.adoc` |
+| Find organization ID | `notes/find-organization-id.adoc` |
+| Find project slug | `tips/find-project-slug.adoc` |
+| Resource class table | Matching file in `execution-resources/` |
+| Pipeline values reference | `pipelines-and-triggers/pipeline-values.adoc` |
+
+### Insert
+
+1. Confirm the target file exists at the path you will put in the include.
+2. Choose the coordinate (`ROOT:partial$` vs `guides:ROOT:partial$`) from the including page's component.
+3. Read the partial for composition: some files already `include::` another partial (for example `steps-to-project-id.adoc` includes `steps-to-project-settings.adoc`). Use the composed file. Do not stack both.
+4. Read the partial for `ifdef::` / `ifndef::`. If present, set the matching page attributes before the include. Examples used today: `:machine:`, `:container:`, `:provisioner:`, `:linux:`, `:macos:`, `:windows:`, `:server:`.
+5. Note the partial's wrapper (`****` sidebar, `NOTE:`, `TIP:`, or bare list items). Only insert when that wrapper fits the page.
+6. If the partial starts with `==` / `===` headings, add `leveloffset` so they nest correctly.
+7. Insert only the `include::` line. Do not copy the partial body into the page.
+8. If the include sits inside a list or tab, read the partial's first lines and confirm the list markers or tab syntax still work. Some nav and create-project partials start with ordered-list `.` items on purpose.
+9. Add an author comment in brackets when that file is already included that way elsewhere, or when the comment helps a human scan the source. Copy an existing comment when one is established (`standalone-unsupported`, `steps-to-project-settings`, `steps-up-to-pipeline`).
+10. Tell the user the path you included and why.
+
+### Create a partial
+
+Create a new partial only when the content will appear on two or more pages, or the user asked for one.
+
+1. Search existing partials first. Extend one if the topic already has a home.
+2. Choose a category directory from the map above. Add a new directory only when none of the existing ones fit.
+3. Name the file descriptively, ending in `.adoc`. Use `-snip.adoc` for FAQ and troubleshooting snippets.
+4. Write content that works in more than one page. No `:page-platform:`, `:page-description:`, or other page-only attributes.
+5. Keep the partial focused on one concept or one set of related steps.
+6. Replace the duplicated page content with includes. Grep for similar wording and offer to switch those pages too.
+7. Mention that later edits to this file change every page that includes it.
+
+### Edit a partial
+
+1. Grep for every include of that file before changing it.
+2. Summarize the pages that will change.
+3. Edit the partial only when the new wording is correct for all of those pages. If it is not, write page-specific content instead of overloading the partial.
+
+## Parameters
+
+Three different things show up in or around includes. Do not mix them up.
+
+**Author comments** in `[brackets]` are for humans. They do not substitute text into the partial. `notes/standalone-unsupported.adoc` does not read the bracket text; every include of that file renders the same support note.
+
+**Include attributes** such as `leveloffset=+2`, `tag=`, or `lines=` change how AsciiDoc includes the file.
+
+**Page attributes** set on the including page control `ifdef::` / `ifndef::` inside the partial. Example from container runner install:
+
+```adoc
+:container:
+
+include::ROOT:partial$runner/install-with-web-app-steps.adoc[]
+```
+
+When a partial uses `ifdef::`, tell the user which attributes they must set. Suggest those attributes if they are missing.
+
+## Do not
+
+- Invent a partial path or guess a filename without Glob/Grep.
+- Copy a partial's body into a page "to make it clearer".
+- Use `ui/src/partials/` files in docs pages.
+- Edit a guides partial to fix one page if that would break the others.
+- Include a Server Admin `installation/` partial from a Cloud guides page.
+
+## Example invocations
+
+```
+/partials
+/partials navigation
+/partials search project settings
+Use a partial for the Docker auth note
+Is there a partial for checking org type?
+```

--- a/skills/partials/SKILL.md
+++ b/skills/partials/SKILL.md
@@ -1,45 +1,55 @@
 ---
 name: partials
 description: >
-  Discover, preview, and insert CircleCI docs AsciiDoc partials with the correct
-  include syntax. Propose when new or existing content should become a shared
-  partial, then create it and replace duplicates after confirmation. Use this
-  skill whenever the user mentions partials, includes, reusable snippets, or
-  /partials, and whenever you are writing or editing .adoc pages that need
-  shared navigation steps, notes, tips, FAQs, troubleshooting, resource tables,
-  runner setup, or other repeated content. Other docs-authoring skills must
+  Discover, preview, and insert CircleCI docs reusable includes: AsciiDoc
+  partials and shared code examples. Propose when new or existing content
+  should become a shared partial or example, then create it and replace
+  duplicates after confirmation. Use this skill whenever the user mentions
+  partials, examples, includes, reusable snippets, /partials, or /examples,
+  and whenever you are writing or editing .adoc pages that need shared
+  navigation steps, notes, tips, FAQs, troubleshooting, resource tables,
+  runner setup, or shared config snippets. Other docs-authoring skills must
   follow this skill instead of copying reusable content by hand.
 ---
 
-# CircleCI Docs Partials
+# CircleCI Docs Partials and Examples
 
-Use existing AsciiDoc partials instead of rewriting shared steps, notes, tables, or FAQs. Always scan the repo. Do not invent filenames or rely on a memorized catalog.
+Two reusable families live next to each other under `docs/guides/modules/ROOT/`:
+
+| Family | Directory | Use for | Include family |
+|---|---|---|---|
+| **Partials** | `partials/` | Shared AsciiDoc prose (steps, notes, FAQs, tables) | `partial$` |
+| **Examples** | `examples/` | Shared code snippets, usually YAML config | `example$` |
+
+Choose the family from the request (`/partials` vs `/examples`) or from the content. Always scan the repo. Do not invent filenames or rely on a memorized catalog.
 
 ## How other skills should use this
 
 If another skill is writing or editing docs content:
 
-1. Read this file before drafting reusable steps, notes, FAQs, tables, or troubleshooting.
+1. Read this file before drafting reusable steps, notes, FAQs, tables, troubleshooting, or config snippets.
 2. Follow **Suggest from context** for the page you are writing.
-3. Insert an `include::` line. Never paste the body of a partial into a page.
-4. If the page restates an existing partial, or the same new chunk will appear on two or more pages, follow **Propose extraction**. Do not extract and replace across pages until the user confirms.
+3. Insert an `include::` line. Never paste the body of a partial or example into a page.
+4. If the page restates an existing include, or the same new chunk will appear on two or more pages, follow **Propose extraction**. Do not extract and replace across pages until the user confirms.
 
 ## Source of truth
 
-Scan these trees. Do not treat the category map below as a file list.
+Scan these trees. Do not treat the category maps below as file lists.
 
 | Content | Path | Ignore |
 |---|---|---|
 | Shared docs partials | `docs/guides/modules/ROOT/partials/` | `ui/src/partials/` (Handlebars UI templates) |
+| Shared code examples | `docs/guides/modules/ROOT/examples/` | External GitHub sample repos linked from pages |
 | Server Admin partials | `docs/server-admin-<version>/modules/ROOT/partials/` | Versioned copies. Edit the version you are working on. |
-
-List files with Glob (`**/partials/**/*.adoc` under `docs/`) or:
 
 ```bash
 find docs/guides/modules/ROOT/partials -name '*.adoc' | sort
+find docs/guides/modules/ROOT/examples -type f | sort
 ```
 
 ## Include syntax
+
+### Partials
 
 **Same component** (a guides page including a guides partial):
 
@@ -69,9 +79,36 @@ include::guides:ROOT:partial$deploy/configure-validation-providers.adoc[leveloff
 
 Do not put a comment and `leveloffset` in the same brackets unless you are sure both are valid attributes.
 
-## Category map
+### Examples
 
-Use the directory name to browse. Confirm the file still exists before inserting.
+Wrap the include in a source or listing block. The example file is raw code, not AsciiDoc.
+
+**Same component:**
+
+```adoc
+.Optional title for the snippet
+[source,yaml]
+----
+include::ROOT:example$category/filename.yml[]
+----
+```
+
+**Cross-component:**
+
+```adoc
+[source,yaml]
+----
+include::guides:ROOT:example$orchestration-examples/job-group.yml[]
+----
+```
+
+Match the page's existing fence style if it already has one (`[source,yaml]` or `[,yaml]`). Default to `[source,yaml]`. Put titles on the listing block (`.Title`), not in the include brackets. Comments that explain the snippet belong in the example file.
+
+## Category maps
+
+Confirm the file still exists before inserting.
+
+### Partials (`partials/`)
 
 | Directory | Use when the page needs |
 |---|---|
@@ -91,89 +128,114 @@ Use the directory name to browse. Confirm the file still exists before inserting
 | `shared-sections/` | Longer shared sections (API token, secrets masking, product features) |
 | `installation/` | Server Admin install-phase partials only |
 
+### Examples (`examples/`)
+
+| Directory | Use when the page needs |
+|---|---|
+| `expression-examples/` | Current expression syntax (`when: pipeline.git.branch == "main"`). Subdirs include `workflow-when/` and `job-filters/` |
+| `logic-statement-examples/` | Legacy logic-statement maps (`when: or: equal:`). Use only when documenting the old syntax |
+| `orchestration-examples/` | Job groups, serial groups, and `override-with` config |
+
+Prefer `expression-examples/` over `logic-statement-examples/` unless the page is explicitly about legacy logic statements.
+
 ## Workflows
 
 Decide which workflow the user asked for. A write-docs skill usually wants **Suggest from context**, then **Insert**. When content is duplicated or clearly reusable, follow **Propose extraction** before writing a second copy.
 
-### Browse (`/partials`, `/partials navigation`)
+`/partials` scopes to `partials/`. `/examples` scopes to `examples/`. If the request is only `/partials` or `/examples`, list that family's category directories first.
 
-1. Resolve the category from the request (`navigation` → `app-navigation/`, `faq` → `faq/`, and so on). If the request is just `/partials`, list the category directories first and ask which to open.
-2. Glob that directory. For each file, give **path**, a **one-line summary** from the actual content, and the **exact `include::` line**. Do not dump every file body.
-3. Preview only the best match (or the one the user picks) by quoting the partial.
+### Browse (`/partials`, `/partials navigation`, `/examples`, `/examples orchestration`)
+
+1. Resolve the family, then the category (`navigation` → `app-navigation/`, `orchestration` → `orchestration-examples/`).
+2. Glob that directory. For each file, give **path**, a **one-line summary** from the actual content, and the **exact `include::` line** (for examples, show the full source-block wrapper). Do not dump every file body.
+3. Preview only the best match (or the one the user picks) by quoting the file.
 4. Ask whether to insert it, unless the user already named the file and said to insert it.
 5. Follow **Insert**.
 
-### Search (`/partials search project settings`)
+### Search (`/partials search project settings`, `/examples search job-group`)
 
-1. Search filenames and file bodies:
+1. Search filenames and file bodies in the chosen family (or both, if the request did not specify):
 
 ```bash
 find docs/guides/modules/ROOT/partials -iname '*<term>*'
 rg -l -i '<term>' docs/guides/modules/ROOT/partials
+find docs/guides/modules/ROOT/examples -iname '*<term>*'
+rg -l -i '<term>' docs/guides/modules/ROOT/examples
 ```
 
 2. Read the matches. Rank in this order:
    1. Filename matches the request
-   2. The partial's primary purpose is the request (`app-navigation/` for "how do I get there", `tips/` for "how do I check X")
-   3. Body-only mentions in `faq/`, `troubleshoot/`, or other pages that just happen to say the words
-3. Show 2–4 candidates with path, one-line summary, and the exact `include::` line.
+   2. The file's primary purpose is the request
+   3. Body-only mentions that just happen to say the words
+3. Show 2–4 candidates with path, one-line summary, and the exact `include::` line (plus the source-block wrapper for examples).
 4. Preview the chosen file, then follow **Insert**.
 
 ### Suggest from context
 
-Use this when writing or editing a page, even if the user did not say "partial".
+Use this when writing or editing a page, even if the user did not say "partial" or "example".
 
-1. Grep the page for existing `include::` lines. Do not re-suggest partials that are already there.
-2. Read the page (or the draft outline) and list repeated or standard chunks: nav steps, support caveats, resource tables, FAQs, runner install, org-type checks.
-3. For each chunk, search `docs/guides/modules/ROOT/partials/` by filename and content.
-4. Read every candidate. Prefer the **most specific** partial:
+1. Grep the page for existing `include::` lines. Do not re-suggest files that are already there.
+2. Read the page (or the draft outline) and list reusable chunks:
+   - Prose: nav steps, support caveats, resource tables, FAQs, runner install, org-type checks → search `partials/`
+   - Code: config snippets, workflow `when` clauses, job groups, serial groups → search `examples/`
+3. For each chunk, search the matching tree by filename and content.
+4. Read every candidate. Prefer the **most specific** file:
    - Finding a project slug → `tips/find-project-slug.adoc`, not the generic project-settings steps
    - Finding a project or org ID → `app-navigation/steps-to-project-id.adoc` or `steps-to-org-id.adoc` (these already include the settings steps)
    - Checking GitHub App vs OAuth → `tips/check-github-type.adoc`
-5. Suggest a partial only when the wording and scope match.
+   - Current workflow/job expressions → `expression-examples/`, not `logic-statement-examples/`
+   - Job groups or serial groups → `orchestration-examples/`
+5. Suggest an include only when the wording and scope match.
 6. If a page has a **shortened** version of a standard nav partial, offer the full partial for that shared prefix and keep the page-specific steps that follow. Do not auto-insert if the reader is clearly already mid-flow (for example, already on the Projects page).
-7. If one candidate is a clear match, insert it and tell the user which partial you used.
+7. If one candidate is a clear match, insert it and tell the user which file you used.
 8. If several could work, show the options and ask.
-9. If none fit, write the content inline. If the same chunk already exists on another page, or will be needed on a second page, follow **Propose extraction**.
+9. If none fit, write the content inline (or in a one-off source block). If the same chunk already exists on another page, or will be needed on a second page, follow **Propose extraction**.
 
 Common starting points (still verify by reading the file):
 
 | Need | First file to open |
 |---|---|
-| Steps to project settings | `app-navigation/steps-to-project-settings.adoc` |
-| Steps to org settings | `app-navigation/steps-to-org-settings.adoc` |
-| Create Project through pipeline setup | `create-project/steps-up-to-pipeline.adoc` |
-| Docker authenticated pulls note | `notes/docker-auth.adoc` |
-| Feature unsupported for some VCS / pipeline types | `notes/standalone-unsupported.adoc` |
-| Check organization type | `tips/check-org-type.adoc` |
-| Check GitHub App vs OAuth | `tips/check-github-type.adoc` |
-| Find organization ID | `notes/find-organization-id.adoc` |
-| Find project slug | `tips/find-project-slug.adoc` |
-| Resource class table | Matching file in `execution-resources/` |
-| Pipeline values reference | `pipelines-and-triggers/pipeline-values.adoc` |
+| Steps to project settings | `partials/app-navigation/steps-to-project-settings.adoc` |
+| Steps to org settings | `partials/app-navigation/steps-to-org-settings.adoc` |
+| Create Project through pipeline setup | `partials/create-project/steps-up-to-pipeline.adoc` |
+| Docker authenticated pulls note | `partials/notes/docker-auth.adoc` |
+| Feature unsupported for some VCS / pipeline types | `partials/notes/standalone-unsupported.adoc` |
+| Check organization type | `partials/tips/check-org-type.adoc` |
+| Check GitHub App vs OAuth | `partials/tips/check-github-type.adoc` |
+| Find organization ID | `partials/notes/find-organization-id.adoc` |
+| Find project slug | `partials/tips/find-project-slug.adoc` |
+| Resource class table | Matching file in `partials/execution-resources/` |
+| Pipeline values reference | `partials/pipelines-and-triggers/pipeline-values.adoc` |
+| Branch or boolean workflow `when` | Matching file in `examples/expression-examples/workflow-when/` |
+| Job group | `examples/orchestration-examples/job-group.yml` |
+| Serial group | `examples/orchestration-examples/serial-group.yml` |
 
 ### Insert
 
 1. Confirm the target file exists at the path you will put in the include.
-2. Choose the coordinate (`ROOT:partial$` vs `guides:ROOT:partial$`) from the including page's component.
-3. Read the partial for composition: some files already `include::` another partial (for example `steps-to-project-id.adoc` includes `steps-to-project-settings.adoc`). Use the composed file. Do not stack both.
-4. Read the partial for `ifdef::` / `ifndef::`. If present, set the matching page attributes before the include. Examples used today: `:machine:`, `:container:`, `:provisioner:`, `:linux:`, `:macos:`, `:windows:`, `:server:`.
-5. Note the partial's wrapper (`****` sidebar, `NOTE:`, `TIP:`, or bare list items). Only insert when that wrapper fits the page.
-6. If the partial starts with `==` / `===` headings, add `leveloffset` so they nest correctly.
-7. Insert only the `include::` line. Do not copy the partial body into the page.
-8. If the include sits inside a list or tab, read the partial's first lines and confirm the list markers or tab syntax still work. Some nav and create-project partials start with ordered-list `.` items on purpose.
-9. Add an author comment in brackets when that file is already included that way elsewhere, or when the comment helps a human scan the source. Copy an existing comment when one is established (`standalone-unsupported`, `steps-to-project-settings`, `steps-up-to-pipeline`).
-10. Tell the user the path you included and why.
+2. Choose the coordinate (`ROOT:…` vs `guides:ROOT:…`) from the including page's component.
+3. For **partials**:
+   1. Read for composition: some files already `include::` another partial (for example `steps-to-project-id.adoc` includes `steps-to-project-settings.adoc`). Use the composed file. Do not stack both.
+   2. Read for `ifdef::` / `ifndef::`. If present, set the matching page attributes before the include. Examples used today: `:machine:`, `:container:`, `:provisioner:`, `:linux:`, `:macos:`, `:windows:`, `:server:`.
+   3. Note the wrapper (`****` sidebar, `NOTE:`, `TIP:`, or bare list items). Only insert when that wrapper fits the page.
+   4. If the partial starts with `==` / `===` headings, add `leveloffset` so they nest correctly.
+   5. Insert only the `include::` line. If it sits inside a list or tab, confirm the list markers still work. Some nav and create-project partials start with ordered-list `.` items on purpose.
+   6. Add an author comment in brackets when that file is already included that way elsewhere. Copy an existing comment when one is established (`standalone-unsupported`, `steps-to-project-settings`, `steps-up-to-pipeline`).
+4. For **examples**:
+   1. Insert the include **inside** a source or listing block. Never drop `include::ROOT:example$…` into prose.
+   2. Do not copy the YAML (or other code) into the page.
+   3. Keep explanatory comments in the example file. Keep the human-facing title on the listing block.
+5. Tell the user the path you included and why.
 
 ### Propose extraction
 
-Use this when existing page content should become a shared partial, or when you are about to write the same chunk in a second place.
+Use this when existing page content should become a shared partial or example, or when you are about to write the same chunk in a second place.
 
 **Extract when all of these are true:**
 
-- The same steps, note, table, or FAQ will appear on **two or more** pages, or already does
+- The same steps, note, table, FAQ, or config snippet will appear on **two or more** pages, or already does
 - The wording can stay synchronized. Callers do not need different facts, audiences, or mid-flow shortcuts
-- The chunk is a complete reusable unit (nav prefix, caveat, table), not a whole page
+- The chunk is a complete reusable unit (nav prefix, caveat, table, or config snippet), not a whole page
 
 **Do not extract when:**
 
@@ -181,40 +243,43 @@ Use this when existing page content should become a shared partial, or when you 
 - A shortened nav path is intentional because the reader is already mid-flow
 - Wrapping or tone would not fit the other pages (`****` sidebar vs bare list vs `NOTE:`)
 - Replacing would drop unique follow-on steps or change meaning
+- A config snippet is a one-off illustration that other pages should not stay synced with
 
 **Propose, then wait.** Do not create a file or rewrite other pages until the user confirms.
 
-1. Search existing partials first. If one already covers this, propose **replacing** the inline copies with that include. Do not create a duplicate partial.
-2. Grep pages (not just `partials/`) for distinctive phrases from the chunk. Read each match. Drop false positives.
+1. Search existing partials and examples first. If one already covers this, propose **replacing** the inline copies with that include. Do not create a duplicate file.
+2. Grep pages (not just `partials/` or `examples/`) for distinctive phrases from the chunk. Read each match. Drop false positives.
 3. Show the proposal:
-   - Reuse an existing partial, or create `docs/guides/modules/ROOT/partials/<category>/<filename>.adoc`
+   - Reuse an existing file, or create `docs/guides/modules/ROOT/partials/<category>/<filename>.adoc` or `docs/guides/modules/ROOT/examples/<category>/<filename>.yml`
    - Why it should be shared
-   - Every page you would change, with a short before/after (inline block → `include::` line)
+   - Every page you would change, with a short before/after (inline block → `include::` line, including the source-block wrapper for examples)
    - Anything you would **not** replace, and why
-4. After the user confirms, follow **Create a partial** if needed, then **Insert** on each agreed page. Replace only the shared prefix. Leave page-specific steps in place.
-5. Report the new or reused path and the list of updated pages. Remind the user that later edits to the partial change all of those pages.
+4. After the user confirms, follow **Create** if needed, then **Insert** on each agreed page. Replace only the shared prefix. Leave page-specific steps in place.
+5. Report the new or reused path and the list of updated pages. Remind the user that later edits to the file change all of those pages.
 
-### Create a partial
+### Create
 
-Create a new partial only after **Propose extraction** is confirmed, or the user asked for one.
+Create a new file only after **Propose extraction** is confirmed, or the user asked for one.
 
-1. Search existing partials first. Extend one if the topic already has a home.
-2. Choose a category directory from the map above. Add a new directory only when none of the existing ones fit.
-3. Name the file descriptively, ending in `.adoc`. Use `-snip.adoc` for FAQ and troubleshooting snippets.
-4. Write content that works in more than one page. No `:page-platform:`, `:page-description:`, or other page-only attributes.
-5. Keep the partial focused on one concept or one set of related steps.
+1. Search existing files first. Extend one if the topic already has a home.
+2. Choose the family and a category directory from the maps above. Add a new directory only when none of the existing ones fit.
+3. Name the file descriptively. Partials end in `.adoc` (use `-snip.adoc` for FAQ and troubleshooting snippets). Examples use the language extension, usually `.yml`.
+4. Write content that works in more than one page.
+   - Partials: no `:page-platform:`, `:page-description:`, or other page-only attributes
+   - Examples: valid, copy-pasteable code. Put comments in the file. Do not wrap the file in AsciiDoc source fences
+5. Keep the file focused on one concept or one set of related steps or one snippet.
 6. Replace the duplicated page content with includes on the pages the user confirmed.
 7. Mention that later edits to this file change every page that includes it.
 
-### Edit a partial
+### Edit
 
 1. Grep for every include of that file before changing it.
 2. Summarize the pages that will change.
-3. Edit the partial only when the new wording is correct for all of those pages. If it is not, write page-specific content instead of overloading the partial.
+3. Edit the file only when the new wording or snippet is correct for all of those pages. If it is not, write page-specific content instead of overloading the shared file.
 
 ## Parameters
 
-Three different things show up in or around includes. Do not mix them up.
+These apply to **partials**. Example includes do not take author comments or `leveloffset` in practice.
 
 **Author comments** in `[brackets]` are for humans. They do not substitute text into the partial. `notes/standalone-unsupported.adoc` does not read the bracket text; every include of that file renders the same support note.
 
@@ -232,12 +297,14 @@ When a partial uses `ifdef::`, tell the user which attributes they must set. Sug
 
 ## Do not
 
-- Invent a partial path or guess a filename without Glob/Grep.
-- Copy a partial's body into a page "to make it clearer".
+- Invent a path or guess a filename without Glob/Grep.
+- Copy a partial or example body into a page "to make it clearer".
+- Insert an `example$` include outside a source or listing block.
 - Extract and replace across pages without listing the consumers and getting confirmation.
 - Use `ui/src/partials/` files in docs pages.
-- Edit a guides partial to fix one page if that would break the others.
+- Edit a shared file to fix one page if that would break the others.
 - Include a Server Admin `installation/` partial from a Cloud guides page.
+- Use a `logic-statement-examples/` snippet when documenting current expression syntax.
 
 ## Example invocations
 
@@ -245,8 +312,13 @@ When a partial uses `ifdef::`, tell the user which attributes they must set. Sug
 /partials
 /partials navigation
 /partials search project settings
+/examples
+/examples orchestration
+/examples search job-group
 Use a partial for the Docker auth note
 Is there a partial for checking org type?
+Is there a shared example for serial groups?
 Should this note be a shared partial?
 This project-settings walkthrough is copied on three pages. Extract it.
+This workflow when clause is copied in the cookbook and the config reference. Extract it.
 ```

--- a/skills/partials/SKILL.md
+++ b/skills/partials/SKILL.md
@@ -2,11 +2,13 @@
 name: partials
 description: >
   Discover, preview, and insert CircleCI docs AsciiDoc partials with the correct
-  include syntax. Use this skill whenever the user mentions partials, includes,
-  reusable snippets, or /partials, and whenever you are writing or editing .adoc
-  pages that need shared navigation steps, notes, tips, FAQs, troubleshooting,
-  resource tables, runner setup, or other repeated content. Other docs-authoring
-  skills must follow this skill instead of copying reusable content by hand.
+  include syntax. Propose when new or existing content should become a shared
+  partial, then create it and replace duplicates after confirmation. Use this
+  skill whenever the user mentions partials, includes, reusable snippets, or
+  /partials, and whenever you are writing or editing .adoc pages that need
+  shared navigation steps, notes, tips, FAQs, troubleshooting, resource tables,
+  runner setup, or other repeated content. Other docs-authoring skills must
+  follow this skill instead of copying reusable content by hand.
 ---
 
 # CircleCI Docs Partials
@@ -20,7 +22,7 @@ If another skill is writing or editing docs content:
 1. Read this file before drafting reusable steps, notes, FAQs, tables, or troubleshooting.
 2. Follow **Suggest from context** for the page you are writing.
 3. Insert an `include::` line. Never paste the body of a partial into a page.
-4. If no partial fits, write the content inline unless it will be reused on two or more pages. Then follow **Create a partial**.
+4. If the page restates an existing partial, or the same new chunk will appear on two or more pages, follow **Propose extraction**. Do not extract and replace across pages until the user confirms.
 
 ## Source of truth
 
@@ -91,7 +93,7 @@ Use the directory name to browse. Confirm the file still exists before inserting
 
 ## Workflows
 
-Decide which workflow the user asked for. A write-docs skill usually wants **Suggest from context**, then **Insert**.
+Decide which workflow the user asked for. A write-docs skill usually wants **Suggest from context**, then **Insert**. When content is duplicated or clearly reusable, follow **Propose extraction** before writing a second copy.
 
 ### Browse (`/partials`, `/partials navigation`)
 
@@ -132,7 +134,7 @@ Use this when writing or editing a page, even if the user did not say "partial".
 6. If a page has a **shortened** version of a standard nav partial, offer the full partial for that shared prefix and keep the page-specific steps that follow. Do not auto-insert if the reader is clearly already mid-flow (for example, already on the Projects page).
 7. If one candidate is a clear match, insert it and tell the user which partial you used.
 8. If several could work, show the options and ask.
-9. If none fit, write the content inline. Offer a new partial only when a second page will need the same text.
+9. If none fit, write the content inline. If the same chunk already exists on another page, or will be needed on a second page, follow **Propose extraction**.
 
 Common starting points (still verify by reading the file):
 
@@ -163,16 +165,45 @@ Common starting points (still verify by reading the file):
 9. Add an author comment in brackets when that file is already included that way elsewhere, or when the comment helps a human scan the source. Copy an existing comment when one is established (`standalone-unsupported`, `steps-to-project-settings`, `steps-up-to-pipeline`).
 10. Tell the user the path you included and why.
 
+### Propose extraction
+
+Use this when existing page content should become a shared partial, or when you are about to write the same chunk in a second place.
+
+**Extract when all of these are true:**
+
+- The same steps, note, table, or FAQ will appear on **two or more** pages, or already does
+- The wording can stay synchronized. Callers do not need different facts, audiences, or mid-flow shortcuts
+- The chunk is a complete reusable unit (nav prefix, caveat, table), not a whole page
+
+**Do not extract when:**
+
+- The content is page-specific or only used once
+- A shortened nav path is intentional because the reader is already mid-flow
+- Wrapping or tone would not fit the other pages (`****` sidebar vs bare list vs `NOTE:`)
+- Replacing would drop unique follow-on steps or change meaning
+
+**Propose, then wait.** Do not create a file or rewrite other pages until the user confirms.
+
+1. Search existing partials first. If one already covers this, propose **replacing** the inline copies with that include. Do not create a duplicate partial.
+2. Grep pages (not just `partials/`) for distinctive phrases from the chunk. Read each match. Drop false positives.
+3. Show the proposal:
+   - Reuse an existing partial, or create `docs/guides/modules/ROOT/partials/<category>/<filename>.adoc`
+   - Why it should be shared
+   - Every page you would change, with a short before/after (inline block → `include::` line)
+   - Anything you would **not** replace, and why
+4. After the user confirms, follow **Create a partial** if needed, then **Insert** on each agreed page. Replace only the shared prefix. Leave page-specific steps in place.
+5. Report the new or reused path and the list of updated pages. Remind the user that later edits to the partial change all of those pages.
+
 ### Create a partial
 
-Create a new partial only when the content will appear on two or more pages, or the user asked for one.
+Create a new partial only after **Propose extraction** is confirmed, or the user asked for one.
 
 1. Search existing partials first. Extend one if the topic already has a home.
 2. Choose a category directory from the map above. Add a new directory only when none of the existing ones fit.
 3. Name the file descriptively, ending in `.adoc`. Use `-snip.adoc` for FAQ and troubleshooting snippets.
 4. Write content that works in more than one page. No `:page-platform:`, `:page-description:`, or other page-only attributes.
 5. Keep the partial focused on one concept or one set of related steps.
-6. Replace the duplicated page content with includes. Grep for similar wording and offer to switch those pages too.
+6. Replace the duplicated page content with includes on the pages the user confirmed.
 7. Mention that later edits to this file change every page that includes it.
 
 ### Edit a partial
@@ -203,6 +234,7 @@ When a partial uses `ifdef::`, tell the user which attributes they must set. Sug
 
 - Invent a partial path or guess a filename without Glob/Grep.
 - Copy a partial's body into a page "to make it clearer".
+- Extract and replace across pages without listing the consumers and getting confirmation.
 - Use `ui/src/partials/` files in docs pages.
 - Edit a guides partial to fix one page if that would break the others.
 - Include a Server Admin `installation/` partial from a Cloud guides page.
@@ -215,4 +247,6 @@ When a partial uses `ifdef::`, tell the user which attributes they must set. Sug
 /partials search project settings
 Use a partial for the Docker auth note
 Is there a partial for checking org type?
+Should this note be a shared partial?
+This project-settings walkthrough is copied on three pages. Extract it.
 ```


### PR DESCRIPTION
Give agents a reusable workflow to scan, preview, and include AsciiDoc partials with the correct syntax so later docs-authoring skills can reuse it instead of copying content.