### PR TITLE
Make testsuite the preferred test command, demote tests to legacy

### DIFF
--- a/docs/guides/modules/ROOT/nav.adoc
+++ b/docs/guides/modules/ROOT/nav.adoc
@@ -148,23 +148,24 @@
 *** xref:test:test.adoc[Automated testing]
 *** xref:test:collect-test-data.adoc[Collecting test data]
 *** xref:insights:insights-tests.adoc[Test Insights]
-** Manage and optimize tests
-*** xref:test:fix-flaky-tests.adoc[Fix flaky tests]
-*** xref:optimize:parallelism-faster-jobs.adoc[Test splitting and parallelism]
-*** xref:optimize:use-the-circleci-cli-to-split-tests.adoc[Use the environment CLI to split tests]
-*** xref:test:troubleshoot-test-splitting.adoc[Troubleshoot test splitting]
-*** xref:test:automate-llm-evaluation-testing-with-the-circleci-evals-orb.adoc[Automate LLM evaluation testing with the CircleCI Evals orb]
 ** Smarter Testing
 *** xref:test:getting-started-with-smarter-testing.adoc[Getting Started With Smarter Testing]
 *** xref:test:set-up-test-impact-analysis.adoc[Set up Test Impact Analysis]
 *** xref:test:use-dynamic-test-splitting.adoc[Use Dynamic Test Splitting]
 *** xref:test:auto-rerun-failed-tests.adoc[Auto Rerun Failed Tests]
 *** xref:test:testsuite-configuration-reference.adoc[Test suite Config Reference]
+** Legacy: `circleci tests` command
+*** xref:optimize:parallelism-faster-jobs.adoc[Test splitting and parallelism]
+*** xref:optimize:use-the-circleci-cli-to-split-tests.adoc[Use the environment CLI to split tests]
+*** xref:test:troubleshoot-test-splitting.adoc[Troubleshoot test splitting]
+*** xref:test:rerun-failed-tests.adoc[Re-run failed tests overview]
+** Manage and optimize tests
+*** xref:test:fix-flaky-tests.adoc[Fix flaky tests]
+*** xref:test:automate-llm-evaluation-testing-with-the-circleci-evals-orb.adoc[Automate LLM evaluation testing with the CircleCI Evals orb]
 ** Testing strategies
 *** xref:test:testing-llm-enabled-applications-through-evaluations.adoc[Testing LLM-enabled applications through evaluations]
 *** xref:test:browser-testing.adoc[Browser testing]
 *** xref:test:code-coverage.adoc[Generate code coverage metrics]
-*** xref:test:rerun-failed-tests.adoc[Re-run failed tests overview]
 *** xref:test:testing-ios.adoc[Testing iOS applications]
 *** xref:test:testing-macos.adoc[Testing macOS applications]
 

--- a/docs/guides/modules/ROOT/partials/notes/smarter-testing-beta.adoc
+++ b/docs/guides/modules/ROOT/partials/notes/smarter-testing-beta.adoc
@@ -1,6 +1,0 @@
-[NOTE]
-====
-*Smarter Testing* is available in beta. This means the product is in early stages and you may encounter bugs, unexpected behavior, or incomplete features. When the feature is made generally available, there will be a cost associated with access and usage.
-
-Refer to our link:https://discuss.circleci.com/t/product-launch-smarter-testing-is-now-in-beta/54497[Discuss post] for more information about our beta launch.
-====

--- a/docs/guides/modules/optimize/pages/parallelism-faster-jobs.adoc
+++ b/docs/guides/modules/optimize/pages/parallelism-faster-jobs.adoc
@@ -12,6 +12,8 @@ Use parallelism and test splitting to:
 
 If you are interested to read about concurrent job runs, see the xref:concurrency.adoc[Concurrency Overview] page.
 
+NOTE: This page covers test splitting with the legacy `circleci tests` command family. CircleCI's preferred way to split tests is now `circleci testsuite`, which supports the same splitting capabilities plus dynamic test splitting. See xref:test:test.adoc#smarter-testing[Get started with Smarter Testing].
+
 [#introduction]
 == Introduction
 

--- a/docs/guides/modules/optimize/pages/use-the-circleci-cli-to-split-tests.adoc
+++ b/docs/guides/modules/optimize/pages/use-the-circleci-cli-to-split-tests.adoc
@@ -11,6 +11,8 @@ NOTE: The `circleci tests` commands are part of the environment CLI as they requ
 
 NOTE: xref:execution-runner:runner-overview.adoc[Self-Hosted Runners] can invoke `circleci-agent` directly instead of using the CLI to split tests. This is because the xref:execution-runner:runner-overview.adoc#circleci-self-hosted-runner-operation[task-agent] already exists on the `$PATH`, removing an additional dependency when splitting tests.
 
+NOTE: `circleci tests glob`/`run`/`split` are legacy commands. CircleCI's preferred way to run and split tests is now `circleci testsuite`. See xref:test:test.adoc#smarter-testing[Get started with Smarter Testing].
+
 [#prerequisites]
 == Prerequisites
 

--- a/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
+++ b/docs/guides/modules/test/pages/auto-rerun-failed-tests.adoc
@@ -1,11 +1,8 @@
 = Auto rerun failed tests
-:page-badge: Beta
 :page-platform: Cloud
 :experimental:
 :page-description: Automatically retry failed tests to improve build reliability
 :page-show-readtime: true
-
-include::ROOT:partial$notes/smarter-testing-beta.adoc[]
 
 Auto rerun failed tests automatically detects and retries test failures during your test run. Compared with the existing xref:rerun-failed-tests.adoc[Rerun Failed Tests] feature that CircleCI provides, auto rerun failed tests eliminates the need to:
 

--- a/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
+++ b/docs/guides/modules/test/pages/getting-started-with-smarter-testing.adoc
@@ -1,12 +1,9 @@
 = Getting started with Smarter Testing
 :page-description: Install and configure Smarter Testing for your project
-:page-badge: Beta
 :page-platform: Cloud
 :experimental:
 :page-show-readtime: true
 :tabs-sync-option:
-
-include::ROOT:partial$notes/smarter-testing-beta.adoc[]
 
 Smarter Testing reduces test execution time while maintaining test confidence. It provides three independent features you can enable incrementally:
 

--- a/docs/guides/modules/test/pages/rerun-failed-tests.adoc
+++ b/docs/guides/modules/test/pages/rerun-failed-tests.adoc
@@ -5,6 +5,8 @@
 
 Use rerun failed tests to only rerun a subset of tests, instead of an entire test suite, when a transient test failure arises.
 
+NOTE: This page covers rerunning failed tests with the legacy `circleci tests run` command. CircleCI's preferred way to rerun failed tests is now `circleci testsuite`'s xref:auto-rerun-failed-tests.adoc[Auto Rerun Failed Tests] feature.
+
 [#introduction]
 == Introduction
 

--- a/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
+++ b/docs/guides/modules/test/pages/set-up-test-impact-analysis.adoc
@@ -1,10 +1,7 @@
 = Set up test impact analysis
 :page-description: Run only the tests impacted by your code changes
-:page-badge: Beta
 :page-platform: Cloud
 :experimental:
-
-include::ROOT:partial$notes/smarter-testing-beta.adoc[]
 
 Test impact analysis speeds up CI by running only the tests affected by your code changes. CircleCI tracks which tests exercise which source files, then skips tests that cover unchanged source files.
 

--- a/docs/guides/modules/test/pages/test.adoc
+++ b/docs/guides/modules/test/pages/test.adoc
@@ -1,6 +1,6 @@
 = Automated testing in CircleCI
 :page-platform: Cloud, Server v4+
-:page-description: An overview of setting up testing automation, integration, and analytics.
+:page-description: An overview of setting up testing automation, integration, and analytics with Smarter Testing.
 :experimental:
 
 [#introduction]
@@ -9,6 +9,14 @@
 CircleCI allows you to automatically test your code before changes are merged. You can integrate testing tools and frameworks such as Jest, Mocha, `pytest`, JUnit, Selenium, XCTest, and more.
 
 When you integrate your tests into your CircleCI pipelines, you deliver software to your users more reliably and efficiently, and get faster feedback. This also means you can fix issues and failed tests faster. Test output data becomes available in CircleCI to help debug failed tests. If you save your test data in CircleCI, you can also take advantage of Test Insights as well as parallelism features to identify opportunities to further optimize your pipelines.
+
+<<basics,Basics>> below covers running your test suite using your native test library and the `run` step, which works with any test runner. `circleci testsuite` is CircleCI's preferred way to run that test command, for all customers: it supports the same test discovery, running, and splitting capabilities as the legacy `circleci tests` command family, plus additional commands (such as `list-tests`, for introspecting which tests will run) and three features unique to link:https://circleci.com/blog/smarter-testing-stop-running-tests-that-dont-matter/[Smarter Testing], each usable on its own:
+
+* *Test impact analysis* -- skip tests that your code changes can't have affected, based on real coverage data rather than heuristics.
+* *Dynamic test splitting* -- keep parallel execution nodes evenly loaded by pulling tests from a shared queue as work becomes available, instead of assigning a fixed split up front.
+* *Auto rerun failed tests* -- automatically retry failed tests to absorb flaky failures without manual re-runs.
+
+See <<smarter-testing,Get started with Smarter Testing>> below to switch, or <<legacy-test-command,Legacy: `circleci tests` command>> if you're on Server or not ready to move yet.
 
 [#basics]
 == Basics
@@ -41,6 +49,8 @@ Depending on your requirements, you might have more complex workflows that orche
 For a more in-depth look at workflows functionality, visit the xref:orchestrate:workflows.adoc[Workflows] page. You can also refer to the xref:toolkit:sample-config.adoc[Sample configuration] page for more workflow examples.
 
 If you need to restrict the connections allowed in your test jobs, consider enabling xref:security:ip-ranges.adoc[IP Ranges]. This enables CircleCI jobs to go through a set of well-defined IP address ranges.
+
+This gets your tests running with your native test library, directly through the `run` step -- the same approach the legacy `circleci tests` command family uses. `circleci testsuite` uses this same `run` step and is CircleCI's preferred way to run it going forward: it matches `circleci tests` feature for feature, and adds test impact analysis, dynamic test splitting, and auto rerun failed tests on top -- see <<smarter-testing,Get started with Smarter Testing>> below.
 
 [#orbs]
 == Use orbs to simplify testing
@@ -106,19 +116,105 @@ When test results are stored, test analytics also become available on the *Tests
 
 More information is available on the xref:insights:insights-tests.adoc[Test Insights] page.
 
-[#rerun-failed-tests-only]
-== Re-run failed tests only (`circleci tests run`)
+[#smarter-testing]
+== Get started with Smarter Testing (`circleci testsuite`)
 
-You can configure jobs to re-run failed tests only. Using this option, when a transient test failure arises, only a subset of tests are re-run instead of the entire test suite. Also, only failed tests from the same commit are re-run, not new ones.
+`circleci testsuite` is CircleCI's preferred way to run tests, for all customers. It supports the same test discovery, running, and splitting capabilities as the legacy `circleci tests` command family, plus additional commands and the Smarter Testing features described below. It's currently available in Cloud only; Server projects should continue to use the <<legacy-test-command,legacy `circleci tests` commands>> for now.
 
-More information on how to use this option is available on the xref:rerun-failed-tests.adoc[Rerun Failed Tests Overview] page.  This functionality uses a command called `circleci tests run`.
+`circleci testsuite` is driven by a single command and a `.circleci/test-suites.yml` configuration file that describes how to discover and run your tests. Setup has two parts:
 
-Historically, when your testing job in a workflow has flaky tests, the only option to get to a successful workflow was to re-run your workflow from failed. This type of re-run executes all tests from your testing job, including tests that passed, which prolongs time-to-feedback and consumes credits unnecessarily.
+. Configure `.circleci/test-suites.yml` to discover and run your tests.
+. Replace your existing test command with `circleci testsuite run`.
+
+To validate your setup locally, ensure the link:https://cli.circleci.com/[latest CircleCI CLI, window=_blank] is installed. The CLI is already available in CI, so no install is needed there.
+
+Use the `doctor` command to set up and validate `test-suites.yml` for a new project:
+
+[,shell]
+----
+circleci testsuite doctor "ci tests"
+----
+
+Then, in the job you built in <<basics,Basics>>, replace `command: npm test` with `circleci testsuite run`, keeping the rest of the job the same:
+
+[,yaml]
+----
+jobs:
+  build-and-test:
+    docker:
+      - image: cimg/node:16.10
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: npm
+      - run:
+          name: Run tests
+          command: circleci testsuite run "ci tests"
+      - store_test_results:
+          # Must match outputs.junit in test-suites.yml
+          path: test-reports
+----
+
+Once a project runs tests through `circleci testsuite`, each feature can be turned on independently with an `options` block in `test-suites.yml`:
+
+[,yaml]
+----
+test-suites:
+  ci tests:
+    options:
+      test-impact-analysis: true
+      dynamic-test-splitting: true
+      max-auto-rerun: 3
+----
+
+[#test-impact-analysis]
+=== Test impact analysis
+
+Test impact analysis uses code coverage data to map which tests exercise which source files. On a feature branch, it starts with your full test suite selected, then conservatively deselects only the tests proven to be unaffected by the files you changed -- routinely skipping a large share of tests without reducing test confidence, since deselection is based on measured coverage rather than guesswork. A full run against your default branch keeps the underlying coverage baseline up to date.
+
+Full setup instructions, including coverage requirements per test runner, are on the xref:set-up-test-impact-analysis.adoc[Set up Test Impact Analysis] page.
+
+[#dynamic-test-splitting]
+=== Dynamic test splitting
+
+`circleci testsuite run` already splits tests across parallel nodes when `parallelism` is set on your job, using the durations reported in your JUnit results. This static split misses fixed costs like runner startup and per-node setup, so nodes can still finish at noticeably different times. Enabling `dynamic-test-splitting` replaces that fixed, up-front split with a shared queue that nodes pull from as they become available, learning the gap between reported and actual runtime as it runs.
+
+See the xref:use-dynamic-test-splitting.adoc[Use Dynamic Test Splitting] page to configure it for your project.
+
+[#auto-rerun-failed-tests]
+=== Auto rerun failed tests
+
+Auto rerun failed tests retries a failing test immediately, without human intervention, up to `max-auto-rerun` times or until `auto-rerun-duration` is reached. If a test eventually passes, its earlier failure is suppressed and the job succeeds; a test that fails consistently still exhausts its retries and fails the job. This is intended for intermittent, flaky failures, not for masking genuine regressions -- it pairs well with test impact analysis, since a smaller, more targeted test selection makes flakiness easier to spot.
+
+See the xref:auto-rerun-failed-tests.adoc[Auto Rerun Failed Tests] page for configuration details.
+
+For the full set of configuration keys available in `test-suites.yml`, refer to the xref:testsuite-configuration-reference.adoc[Test suite Config Reference].
 
 [#next-steps]
 == Next steps
 
-* Further optimize your pipelines with xref:optimize:parallelism-faster-jobs.adoc[Parallelism and Test Splitting].
+* Get started with xref:getting-started-with-smarter-testing.adoc[Smarter Testing] end to end.
 * Integrate tests for xref:testing-macos.adoc[macOS] or xref:testing-ios.adoc[iOS] apps.
 * Read our xref:browser-testing.adoc[Browser Testing] guide to common methods for running and debugging browser tests in CircleCI.
 * To get event-based notifications in Slack about your pipelines (for example, if a job passes or fails), try our xref:getting-started:slack-orb-tutorial.adoc[Slack Orb] tutorial.
+
+[#legacy-test-command]
+== Legacy: `circleci tests` command
+
+`circleci tests` (`glob`, `run`, `split`) is CircleCI's original test command family, wired up as individual steps in your job to discover, run, split, and rerun tests. `circleci testsuite` now supports the same capabilities, plus additional functionality, and is CircleCI's preferred solution for all customers going forward. `circleci tests` is considered legacy, but remains fully supported, and is currently required for Server projects, since `circleci testsuite` is Cloud only.
+
+[#legacy-test-splitting]
+=== Test splitting and parallelism (`circleci tests split`)
+
+Splitting your test suite across parallel execution nodes reduces the time it takes to run your tests. `circleci testsuite run` already does this using static, timing-based assignment when `parallelism` is set on your job, with <<dynamic-test-splitting,dynamic test splitting>> available as a further improvement. Without `circleci testsuite`, splitting is handled by the `circleci tests split` command instead.
+
+See xref:optimize:parallelism-faster-jobs.adoc[Test splitting and parallelism] and xref:optimize:use-the-circleci-cli-to-split-tests.adoc[Use the environment CLI to split tests] for setup details.
+
+[#legacy-rerun-failed-tests]
+=== Re-run failed tests only (`circleci tests run`)
+
+You can configure jobs to re-run failed tests only. Using this option, when a transient test failure arises, only a subset of tests are re-run instead of the entire test suite. Also, only failed tests from the same commit are re-run, not new ones.
+
+More information on how to use this option is available on the xref:rerun-failed-tests.adoc[Rerun Failed Tests Overview] page. This functionality uses a command called `circleci tests run`, which Smarter Testing's <<smarter-testing,auto rerun failed tests>> feature supersedes for projects on `circleci testsuite`.
+
+Historically, when your testing job in a workflow has flaky tests, the only option to get to a successful workflow was to re-run your workflow from failed. This type of re-run executes all tests from your testing job, including tests that passed, which prolongs time-to-feedback and consumes credits unnecessarily.

--- a/docs/guides/modules/test/pages/testsuite-configuration-reference.adoc
+++ b/docs/guides/modules/test/pages/testsuite-configuration-reference.adoc
@@ -1,11 +1,8 @@
 = Testsuite configuration reference
-:page-badge: Beta
 :page-platform: Cloud
 :experimental:
 :page-description: Reference for .circleci/test-suites.yml
 :page-show-readtime: true
-
-include::ROOT:partial$notes/smarter-testing-beta.adoc[]
 
 This document is a reference for the CircleCI Smarter Testing test suite configuration keys used in the `.circleci/test-suites.yml` file.
 

--- a/docs/guides/modules/test/pages/troubleshoot-test-splitting.adoc
+++ b/docs/guides/modules/test/pages/troubleshoot-test-splitting.adoc
@@ -3,6 +3,8 @@
 :page-description: Tips and common errors to help troubleshoot your CircleCI test splitting implementation.
 :experimental:
 
+NOTE: This page covers troubleshooting the legacy `circleci tests` command family. CircleCI's preferred way to run and split tests is now `circleci testsuite`. See xref:test.adoc#smarter-testing[Get started with Smarter Testing].
+
 [#using-test-splitting-with-python-django-tests]
 == Using test splitting with Python Django tests
 

--- a/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
+++ b/docs/guides/modules/test/pages/use-dynamic-test-splitting.adoc
@@ -1,10 +1,7 @@
 = Use dynamic test splitting
-:page-badge: Beta
 :page-platform: Cloud
 :experimental:
 :page-description: Evenly distribute tests across parallel execution nodes
-
-include::ROOT:partial$notes/smarter-testing-beta.adoc[]
 
 Dynamic test splitting reduces overall pipeline time by distributing test atoms across parallel nodes so all nodes finish at the same time. Unlike static test splitting, which pre-assigns tests upfront, dynamic test splitting redistributes work to nodes that are ready. Dynamic test splitting prevents nodes from sitting idle while others finish late.
 


### PR DESCRIPTION
## Summary
Restructures the testing docs so `circleci testsuite` (Smarter Testing) is presented as CircleCI's preferred solution for all customers, with the legacy `circleci tests` command family clearly labeled as legacy but still fully documented for existing customers.

- Reworked `test.adoc`: Basics keeps the native `npm test` example, followed by a "Get started with Smarter Testing" section (`doctor`/`run`, `test-suites.yml` options, test impact analysis, dynamic test splitting, auto rerun failed tests), and a consolidated "Legacy: `circleci tests` command" section.
- Reordered `nav.adoc` so Smarter Testing appears above the renamed "Legacy: `circleci tests` command" group.
- Added cross-links from `parallelism-faster-jobs.adoc`, `use-the-circleci-cli-to-split-tests.adoc`, `rerun-failed-tests.adoc`, and `troubleshoot-test-splitting.adoc` pointing to their `testsuite` equivalents.
- Dropped the beta badge and beta note across the Smarter Testing pages, and removed the now-unused `smarter-testing-beta.adoc` partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)