### PR TITLE
ditributor continue to support machine: true without a specified imag…

### DIFF
--- a/docs/guides/modules/execution-managed/pages/executor-intro.adoc
+++ b/docs/guides/modules/execution-managed/pages/executor-intro.adoc
@@ -64,8 +64,6 @@ Find out more about the Docker execution environment on the xref:using-docker.ad
 [#linux-vm]
 == Linux VM
 
-NOTE: *CircleCI Cloud* The use of `machine: true` is deprecated. You must specify an image to use.
-
 To access the Linux VM execution environment, use the `machine` executor and specify a Linux image. For a full list of `machine` images, see the link:https://circleci.com/developer/images?imageType=machine[CircleCI Developer Hub].
 
 [tabs]

--- a/docs/guides/modules/execution-managed/pages/using-linuxvm.adoc
+++ b/docs/guides/modules/execution-managed/pages/using-linuxvm.adoc
@@ -9,9 +9,6 @@ Using the machine executor gives your application full access to OS resources an
 To use the machine executor, use the xref:reference:ROOT:configuration-reference.adoc#machine[`machine` key] in your job configuration and specify an image:
 
 ****
-We have deprecated the use of `machine: true` on **CircleCI Cloud**. You must specify an image to use.
-
-You can still use `machine: true` with:
 
 * Self-hosted runners
 * The machine executor on CircleCI Server.

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -788,7 +788,7 @@ Configure a job to use the Docker execution environment using the `docker` key w
 | Key | Required | Type | Description
 
 | `image`
-| Y
+| N
 | String
 | The name of a custom Docker image to use. The first `image` listed under a job defines the job's own primary container image where all steps will run.
 

--- a/docs/reference/modules/ROOT/pages/configuration-reference.adoc
+++ b/docs/reference/modules/ROOT/pages/configuration-reference.adoc
@@ -997,8 +997,6 @@ jobs:
 [#machine]
 === *`machine`*
 
-NOTE: *Using CircleCI Cloud?* The use of `machine: true` is deprecated. You must specify an image to use.
-
 The machine executor is configured using the `machine` key, which takes a map:
 
 [.table-scroll]


### PR DESCRIPTION


# Description
Remove notes in docs that mentions `The use of machine: true is deprecated. You must specify an image to use.`

ditributor will continue to support `machine: true` without a specified image in server and cloud. If the config validators stop permitting `machine: true` then the note officially becomes true. However that is not the case today

# Reasons

Prevent from misinforming/confusing customers and internal devs on how to write their config.

# Content checks
Please follow our style when contributing to CircleCI docs. View our [style guide](https://circleci.com/docs/style/style-guide-overview) or check out our [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.

**Preview your changes:**
- [ ] View the Vale linter results, select the `ci/circleci: lint` job at the bottom of your PR. You will be redirected to the `vale/lint` job output in CircleCI.
- [ ] Preview your changes, select the `ci/circleci: build` job at the bottom of your PR and you will be redirected to CircleCI. Select the Artifacts tab and select `index.html` to open a preview version of the docs site built for your latest commit.

Take a moment to check through the following items when submitting your PR (this is just a guide so will not be relevant for all PRs):

**Content structure:**
- [ ] Break up walls of text by adding paragraph breaks.
- [ ] Consider if the content could benefit from more structure, such as lists or tables, to make it easier to consume.
- [ ] Consider whether the content would benefit from more subsections (h2-h6 headings) to make it easier to consume.
- [ ] Include relevant backlinks to other CircleCI docs/pages.

**Formatting:**
- [ ] Keep the title between 20 and 70 characters.
- [ ] Check all headings h1-h6 are in sentence case (only first letter is capitalized).
